### PR TITLE
Fix test assertions and trip delete cascade

### DIFF
--- a/src/server/routers/datePoll.test.ts
+++ b/src/server/routers/datePoll.test.ts
@@ -57,7 +57,7 @@ describe.skipIf(skip)("datePoll router", () => {
         startDate: "2026-11-01",
         endDate: "2026-11-04",
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("vote — member can vote", async () => {

--- a/src/server/routers/events.test.ts
+++ b/src/server/routers/events.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(skip)("events router", () => {
         location: "Nowhere",
         dates: "Never",
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("getByTrip — any member can view", async () => {

--- a/src/server/routers/expenses.test.ts
+++ b/src/server/routers/expenses.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(skip)("expenses router", () => {
         paidByUserId: memberId,
         splitAmong: [memberId],
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("list — any member can view with splits", async () => {
@@ -92,7 +92,7 @@ describe.skipIf(skip)("expenses router", () => {
         expenseId,
         splits: [{ userId: memberId, amount: 0 }],
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("remove — owner can remove", async () => {

--- a/src/server/routers/ideas.test.ts
+++ b/src/server/routers/ideas.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(skip)("ideas router", () => {
         title: "Nope",
         location: "Nowhere",
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("list — any member can list ideas with votes", async () => {
@@ -95,7 +95,7 @@ describe.skipIf(skip)("ideas router", () => {
 
   it("remove — planner cannot remove", async () => {
     const caller = createTestCaller(plannerId);
-    await expect(caller.ideas.remove({ tripId, ideaId })).rejects.toThrow("FORBIDDEN");
+    await expect(caller.ideas.remove({ tripId, ideaId })).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("remove — owner can remove", async () => {

--- a/src/server/routers/quickInfoTiles.test.ts
+++ b/src/server/routers/quickInfoTiles.test.ts
@@ -57,7 +57,7 @@ describe.skipIf(skip)("quickInfoTiles router", () => {
         label: "Wifi",
         value: "password123",
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("list — any member can view tiles", async () => {

--- a/src/server/routers/reservations.test.ts
+++ b/src/server/routers/reservations.test.ts
@@ -60,7 +60,7 @@ describe.skipIf(skip)("reservations router", () => {
         title: "Nope",
         date: "2026-10-06",
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("list — any member can view", async () => {

--- a/src/server/routers/rounds.test.ts
+++ b/src/server/routers/rounds.test.ts
@@ -90,7 +90,7 @@ describe.skipIf(skip)("rounds router", () => {
         format: "skins",
         pointsAvailable: 4,
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("remove — owner can remove", async () => {

--- a/src/server/routers/series.test.ts
+++ b/src/server/routers/series.test.ts
@@ -72,7 +72,7 @@ describe.skipIf(skip)("series router", () => {
     const caller = createTestCaller(otherUserId);
     await expect(
       caller.series.linkTrip({ seriesId, tripId })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("transferOwnership — owner can transfer", async () => {
@@ -91,6 +91,6 @@ describe.skipIf(skip)("series router", () => {
         seriesId,
         newOwnerId: ownerUserId,
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });

--- a/src/server/routers/sideEvents.test.ts
+++ b/src/server/routers/sideEvents.test.ts
@@ -72,7 +72,7 @@ describe.skipIf(skip)("sideEvents router", () => {
         icon: "❌",
         pointsAvailable: 1,
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("list — member can list side events", async () => {
@@ -100,6 +100,6 @@ describe.skipIf(skip)("sideEvents router", () => {
         sideEventId,
         result: { [teamAId]: 0, [teamBId]: 1 },
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });

--- a/src/server/routers/teamAssignments.test.ts
+++ b/src/server/routers/teamAssignments.test.ts
@@ -90,6 +90,6 @@ describe.skipIf(skip)("teamAssignments router", () => {
         teamId,
         userId: ownerId,
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });

--- a/src/server/routers/tripMembers.test.ts
+++ b/src/server/routers/tripMembers.test.ts
@@ -62,14 +62,14 @@ describe.skipIf(skip)("tripMembers router", () => {
     const caller = createTestCaller(memberId);
     await expect(
       caller.tripMembers.add({ tripId, userId: randomUUID() })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("add — duplicate throws CONFLICT", async () => {
     const caller = createTestCaller(plannerId);
     await expect(
       caller.tripMembers.add({ tripId, userId: newUserId })
-    ).rejects.toThrow("CONFLICT");
+    ).rejects.toMatchObject({ code: "CONFLICT" });
   });
 
   // updateRole
@@ -94,7 +94,7 @@ describe.skipIf(skip)("tripMembers router", () => {
     const caller = createTestCaller(plannerId);
     await expect(
       caller.tripMembers.updateRole({ tripId, userId: memberId, role: "Planner" })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   // updateRsvp

--- a/src/server/routers/trips.test.ts
+++ b/src/server/routers/trips.test.ts
@@ -96,7 +96,7 @@ describe.skipIf(skip)("trips router", () => {
 
   it("getById — outsider is FORBIDDEN", async () => {
     const caller = createTestCaller(outsiderId);
-    await expect(caller.trips.getById({ tripId })).rejects.toThrow("FORBIDDEN");
+    await expect(caller.trips.getById({ tripId })).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   // -------------------------------------------------------------------------
@@ -115,7 +115,7 @@ describe.skipIf(skip)("trips router", () => {
     const caller = createTestCaller(memberId);
     await expect(
       caller.trips.update({ tripId, title: "Hacked" })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   // -------------------------------------------------------------------------
@@ -140,7 +140,7 @@ describe.skipIf(skip)("trips router", () => {
         title: "Somewhere",
         location: "Nowhere",
       })
-    ).rejects.toThrow("FORBIDDEN");
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("unlockDestination — owner can unlock", async () => {
@@ -154,7 +154,7 @@ describe.skipIf(skip)("trips router", () => {
   // -------------------------------------------------------------------------
   it("delete — member cannot delete", async () => {
     const caller = createTestCaller(memberId);
-    await expect(caller.trips.delete({ tripId })).rejects.toThrow("FORBIDDEN");
+    await expect(caller.trips.delete({ tripId })).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
   it("delete — owner can delete", async () => {

--- a/src/server/routers/trips.ts
+++ b/src/server/routers/trips.ts
@@ -276,6 +276,95 @@ export const tripsRouter = router({
     .input(z.object({ tripId: z.string() }))
     .use(requireTripRole("Owner"))
     .mutation(async ({ ctx }) => {
+      // Delete dependent records first (no ON DELETE CASCADE in schema).
+      // Order matters: children before parents.
+
+      // 1. Tables with direct trip_id FK — deep children first
+      const tripTables = [
+        "idea_votes",
+        "idea_comments",
+        "ideas",
+        "messages",
+        "reservations",
+        "quick_info_tiles",
+      ] as const;
+      for (const t of tripTables) {
+        await ctx.supabase.from(t).delete().eq("trip_id", ctx.tripId);
+      }
+
+      // 2. Notification reads → notification_events (has trip_id)
+      const { data: notifIds } = await ctx.supabase
+        .from("notification_events")
+        .select("id")
+        .eq("trip_id", ctx.tripId);
+      if (notifIds?.length) {
+        await ctx.supabase
+          .from("notification_reads")
+          .delete()
+          .in("notification_id", notifIds.map((n) => n.id));
+      }
+      await ctx.supabase.from("notification_events").delete().eq("trip_id", ctx.tripId);
+
+      // 3. Expense splits → expenses (has trip_id)
+      const { data: expIds } = await ctx.supabase
+        .from("expenses")
+        .select("id")
+        .eq("trip_id", ctx.tripId);
+      if (expIds?.length) {
+        await ctx.supabase
+          .from("expense_splits")
+          .delete()
+          .in("expense_id", expIds.map((e) => e.id));
+      }
+      await ctx.supabase.from("expenses").delete().eq("trip_id", ctx.tripId);
+
+      // 4. Date poll votes → date_windows (has trip_id)
+      const { data: winIds } = await ctx.supabase
+        .from("date_windows")
+        .select("id")
+        .eq("trip_id", ctx.tripId);
+      if (winIds?.length) {
+        await ctx.supabase
+          .from("date_poll_votes")
+          .delete()
+          .in("window_id", winIds.map((w) => w.id));
+      }
+      // Unlock date_polls.locked_window_id before deleting windows
+      await ctx.supabase
+        .from("date_polls")
+        .update({ locked_window_id: null })
+        .eq("trip_id", ctx.tripId);
+      await ctx.supabase.from("date_windows").delete().eq("trip_id", ctx.tripId);
+      await ctx.supabase.from("date_polls").delete().eq("trip_id", ctx.tripId);
+
+      // 5. Competition chain: event → teams/rounds/side_events → children
+      const { data: ev } = await ctx.supabase
+        .from("events")
+        .select("id")
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+
+      if (ev) {
+        // group_results → rounds, play_groups → rounds
+        const { data: roundIds } = await ctx.supabase
+          .from("rounds")
+          .select("id")
+          .eq("event_id", ev.id);
+        if (roundIds?.length) {
+          const rIds = roundIds.map((r) => r.id);
+          await ctx.supabase.from("group_results").delete().in("round_id", rIds);
+        }
+        await ctx.supabase.from("play_groups").delete().eq("event_id", ev.id);
+        await ctx.supabase.from("rounds").delete().eq("event_id", ev.id);
+        await ctx.supabase.from("team_assignments").delete().eq("event_id", ev.id);
+        await ctx.supabase.from("side_events").delete().eq("event_id", ev.id);
+        await ctx.supabase.from("teams").delete().eq("event_id", ev.id);
+        await ctx.supabase.from("events").delete().eq("id", ev.id);
+      }
+
+      // 6. trip_members last (before trips itself)
+      await ctx.supabase.from("trip_members").delete().eq("trip_id", ctx.tripId);
+
       const { error } = await ctx.supabase
         .from("trips")
         .delete()

--- a/src/server/routers/users.test.ts
+++ b/src/server/routers/users.test.ts
@@ -42,7 +42,7 @@ describe.skipIf(skip)("users router", () => {
 
   it("getMe throws UNAUTHORIZED for anonymous callers", async () => {
     const caller = createAnonCaller();
-    await expect(caller.users.getMe()).rejects.toThrow("UNAUTHORIZED");
+    await expect(caller.users.getMe()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
   });
 
   // -------------------------------------------------------------------------
@@ -63,7 +63,7 @@ describe.skipIf(skip)("users router", () => {
 
   it("updateMe throws BAD_REQUEST when no fields provided", async () => {
     const caller = createTestCaller(userId);
-    await expect(caller.users.updateMe({})).rejects.toThrow("BAD_REQUEST");
+    await expect(caller.users.updateMe({})).rejects.toMatchObject({ code: "BAD_REQUEST" });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix all 23 failing Vitest assertions: `.toThrow("FORBIDDEN")` → `.toMatchObject({ code: "FORBIDDEN" })` (and BAD_REQUEST, UNAUTHORIZED, CONFLICT)
- Tests were checking tRPC error **message** string, but "FORBIDDEN" is the error **code** property — the messages are descriptive like "Requires Planner role or higher"
- Fix trip delete mutation to cascade-delete dependent records before the trip itself, since the schema has no `ON DELETE CASCADE` on FK constraints

## Test plan
- [ ] CI Vitest tests pass (all 23 previously-failing assertions now check `code` correctly)
- [ ] Trip delete test passes (dependent records cleaned up before trip deletion)
- [ ] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)