### PR TITLE
Date poll lifecycle, notification stacking, and UX polish

### DIFF
--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -394,18 +394,24 @@ export function DatesPlanningRow({
     : pollState === "draft"
     ? isOwner
       ? "Building Poll"
-      : `Dates TBD: ${ownerDisplayName} is working on it.`
+      : `Dates TBD: ${ownerDisplayName} is working on it`
     : pollState === "closed"
     ? isOwner
       ? "Poll Closed"
-      : `Dates TBD: ${ownerDisplayName} is working on it.`
+      : `Dates TBD: ${ownerDisplayName} is working on it`
     : isOwner
     ? "Set Dates"
-    : `Dates TBD: ${ownerDisplayName} is working on it.`;
+    : `Dates TBD: ${ownerDisplayName} is working on it`;
 
   const headerNote = useMemo(() => {
     if (datesLocked) {
       return formatDateRangeCompact(trip.start_date, trip.end_date);
+    }
+    // Non-owners only see the note when poll is active (so they know to vote)
+    if (!isOwner) {
+      return pollState === "active"
+        ? `Poll active · ${windows.length} option${windows.length !== 1 ? "s" : ""}`
+        : "";
     }
     if (pollState === "active")
       return `Poll active · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
@@ -414,7 +420,7 @@ export function DatesPlanningRow({
     if (pollState === "closed")
       return `Poll closed · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
     return "";
-  }, [datesLocked, pollState, windows.length, trip.start_date, trip.end_date]);
+  }, [datesLocked, isOwner, pollState, windows.length, trip.start_date, trip.end_date]);
 
   // Non-owners can expand when dates are locked (to see them) or when a
   // poll is active (to vote). Owners can always expand.
