### PR TITLE
fix: inline vote buttons on idea cards, vote status in co-planners

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -267,6 +267,15 @@ Requires joining trip_members.rsvp_status in the dashboard trips query.
 
 ---
 
+### Unread message count persistence
+
+The floating chat button unread count currently resets on page reload
+(tracked in component state/sessionStorage only). A proper unread count
+requires a last_read_at timestamp per user per trip in the database.
+Schema: add last_read_at to trip_members or a separate message_reads table.
+
+---
+
 ## UX Polish (Logged, Not Urgent)
 
 ### Field Mode (outdoor scoring)

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -52,7 +52,7 @@
 | Action | Owner | Planner | Member | Gate | Component |
 |--------|:-----:|:-------:|:------:|------|-----------|
 | Add idea / destination option | ✓ | ✓ | — | `canEdit` | TripDetail HomeTab, IdeaComparison |
-| Remove idea | ✓ | — | — | `isOwner` | IdeaComparison |
+| Remove idea | ✓ | ✓ | — | `canEdit` | IdeaComparison |
 | Edit idea description | ✓ | ✓ | — | `canEdit` | IdeaComparison |
 | Edit idea pros / cons | ✓ | ✓ | — | `canEdit` | TripDetail HomeTab, IdeaComparison |
 | Remove golf course from idea | ✓ | ✓ | — | `canEdit` | IdeaComparison |