@@ -874,7 +880,7 @@ export function DatesPlanningRow({
           className="text-[13px] leading-relaxed"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
-          The trip organizer is asking for everyone&apos;s input — please
+          {ownerDisplayName} is asking for everyone&apos;s input — please
           mark your availability for the dates below.
         </p>
 

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -385,7 +385,7 @@ export function DatesPlanningRow({
     ? "Checking Availability"
     : isOwner
     ? "Set Dates"
-    : `${ownerDisplayName} is working on dates`;
+    : `Dates TBD: ${ownerDisplayName} is working on it.`;
 
   const headerNote = useMemo(() => {
     if (datesLocked) {
@@ -393,7 +393,7 @@ export function DatesPlanningRow({
     }
     if (pollActive)
       return `Poll active · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
-    return "Dates TBD";
+    return "";
   }, [datesLocked, pollActive, windows.length, trip.start_date, trip.end_date]);
 
   // Non-owners can expand when dates are locked (to see them) or when a

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -954,8 +954,11 @@ export function DatesPlanningRow({
   }
 
   function renderBody() {
-    // Locked view: show the range and a Change dates → button opening the modal
+    // Locked view: show the range and a Change dates → button.
+    // For poll-set dates: go straight back to poll draft state (no modal needed).
+    // For direct-set dates: open the change-dates modal.
     if (datesLocked) {
+      const fromPoll = trip.date_set_method === "poll";
       return (
         <div className="space-y-2">
           <p
@@ -970,11 +973,16 @@ export function DatesPlanningRow({
           </p>
           {isOwner && (
             <button
-              onClick={() => setShowChangeDates(true)}
-              className="text-xs font-medium"
+              onClick={
+                fromPoll
+                  ? () => unlockDates.mutate({ tripId })
+                  : () => setShowChangeDates(true)
+              }
+              disabled={fromPoll && unlockDates.isPending}
+              className="text-xs font-medium transition-opacity disabled:opacity-50"
               style={{ color: "var(--color-bt-accent)" }}
             >
-              Change dates →
+              {fromPoll && unlockDates.isPending ? "Going back…" : "Change dates →"}
             </button>
           )}
         </div>

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -911,18 +911,11 @@ export function DatesPlanningRow({
           </p>
           {isOwner && (
             <button
-              onClick={() => {
-                if (trip.date_set_method === "poll") {
-                  unlockDates.mutate({ tripId });
-                } else {
-                  setShowChangeDates(true);
-                }
-              }}
-              disabled={unlockDates.isPending}
+              onClick={() => setShowChangeDates(true)}
               className="text-xs font-medium"
               style={{ color: "var(--color-bt-accent)" }}
             >
-              {unlockDates.isPending ? "Unlocking…" : "Change dates →"}
+              Change dates →
             </button>
           )}
         </div>
@@ -1014,6 +1007,10 @@ export function DatesPlanningRow({
             );
           }}
           isPending={lockDates.isPending}
+          onClear={() => {
+            unlockDates.mutate({ tripId }, { onSuccess() { setShowChangeDates(false); } });
+          }}
+          isClearPending={unlockDates.isPending}
         />
       )}
 
@@ -1066,6 +1063,8 @@ function ChangeDatesModal({
   onClose,
   onSubmit,
   isPending,
+  onClear,
+  isClearPending,
 }: {
   tripId: string;
   initialStart: string;
@@ -1074,6 +1073,8 @@ function ChangeDatesModal({
   onClose: () => void;
   onSubmit: (startDate: string, endDate: string) => void;
   isPending: boolean;
+  onClear: () => void;
+  isClearPending: boolean;
 }) {
   useModalBackButton(onClose);
   const [startDate, setStartDate] = useState(initialStart);
@@ -1133,6 +1134,18 @@ function ChangeDatesModal({
           }}
         >
           {isPending ? "Updating..." : "Update dates"}
+        </button>
+
+        <button
+          onClick={onClear}
+          disabled={isClearPending || isPending}
+          className="mt-2 w-full rounded-xl border py-2.5 text-sm font-medium transition-opacity hover:opacity-80 disabled:opacity-40"
+          style={{
+            borderColor: "var(--color-bt-danger-border)",
+            color: "var(--color-bt-danger)",
+          }}
+        >
+          {isClearPending ? "Clearing..." : "Clear dates"}
         </button>
 
         <button

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -374,11 +374,18 @@ export function DatesPlanningRow({
     ? "inProgress"
     : "none";
 
+  const ownerDisplayName = useMemo(() => {
+    const owner = members.find((m) => m.role === "Owner");
+    return owner?.displayName ?? "Your organizer";
+  }, [members]);
+
   const headerLabel = datesLocked
     ? "Dates Selected"
     : pollActive
     ? "Checking Availability"
-    : "Set Dates";
+    : isOwner
+    ? "Set Dates"
+    : `${ownerDisplayName} is working on dates`;
 
   const headerNote = useMemo(() => {
     if (datesLocked) {
@@ -978,6 +985,7 @@ export function DatesPlanningRow({
         state={state}
         isOpen={effectiveOpen}
         onToggle={handleToggle}
+        noExpand={!canExpand}
       >
         {renderBody()}
       </PlanningRow>

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { Calendar, X } from "lucide-react";
+import { Calendar, Plus, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
@@ -463,73 +463,18 @@ export function DatesPlanningRow({
     );
   };
 
+  const handlePollTheCrew = () => {
+    setPollActive.mutate({ tripId, state: "draft" });
+  };
+
   const handleNevermind = () => {
     setPollActive.mutate({ tripId, state: null });
   };
 
   // ── Body renderers ─────────────────────────────────────────────────────
 
-  function renderDatePickerRow(buttonMode: "set" | "poll" | "both") {
+  function renderDatePickerRow(buttonMode: "set" | "poll") {
     const valid = !!directStart && !!directEnd && directStart < directEnd;
-    if (buttonMode === "both") {
-      return (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <input
-              type="date"
-              value={directStart}
-              onChange={(e) => setDirectStart(e.target.value)}
-              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-            <input
-              type="date"
-              value={directEnd}
-              onChange={(e) => setDirectEnd(e.target.value)}
-              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-          </div>
-          <div className="flex gap-2">
-            <button
-              disabled={!valid || lockDates.isPending}
-              onClick={handleSetDates}
-              className="flex-1 rounded-xl px-3 py-2.5 text-sm font-semibold transition-opacity"
-              style={{
-                background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-                color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
-                opacity: valid ? 1 : 0.6,
-                cursor: valid ? "pointer" : "not-allowed",
-              }}
-            >
-              {lockDates.isPending ? "Setting…" : "Set dates"}
-            </button>
-            <button
-              disabled={!valid || addWindow.isPending}
-              onClick={handleAddToPoll}
-              className="flex-1 rounded-xl px-3 py-2.5 text-sm font-semibold transition-opacity"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                color: valid ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
-                border: `1px solid ${valid ? "var(--color-bt-border)" : "var(--color-bt-border)"}`,
-                opacity: valid ? 1 : 0.6,
-                cursor: valid ? "pointer" : "not-allowed",
-              }}
-            >
-              {addWindow.isPending ? "Adding…" : "Add to poll"}
-            </button>
-          </div>
-        </div>
-      );
-    }
     const busy =
       buttonMode === "set" ? lockDates.isPending : addWindow.isPending;
     const label =
@@ -1044,7 +989,6 @@ export function DatesPlanningRow({
 
     // Owner view
     const showInputRow = pollState !== "active" && pollState !== "closed";
-    const inputMode = pollState === "draft" ? "poll" : "both";
 
     return (
       <div className="space-y-0">
@@ -1060,8 +1004,26 @@ export function DatesPlanningRow({
             {/* In poll draft mode, list existing windows as text rows above the inputs */}
             {pollState === "draft" && renderWindowTextRows()}
 
-            {/* Date pickers + action button(s) */}
-            {renderDatePickerRow(inputMode)}
+            {/* Date pickers + action button */}
+            {renderDatePickerRow(pollState === "draft" ? "poll" : "set")}
+
+            {/* Poll the crew — only in null (direct) mode */}
+            {pollState === null && (
+              <div className="mt-3 flex gap-2">
+                <button
+                  onClick={handlePollTheCrew}
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
+                  style={{
+                    border: "1.5px dashed var(--color-bt-accent)",
+                    color: "var(--color-bt-accent)",
+                    background: "transparent",
+                  }}
+                >
+                  <Plus size={14} />
+                  Poll the crew
+                </button>
+              </div>
+            )}
           </>
         )}
 

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -393,7 +393,7 @@ export function DatesPlanningRow({
     }
     if (pollActive)
       return `Poll active · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
-    return "Not set yet";
+    return "Dates TBD";
   }, [datesLocked, pollActive, windows.length, trip.start_date, trip.end_date]);
 
   // Non-owners can expand when dates are locked (to see them) or when a

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -87,7 +87,15 @@ export function DatesPlanningRow({
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
 
-  const { data: poll } = trpc.datePoll.get.useQuery({ tripId });
+  // Refresh votes every 30 s while the owner has the panel open and the poll
+  // is active — lets them watch responses come in without a manual reload.
+  const liveVotePolling =
+    isOwner && isOpen && trip.date_poll_state === "active" && !trip.start_date;
+
+  const { data: poll } = trpc.datePoll.get.useQuery(
+    { tripId },
+    { refetchInterval: liveVotePolling ? 30_000 : false }
+  );
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
 
   const rawWindows = (poll?.windows ?? []) as PollWindow[];

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -322,6 +322,32 @@ export function DatesPlanningRow({
   });
 
   const lockWindow = trpc.datePoll.lockWindow.useMutation({
+    async onMutate(vars) {
+      await utils.trips.getById.cancel({ tripId });
+      const prevTrip = utils.trips.getById.getData({ tripId });
+      // Find the window dates from the local poll cache
+      const pollData = utils.datePoll.get.getData({ tripId });
+      const win = pollData?.windows.find((w) => w.id === vars.windowId);
+      if (win) {
+        utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+          old
+            ? {
+                ...old,
+                start_date: win.start_date,
+                end_date: win.end_date,
+                date_set_method: "poll" as const,
+                date_poll_active: false,
+                date_poll_state: null,
+              }
+            : old
+        );
+      }
+      return { prevTrip };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prevTrip !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prevTrip);
+    },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
       utils.trips.getById.invalidate({ tripId });

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -827,9 +827,9 @@ export function DatesPlanningRow({
                     onClick: () => setPollActive.mutate({ tripId, state: "closed" }),
                   },
                   {
-                    label: "Restart Poll",
+                    label: "Reset Poll",
                     enabled: pollState === "closed",
-                    onClick: () => setPollActive.mutate({ tripId, state: "active" }),
+                    onClick: () => setPollActive.mutate({ tripId, state: "draft" }),
                   },
                 ] as const
               ).map(({ label, enabled, onClick }) => (

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { Calendar, Plus, X } from "lucide-react";
+import { Calendar, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
@@ -94,7 +94,7 @@ export function DatesPlanningRow({
   const windows = useMemo(() => sortWindows(rawWindows), [rawWindows]);
 
   const datesLocked = !!(trip.start_date && trip.end_date);
-  const pollActive = !!trip.date_poll_active;
+  const pollState = trip.date_poll_state ?? null;
   const hasWindows = windows.length > 0;
 
   // Manual date picker state — shared between the empty/idle state and the
@@ -122,6 +122,7 @@ export function DatesPlanningRow({
               end_date: vars.endDate,
               date_set_method: vars.method,
               date_poll_active: false,
+              date_poll_state: null,
             }
           : old
       );
@@ -146,7 +147,13 @@ export function DatesPlanningRow({
       await utils.trips.getById.cancel({ tripId });
       const prevTrip = utils.trips.getById.getData({ tripId });
       utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
-        old ? { ...old, date_poll_active: vars.active } : old
+        old
+          ? {
+              ...old,
+              date_poll_state: vars.state,
+              date_poll_active: vars.state === "active",
+            }
+          : old
       );
       return { prevTrip };
     },
@@ -332,6 +339,7 @@ export function DatesPlanningRow({
               start_date: null,
               end_date: null,
               date_poll_active: old.date_set_method === "poll",
+              date_poll_state: old.date_set_method === "poll" ? "draft" : null,
             }
           : old
       );
@@ -370,7 +378,7 @@ export function DatesPlanningRow({
 
   const state: ArcCardState = datesLocked
     ? "done"
-    : pollActive
+    : pollState !== null
     ? "inProgress"
     : "none";
 
@@ -381,8 +389,16 @@ export function DatesPlanningRow({
 
   const headerLabel = datesLocked
     ? "Dates Selected"
-    : pollActive
+    : pollState === "active"
     ? "Checking Availability"
+    : pollState === "draft"
+    ? isOwner
+      ? "Building Poll"
+      : `Dates TBD: ${ownerDisplayName} is working on it.`
+    : pollState === "closed"
+    ? isOwner
+      ? "Poll Closed"
+      : `Dates TBD: ${ownerDisplayName} is working on it.`
     : isOwner
     ? "Set Dates"
     : `Dates TBD: ${ownerDisplayName} is working on it.`;
@@ -391,14 +407,18 @@ export function DatesPlanningRow({
     if (datesLocked) {
       return formatDateRangeCompact(trip.start_date, trip.end_date);
     }
-    if (pollActive)
+    if (pollState === "active")
       return `Poll active · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
+    if (pollState === "draft")
+      return `Building · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
+    if (pollState === "closed")
+      return `Poll closed · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
     return "";
-  }, [datesLocked, pollActive, windows.length, trip.start_date, trip.end_date]);
+  }, [datesLocked, pollState, windows.length, trip.start_date, trip.end_date]);
 
   // Non-owners can expand when dates are locked (to see them) or when a
   // poll is active (to vote). Owners can always expand.
-  const canExpand = isOwner || datesLocked || (pollActive && hasWindows);
+  const canExpand = isOwner || datesLocked || (pollState === "active" && hasWindows);
   const effectiveOpen = isOpen && canExpand;
   const handleToggle = canExpand ? onToggle : () => {};
 
@@ -437,26 +457,73 @@ export function DatesPlanningRow({
     );
   };
 
-  const handlePollTheCrew = () => {
-    setPollActive.mutate({ tripId, active: true });
-  };
-
   const handleNevermind = () => {
-    // Pre-fill the manual pickers from the first poll window so the user has
-    // something to confirm. Poll windows are intentionally NOT removed — if
-    // the user toggles back to "Poll the crew" their work is intact.
-    const first = windows[0];
-    if (first) {
-      setDirectStart(first.start_date);
-      setDirectEnd(first.end_date);
-    }
-    setPollActive.mutate({ tripId, active: false });
+    setPollActive.mutate({ tripId, state: null });
   };
 
   // ── Body renderers ─────────────────────────────────────────────────────
 
-  function renderDatePickerRow(buttonMode: "set" | "poll") {
+  function renderDatePickerRow(buttonMode: "set" | "poll" | "both") {
     const valid = !!directStart && !!directEnd && directStart < directEnd;
+    if (buttonMode === "both") {
+      return (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              value={directStart}
+              onChange={(e) => setDirectStart(e.target.value)}
+              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+            <input
+              type="date"
+              value={directEnd}
+              onChange={(e) => setDirectEnd(e.target.value)}
+              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              disabled={!valid || lockDates.isPending}
+              onClick={handleSetDates}
+              className="flex-1 rounded-xl px-3 py-2.5 text-sm font-semibold transition-opacity"
+              style={{
+                background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+                opacity: valid ? 1 : 0.6,
+                cursor: valid ? "pointer" : "not-allowed",
+              }}
+            >
+              {lockDates.isPending ? "Setting…" : "Set dates"}
+            </button>
+            <button
+              disabled={!valid || addWindow.isPending}
+              onClick={handleAddToPoll}
+              className="flex-1 rounded-xl px-3 py-2.5 text-sm font-semibold transition-opacity"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                color: valid ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+                border: `1px solid ${valid ? "var(--color-bt-border)" : "var(--color-bt-border)"}`,
+                opacity: valid ? 1 : 0.6,
+                cursor: valid ? "pointer" : "not-allowed",
+              }}
+            >
+              {addWindow.isPending ? "Adding…" : "Add to poll"}
+            </button>
+          </div>
+        </div>
+      );
+    }
     const busy =
       buttonMode === "set" ? lockDates.isPending : addWindow.isPending;
     const label =
@@ -530,7 +597,7 @@ export function DatesPlanningRow({
                   · {nights} night{nights !== 1 ? "s" : ""}
                 </span>
               </div>
-              {canEdit && (
+              {canEdit && pollState !== "active" && (
                 <button
                   onClick={() =>
                     removeWindowM.mutate({ tripId, windowId: w.id })
@@ -611,7 +678,7 @@ export function DatesPlanningRow({
               style={{ background: "var(--color-bt-card-raised)" }}
             >
               {hasWindows ? (
-                canEdit && isOwner ? (
+                canEdit && isOwner && pollState === "closed" ? (
                   <button
                     onClick={() => setShowSelectDateModal(true)}
                     className="w-full rounded-lg px-2 py-1.5 text-[11px] font-semibold transition-opacity"
@@ -744,16 +811,57 @@ export function DatesPlanningRow({
         </div>
 
         {canEdit && (
-          <button
-            onClick={handleNevermind}
-            className="w-full rounded-xl py-3 text-sm font-medium transition-colors"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              color: "var(--color-bt-text-dim)",
-            }}
-          >
-            Nevermind, Set Dates Manually
-          </button>
+          <>
+            {/* Lifecycle buttons — always visible, each enabled only in the right state */}
+            <div className="flex gap-2">
+              {(
+                [
+                  {
+                    label: "Start Poll",
+                    enabled: pollState === "draft" && hasWindows,
+                    onClick: () => setPollActive.mutate({ tripId, state: "active" }),
+                  },
+                  {
+                    label: "Stop Poll",
+                    enabled: pollState === "active",
+                    onClick: () => setPollActive.mutate({ tripId, state: "closed" }),
+                  },
+                  {
+                    label: "Restart Poll",
+                    enabled: pollState === "closed",
+                    onClick: () => setPollActive.mutate({ tripId, state: "active" }),
+                  },
+                ] as const
+              ).map(({ label, enabled, onClick }) => (
+                <button
+                  key={label}
+                  onClick={enabled ? onClick : undefined}
+                  className="flex-1 rounded-xl py-2.5 text-sm font-medium transition-opacity"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text)",
+                    border: "1px solid var(--color-bt-border)",
+                    opacity: enabled ? 1 : 0.35,
+                    cursor: enabled ? "pointer" : "not-allowed",
+                    pointerEvents: enabled ? undefined : "none",
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            <button
+              onClick={handleNevermind}
+              className="w-full rounded-xl py-3 text-sm font-medium transition-colors"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              Nevermind, Set Dates Manually
+            </button>
+          </>
         )}
       </div>
     );
@@ -924,46 +1032,35 @@ export function DatesPlanningRow({
 
     // Non-owner view: simplified poll-only panel (Planners and Members alike)
     if (!isOwner) {
-      if (pollActive && hasWindows) return renderMemberPollView();
+      if (pollState === "active" && hasWindows) return renderMemberPollView();
       return null;
     }
 
     // Owner view
+    const showInputRow = pollState !== "active" && pollState !== "closed";
+    const inputMode = pollState === "draft" ? "poll" : "both";
+
     return (
       <div className="space-y-0">
-        <p
-          className="mb-3 text-[13px]"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          When are you going?
-        </p>
-
-        {/* In poll mode, list existing windows as text rows above the inputs */}
-        {pollActive && renderWindowTextRows()}
-
-        {/* Dual-mode date pickers + primary button */}
-        {renderDatePickerRow(pollActive ? "poll" : "set")}
-
-        {/* Poll the crew toggle — only when not in poll mode */}
-        {!pollActive && (
-          <div className="mt-3 flex gap-2">
-            <button
-              onClick={handlePollTheCrew}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
-              style={{
-                border: "1.5px dashed var(--color-bt-accent)",
-                color: "var(--color-bt-accent)",
-                background: "transparent",
-              }}
+        {showInputRow && (
+          <>
+            <p
+              className="mb-3 text-[13px]"
+              style={{ color: "var(--color-bt-text-dim)" }}
             >
-              <Plus size={14} />
-              Poll the crew
-            </button>
-          </div>
+              When are you going?
+            </p>
+
+            {/* In poll draft mode, list existing windows as text rows above the inputs */}
+            {pollState === "draft" && renderWindowTextRows()}
+
+            {/* Date pickers + action button(s) */}
+            {renderDatePickerRow(inputMode)}
+          </>
         )}
 
-        {/* Polling grid — visible whenever poll mode is active */}
-        {pollActive && renderPollGrid()}
+        {/* Polling grid — visible whenever poll mode is engaged (draft/active/closed) */}
+        {pollState !== null && renderPollGrid()}
       </div>
     );
   }
@@ -974,7 +1071,7 @@ export function DatesPlanningRow({
         icon={<Calendar size={16} />}
         label={headerLabel}
         note={headerNote}
-        warnState={pollActive}
+        warnState={pollState !== null}
         state={state}
         isOpen={effectiveOpen}
         onToggle={handleToggle}

--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -663,26 +663,12 @@ export function DatesPlanningRow({
               style={{ background: "var(--color-bt-card-raised)" }}
             >
               {hasWindows ? (
-                canEdit && isOwner && pollState === "closed" ? (
-                  <button
-                    onClick={() => setShowSelectDateModal(true)}
-                    className="w-full rounded-lg px-2 py-1.5 text-[11px] font-semibold transition-opacity"
-                    style={{
-                      border: "1.5px solid var(--color-bt-accent)",
-                      color: "var(--color-bt-accent)",
-                      background: "transparent",
-                    }}
-                  >
-                    Select date
-                  </button>
-                ) : (
-                  <span
-                    className="text-[11px] font-semibold uppercase tracking-wider"
-                    style={{ color: "var(--color-bt-text-dim)" }}
-                  >
-                    Crew
-                  </span>
-                )
+                <span
+                  className="text-[11px] font-semibold uppercase tracking-wider"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  Crew
+                </span>
               ) : (
                 <span
                   className="text-xs italic"
@@ -834,6 +820,21 @@ export function DatesPlanningRow({
                   {label}
                 </button>
               ))}
+
+              {/* Select date — always-on escape valve, far right */}
+              {hasWindows && (
+                <button
+                  onClick={() => setShowSelectDateModal(true)}
+                  className="flex-1 rounded-xl py-2.5 text-sm font-medium transition-opacity"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-accent)",
+                    border: "1px solid var(--color-bt-accent-border)",
+                  }}
+                >
+                  Select date
+                </button>
+              )}
             </div>
 
             <button

--- a/src/app/trips/[tripId]/components/PlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/PlanningRow.tsx
@@ -78,15 +78,17 @@ export function PlanningRow({
           <p className="text-sm font-semibold leading-tight" style={{ color: labelColor }}>
             {label}
           </p>
-          <p
-            className="mt-0.5 text-xs"
-            style={{
-              color: noteWarn ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)",
-              fontWeight: noteWarn ? 500 : undefined,
-            }}
-          >
-            {note}
-          </p>
+          {note && (
+            <p
+              className="mt-0.5 text-xs"
+              style={{
+                color: noteWarn ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)",
+                fontWeight: noteWarn ? 500 : undefined,
+              }}
+            >
+              {note}
+            </p>
+          )}
         </div>
         {headerAction && (
           <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0">

--- a/src/app/trips/[tripId]/components/PlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/PlanningRow.tsx
@@ -15,6 +15,8 @@ export interface PlanningRowProps {
   state: ArcCardState;
   isOpen: boolean;
   onToggle: () => void;
+  /** Hide the expand chevron and make the row non-interactive (read-only status display) */
+  noExpand?: boolean;
   /** Optional element rendered right-aligned in the header, before the chevron */
   headerAction?: React.ReactNode;
   children?: React.ReactNode;
@@ -29,6 +31,7 @@ export function PlanningRow({
   state,
   isOpen,
   onToggle,
+  noExpand,
   headerAction,
   children,
 }: PlanningRowProps) {
@@ -57,11 +60,11 @@ export function PlanningRow({
       }}
     >
       <div
-        role="button"
-        tabIndex={0}
-        className="flex w-full cursor-pointer items-center gap-3 px-4 py-3.5 text-left"
-        onClick={onToggle}
-        onKeyDown={(e) => {
+        role={noExpand ? undefined : "button"}
+        tabIndex={noExpand ? undefined : 0}
+        className={`flex w-full items-center gap-3 px-4 py-3.5 text-left ${noExpand ? "cursor-default" : "cursor-pointer"}`}
+        onClick={noExpand ? undefined : onToggle}
+        onKeyDown={noExpand ? undefined : (e) => {
           if (e.key === "Enter" || e.key === " ") onToggle();
         }}
       >
@@ -90,14 +93,16 @@ export function PlanningRow({
             {headerAction}
           </div>
         )}
-        <ChevronDown
-          size={15}
-          className="flex-shrink-0 transition-transform duration-200"
-          style={{
-            color: "var(--color-bt-text-dim)",
-            transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
-          }}
-        />
+        {!noExpand && (
+          <ChevronDown
+            size={15}
+            className="flex-shrink-0 transition-transform duration-200"
+            style={{
+              color: "var(--color-bt-text-dim)",
+              transform: isOpen ? "rotate(180deg)" : "rotate(0deg)",
+            }}
+          />
+        )}
       </div>
 
       {isOpen && children && (

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -1114,7 +1114,9 @@ function PlanningSection({
   onMakeOfficial?: (message: string) => void;
 }) {
   const utils = trpc.useUtils();
-  const [openRow, setOpenRow] = useState<string | null>(null);
+  const [openRow, setOpenRow] = useState<string | null>(
+    trip.date_poll_active ? "dates" : null
+  );
   const [showSetDest, setShowSetDest] = useState(false);
   // Edge case: PLANNING stage with no locked destination (old data / migration artifact).
   // Initialize open so the owner is prompted to fix it immediately on mount.

--- a/src/app/trips/[tripId]/tabs/types.ts
+++ b/src/app/trips/[tripId]/tabs/types.ts
@@ -11,6 +11,7 @@ export interface TripData {
   end_date?: string | null;
   date_set_method?: "direct" | "poll" | null;
   date_poll_active?: boolean | null;
+  date_poll_state?: "draft" | "active" | "closed" | null;
   accommodation?: string | null;
   notes?: string | null;
   activities?: string[] | null;

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -141,11 +141,10 @@ export const TopNav: FC<TopNavProps> = ({
               />
               <div
                 data-testid="notification-dropdown"
-                className="overflow-hidden rounded-xl shadow-2xl z-50 fixed left-4 right-4 top-14 sm:absolute sm:left-auto sm:right-0 sm:top-11 sm:w-[380px]"
+                className="overflow-hidden rounded-xl shadow-2xl z-50 fixed right-4 top-14 w-[calc(100vw-32px)] max-w-[380px] sm:absolute sm:right-0 sm:top-11 sm:w-[380px]"
                 style={{
                   background: "var(--color-bt-card)",
                   border: "1px solid var(--color-bt-border)",
-                  maxWidth: "calc(100vw - 32px)",
                 }}
               >
                 <div

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Bell,
@@ -67,6 +67,27 @@ export const TopNav: FC<TopNavProps> = ({
     if (open) document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
+
+  // Collapse duplicate notifications (same type + trip) into a single row.
+  // Notifications arrive newest-first, so the first occurrence of each key
+  // is always the most recent one to display.
+  const groupedNotifications = useMemo(() => {
+    const seen = new Map<string, { latest: Notification; count: number; hasUnread: boolean }>();
+    for (const n of notifications) {
+      const key = `${n.type}__${n.trip_id}`;
+      const existing = seen.get(key);
+      if (!existing) {
+        seen.set(key, { latest: n, count: 1, hasUnread: !n.read });
+      } else {
+        seen.set(key, {
+          latest: existing.latest,
+          count: existing.count + 1,
+          hasUnread: existing.hasUnread || !n.read,
+        });
+      }
+    }
+    return Array.from(seen.values());
+  }, [notifications]);
 
   const handleBellClick = () => {
     setOpen((prev) => !prev);
@@ -152,7 +173,7 @@ export const TopNav: FC<TopNavProps> = ({
                   className="overflow-y-auto"
                   style={{ maxHeight: "min(480px, calc(100vh - 80px))" }}
                 >
-                {notifications.length === 0 ? (
+                {groupedNotifications.length === 0 ? (
                   <div
                     className="px-4 py-8 text-center text-[13px]"
                     style={{ color: "var(--color-bt-text-dim)" }}
@@ -160,7 +181,7 @@ export const TopNav: FC<TopNavProps> = ({
                     No notifications yet
                   </div>
                 ) : (
-                  notifications.slice(0, 20).map((n, idx) => {
+                  groupedNotifications.slice(0, 20).map(({ latest: n, count, hasUnread }, idx) => {
                     const Icon = NOTIFICATION_ICONS[n.type] ?? Bell;
                     return (
                       <button
@@ -171,13 +192,13 @@ export const TopNav: FC<TopNavProps> = ({
                         }}
                         className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
                         style={{
-                          background: n.read ? "transparent" : "var(--color-bt-card-raised)",
-                          borderBottom: idx < Math.min(notifications.length, 20) - 1
+                          background: hasUnread ? "var(--color-bt-card-raised)" : "transparent",
+                          borderBottom: idx < Math.min(groupedNotifications.length, 20) - 1
                             ? "0.5px solid var(--color-bt-border)"
                             : undefined,
                         }}
                       >
-                        {!n.read ? (
+                        {hasUnread ? (
                           <span
                             className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full"
                             style={{ background: "var(--color-bt-accent)" }}
@@ -194,7 +215,7 @@ export const TopNav: FC<TopNavProps> = ({
                           <p
                             className="text-[13px] leading-snug"
                             style={{
-                              color: n.read ? "var(--color-bt-text-dim)" : "var(--color-bt-text)",
+                              color: hasUnread ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
                               display: "-webkit-box",
                               WebkitLineClamp: 2,
                               WebkitBoxOrient: "vertical",
@@ -205,12 +226,26 @@ export const TopNav: FC<TopNavProps> = ({
                             {getNotificationText(n)}
                           </p>
                         </div>
-                        <span
-                          className="mt-0.5 flex-shrink-0 text-[11px] whitespace-nowrap"
-                          style={{ color: "var(--color-bt-text-dim)" }}
-                        >
-                          {relativeTime(n.created_at)}
-                        </span>
+                        <div className="ml-1 flex flex-shrink-0 flex-col items-end gap-1">
+                          <span
+                            className="text-[11px] whitespace-nowrap"
+                            style={{ color: "var(--color-bt-text-dim)" }}
+                          >
+                            {relativeTime(n.created_at)}
+                          </span>
+                          {count > 1 && (
+                            <span
+                              className="rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none"
+                              style={{
+                                background: "var(--color-bt-card-raised)",
+                                color: "var(--color-bt-text-dim)",
+                                border: "1px solid var(--color-bt-border)",
+                              }}
+                            >
+                              ×{count}
+                            </span>
+                          )}
+                        </div>
                       </button>
                     );
                   })

--- a/src/server/routers/datePoll.test.ts
+++ b/src/server/routers/datePoll.test.ts
@@ -276,4 +276,38 @@ describe("datePoll router", () => {
       caller.datePoll.removeWindow({ tripId, windowId: windowId })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
+
+  // ── resetVotes ──────────────────────────────────────────────────────────
+
+  it("resetVotes — owner can clear all votes including other members' votes", async () => {
+    const ownerCaller = ctx.caller();
+    const memberCaller = ctx.callerAs("member");
+    const memberUser = ctx.getUser("member");
+
+    // Member casts a vote
+    await memberCaller.datePoll.vote({ tripId, windowId, answer: "yes" });
+
+    // Owner casts a vote too
+    await ownerCaller.datePoll.vote({ tripId, windowId, answer: "maybe" });
+
+    // Confirm both votes exist
+    const before = await ownerCaller.datePoll.get({ tripId });
+    const win = before.windows.find((w) => w.id === windowId);
+    expect(win?.votes.some((v) => v.user_id === memberUser.id)).toBe(true);
+
+    // Owner resets
+    await ownerCaller.datePoll.resetVotes({ tripId });
+
+    // All votes should be gone
+    const after = await ownerCaller.datePoll.get({ tripId });
+    const winAfter = after.windows.find((w) => w.id === windowId);
+    expect(winAfter?.votes.length).toBe(0);
+  });
+
+  it("resetVotes — member cannot reset", async () => {
+    const caller = ctx.callerAs("member");
+    await expect(
+      caller.datePoll.resetVotes({ tripId })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
 });

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -447,12 +447,15 @@ export const datePollRouter = router({
         });
       }
 
-      // Update the trip's start/end dates
+      // Update the trip's start/end dates and mark as poll-sourced
       const { data, error } = await ctx.supabase
         .from("trips")
         .update({
           start_date: window.start_date,
           end_date: window.end_date,
+          date_set_method: "poll",
+          date_poll_active: false,
+          date_poll_state: null,
         })
         .eq("id", ctx.tripId)
         .select()

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -89,6 +89,13 @@ export const datePollRouter = router({
         });
       }
 
+      // Auto-advance to draft state when the first window is added
+      await ctx.supabase
+        .from("trips")
+        .update({ date_poll_state: "draft" })
+        .eq("id", ctx.tripId)
+        .is("date_poll_state", null);
+
       return data;
     }),
 
@@ -529,6 +536,7 @@ export const datePollRouter = router({
           start_date: null,
           end_date: null,
           date_poll_active: wasFromPoll,
+          date_poll_state: wasFromPoll ? "draft" : null,
         })
         .eq("id", ctx.tripId)
         .select()

--- a/src/server/routers/trips.test.ts
+++ b/src/server/routers/trips.test.ts
@@ -386,3 +386,84 @@ describe("trips router — stage model", () => {
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });
+
+// ── setDatePollActive — poll lifecycle state machine ──────────────────────
+
+describe("trips router — setDatePollActive state machine", () => {
+  let ctx: TestContext;
+  let pollTripId: string;
+
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    const caller = ctx.caller();
+    const id = `test-poll-state-${Date.now()}`;
+    await caller.trips.create({ id, title: "Poll State Test" });
+    ctx.trackTrip(id);
+    pollTripId = id;
+    // Advance to planning so dates panel is active
+    await ctx.admin
+      .from("trips")
+      .update({ stage: "planning", locked_destination_title: "Test Dest" })
+      .eq("id", pollTripId);
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it("setDatePollActive — owner can set state to draft", async () => {
+    const caller = ctx.caller();
+    await caller.trips.setDatePollActive({ tripId: pollTripId, state: "draft" });
+    const { data } = await ctx.admin
+      .from("trips")
+      .select("date_poll_state, date_poll_active")
+      .eq("id", pollTripId)
+      .single();
+    expect(data?.date_poll_state).toBe("draft");
+    expect(data?.date_poll_active).toBe(false);
+  });
+
+  it("setDatePollActive — owner can set state to active (date_poll_active = true)", async () => {
+    const caller = ctx.caller();
+    await caller.trips.setDatePollActive({ tripId: pollTripId, state: "active" });
+    const { data } = await ctx.admin
+      .from("trips")
+      .select("date_poll_state, date_poll_active")
+      .eq("id", pollTripId)
+      .single();
+    expect(data?.date_poll_state).toBe("active");
+    expect(data?.date_poll_active).toBe(true);
+  });
+
+  it("setDatePollActive — owner can set state to closed (date_poll_active = false)", async () => {
+    const caller = ctx.caller();
+    await caller.trips.setDatePollActive({ tripId: pollTripId, state: "closed" });
+    const { data } = await ctx.admin
+      .from("trips")
+      .select("date_poll_state, date_poll_active")
+      .eq("id", pollTripId)
+      .single();
+    expect(data?.date_poll_state).toBe("closed");
+    expect(data?.date_poll_active).toBe(false);
+  });
+
+  it("setDatePollActive — owner can set state to null (exit poll mode)", async () => {
+    const caller = ctx.caller();
+    await caller.trips.setDatePollActive({ tripId: pollTripId, state: null });
+    const { data } = await ctx.admin
+      .from("trips")
+      .select("date_poll_state, date_poll_active")
+      .eq("id", pollTripId)
+      .single();
+    expect(data?.date_poll_state).toBeNull();
+    expect(data?.date_poll_active).toBe(false);
+  });
+
+  it("setDatePollActive — planner cannot call", async () => {
+    await ctx.addTripMember(pollTripId, "planner", "Planner");
+    const caller = ctx.callerAs("planner");
+    await expect(
+      caller.trips.setDatePollActive({ tripId: pollTripId, state: "active" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/src/server/routers/trips.ts
+++ b/src/server/routers/trips.ts
@@ -625,15 +625,23 @@ export const tripsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // setDatePollActive — Owner toggles whether the crew sees the poll grid
+  // setDatePollActive — Owner advances the poll through draft/active/closed
   // -----------------------------------------------------------------------
   setDatePollActive: authedProcedure
-    .input(z.object({ tripId: z.string(), active: z.boolean() }))
+    .input(
+      z.object({
+        tripId: z.string(),
+        state: z.enum(["draft", "active", "closed"]).nullable(),
+      })
+    )
     .use(requireTripRole("Owner"))
     .mutation(async ({ ctx, input }) => {
       const { error } = await ctx.supabase
         .from("trips")
-        .update({ date_poll_active: input.active })
+        .update({
+          date_poll_state: input.state,
+          date_poll_active: input.state === "active",
+        })
         .eq("id", ctx.tripId);
 
       if (error) {
@@ -644,7 +652,7 @@ export const tripsRouter = router({
       }
 
       // Notify all trip members when poll becomes active
-      if (input.active) {
+      if (input.state === "active") {
         try {
           const { data: tripData } = await ctx.supabase
             .from("trips")

--- a/supabase/migrations/20260411143951_036_date_poll_state.sql
+++ b/supabase/migrations/20260411143951_036_date_poll_state.sql
@@ -1,0 +1,8 @@
+ALTER TABLE trips
+  ADD COLUMN date_poll_state text
+    CHECK (date_poll_state IN ('draft', 'active', 'closed'));
+
+-- Backfill: existing active polls move to 'active' state
+UPDATE trips
+  SET date_poll_state = 'active'
+  WHERE date_poll_active = true;

--- a/supabase/migrations/20260411151839_037_owner_delete_poll_votes.sql
+++ b/supabase/migrations/20260411151839_037_owner_delete_poll_votes.sql
@@ -1,0 +1,16 @@
+-- Allow trip owners to delete any vote on their trip's date windows
+-- (needed for the "Reset votes" feature — regular RLS only lets users
+--  delete their own rows, so the owner's client silently skipped others)
+CREATE POLICY "trip_owner_can_delete_poll_votes"
+  ON date_poll_votes
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM date_windows dw
+      JOIN trip_members tm ON tm.trip_id = dw.trip_id
+      WHERE dw.id = date_poll_votes.window_id
+        AND tm.user_id = auth.uid()::text
+        AND tm.role = 'Owner'
+    )
+  );


### PR DESCRIPTION
## Summary

- **Three-state date poll lifecycle** — `draft` / `active` / `closed` state machine replaces the old boolean toggle. New lifecycle button row: Start Poll, Stop Poll, Reset Poll, Select date (always-on escape valve). Poll the crew now enters draft mode instead of going live immediately.
- **Poll flow correctness** — `lockWindow` writes `date_set_method=poll` and clears poll state so "Change dates" always routes back to poll draft; `unlockDates` restores the correct state for both direct and poll flows; `addWindow` auto-advances to draft.
- **Non-owner dates panel** — no expand chevron, owner name in label and poll invitation message, secondary note hidden for non-owners, panel auto-opens when poll is active.
- **Reset votes RLS fix** (migration 037) — owner can now actually clear all members' votes; previously a silent no-op due to missing DELETE RLS policy.
- **30-second live vote refresh** — `datePoll.get` auto-polls while owner has an active poll panel open.
- **Notification stacking** — duplicate notifications (same type + trip) collapse to one row with ×N count badge.
- **Notification dropdown width** — capped at 380px at all viewport sizes.

## Test plan
- [ ] Set dates directly, clear, poll the crew — full lifecycle works end to end
- [ ] Reset votes clears all members' votes, not just owner's
- [ ] Non-owner sees poll grid only when poll is active; sees owner name in header
- [ ] "Change dates" from poll-locked date goes straight back to poll draft, no modal
- [ ] "Change dates" from direct-locked date opens modal as before
- [ ] Duplicate notifications stack with count badge
- [ ] Notification dropdown never exceeds 380px wide
- [ ] All 292 Vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)