--- a/src/app/trips/[tripId]/components/ChatDrawer.tsx
+++ b/src/app/trips/[tripId]/components/ChatDrawer.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Send, X } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useRealtimeChat } from "@/hooks/useRealtimeChat";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+
+interface ChatMessage {
+  id: string;
+  trip_id: string;
+  user_id: string;
+  channel: string;
+  team_id: string | null;
+  text: string;
+  created_at: string;
+  _optimistic?: boolean;
+}
+
+interface ChatDrawerProps {
+  tripId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  memberNames: Record<string, string>;
+}
+
+export function ChatDrawer({ tripId, isOpen, onClose, memberNames }: ChatDrawerProps) {
+  if (!isOpen) return null;
+  return <ChatDrawerInner tripId={tripId} onClose={onClose} memberNames={memberNames} />;
+}
+
+function ChatDrawerInner({
+  tripId,
+  onClose,
+  memberNames,
+}: {
+  tripId: string;
+  onClose: () => void;
+  memberNames: Record<string, string>;
+}) {
+  const currentUser = useCurrentUser();
+  const utils = trpc.useUtils();
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLInputElement>(null);
+  const [text, setText] = useState("");
+  const [optimisticMessages, setOptimisticMessages] = useState<ChatMessage[]>([]);
+
+  useRealtimeChat(tripId, "trip");
+  useModalBackButton(onClose);
+
+  const { data: messages = [] } = trpc.messages.list.useQuery(
+    { tripId, channel: "trip", limit: 50 }
+  );
+
+  const realIds = new Set(messages.map((m) => m.id));
+  const pending = optimisticMessages.filter((m) => !realIds.has(m.id));
+  const displayed: ChatMessage[] = (messages as ChatMessage[])
+    .slice()
+    .reverse()
+    .concat(pending);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [displayed.length]);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
+  const sendMessage = trpc.messages.send.useMutation({
+    onSuccess: async () => {
+      await utils.messages.list.invalidate({ tripId, channel: "trip" });
+    },
+    onError: (_, variables) => {
+      setOptimisticMessages((prev) => prev.filter((m) => m.id !== variables.id));
+    },
+  });
+
+  const handleSend = useCallback(() => {
+    const current = textareaRef.current?.value ?? text;
+    const trimmed = current.trim();
+    if (!trimmed || sendMessage.isPending || !currentUser?.id) return;
+
+    const id = crypto.randomUUID();
+    setOptimisticMessages((prev) => [
+      ...prev,
+      {
+        id,
+        trip_id: tripId,
+        user_id: currentUser.id,
+        channel: "trip",
+        team_id: null,
+        text: trimmed,
+        created_at: new Date().toISOString(),
+        _optimistic: true,
+      },
+    ]);
+
+    setText("");
+    if (textareaRef.current) textareaRef.current.value = "";
+    sendMessage.mutate({ tripId, id, channel: "trip", text: trimmed });
+  }, [text, sendMessage, currentUser?.id, tripId]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end lg:hidden"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        className="flex w-full flex-col rounded-t-2xl"
+        style={{
+          background: "var(--color-bt-card)",
+          height: "70vh",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pt-3 pb-2">
+          <div
+            className="h-1 w-8 rounded-full"
+            style={{ background: "var(--color-bt-border)" }}
+          />
+        </div>
+
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-4 pb-2"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        >
+          <p
+            className="text-[13px] font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Crew Chat
+          </p>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+            aria-label="Close chat"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 min-h-0">
+          {displayed.length === 0 && (
+            <p className="text-center text-xs mt-8" style={{ color: "var(--color-bt-text-dim)" }}>
+              No messages yet. Say something!
+            </p>
+          )}
+          {displayed.map((msg) => {
+            const isMe = msg.user_id === currentUser?.id;
+            const time = new Date(msg.created_at).toLocaleTimeString("en-US", {
+              hour: "numeric",
+              minute: "2-digit",
+            });
+            return (
+              <div
+                key={msg.id}
+                className={`flex flex-col gap-0.5 ${isMe ? "items-end" : "items-start"}`}
+              >
+                {!isMe && (
+                  <p className="px-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                    {memberNames[msg.user_id] ?? "Unknown"}
+                  </p>
+                )}
+                <div
+                  className="max-w-[80%] rounded-2xl px-4 py-2 text-sm"
+                  style={{
+                    background: isMe ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+                    border: `1px solid ${isMe ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+                    color: "var(--color-bt-text)",
+                    opacity: msg._optimistic ? 0.6 : 1,
+                  }}
+                >
+                  {msg.text}
+                </div>
+                <p className="px-1 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  {time}
+                </p>
+              </div>
+            );
+          })}
+          <div ref={bottomRef} />
+        </div>
+
+        {/* Input */}
+        <div
+          className="flex items-center gap-2 px-4 py-3"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        >
+          <input
+            ref={textareaRef}
+            type="text"
+            placeholder="Say something..."
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSend(); } }}
+            className="min-w-0 flex-1 rounded-full border px-3 py-2 text-sm outline-none"
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+          <button
+            onClick={handleSend}
+            disabled={sendMessage.isPending || !text.trim()}
+            className="flex h-8 w-8 items-center justify-center rounded-full disabled:opacity-30"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            aria-label="Send message"
+          >
+            <Send size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/ChatDrawer.tsx
+++ b/src/app/trips/[tripId]/components/ChatDrawer.tsx
@@ -148,7 +148,7 @@ function ChatDrawerInner({
         </div>
 
         {/* Messages */}
-        <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3 min-h-0">
+        <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3 min-h-0">
           {displayed.length === 0 && (
             <p className="text-center text-xs mt-8" style={{ color: "var(--color-bt-text-dim)" }}>
               No messages yet. Say something!
@@ -163,13 +163,18 @@ function ChatDrawerInner({
             return (
               <div
                 key={msg.id}
-                className={`flex flex-col gap-0.5 ${isMe ? "items-end" : "items-start"}`}
+                className={`flex flex-col ${isMe ? "items-end" : "items-start"}`}
               >
-                {!isMe && (
-                  <p className="px-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                    {memberNames[msg.user_id] ?? "Unknown"}
-                  </p>
-                )}
+                <div className="flex items-center gap-1.5 px-1 mb-0.5">
+                  <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                    {time}
+                  </span>
+                  {!isMe && (
+                    <span className="text-xs font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
+                      {memberNames[msg.user_id] ?? "Unknown"}
+                    </span>
+                  )}
+                </div>
                 <div
                   className="max-w-[80%] rounded-2xl px-4 py-2 text-sm"
                   style={{
@@ -181,9 +186,6 @@ function ChatDrawerInner({
                 >
                   {msg.text}
                 </div>
-                <p className="px-1 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                  {time}
-                </p>
               </div>
             );
           })}

--- a/src/app/trips/[tripId]/components/FloatingChatButton.tsx
+++ b/src/app/trips/[tripId]/components/FloatingChatButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+
+interface FloatingChatButtonProps {
+  onClick: () => void;
+  unreadCount?: number;
+}
+
+export function FloatingChatButton({ onClick, unreadCount = 0 }: FloatingChatButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      data-testid="floating-chat-btn"
+      className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95 lg:hidden"
+      style={{ background: "var(--color-bt-accent)" }}
+      aria-label="Open crew chat"
+    >
+      <MessageCircle size={20} style={{ color: "var(--color-bt-base)" }} />
+      {unreadCount > 0 && (
+        <span
+          className="absolute -right-0.5 -top-0.5 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold text-white"
+          style={{ background: "var(--color-bt-warning)" }}
+        >
+          {unreadCount > 9 ? "9+" : unreadCount}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -650,7 +650,7 @@ function DeleteConfirmModal({
           Remove {idea.title}?
         </p>
         <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          This will permanently delete this idea and all its votes. The crew chat stays intact.
+          This will permanently delete this idea and all its votes.
         </p>
         <div className="flex gap-2">
           <button

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1830,13 +1830,8 @@ export default function IdeaZonePanel({
     return <ZeroIdeasFork tripId={tripId} canEdit={canEdit} />;
   }
 
-  // Sort: leading first, then by votes desc
-  const sorted = ideasTyped.slice().sort((a, b) => {
-    const aLeading = isLeading(a) ? 1 : 0;
-    const bLeading = isLeading(b) ? 1 : 0;
-    if (aLeading !== bLeading) return bLeading - aLeading;
-    return b.votes.length - a.votes.length;
-  });
+  // Preserve creation order — no reordering by votes (too jarring)
+  const sorted = ideasTyped;
 
   return (
     <div>

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useTheme } from "next-themes";
 import { UserAvatar } from "@/components/UserAvatar";
 import {
@@ -15,15 +15,14 @@ import {
   Trash2,
   Check,
   Plus,
-  Send,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
-import { useRealtimeChat } from "@/hooks/useRealtimeChat";
 import { temporalGradient } from "@/lib/temporalGradient";
 import { CatalogBrowser } from "../compare/CatalogBrowser";
 import { CrewSearchInput } from "@/components/CrewSearchInput";
+import { SidebarChatPanel } from "./PlanningChatPanel";
 import type { CatalogIdea, TripData } from "@/app/trips/[tripId]/tabs/types";
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -1473,175 +1472,6 @@ function SetDestinationSheet({
   );
 }
 
-// ── CrewChatWidget (desktop only) ─────────────────────────────────────────
-
-interface ChatMessage {
-  id: string;
-  trip_id: string;
-  user_id: string;
-  channel: string;
-  team_id: string | null;
-  text: string;
-  created_at: string;
-  _optimistic?: boolean;
-}
-
-function CrewChatWidget({
-  tripId,
-  memberNames,
-}: {
-  tripId: string;
-  memberNames: Record<string, string>;
-}) {
-  const currentUser = useCurrentUser();
-  const utils = trpc.useUtils();
-  const bottomRef = useRef<HTMLDivElement>(null);
-  const [text, setText] = useState("");
-  const [optimisticMessages, setOptimisticMessages] = useState<ChatMessage[]>([]);
-
-  useRealtimeChat(tripId, "trip");
-
-  const { data: messages = [] } = trpc.messages.list.useQuery(
-    { tripId, channel: "trip", limit: 30 }
-  );
-
-  const realIds = new Set(messages.map((m) => m.id));
-  const pending = optimisticMessages.filter((m) => !realIds.has(m.id));
-  const displayed: ChatMessage[] = (messages as ChatMessage[])
-    .slice()
-    .reverse()
-    .concat(pending);
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [displayed.length]);
-
-  const sendMessage = trpc.messages.send.useMutation({
-    onSuccess: async () => {
-      await utils.messages.list.invalidate({ tripId, channel: "trip" });
-    },
-    onError: (_, variables) => {
-      setOptimisticMessages((prev) => prev.filter((m) => m.id !== variables.id));
-    },
-  });
-
-  const handleSend = () => {
-    const trimmed = text.trim();
-    if (!trimmed || sendMessage.isPending || !currentUser?.id) return;
-
-    const id = crypto.randomUUID();
-    setOptimisticMessages((prev) => [
-      ...prev,
-      {
-        id,
-        trip_id: tripId,
-        user_id: currentUser.id,
-        channel: "trip",
-        team_id: null,
-        text: trimmed,
-        created_at: new Date().toISOString(),
-        _optimistic: true,
-      },
-    ]);
-
-    setText("");
-    sendMessage.mutate({ tripId, id, channel: "trip", text: trimmed });
-  };
-
-  return (
-    <div
-      className="hidden lg:flex flex-col rounded-xl border"
-      style={{
-        background: "var(--color-bt-card)",
-        borderColor: "var(--color-bt-border)",
-        height: "300px",
-      }}
-    >
-      {/* Header */}
-      <div
-        className="flex-shrink-0 px-3 py-2"
-        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
-      >
-        <p
-          className="text-[11px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Crew Chat
-        </p>
-      </div>
-
-      {/* Messages */}
-      <div className="flex-1 space-y-2.5 overflow-y-auto px-3 py-2 min-h-0">
-        {displayed.length === 0 && (
-          <p className="py-4 text-center text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
-            No messages yet
-          </p>
-        )}
-        {displayed.map((msg) => {
-          const isMe = msg.user_id === currentUser?.id;
-          const name = memberNames[msg.user_id] ?? msg.user_id.slice(0, 6);
-          return (
-            <div key={msg.id} className="flex items-start gap-2">
-              <div className="mt-0.5 flex-shrink-0">
-                <UserAvatar name={name} avatarUrl={null} size="sm" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                  <span className="font-semibold" style={{ color: isMe ? "var(--color-bt-accent)" : "var(--color-bt-text)" }}>
-                    {isMe ? "You" : name}
-                  </span>
-                </p>
-                <p
-                  className="text-sm"
-                  style={{
-                    color: "var(--color-bt-text)",
-                    opacity: msg._optimistic ? 0.5 : 1,
-                  }}
-                >
-                  {msg.text}
-                </p>
-              </div>
-            </div>
-          );
-        })}
-        <div ref={bottomRef} />
-      </div>
-
-      {/* Input */}
-      <div
-        className="flex flex-shrink-0 items-center gap-2 px-3 py-2"
-        style={{ borderTop: "1px solid var(--color-bt-border)" }}
-      >
-        <input
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              handleSend();
-            }
-          }}
-          placeholder="Say something..."
-          className="min-w-0 flex-1 rounded-full border px-3 py-1.5 text-sm outline-none"
-          style={{
-            background: "var(--color-bt-base)",
-            borderColor: "var(--color-bt-border)",
-            color: "var(--color-bt-text)",
-          }}
-        />
-        <button
-          onClick={handleSend}
-          disabled={sendMessage.isPending || !text.trim()}
-          className="flex h-7 w-7 items-center justify-center rounded-full disabled:opacity-30"
-          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-        >
-          <Send size={13} />
-        </button>
-      </div>
-    </div>
-  );
-}
-
 // ── CoPlannerPanel (IDEA stage — enhanced co-planners mini panel) ─────────
 
 function CoPlannerPanel({
@@ -1890,7 +1720,7 @@ export default function IdeaZonePanel({
             allVoterIds={allVoterIds}
           />
 
-          <CrewChatWidget
+          <SidebarChatPanel
             tripId={tripId}
             memberNames={Object.fromEntries(
               members.map((m) => [m.memberId, m.displayName])

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -15,6 +15,8 @@ import {
   Trash2,
   Check,
   Plus,
+  MessageCircle,
+  Users,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -1496,7 +1498,7 @@ function CoPlannerPanel({
 
   return (
     <div
-      className="rounded-xl border px-3 py-3"
+      className="hidden lg:block rounded-xl border px-3 py-3"
       style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
     >
       <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -1557,6 +1559,120 @@ function CoPlannerPanel({
   );
 }
 
+// ── MobileCoPlannerSheet ──────────────────────────────────────────────────
+
+function MobileCoPlannerSheet({
+  tripId,
+  members,
+  isOwner,
+  allVoterIds,
+  onClose,
+}: {
+  tripId: string;
+  members: Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>;
+  isOwner: boolean;
+  allVoterIds: Set<string>;
+  onClose: () => void;
+}) {
+  const currentUser = useCurrentUser();
+  const utils = trpc.useUtils();
+
+  const planners = members.filter((m) => m.role === "Owner" || m.role === "Planner");
+
+  const demote = trpc.tripMembers.updateRole.useMutation({
+    onSuccess: () => utils.tripMembers.list.invalidate({ tripId }),
+  });
+
+  useModalBackButton(onClose);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end lg:hidden"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        className="flex w-full max-h-[80vh] flex-col rounded-t-2xl"
+        style={{ background: "var(--color-bt-card)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pt-3 pb-2">
+          <div className="h-1 w-8 rounded-full" style={{ background: "var(--color-bt-border)" }} />
+        </div>
+
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-4 pb-2"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        >
+          <p className="text-[13px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Co-planners
+          </p>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Planner list */}
+        <div className="overflow-y-auto px-4 py-3 space-y-2">
+          {planners.map((m) => {
+            const isSelf = m.user_id === currentUser?.id;
+            const canRemove = isOwner && !isSelf && m.role !== "Owner";
+            const hasVoted = allVoterIds.has(m.user_id);
+            return (
+              <div key={m.user_id ?? m.memberId} className="flex items-center gap-3">
+                <UserAvatar name={m.displayName} avatarUrl={null} size="sm" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm" style={{ color: "var(--color-bt-text)" }}>
+                    {m.displayName}
+                  </p>
+                </div>
+                <span className="text-xs flex-shrink-0" style={{ color: hasVoted ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>
+                  {hasVoted ? "Voted \u2713" : "Not voted"}
+                </span>
+                {canRemove && (
+                  <button
+                    onClick={() => demote.mutate({ tripId, userId: m.user_id, role: "Member" })}
+                    className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-70"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    <X size={14} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+
+          {/* Add planner */}
+          {isOwner && (
+            <div className="mt-3 pt-3" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+              <p className="mb-2 text-[11px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
+                Get some help
+              </p>
+              <CrewSearchInput
+                tripId={tripId}
+                defaultRole="Planner"
+                defaultStatus="draft"
+                allowGhost={false}
+                allowInvite
+                showSearchIcon
+                placeholder="Search by email..."
+                frequentTripmates={[]}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── IdeaZonePanel ─────────────────────────────────────────────────────────
 
 export default function IdeaZonePanel({
@@ -1564,11 +1680,14 @@ export default function IdeaZonePanel({
   canEdit,
   isOwner,
   onTabChange,
+  onOpenChat,
 }: {
   trip: TripData;
   canEdit: boolean;
   isOwner: boolean;
   onTabChange?: (tab: string) => void;
+  /** Opens the mobile ChatDrawer (managed in page.tsx) */
+  onOpenChat?: () => void;
 }) {
   const currentUser = useCurrentUser();
   const tripId = trip.id;
@@ -1576,6 +1695,7 @@ export default function IdeaZonePanel({
   const [showAddModal, setShowAddModal] = useState(false);
   const [deleteIdea, setDeleteIdea] = useState<Idea | null>(null);
   const [setDestinationIdea, setSetDestinationIdea] = useState<Idea | null>(null);
+  const [showMobileCoPlanners, setShowMobileCoPlanners] = useState(false);
 
   useEffect(() => {
     if (showAddModal) {
@@ -1656,28 +1776,6 @@ export default function IdeaZonePanel({
           />
         ))}
 
-        {canEdit && (
-          <button
-            data-testid="add-idea-btn"
-            onClick={() => setShowAddModal(true)}
-            className="flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{
-              border: "1.5px dashed var(--color-bt-accent)",
-              color: "var(--color-bt-accent)",
-              background: "transparent",
-            }}
-          >
-            <Plus size={16} />
-            Add destination idea
-          </button>
-        )}
-
-        <CoPlannerPanel
-          tripId={tripId}
-          members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
-          isOwner={isOwner}
-          allVoterIds={allVoterIds}
-        />
       </div>
 
       {/* ── Desktop layout ────────────────────────────────────────────── */}
@@ -1752,6 +1850,50 @@ export default function IdeaZonePanel({
           tripId={tripId}
           idea={setDestinationIdea}
           onClose={() => setSetDestinationIdea(null)}
+        />
+      )}
+
+      {/* ── Mobile floating action buttons (IDEA stage) ─────────────── */}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col-reverse gap-3 lg:hidden">
+        {canEdit && (
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
+            style={{ background: "var(--color-bt-accent)" }}
+            aria-label="Add destination idea"
+          >
+            <Plus size={20} style={{ color: "var(--color-bt-base)" }} />
+          </button>
+        )}
+        <button
+          onClick={() => setShowMobileCoPlanners(true)}
+          className="flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
+          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+          aria-label="View co-planners"
+        >
+          <Users size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+        </button>
+        {onOpenChat && (
+          <button
+            onClick={onOpenChat}
+            data-testid="floating-chat-btn"
+            className="flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
+            style={{ background: "var(--color-bt-accent)" }}
+            aria-label="Open crew chat"
+          >
+            <MessageCircle size={20} style={{ color: "var(--color-bt-base)" }} />
+          </button>
+        )}
+      </div>
+
+      {/* ── Mobile co-planners bottom sheet ──────────────────────────── */}
+      {showMobileCoPlanners && (
+        <MobileCoPlannerSheet
+          tripId={tripId}
+          members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
+          isOwner={isOwner}
+          allVoterIds={allVoterIds}
+          onClose={() => setShowMobileCoPlanners(false)}
         />
       )}
     </div>

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -60,6 +60,10 @@ function IdeaCard({
   isOwner,
   isLeading,
   tripStartDate,
+  currentUserId,
+  memberData,
+  onVote,
+  votePending,
   onSetDestination,
   onDelete,
 }: {
@@ -69,6 +73,10 @@ function IdeaCard({
   isOwner: boolean;
   isLeading?: boolean;
   tripStartDate?: string | null;
+  currentUserId?: string;
+  memberData: { memberId: string; displayName: string }[];
+  onVote: (ideaId: string) => void;
+  votePending: boolean;
   onSetDestination: (idea: Idea) => void;
   onDelete: (idea: Idea) => void;
 }) {
@@ -163,6 +171,66 @@ function IdeaCard({
             }}
           />
         )}
+        {/* Vote button + voter avatars — top-left overlay */}
+        <div className="absolute left-3 top-3 z-10 flex flex-col items-start gap-1.5">
+          {(() => {
+            const isVoted = idea.votes.some((v) => v.user_id === currentUserId);
+            return (
+              <button
+                data-testid={`vote-idea-${idea.id}`}
+                disabled={votePending}
+                onClick={(e) => { e.stopPropagation(); onVote(idea.id); }}
+                className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[13px] font-medium transition-all disabled:opacity-40"
+                style={isVoted ? {
+                  background: "var(--color-bt-accent)",
+                  color: "var(--color-bt-base)",
+                } : {
+                  background: "color-mix(in srgb, var(--color-bt-card) 80%, transparent)",
+                  border: "1px solid var(--color-bt-border)",
+                  color: "var(--color-bt-text-dim)",
+                }}
+              >
+                <ThumbsUp size={14} />
+                {isVoted ? "My vote" : "Vote"}
+              </button>
+            );
+          })()}
+          {idea.votes.length > 0 && (() => {
+            const voterIds = idea.votes.map((v) => v.user_id);
+            const visible = voterIds.slice(0, 4);
+            const overflow = voterIds.length - visible.length;
+            return (
+              <div className="flex items-center">
+                {visible.map((voterId, idx) => {
+                  const member = memberData.find((m) => m.memberId === voterId);
+                  const name = member?.displayName ?? voterId.slice(0, 8);
+                  return (
+                    <div
+                      key={voterId}
+                      style={{ marginLeft: idx === 0 ? 0 : -6, zIndex: visible.length - idx }}
+                      className="relative"
+                    >
+                      <UserAvatar name={name} avatarUrl={null} sizePx={20} />
+                    </div>
+                  );
+                })}
+                {overflow > 0 && (
+                  <span
+                    className="flex h-5 items-center rounded-full px-1.5 text-[10px] font-semibold"
+                    style={{
+                      marginLeft: -6,
+                      background: "var(--color-bt-card-raised)",
+                      color: "var(--color-bt-text-dim)",
+                    }}
+                  >
+                    +{overflow}
+                  </span>
+                )}
+              </div>
+            );
+          })()}
+        </div>
+
         {idea.cost_tier && (
           <div className="absolute right-3 top-3">
             <span
@@ -1717,11 +1785,41 @@ export default function IdeaZonePanel({
   const maxVotes = Math.max(...ideasTyped.map((i) => i.votes.length), 0);
   const isLeading = (idea: Idea) => maxVotes > 0 && idea.votes.length === maxVotes;
 
-  // Member data for VotingPanel voter avatars
+  // Member data for voter avatars
   const memberData = members.map((m) => ({
     memberId: m.user_id,
     displayName: m.displayName,
   }));
+
+  // Vote mutation (lifted from VotingPanel so IdeaCards can use it)
+  const utils = trpc.useUtils();
+  const [votePendingId, setVotePendingId] = useState<string | null>(null);
+  const voteMutation = trpc.ideas.vote.useMutation({
+    async onMutate({ ideaId }) {
+      setVotePendingId(ideaId);
+      await utils.ideas.list.cancel({ tripId });
+      const prev = utils.ideas.list.getData({ tripId });
+      utils.ideas.list.setData({ tripId }, (prev ?? []).map((i) => {
+        const clickingCurrentPick = i.id === ideaId && i.votes.some((v: { user_id: string }) => v.user_id === currentUser?.id);
+        if (clickingCurrentPick) {
+          return { ...i, votes: i.votes.filter((v: { user_id: string }) => v.user_id !== currentUser?.id) };
+        }
+        const withoutMe = i.votes.filter((v: { user_id: string }) => v.user_id !== currentUser?.id);
+        if (i.id !== ideaId) return { ...i, votes: withoutMe };
+        return { ...i, votes: [...withoutMe, { idea_id: ideaId, user_id: currentUser?.id ?? "", created_at: new Date().toISOString() }] };
+      }));
+      return { prev };
+    },
+    onError(_err, _vars, context) {
+      if (context?.prev !== undefined) utils.ideas.list.setData({ tripId }, context.prev);
+    },
+    onSettled() {
+      setVotePendingId(null);
+      utils.ideas.list.invalidate({ tripId });
+    },
+  });
+
+  const handleVote = (ideaId: string) => voteMutation.mutate({ tripId, ideaId });
 
   if (ideasTyped.length === 0) {
     return <ZeroIdeasFork tripId={tripId} canEdit={canEdit} />;
@@ -1735,19 +1833,10 @@ export default function IdeaZonePanel({
     return b.votes.length - a.votes.length;
   });
 
-  const votingPanelIdeas = ideasTyped.slice().sort((a, b) => b.votes.length - a.votes.length);
-
   return (
     <div>
       {/* ── Mobile layout ─────────────────────────────────────────────── */}
       <div className="lg:hidden space-y-4 p-4">
-        <VotingPanel
-          tripId={tripId}
-          ideas={votingPanelIdeas}
-          currentUserId={currentUser?.id}
-          members={memberData}
-        />
-
         {sorted.map((idea) => (
           <IdeaCard
             key={idea.id}
@@ -1757,6 +1846,10 @@ export default function IdeaZonePanel({
             isOwner={isOwner}
             isLeading={isLeading(idea)}
             tripStartDate={trip.start_date}
+            currentUserId={currentUser?.id}
+            memberData={memberData}
+            onVote={handleVote}
+            votePending={votePendingId === idea.id}
             onSetDestination={setSetDestinationIdea}
             onDelete={setDeleteIdea}
           />
@@ -1792,6 +1885,10 @@ export default function IdeaZonePanel({
               isOwner={isOwner}
               isLeading={isLeading(idea)}
               tripStartDate={trip.start_date}
+              currentUserId={currentUser?.id}
+              memberData={memberData}
+              onVote={handleVote}
+              votePending={votePendingId === idea.id}
               onSetDestination={setSetDestinationIdea}
               onDelete={setDeleteIdea}
             />
@@ -1820,13 +1917,6 @@ export default function IdeaZonePanel({
             tripId={tripId}
             members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
             isOwner={isOwner}
-          />
-
-          <VotingPanel
-            tripId={tripId}
-            ideas={votingPanelIdeas}
-            currentUserId={currentUser?.id}
-            members={memberData}
           />
 
           <CrewChatWidget

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -597,7 +597,7 @@ function IdeaCard({
               ) : (
                 <span />
               )}
-              {canEdit && (
+              {isOwner && (
                 <button
                   data-testid={`remove-idea-${idea.id}`}
                   onClick={() => onDelete(idea)}

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -675,7 +675,7 @@ function DeleteConfirmModal({
           Remove {idea.title}?
         </p>
         <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          This will permanently delete this idea along with all its votes and comments. You can&apos;t recover any of that.
+          This will permanently delete this idea and all its votes. The crew chat stays intact.
         </p>
         <div className="flex gap-2">
           <button

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -58,7 +58,6 @@ function IdeaCard({
   tripId,
   canEdit,
   isOwner,
-  isLeading,
   tripStartDate,
   currentUserId,
   memberData,
@@ -71,7 +70,6 @@ function IdeaCard({
   tripId: string;
   canEdit: boolean;
   isOwner: boolean;
-  isLeading?: boolean;
   tripStartDate?: string | null;
   currentUserId?: string;
   memberData: { memberId: string; displayName: string }[];
@@ -143,8 +141,7 @@ function IdeaCard({
       className="overflow-hidden rounded-2xl transition-shadow"
       style={{
         background: "var(--color-bt-card)",
-        border: `1px solid ${isLeading ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
-        borderLeft: isLeading ? "4px solid var(--color-bt-accent)" : undefined,
+        border: "1px solid var(--color-bt-border)",
         boxShadow: "var(--shadow-card)",
       }}
     >
@@ -590,43 +587,22 @@ function IdeaCard({
               style={{ borderTop: "1px solid var(--color-bt-border)" }}
             >
               {isOwner ? (
-                isLeading ? (
-                  <button
-                    data-testid={`set-destination-${idea.id}`}
-                    onClick={() => onSetDestination(idea)}
-                    className="flex-1 rounded-lg py-2.5 text-sm font-semibold transition-opacity hover:opacity-90"
-                    style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-                  >
-                    Set as destination and start planning
-                  </button>
-                ) : (
-                  <button
-                    data-testid={`set-destination-${idea.id}`}
-                    onClick={() => onSetDestination(idea)}
-                    className="text-sm font-medium transition-opacity hover:opacity-70"
-                    style={{ color: "var(--color-bt-accent)" }}
-                  >
-                    Set as destination
-                  </button>
-                )
+                <button
+                  data-testid={`set-destination-${idea.id}`}
+                  onClick={() => onSetDestination(idea)}
+                  className="text-sm font-medium transition-opacity hover:opacity-70"
+                  style={{ color: "var(--color-bt-accent)" }}
+                >
+                  Set as destination
+                </button>
               ) : (
                 <span />
               )}
-              {canEdit && !isLeading && (
+              {canEdit && (
                 <button
                   data-testid={`remove-idea-${idea.id}`}
                   onClick={() => onDelete(idea)}
                   className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  <Trash2 size={14} />
-                </button>
-              )}
-              {canEdit && isLeading && (
-                <button
-                  data-testid={`remove-idea-${idea.id}`}
-                  onClick={() => onDelete(idea)}
-                  className="ml-2 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
                   style={{ color: "var(--color-bt-text-dim)" }}
                 >
                   <Trash2 size={14} />
@@ -1783,10 +1759,6 @@ export default function IdeaZonePanel({
 
   const ideasTyped = ideas as Idea[];
 
-  // Compute leading
-  const maxVotes = Math.max(...ideasTyped.map((i) => i.votes.length), 0);
-  const isLeading = (idea: Idea) => maxVotes > 0 && idea.votes.length === maxVotes;
-
   // Member data for voter avatars
   const memberData = members.map((m) => ({
     memberId: m.user_id,
@@ -1844,7 +1816,6 @@ export default function IdeaZonePanel({
             tripId={tripId}
             canEdit={canEdit}
             isOwner={isOwner}
-            isLeading={isLeading(idea)}
             tripStartDate={trip.start_date}
             currentUserId={currentUser?.id}
             memberData={memberData}
@@ -1883,7 +1854,6 @@ export default function IdeaZonePanel({
               tripId={tripId}
               canEdit={canEdit}
               isOwner={isOwner}
-              isLeading={isLeading(idea)}
               tripStartDate={trip.start_date}
               currentUserId={currentUser?.id}
               memberData={memberData}

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1496,7 +1496,7 @@ function CoPlannerPanel({
 
   return (
     <div
-      className="hidden lg:block rounded-xl border px-3 py-3"
+      className="rounded-xl border px-3 py-3"
       style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
     >
       <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -1671,6 +1671,13 @@ export default function IdeaZonePanel({
             Add destination idea
           </button>
         )}
+
+        <CoPlannerPanel
+          tripId={tripId}
+          members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
+          isOwner={isOwner}
+          allVoterIds={allVoterIds}
+        />
       </div>
 
       {/* ── Desktop layout ────────────────────────────────────────────── */}

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1183,7 +1183,7 @@ function AddIdeasModal({ tripId, onClose }: { tripId: string; onClose: () => voi
       >
         <div className="flex items-center justify-between px-5 pt-4 pb-0">
           <p className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Add ideas
+            Add destination ideas
           </p>
           <button
             onClick={onClose}
@@ -1506,7 +1506,7 @@ function CrewChatWidget({
 
   return (
     <div
-      className="hidden lg:flex mt-3 flex-col rounded-xl border"
+      className="hidden lg:flex flex-col rounded-xl border"
       style={{
         background: "var(--color-bt-card)",
         borderColor: "var(--color-bt-border)",
@@ -1619,7 +1619,7 @@ function CoPlannerPanel({
 
   return (
     <div
-      className="hidden lg:block mt-3 rounded-xl border px-3 py-3"
+      className="hidden lg:block rounded-xl border px-3 py-3"
       style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
     >
       <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -1662,13 +1662,17 @@ function CoPlannerPanel({
       {/* Add planner — reuses CrewSearchInput with Planner default */}
       {isOwner && (
         <div className="mt-3 pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          <p className="mb-2 text-[11px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
+            Get some help
+          </p>
           <CrewSearchInput
             tripId={tripId}
             defaultRole="Planner"
             defaultStatus="draft"
-            allowGhost
+            allowGhost={false}
             allowInvite
-            placeholder="Add a planner by email..."
+            showSearchIcon
+            placeholder="Search by email..."
             frequentTripmates={[]}
           />
         </div>
@@ -1770,7 +1774,7 @@ export default function IdeaZonePanel({
             }}
           >
             <Plus size={16} />
-            Add idea
+            Add destination idea
           </button>
         )}
       </div>
@@ -1795,14 +1799,7 @@ export default function IdeaZonePanel({
         </div>
 
         {/* Right: sidebar */}
-        <div className="w-[320px] flex-shrink-0 sticky top-4 self-start space-y-0">
-          <VotingPanel
-            tripId={tripId}
-            ideas={votingPanelIdeas}
-            currentUserId={currentUser?.id}
-            members={memberData}
-          />
-
+        <div className="w-[320px] flex-shrink-0 sticky top-4 self-start space-y-3">
           {canEdit && (
             <button
               data-testid="add-idea-btn"
@@ -1815,21 +1812,28 @@ export default function IdeaZonePanel({
               }}
             >
               <Plus size={16} />
-              Add idea
+              Add destination idea
             </button>
           )}
+
+          <CoPlannerPanel
+            tripId={tripId}
+            members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
+            isOwner={isOwner}
+          />
+
+          <VotingPanel
+            tripId={tripId}
+            ideas={votingPanelIdeas}
+            currentUserId={currentUser?.id}
+            members={memberData}
+          />
 
           <CrewChatWidget
             tripId={tripId}
             memberNames={Object.fromEntries(
               members.map((m) => [m.memberId, m.displayName])
             )}
-          />
-
-          <CoPlannerPanel
-            tripId={tripId}
-            members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
-            isOwner={isOwner}
           />
         </div>
       </div>

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -23,6 +23,7 @@ import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { useRealtimeChat } from "@/hooks/useRealtimeChat";
 import { temporalGradient } from "@/lib/temporalGradient";
 import { CatalogBrowser } from "../compare/CatalogBrowser";
+import { CrewSearchInput } from "@/components/CrewSearchInput";
 import type { CatalogIdea, TripData } from "@/app/trips/[tripId]/tabs/types";
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -1597,33 +1598,43 @@ function CrewChatWidget({
   );
 }
 
-// ── CoPlannerChip ─────────────────────────────────────────────────────────
+// ── CoPlannerPanel (IDEA stage — enhanced co-planners mini panel) ─────────
 
-function CoPlannerChip({
+function CoPlannerPanel({
+  tripId,
   members,
-  onTabChange,
+  isOwner,
 }: {
-  members: Array<{ user_id: string; role: string; status: string; displayName: string }>;
-  onTabChange?: (tab: string) => void;
+  tripId: string;
+  members: Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>;
+  isOwner: boolean;
 }) {
+  const currentUser = useCurrentUser();
+  const utils = trpc.useUtils();
   const planners = members.filter((m) => m.role === "Owner" || m.role === "Planner");
-  const visible = planners.slice(0, 4);
-  const overflow = planners.length - visible.length;
+
+  const demote = trpc.tripMembers.updateRole.useMutation({
+    onSuccess: () => utils.tripMembers.list.invalidate({ tripId }),
+  });
 
   return (
     <div
-      className="hidden lg:block mt-3 rounded-xl px-3 py-2"
-      style={{ background: "var(--color-bt-card-raised)" }}
+      className="hidden lg:block mt-3 rounded-xl border px-3 py-3"
+      style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
     >
-      <p className="mb-2 text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+      <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
         Co-planners
       </p>
+
+      {/* Existing planners */}
       <div className="space-y-1.5">
-        {visible.map((m) => {
+        {planners.map((m) => {
           const isPending = m.status === "invited";
-          const roleColor = m.role === "Owner" ? "var(--color-bt-owner)" : "var(--color-bt-planning)";
+          const roleColor = m.role === "Owner" ? "var(--color-bt-owner)" : "var(--color-bt-accent)";
+          const isSelf = m.user_id === currentUser?.id;
+          const canRemove = isOwner && !isSelf && m.role !== "Owner";
           return (
-            <div key={m.user_id} className="flex items-center gap-2">
+            <div key={m.user_id ?? m.memberId} className="flex items-center gap-2">
               <UserAvatar name={m.displayName} avatarUrl={null} size="sm" />
               <div className="min-w-0 flex-1">
                 <p className="truncate text-xs" style={{ color: isPending ? "var(--color-bt-text-dim)" : "var(--color-bt-text)" }}>
@@ -1633,23 +1644,34 @@ function CoPlannerChip({
               <span className="text-[10px] font-semibold flex-shrink-0" style={{ color: isPending ? "var(--color-bt-ready)" : roleColor }}>
                 {isPending ? "Invited" : m.role}
               </span>
+              {canRemove && (
+                <button
+                  onClick={() => demote.mutate({ tripId, userId: m.user_id, role: "Member" })}
+                  className="flex h-5 w-5 items-center justify-center rounded-full transition-opacity hover:opacity-70"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                  aria-label={`Remove ${m.displayName} as planner`}
+                >
+                  <X size={12} />
+                </button>
+              )}
             </div>
           );
         })}
-        {overflow > 0 && (
-          <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            +{overflow} more
-          </p>
-        )}
       </div>
-      {onTabChange && (
-        <button
-          onClick={() => onTabChange("crew")}
-          className="mt-2 text-xs font-medium transition-opacity hover:opacity-70"
-          style={{ color: "var(--color-bt-accent)" }}
-        >
-          Manage in Crew tab &rarr;
-        </button>
+
+      {/* Add planner — reuses CrewSearchInput with Planner default */}
+      {isOwner && (
+        <div className="mt-3 pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          <CrewSearchInput
+            tripId={tripId}
+            defaultRole="Planner"
+            defaultStatus="draft"
+            allowGhost
+            allowInvite
+            placeholder="Add a planner by email..."
+            frequentTripmates={[]}
+          />
+        </div>
       )}
     </div>
   );
@@ -1804,9 +1826,10 @@ export default function IdeaZonePanel({
             )}
           />
 
-          <CoPlannerChip
-            members={members}
-            onTabChange={onTabChange}
+          <CoPlannerPanel
+            tripId={tripId}
+            members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
+            isOwner={isOwner}
           />
         </div>
       </div>

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -597,7 +597,7 @@ function IdeaCard({
               ) : (
                 <span />
               )}
-              {isOwner && (
+              {canEdit && (
                 <button
                   data-testid={`remove-idea-${idea.id}`}
                   onClick={() => onDelete(idea)}

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1672,10 +1672,13 @@ function CoPlannerPanel({
   tripId,
   members,
   isOwner,
+  allVoterIds,
 }: {
   tripId: string;
   members: Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>;
   isOwner: boolean;
+  /** Set of user IDs who have voted on any idea */
+  allVoterIds: Set<string>;
 }) {
   const currentUser = useCurrentUser();
   const utils = trpc.useUtils();
@@ -1697,20 +1700,19 @@ function CoPlannerPanel({
       {/* Existing planners */}
       <div className="space-y-1.5">
         {planners.map((m) => {
-          const isPending = m.status === "invited";
-          const roleColor = m.role === "Owner" ? "var(--color-bt-owner)" : "var(--color-bt-accent)";
           const isSelf = m.user_id === currentUser?.id;
           const canRemove = isOwner && !isSelf && m.role !== "Owner";
+          const hasVoted = allVoterIds.has(m.user_id);
           return (
             <div key={m.user_id ?? m.memberId} className="flex items-center gap-2">
               <UserAvatar name={m.displayName} avatarUrl={null} size="sm" />
               <div className="min-w-0 flex-1">
-                <p className="truncate text-xs" style={{ color: isPending ? "var(--color-bt-text-dim)" : "var(--color-bt-text)" }}>
+                <p className="truncate text-xs" style={{ color: "var(--color-bt-text)" }}>
                   {m.displayName}
                 </p>
               </div>
-              <span className="text-[10px] font-semibold flex-shrink-0" style={{ color: isPending ? "var(--color-bt-ready)" : roleColor }}>
-                {isPending ? "Invited" : m.role}
+              <span className="text-xs flex-shrink-0" style={{ color: hasVoted ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>
+                {hasVoted ? "Voted \u2713" : "Not voted"}
               </span>
               {canRemove && (
                 <button
@@ -1821,6 +1823,9 @@ export default function IdeaZonePanel({
 
   const handleVote = (ideaId: string) => voteMutation.mutate({ tripId, ideaId });
 
+  // All user IDs who have voted on any idea in this trip
+  const allVoterIds = new Set(ideasTyped.flatMap((i) => i.votes.map((v) => v.user_id)));
+
   if (ideasTyped.length === 0) {
     return <ZeroIdeasFork tripId={tripId} canEdit={canEdit} />;
   }
@@ -1917,6 +1922,7 @@ export default function IdeaZonePanel({
             tripId={tripId}
             members={members as Array<{ user_id: string; memberId: string; role: string; status: string; displayName: string }>}
             isOwner={isOwner}
+            allVoterIds={allVoterIds}
           />
 
           <CrewChatWidget

--- a/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
+++ b/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Send } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useRealtimeChat } from "@/hooks/useRealtimeChat";
+
+interface ChatMessage {
+  id: string;
+  trip_id: string;
+  user_id: string;
+  channel: string;
+  team_id: string | null;
+  text: string;
+  created_at: string;
+  _optimistic?: boolean;
+}
+
+interface PlanningChatPanelProps {
+  tripId: string;
+  memberNames: Record<string, string>;
+}
+
+export function PlanningChatPanel({ tripId, memberNames }: PlanningChatPanelProps) {
+  const currentUser = useCurrentUser();
+  const utils = trpc.useUtils();
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const [text, setText] = useState("");
+  const [optimisticMessages, setOptimisticMessages] = useState<ChatMessage[]>([]);
+
+  useRealtimeChat(tripId, "trip");
+
+  const { data: messages = [] } = trpc.messages.list.useQuery(
+    { tripId, channel: "trip", limit: 30 }
+  );
+
+  const realIds = new Set(messages.map((m) => m.id));
+  const pending = optimisticMessages.filter((m) => !realIds.has(m.id));
+  const displayed: ChatMessage[] = (messages as ChatMessage[])
+    .slice()
+    .reverse()
+    .concat(pending);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [displayed.length]);
+
+  const sendMessage = trpc.messages.send.useMutation({
+    onSuccess: async () => {
+      await utils.messages.list.invalidate({ tripId, channel: "trip" });
+    },
+    onError: (_, variables) => {
+      setOptimisticMessages((prev) => prev.filter((m) => m.id !== variables.id));
+    },
+  });
+
+  const handleSend = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed || sendMessage.isPending || !currentUser?.id) return;
+
+    const id = crypto.randomUUID();
+    setOptimisticMessages((prev) => [
+      ...prev,
+      {
+        id,
+        trip_id: tripId,
+        user_id: currentUser.id,
+        channel: "trip",
+        team_id: null,
+        text: trimmed,
+        created_at: new Date().toISOString(),
+        _optimistic: true,
+      },
+    ]);
+
+    setText("");
+    sendMessage.mutate({ tripId, id, channel: "trip", text: trimmed });
+  }, [text, sendMessage, currentUser?.id, tripId]);
+
+  return (
+    <div
+      className="hidden lg:flex flex-col rounded-xl border"
+      style={{
+        background: "var(--color-bt-card)",
+        borderColor: "var(--color-bt-border)",
+        minHeight: "300px",
+        maxHeight: "500px",
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex-shrink-0 px-3 py-2"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <p
+          className="text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Crew Chat
+        </p>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 space-y-2.5 overflow-y-auto px-3 py-2 min-h-0">
+        {displayed.length === 0 && (
+          <p className="text-center text-xs mt-8" style={{ color: "var(--color-bt-text-dim)" }}>
+            No messages yet. Say something!
+          </p>
+        )}
+        {displayed.map((msg) => {
+          const isMe = msg.user_id === currentUser?.id;
+          const time = new Date(msg.created_at).toLocaleTimeString("en-US", {
+            hour: "numeric",
+            minute: "2-digit",
+          });
+          return (
+            <div
+              key={msg.id}
+              className={`flex flex-col gap-0.5 ${isMe ? "items-end" : "items-start"}`}
+            >
+              {!isMe && (
+                <p className="px-1 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  {memberNames[msg.user_id] ?? "Unknown"}
+                </p>
+              )}
+              <div
+                className="max-w-[85%] rounded-2xl px-3 py-1.5 text-sm"
+                style={{
+                  background: isMe ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+                  border: `1px solid ${isMe ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+                  color: "var(--color-bt-text)",
+                  opacity: msg._optimistic ? 0.6 : 1,
+                }}
+              >
+                {msg.text}
+              </div>
+              <p className="px-1 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                {time}
+              </p>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div
+        className="flex items-center gap-2 px-3 py-2"
+        style={{ borderTop: "1px solid var(--color-bt-border)" }}
+      >
+        <input
+          type="text"
+          placeholder="Say something..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSend(); } }}
+          className="min-w-0 flex-1 rounded-full border px-3 py-1.5 text-sm outline-none"
+          style={{
+            background: "var(--color-bt-base)",
+            borderColor: "var(--color-bt-border)",
+            color: "var(--color-bt-text)",
+          }}
+        />
+        <button
+          onClick={handleSend}
+          disabled={sendMessage.isPending || !text.trim()}
+          className="flex h-7 w-7 items-center justify-center rounded-full disabled:opacity-30"
+          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+          aria-label="Send message"
+        >
+          <Send size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
+++ b/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
@@ -103,7 +103,7 @@ export function SidebarChatPanel({ tripId, memberNames }: SidebarChatPanelProps)
       </div>
 
       {/* Messages */}
-      <div className="flex-1 space-y-2.5 overflow-y-auto px-3 py-2 min-h-0">
+      <div className="flex-1 space-y-1.5 overflow-y-auto px-3 py-2 min-h-0">
         {displayed.length === 0 && (
           <p className="text-center text-xs mt-8" style={{ color: "var(--color-bt-text-dim)" }}>
             No messages yet. Say something!
@@ -118,13 +118,18 @@ export function SidebarChatPanel({ tripId, memberNames }: SidebarChatPanelProps)
           return (
             <div
               key={msg.id}
-              className={`flex flex-col gap-0.5 ${isMe ? "items-end" : "items-start"}`}
+              className={`flex flex-col ${isMe ? "items-end" : "items-start"}`}
             >
-              {!isMe && (
-                <p className="px-1 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                  {memberNames[msg.user_id] ?? "Unknown"}
-                </p>
-              )}
+              <div className="flex items-center gap-1.5 px-1 mb-0.5">
+                <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  {time}
+                </span>
+                {!isMe && (
+                  <span className="text-[10px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
+                    {memberNames[msg.user_id] ?? "Unknown"}
+                  </span>
+                )}
+              </div>
               <div
                 className="max-w-[85%] rounded-2xl px-3 py-1.5 text-sm"
                 style={{
@@ -136,9 +141,6 @@ export function SidebarChatPanel({ tripId, memberNames }: SidebarChatPanelProps)
               >
                 {msg.text}
               </div>
-              <p className="px-1 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                {time}
-              </p>
             </div>
           );
         })}

--- a/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
+++ b/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
@@ -17,12 +17,13 @@ interface ChatMessage {
   _optimistic?: boolean;
 }
 
-interface PlanningChatPanelProps {
+interface SidebarChatPanelProps {
   tripId: string;
   memberNames: Record<string, string>;
 }
 
-export function PlanningChatPanel({ tripId, memberNames }: PlanningChatPanelProps) {
+/** Shared desktop sidebar chat — used in both IDEA and PLANNING stages */
+export function SidebarChatPanel({ tripId, memberNames }: SidebarChatPanelProps) {
   const currentUser = useCurrentUser();
   const utils = trpc.useUtils();
   const bottomRef = useRef<HTMLDivElement>(null);

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -142,7 +142,8 @@ export default function TripDetailPage() {
   const status = getTripStatus(trip);
   const tripIsReadOnly = checkReadOnly(trip);
   const stage = (trip as { stage?: string }).stage ?? "idea";
-  const showFloatingChat = (stage === "idea" || stage === "planning") && activeTab === "home";
+  // IDEA stage: IdeaZonePanel renders its own floating action buttons
+  const showFloatingChat = stage === "planning" && activeTab === "home";
   // When exploring (comparison_mode=true, no lock), don't fall back to
   // trip.location — lockDestination writes to that column and unlockDestination
   // doesn't clear it, so the old destination would bleed through to the header.
@@ -252,6 +253,7 @@ export default function TripDetailPage() {
             isOwner={isOwner}
             onTabChange={(tab) => setActiveTab(tab as TabId)}
             onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
+            onOpenChat={() => setShowChatDrawer(true)}
           />
         )}
         {activeTab === "schedule" && (

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -138,6 +138,7 @@ export default function TripDetailPage() {
 
   const status = getTripStatus(trip);
   const tripIsReadOnly = checkReadOnly(trip);
+  const stage = (trip as { stage?: string }).stage ?? "idea";
   // When exploring (comparison_mode=true, no lock), don't fall back to
   // trip.location — lockDestination writes to that column and unlockDestination
   // doesn't clear it, so the old destination would bleed through to the header.
@@ -180,7 +181,7 @@ export default function TripDetailPage() {
         <TripHeader
           tripName={trip.title}
           status={status}
-          stage={(trip as { stage?: string }).stage ?? "idea"}
+          stage={stage}
           countdownText={countdownLabel(trip)}
           location={destLocation}
           lockedTitle={trip.locked_destination_title}
@@ -199,7 +200,7 @@ export default function TripDetailPage() {
           }}
           onDatesTap={() => setActiveTab("schedule")}
           onStepClick={(stepKey) => {
-            if (stepKey === "going" && isOwner && (trip as { stage?: string }).stage === "planning") {
+            if (stepKey === "going" && isOwner && stage === "planning") {
               setShowAdvanceSheet("going");
             }
           }}
@@ -212,7 +213,7 @@ export default function TripDetailPage() {
       </div>
 
       {/* ── Tab content ──────────────────────────────────────────────────── */}
-      <main className="mx-auto max-w-[1280px] pb-24 pt-4">
+      <main className={`mx-auto max-w-[1280px] pt-4 ${stage === "idea" || stage === "planning" ? "pb-6" : "pb-24"}`}>
         {/* Read-only banner */}
         {tripIsReadOnly && activeTab === "home" && (
           <div
@@ -249,8 +250,10 @@ export default function TripDetailPage() {
         )}
       </main>
 
-      {/* ── Bottom navigation ─────────────────────────────────────────────── */}
-      <TripBottomNav tripId={tripId} eventId={trip.event_id} />
+      {/* ── Bottom navigation (READY+ stages only) ────────────────────────── */}
+      {stage !== "idea" && stage !== "planning" && (
+        <TripBottomNav tripId={tripId} eventId={trip.event_id} />
+      )}
 
       {/* ── Settings modal ────────────────────────────────────────────────── */}
       {showSettings && role && (

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -99,7 +99,7 @@ export default function TripDetailPage() {
   // ── Toast auto-dismiss ────────────────────────────────────────────────────
   useEffect(() => {
     if (!toast) return;
-    const t = setTimeout(() => setToast(null), 5000);
+    const t = setTimeout(() => setToast(null), 3000);
     return () => clearTimeout(t);
   }, [toast]);
 
@@ -206,10 +206,24 @@ export default function TripDetailPage() {
           }}
         />
 
-        {/* ── Tab bar ───────────────────────────────────────────────────── */}
-        <div className="mt-4">
-          <TripTabBar activeTab={activeTab} onTabChange={setActiveTab} showComp={showComp} canEdit={canEdit} />
-        </div>
+        {/* ── Tab bar (hidden in IDEA stage) ──────────────────────────── */}
+        {stage !== "idea" && (
+          <div className="mt-4">
+            <TripTabBar
+              activeTab={activeTab}
+              onTabChange={(tab) => {
+                if (stage === "planning" && tab === "expenses") {
+                  setToast({ message: "Expenses are available once the trip moves to Ready.", variant: "warning" });
+                  return;
+                }
+                setActiveTab(tab);
+              }}
+              showComp={showComp}
+              canEdit={canEdit}
+              stage={stage}
+            />
+          </div>
+        )}
       </div>
 
       {/* ── Tab content ──────────────────────────────────────────────────── */}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -20,6 +20,8 @@ import { ExpensesTab } from "./tabs/ExpensesTab";
 import { formatDateRange } from "@/lib/dates";
 import { isReadOnly as checkReadOnly, countdownLabel } from "@/lib/tripStatus";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { FloatingChatButton } from "./components/FloatingChatButton";
+import { ChatDrawer } from "./components/ChatDrawer";
 
 // ── TripDetailPage ────────────────────────────────────────────────────────
 
@@ -31,6 +33,7 @@ export default function TripDetailPage() {
   const [compUnlocked, setCompUnlocked] = useState(false);
   const [showAdvanceSheet, setShowAdvanceSheet] = useState<"going" | null>(null);
   const [toast, setToast] = useState<{ message: string; variant: "warning" } | null>(null);
+  const [showChatDrawer, setShowChatDrawer] = useState(false);
 
   // ── Data ──────────────────────────────────────────────────────────────────
   const {
@@ -47,7 +50,7 @@ export default function TripDetailPage() {
   // states so the page waits for ALL data before rendering — no 2-phase pop-in.
   const { isLoading: ideasLoading } = trpc.ideas.list.useQuery({ tripId });
   const { isLoading: pollLoading } = trpc.datePoll.get.useQuery({ tripId });
-  const { isLoading: membersLoading } = trpc.tripMembers.list.useQuery({ tripId });
+  const { data: members = [], isLoading: membersLoading } = trpc.tripMembers.list.useQuery({ tripId });
   const { isLoading: reservationsLoading } = trpc.reservations.list.useQuery({ tripId });
   const { isLoading: tilesLoading } = trpc.quickInfoTiles.list.useQuery({ tripId });
 
@@ -139,6 +142,7 @@ export default function TripDetailPage() {
   const status = getTripStatus(trip);
   const tripIsReadOnly = checkReadOnly(trip);
   const stage = (trip as { stage?: string }).stage ?? "idea";
+  const showFloatingChat = (stage === "idea" || stage === "planning") && activeTab === "home";
   // When exploring (comparison_mode=true, no lock), don't fall back to
   // trip.location — lockDestination writes to that column and unlockDestination
   // doesn't clear it, so the old destination would bleed through to the header.
@@ -296,6 +300,19 @@ export default function TripDetailPage() {
           }}
         />
       )}
+
+      {/* ── Floating chat button + drawer (IDEA/PLANNING mobile) ──────── */}
+      {showFloatingChat && (
+        <FloatingChatButton onClick={() => setShowChatDrawer(true)} />
+      )}
+      <ChatDrawer
+        tripId={tripId}
+        isOpen={showChatDrawer}
+        onClose={() => setShowChatDrawer(false)}
+        memberNames={Object.fromEntries(
+          members.map((m: { user_id: string | null; memberId: string; displayName: string }) => [m.user_id ?? m.memberId, m.displayName])
+        )}
+      />
 
       {/* ── Toast notification ─────────────────────────────────────────── */}
       {toast && (

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -33,7 +33,7 @@ import { hashToHue } from "@/components/LocationHero";
 import { DatesSection } from "./DatesSection";
 import { PendingActionsCard } from "@/components/PendingActionsCard";
 import IdeaZonePanel from "../components/IdeaZonePanel";
-import { PlanningChatPanel } from "../components/PlanningChatPanel";
+import { SidebarChatPanel } from "../components/PlanningChatPanel";
 import type { TabProps, TripData } from "./types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -1798,7 +1798,7 @@ export function HomeTab({
         <div className="mt-4 space-y-4 lg:mt-0">
           {/* PLANNING stage: crew chat (desktop) + logistics below */}
           {stage === "planning" && (
-            <PlanningChatPanel
+            <SidebarChatPanel
               tripId={trip.id}
               memberNames={Object.fromEntries(
                 members.map((m: { user_id?: string | null; memberId?: string; displayName: string }) => [m.user_id ?? m.memberId ?? "", m.displayName])

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -1603,7 +1603,8 @@ export function HomeTab({
   isOwner,
   onTabChange,
   onEnableComp,
-}: TabProps & { onTabChange?: (tab: string) => void; onEnableComp?: () => void }) {
+  onOpenChat,
+}: TabProps & { onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void }) {
   const { data: ideas = [] } = trpc.ideas.list.useQuery({ tripId: trip.id });
   const { data: poll } = trpc.datePoll.get.useQuery({ tripId: trip.id });
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId: trip.id });
@@ -1683,6 +1684,7 @@ export function HomeTab({
         canEdit={canEditProp}
         isOwner={!!isOwner}
         onTabChange={onTabChange}
+        onOpenChat={onOpenChat}
       />
     );
   }

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -1784,12 +1784,14 @@ export function HomeTab({
             />
           )}
 
-          {/* Competition panel */}
-          <CompetitionPanel
-            trip={trip}
-            canEdit={canEditProp}
-            onSetupComp={onEnableComp}
-          />
+          {/* Competition panel — only in READY stage and beyond */}
+          {stage !== "idea" && stage !== "planning" && (
+            <CompetitionPanel
+              trip={trip}
+              canEdit={canEditProp}
+              onSetupComp={onEnableComp}
+            />
+          )}
         </div>
 
         {/* ── Right column: per-stage supplementary content ─────────── */}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -33,6 +33,7 @@ import { hashToHue } from "@/components/LocationHero";
 import { DatesSection } from "./DatesSection";
 import { PendingActionsCard } from "@/components/PendingActionsCard";
 import IdeaZonePanel from "../components/IdeaZonePanel";
+import { PlanningChatPanel } from "../components/PlanningChatPanel";
 import type { TabProps, TripData } from "./types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -1793,14 +1794,14 @@ export function HomeTab({
 
         {/* ── Right column: per-stage supplementary content ─────────── */}
         <div className="mt-4 space-y-4 lg:mt-0">
-          {/* IDEA stage: quick info */}
-          {stage === "idea" && (
-            <QuickInfoSection tripId={trip.id} isOwner={!!isOwner} />
-          )}
-
-          {/* PLANNING stage: quick info */}
+          {/* PLANNING stage: crew chat (desktop) + logistics below */}
           {stage === "planning" && (
-            <QuickInfoSection tripId={trip.id} isOwner={!!isOwner} />
+            <PlanningChatPanel
+              tripId={trip.id}
+              memberNames={Object.fromEntries(
+                members.map((m: { user_id?: string | null; memberId?: string; displayName: string }) => [m.user_id ?? m.memberId ?? "", m.displayName])
+              )}
+            />
           )}
 
           {/* GOING/NOW stage: quick info + confirmed dates */}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Calendar,
   CalendarDays,
@@ -7,11 +8,13 @@ import {
   Clock,
   Utensils,
   Car,
+  Plus,
   X,
 } from "lucide-react";
 import { EmptyState } from "@/components/EmptyState";
 import { trpc } from "@/lib/trpc-client";
 import { parseLocalDate } from "@/lib/dates";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
 import type { TabProps } from "./types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -37,12 +40,167 @@ const RES_ICON: Record<ReservationType, React.ReactNode> = {
   transport: <Car size={16} />,
 };
 
+const RES_TYPES: { value: ReservationType; label: string }[] = [
+  { value: "accommodation", label: "Accommodation" },
+  { value: "tee-time", label: "Tee Time" },
+  { value: "restaurant", label: "Restaurant" },
+  { value: "transport", label: "Transport" },
+];
+
 function fmtDate(d: string) {
   return parseLocalDate(d).toLocaleDateString("en-US", {
     weekday: "short",
     month: "short",
     day: "numeric",
   });
+}
+
+// ── AddReservationModal ─────────────────────────────────────────────────
+
+function AddReservationModal({
+  tripId,
+  onClose,
+}: {
+  tripId: string;
+  onClose: () => void;
+}) {
+  useModalBackButton(onClose);
+  const utils = trpc.useUtils();
+  const [type, setType] = useState<ReservationType>("accommodation");
+  const [title, setTitle] = useState("");
+  const [date, setDate] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [confirmationNumber, setConfirmationNumber] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const create = trpc.reservations.create.useMutation({
+    onSuccess: () => {
+      utils.reservations.list.invalidate({ tripId });
+      onClose();
+    },
+  });
+
+  const handleSubmit = () => {
+    if (!title.trim() || !date) return;
+    create.mutate({
+      tripId,
+      id: crypto.randomUUID(),
+      type,
+      title: title.trim(),
+      date,
+      startTime: startTime || undefined,
+      confirmationNumber: confirmationNumber || undefined,
+      notes: notes || undefined,
+    });
+  };
+
+  const inputStyle = {
+    background: "var(--color-bt-card-raised)",
+    borderColor: "var(--color-bt-border)",
+    color: "var(--color-bt-text)",
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[480px] rounded-t-2xl p-5 lg:rounded-2xl"
+        style={{ background: "var(--color-bt-card)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          Add Reservation
+        </h2>
+
+        {/* Type selector */}
+        <div className="mt-3 flex flex-wrap gap-2">
+          {RES_TYPES.map(({ value, label }) => (
+            <button
+              key={value}
+              onClick={() => setType(value)}
+              className="rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+              style={{
+                background: type === value ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                color: type === value ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+                border: type === value ? "none" : "1px solid var(--color-bt-border)",
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Title */}
+        <input
+          type="text"
+          placeholder="Name (e.g. Hilton Downtown)"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="mt-3 w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+          style={inputStyle}
+        />
+
+        {/* Date + time row */}
+        <div className="mt-2 flex gap-2">
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
+            style={inputStyle}
+          />
+          <input
+            type="time"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            className="w-32 rounded-xl border px-3 py-2.5 text-sm outline-none"
+            style={inputStyle}
+            placeholder="Time"
+          />
+        </div>
+
+        {/* Confirmation # */}
+        <input
+          type="text"
+          placeholder="Confirmation # (optional)"
+          value={confirmationNumber}
+          onChange={(e) => setConfirmationNumber(e.target.value)}
+          className="mt-2 w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+          style={inputStyle}
+        />
+
+        {/* Notes */}
+        <textarea
+          placeholder="Notes (optional)"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={2}
+          className="mt-2 w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+          style={inputStyle}
+        />
+
+        {/* Actions */}
+        <button
+          onClick={handleSubmit}
+          disabled={create.isPending || !title.trim() || !date}
+          className="mt-4 w-full rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+        >
+          {create.isPending ? "Adding..." : "Add Reservation"}
+        </button>
+        <button
+          onClick={onClose}
+          className="mt-2 w-full rounded-xl py-2.5 text-sm transition-opacity hover:opacity-80"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
 }
 
 // ── Reservations section ─────────────────────────────────────────────────
@@ -131,17 +289,40 @@ function ReservationsSection({
 // ── ScheduleTab ─────────────────────────────────────────────────────────
 
 export function ScheduleTab({ trip, canEdit }: TabProps) {
+  const [showAdd, setShowAdd] = useState(false);
+
   return (
     <div className="px-4">
       <section>
-        <h2
-          className="mt-0 mb-3 text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Reservations
-        </h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Reservations
+          </h2>
+          {canEdit && (
+            <button
+              data-testid="add-reservation-btn"
+              onClick={() => setShowAdd(true)}
+              className="flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors hover:opacity-80"
+              style={{
+                border: "1.5px dashed var(--color-bt-accent)",
+                color: "var(--color-bt-accent)",
+                background: "transparent",
+              }}
+            >
+              <Plus size={14} />
+              Add
+            </button>
+          )}
+        </div>
         <ReservationsSection tripId={trip.id} canEdit={canEdit} />
       </section>
+
+      {showAdd && (
+        <AddReservationModal tripId={trip.id} onClose={() => setShowAdd(false)} />
+      )}
     </div>
   );
 }

--- a/src/components/CrewSearchInput.tsx
+++ b/src/components/CrewSearchInput.tsx
@@ -56,11 +56,25 @@ export function CrewSearchInput({
 
   // ── Mutations ──────────────────────────────────────────────────────────
 
+  const updateRole = trpc.tripMembers.updateRole.useMutation({
+    onSuccess() {
+      resetAll();
+      utils.tripMembers.list.invalidate({ tripId });
+      onAdded?.();
+    },
+  });
+
   const addMember = trpc.tripMembers.add.useMutation({
     onSuccess() {
       resetAll();
       utils.tripMembers.list.invalidate({ tripId });
       onAdded?.();
+    },
+    onError(err) {
+      // Already on trip — promote to the desired role instead
+      if (err.data?.code === "CONFLICT" && search.kind === "found") {
+        updateRole.mutate({ tripId, userId: search.user.id, role: defaultRole });
+      }
     },
   });
 

--- a/src/components/CrewSearchInput.tsx
+++ b/src/components/CrewSearchInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Check, Ghost, Link, Loader2, Plus, UserPlus } from "lucide-react";
+import { Check, Ghost, Link, Loader2, Plus, Search, UserPlus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { UserAvatar } from "@/components/UserAvatar";
 
@@ -16,6 +16,8 @@ export interface CrewSearchInputProps {
   /** Show "Send invite" path when no account found */
   allowInvite?: boolean;
   placeholder?: string;
+  /** Show search icon in the input */
+  showSearchIcon?: boolean;
   onAdded?: () => void;
   frequentTripmates?: Array<{
     id: string;
@@ -38,6 +40,7 @@ export function CrewSearchInput({
   defaultStatus = "draft",
   allowGhost = false,
   allowInvite = true,
+  showSearchIcon = false,
   placeholder = "email@example.com",
   onAdded,
   frequentTripmates = [],
@@ -190,25 +193,34 @@ export function CrewSearchInput({
 
       {/* Email input + Find button */}
       <div className="flex gap-1.5">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => {
-            setEmail(e.target.value);
-            setSearch({ kind: "idle" });
-            setInviteError(null);
-            setAlreadyMemberName(null);
-            setShowNameOnly(false);
-          }}
-          onKeyDown={(e) => { if (e.key === "Enter") handleLookup(); }}
-          placeholder={placeholder}
-          className="flex-1 rounded-lg border px-2.5 py-1.5 text-xs outline-none"
-          style={{
-            background: "var(--color-bt-base)",
-            borderColor: "var(--color-bt-border)",
-            color: "var(--color-bt-text)",
-          }}
-        />
+        <div className="relative flex-1">
+          {showSearchIcon && (
+            <Search
+              size={12}
+              className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            />
+          )}
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setSearch({ kind: "idle" });
+              setInviteError(null);
+              setAlreadyMemberName(null);
+              setShowNameOnly(false);
+            }}
+            onKeyDown={(e) => { if (e.key === "Enter") handleLookup(); }}
+            placeholder={placeholder}
+            className={`w-full rounded-lg border py-1.5 text-xs outline-none ${showSearchIcon ? "pl-7 pr-2.5" : "px-2.5"}`}
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+        </div>
         <button
           onClick={handleLookup}
           disabled={!email.includes("@")}

--- a/src/components/TripTabBar.test.tsx
+++ b/src/components/TripTabBar.test.tsx
@@ -83,6 +83,78 @@ describe("TripBottomNav — back navigation contract", () => {
   });
 });
 
+// ── Stage-gating tests ─────────────────────────────────────────────────
+
+describe("Stage-gated bottom nav visibility", () => {
+  function showBottomNav(stage: string) {
+    return stage !== "idea" && stage !== "planning";
+  }
+
+  it("hidden in idea stage", () => {
+    expect(showBottomNav("idea")).toBe(false);
+  });
+
+  it("hidden in planning stage", () => {
+    expect(showBottomNav("planning")).toBe(false);
+  });
+
+  it("visible in going stage", () => {
+    expect(showBottomNav("going")).toBe(true);
+  });
+
+  it("visible in done stage", () => {
+    expect(showBottomNav("done")).toBe(true);
+  });
+});
+
+describe("Stage-gated tab bar — tab filtering", () => {
+  const ALL_TAB_IDS = ["home", "crew", "schedule", "expenses", "comp"];
+
+  function getVisibleTabs(stage: string, canEdit: boolean, showComp: boolean) {
+    return ALL_TAB_IDS.filter((id) => {
+      if (id === "comp") {
+        if (stage === "planning") return false;
+        return canEdit && showComp;
+      }
+      return true;
+    });
+  }
+
+  it("PLANNING stage hides Competition tab even when comp exists", () => {
+    const tabs = getVisibleTabs("planning", true, true);
+    expect(tabs).not.toContain("comp");
+    expect(tabs).toEqual(["home", "crew", "schedule", "expenses"]);
+  });
+
+  it("READY stage shows Competition tab when comp exists", () => {
+    const tabs = getVisibleTabs("going", true, true);
+    expect(tabs).toContain("comp");
+  });
+
+  it("Expenses tab is always present in tab list (disabled state handled at click level)", () => {
+    const tabs = getVisibleTabs("planning", true, false);
+    expect(tabs).toContain("expenses");
+  });
+});
+
+describe("Competition CTA stage gating", () => {
+  function showCompetitionCTA(stage: string) {
+    return stage !== "idea" && stage !== "planning";
+  }
+
+  it("hidden in idea stage", () => {
+    expect(showCompetitionCTA("idea")).toBe(false);
+  });
+
+  it("hidden in planning stage", () => {
+    expect(showCompetitionCTA("planning")).toBe(false);
+  });
+
+  it("visible in going stage", () => {
+    expect(showCompetitionCTA("going")).toBe(true);
+  });
+});
+
 describe("GlobalBottomNav — item visibility", () => {
   function getVisibleItems(activeTripId: string | null) {
     const items = [

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -23,6 +23,8 @@ interface TripTabBarProps {
   onTabChange: (tab: TabId) => void;
   showComp?: boolean;
   canEdit?: boolean;
+  /** Trip stage — used to disable Expenses in PLANNING and hide Competition */
+  stage?: string;
 }
 
 export const TripTabBar: FC<TripTabBarProps> = ({
@@ -30,12 +32,17 @@ export const TripTabBar: FC<TripTabBarProps> = ({
   onTabChange,
   showComp = false,
   canEdit = false,
+  stage,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [iconMode, setIconMode] = useState(false);
 
   const tabs = ALL_TABS.filter((t) => {
-    if (t.id === "comp") return canEdit && showComp;
+    if (t.id === "comp") {
+      // In PLANNING stage, never show Competition tab
+      if (stage === "planning") return false;
+      return canEdit && showComp;
+    }
     return true;
   });
 
@@ -58,6 +65,7 @@ export const TripTabBar: FC<TripTabBarProps> = ({
     >
       {tabs.map(({ id, label, Icon }) => {
         const active = activeTab === id;
+        const isDisabled = stage === "planning" && id === "expenses";
         return (
           <button
             key={id}
@@ -65,10 +73,16 @@ export const TripTabBar: FC<TripTabBarProps> = ({
             onClick={() => onTabChange(id)}
             className="flex flex-1 flex-col items-center justify-center gap-0.5 py-2.5 text-xs font-medium transition-colors"
             style={{
-              color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+              color: isDisabled
+                ? "var(--color-bt-text-dim)"
+                : active
+                  ? "var(--color-bt-accent)"
+                  : "var(--color-bt-text-dim)",
               borderBottom: active
                 ? "2px solid var(--color-bt-accent)"
                 : "2px solid transparent",
+              opacity: isDisabled ? 0.4 : 1,
+              cursor: isDisabled ? "not-allowed" : "pointer",
             }}
           >
             {iconMode ? (

--- a/src/server/routers/ideas.ts
+++ b/src/server/routers/ideas.ts
@@ -182,11 +182,11 @@ export const ideasRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // remove — Owner only (isOwner)
+  // remove — Owner or Planner (canEdit)
   // -----------------------------------------------------------------------
   remove: authedProcedure
     .input(z.object({ tripId: z.string(), ideaId: z.string() }))
-    .use(requireTripRole("Owner"))
+    .use(requireTripRole("Planner"))
     .mutation(async ({ ctx, input }) => {
       // Delete votes first
       await ctx.supabase


### PR DESCRIPTION
## Summary
- **Inline vote button** on each idea card hero image (top-left) — ghost pill when unvoted, teal pill when voted, toggles on click
- **Voter avatars** below the vote button showing who voted for each idea (max 4 + overflow chip)
- **Removed VotingPanel** ("CREW VOTES") from the right column entirely
- **Co-planners panel** now shows "Voted ✓" / "Not voted" instead of role badges (Owner/Planner)
- **Delete modal text** updated: "This will permanently delete this idea and all its votes. The crew chat stays intact."

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 288 Vitest tests pass
- [ ] Vote button appears top-left of each idea card hero image
- [ ] Unvoted: ghost pill with thumbs up + "Vote"
- [ ] Voted: teal filled pill with thumbs up + "My vote"
- [ ] Voter avatars appear below button, max 4 + overflow
- [ ] Co-planners shows "Voted ✓" or "Not voted"
- [ ] Delete modal text matches spec
- [ ] No hardcoded hex values

🤖 Generated with [Claude Code](https://claude.com/claude-code)