### PR TITLE
Lodging, crew, and invitation UX overhaul

### DIFF
--- a/src/app/trips/[tripId]/components/AddPropertySheet.tsx
+++ b/src/app/trips/[tripId]/components/AddPropertySheet.tsx
@@ -350,7 +350,7 @@ export function AddPropertySheet({
                     style={inputStyle}
                   />
                 </Field>
-                <Field label="Total price">
+                <Field label="Price">
                   <input
                     type="text"
                     placeholder="e.g. $2,400"

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1556,7 +1556,7 @@ function CoPlannerPanel({
       style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
     >
       <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-        Co-planners
+        Planners
       </p>
 
       {/* Existing planners */}
@@ -1661,7 +1661,7 @@ function MobileCoPlannerSheet({
           style={{ borderBottom: "1px solid var(--color-bt-border)" }}
         >
           <p className="text-[13px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-            Co-planners
+            Planners
           </p>
           <button
             onClick={onClose}

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -623,12 +623,12 @@ function IdeaCard({
 
           {/* Lodging options */}
           <div>
-            {/* Header row: LODGING label + inline + Add button */}
+            {/* Header row: LODGING IDEAS label + inline Add (only when options exist) */}
             <div className="mb-1.5 flex items-center justify-between">
               <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
                 Lodging Ideas
               </p>
-              {canEdit && (
+              {canEdit && lodgingOptions.length > 0 && (
                 <button
                   data-testid={`add-lodging-empty-${idea.id}`}
                   onClick={() => setShowAddLodging(true)}
@@ -639,6 +639,18 @@ function IdeaCard({
                 </button>
               )}
             </div>
+
+            {/* Empty state: full-width Add button below header */}
+            {canEdit && lodgingOptions.length === 0 && (
+              <button
+                data-testid={`add-lodging-empty-${idea.id}`}
+                onClick={() => setShowAddLodging(true)}
+                className="mb-1.5 flex items-center gap-1 text-xs"
+                style={{ color: "var(--color-bt-accent)" }}
+              >
+                <Plus size={13} /> Add a property
+              </button>
+            )}
 
             <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
               {lodgingOptions.map((opt) => {

--- a/src/app/trips/[tripId]/components/NextStepsPanel.tsx
+++ b/src/app/trips/[tripId]/components/NextStepsPanel.tsx
@@ -1,21 +1,19 @@
 "use client";
 
 import { useMemo } from "react";
-import { MapPin, CalendarDays, Users, Send } from "lucide-react";
+import { MapPin, CalendarDays, Users } from "lucide-react";
 import type { TripData } from "../tabs/types";
 
 interface NextStepsPanelProps {
   trip: TripData;
   crewCount: number;
   isOwner: boolean;
-  onMakeOfficial?: (message: string) => void;
 }
 
 export function NextStepsPanel({
   trip,
   crewCount,
   isOwner,
-  onMakeOfficial,
 }: NextStepsPanelProps) {
   const steps = useMemo(() => {
     const items: { icon: typeof MapPin; text: string }[] = [];
@@ -49,59 +47,36 @@ export function NextStepsPanel({
     crewCount,
   ]);
 
-  const allGreen = steps.length === 0;
-
-  // Nothing to show: all steps resolved and user is not owner (no CTA)
-  if (allGreen && !isOwner) return null;
-  // Nothing to show: all steps resolved, owner, but no callback
-  if (allGreen && !onMakeOfficial) return null;
+  if (steps.length === 0) return null;
 
   return (
     <div className="mb-4">
-      {steps.length > 0 && (
-        <>
-          <p
-            className="mb-2 text-[11px] font-medium uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Next steps
-          </p>
-          <div className="space-y-1">
-            {steps.map((step) => {
-              const Icon = step.icon;
-              return (
-                <div key={step.text} className="flex items-start gap-2">
-                  <Icon
-                    size={14}
-                    className="mt-0.5 flex-shrink-0"
-                    style={{ color: "var(--color-bt-accent)" }}
-                  />
-                  <span
-                    className="text-[13px]"
-                    style={{ color: "var(--color-bt-text-dim)" }}
-                  >
-                    {step.text}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </>
-      )}
-
-      {allGreen && isOwner && onMakeOfficial && (
-        <button
-          onClick={() => onMakeOfficial(trip.about_message!)}
-          className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 animate-fade-in"
-          style={{
-            background: "var(--color-bt-accent)",
-            color: "var(--color-bt-base)",
-          }}
-        >
-          <Send size={18} />
-          Let&apos;s Go! 🎉
-        </button>
-      )}
+      <p
+        className="mb-2 text-[11px] font-medium uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Next steps
+      </p>
+      <div className="space-y-1">
+        {steps.map((step) => {
+          const Icon = step.icon;
+          return (
+            <div key={step.text} className="flex items-start gap-2">
+              <Icon
+                size={14}
+                className="mt-0.5 flex-shrink-0"
+                style={{ color: "var(--color-bt-accent)" }}
+              />
+              <span
+                className="text-[13px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {step.text}
+              </span>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/components/TravelEntryForm.tsx
+++ b/src/app/trips/[tripId]/components/TravelEntryForm.tsx
@@ -37,7 +37,6 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
   );
   const [detail, setDetail] = useState(currentTravel?.travel_detail ?? "");
   const [airline, setAirline] = useState(currentTravel?.flight_airline ?? "");
-  const [flightNum, setFlightNum] = useState(currentTravel?.flight_number ?? "");
   const [arrivalTime, setArrivalTime] = useState(currentTravel?.flight_arrival_time ?? "");
   const [airport, setAirport] = useState(currentTravel?.flight_airport ?? "");
   const [shared, setShared] = useState(currentTravel?.travel_shared ?? true);
@@ -49,7 +48,6 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
       setMode(currentTravel.travel_mode as TravelMode);
       setDetail(currentTravel.travel_detail ?? "");
       setAirline(currentTravel.flight_airline ?? "");
-      setFlightNum(currentTravel.flight_number ?? "");
       setArrivalTime(currentTravel.flight_arrival_time ?? "");
       setAirport(currentTravel.flight_airport ?? "");
       setShared(currentTravel.travel_shared ?? true);
@@ -71,7 +69,7 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
       travelMode: mode,
       travelDetail: detail.trim() || null,
       flightAirline: airline.trim() || null,
-      flightNumber: flightNum.trim() || null,
+      flightNumber: null,
       flightArrivalTime: arrivalTime || null,
       flightAirport: airport.trim() || null,
       travelShared: shared,
@@ -90,7 +88,6 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
     if (currentTravel?.travel_mode === "flying") {
       summary = [
         currentTravel.flight_airline,
-        currentTravel.flight_number,
         currentTravel.flight_airport && `→ ${currentTravel.flight_airport}`,
       ]
         .filter(Boolean)
@@ -168,26 +165,18 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
       {/* Flying fields */}
       {mode === "flying" && (
         <div className="mt-3 space-y-2">
-          <input
-            type="text"
-            placeholder="Airline"
-            value={airline}
-            onChange={(e) => setAirline(e.target.value)}
-            className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
-            style={inputStyle}
-          />
           <div className="flex gap-2">
             <input
               type="text"
-              placeholder="Flight number"
-              value={flightNum}
-              onChange={(e) => setFlightNum(e.target.value)}
+              placeholder="Flight (e.g. Delta 1733)"
+              value={airline}
+              onChange={(e) => setAirline(e.target.value)}
               className="flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
               style={inputStyle}
             />
             <input
               type="text"
-              placeholder="Airport (e.g. JAX)"
+              placeholder="Airport (e.g. SAV)"
               value={airport}
               onChange={(e) => setAirport(e.target.value)}
               className="w-28 rounded-xl border px-3 py-2.5 text-sm outline-none"

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { MoreHorizontal, Lock, HelpCircle, X, MessageCircle } from "lucide-react";
+import { MoreHorizontal, Lock, HelpCircle, X, MessageCircle, Send, Mail } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useTripRole } from "@/hooks/useTripRole";
 import { TripBottomNav, type TabId } from "@/components/BottomNav";
@@ -38,6 +38,7 @@ export default function TripDetailPage() {
   const [showAdvanceSheet, setShowAdvanceSheet] = useState<"going" | null>(null);
   const [pendingRsvpMessage, setPendingRsvpMessage] = useState<string>("");
   const [showHelpSheet, setShowHelpSheet] = useState(false);
+  const [showInvitationModal, setShowInvitationModal] = useState(false);
   const [toast, setToast] = useState<{ message: string; variant: "warning" } | null>(null);
   const [showChatDrawer, setShowChatDrawer] = useState(false);
 
@@ -309,11 +310,20 @@ export default function TripDetailPage() {
             </div>
             {/* Right: persistent sidebar — desktop only */}
             <div className="hidden lg:flex lg:flex-col gap-4">
+              {isOwner && (
+                <button
+                  onClick={() => setShowInvitationModal(true)}
+                  className="flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90"
+                  style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                >
+                  <Send size={15} />
+                  Write Invitation
+                </button>
+              )}
               <NextStepsPanel
                 trip={trip}
                 crewCount={members.length}
                 isOwner={isOwner}
-                onMakeOfficial={isOwner ? (message) => { setPendingRsvpMessage(message); setShowAdvanceSheet("going"); } : undefined}
               />
               <SidebarChatPanel
                 tripId={tripId}
@@ -398,6 +408,24 @@ export default function TripDetailPage() {
           tripName={trip.title}
           viewerRole={role}
           onClose={() => setShowSettings(false)}
+        />
+      )}
+
+      {/* ── Write Invitation modal ───────────────────────────────────────── */}
+      {showInvitationModal && trip && (
+        <WriteInvitationModal
+          tripId={tripId}
+          trip={trip}
+          onClose={() => setShowInvitationModal(false)}
+          onAdvanced={(ghosts) => {
+            setShowInvitationModal(false);
+            if (ghosts.length > 0) {
+              setToast({
+                message: `No email on file for: ${ghosts.join(", ")}. They won't receive the RSVP blast.`,
+                variant: "warning",
+              });
+            }
+          }}
         />
       )}
 
@@ -498,6 +526,134 @@ export default function TripDetailPage() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// ── WriteInvitationModal ────────────────────────────────────────────────
+
+function WriteInvitationModal({
+  tripId,
+  trip,
+  onClose,
+  onAdvanced,
+}: {
+  tripId: string;
+  trip: { about_message?: string | null; locked_destination_title?: string | null; start_date?: string | null; end_date?: string | null };
+  onClose: () => void;
+  onAdvanced: (ghostsWithoutEmail: string[]) => void;
+}) {
+  const utils = trpc.useUtils();
+  const [message, setMessage] = useState(trip.about_message ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const { data: poll } = trpc.datePoll.get.useQuery({ tripId });
+  const hasLockedDate = !!poll?.lockedWindowId;
+
+  const updateMessage = trpc.trips.updateAboutMessage.useMutation({
+    onSuccess() {
+      setSaving(false);
+      utils.trips.getById.invalidate({ tripId });
+    },
+    onError() { setSaving(false); },
+  });
+
+  const advance = trpc.trips.advanceToGoing.useMutation({
+    onSuccess(result) {
+      utils.trips.getById.invalidate({ tripId });
+      utils.trips.list.invalidate();
+      onAdvanced(result.ghostsWithoutEmail ?? []);
+    },
+  });
+
+  useModalBackButton(onClose);
+
+  const handleBlur = () => {
+    const trimmed = message.trim();
+    if (trimmed === (trip.about_message?.trim() ?? "")) return;
+    setSaving(true);
+    updateMessage.mutate({ tripId, aboutMessage: trimmed });
+  };
+
+  const destination = trip.locked_destination_title ?? "";
+  const dateRange = formatDateRange(trip.start_date, trip.end_date);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[560px] rounded-t-2xl p-6 lg:rounded-2xl"
+        style={{ background: "var(--color-bt-card)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-1 flex items-center gap-2">
+          <Mail size={16} style={{ color: "var(--color-bt-accent)" }} />
+          <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            Write your invitation
+          </h2>
+        </div>
+        <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+          Write a message to your crew — this goes out by email when you make the trip official.
+        </p>
+
+        {(destination || dateRange) && (
+          <div
+            className="mb-3 rounded-xl px-3 py-2 text-[13px]"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
+          >
+            {dateRange ? `${dateRange} · ${destination}` : destination}
+          </div>
+        )}
+
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onBlur={handleBlur}
+          placeholder="Hey crew, here's the plan..."
+          rows={4}
+          className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            borderColor: "var(--color-bt-border)",
+            color: "var(--color-bt-text)",
+          }}
+        />
+        {saving && (
+          <p className="mt-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Saving…</p>
+        )}
+
+        {!hasLockedDate && (
+          <div
+            className="mt-3 flex items-start gap-3 rounded-xl px-4 py-3"
+            style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
+          >
+            <span style={{ color: "var(--color-bt-warning)" }}>⚠</span>
+            <p className="text-sm" style={{ color: "var(--color-bt-warning)" }}>
+              Lock a date first — your crew will want to know when.
+            </p>
+          </div>
+        )}
+
+        <button
+          onClick={() => advance.mutate({ tripId, aboutMessage: message.trim() })}
+          disabled={advance.isPending || !hasLockedDate || !message.trim()}
+          className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+        >
+          <Send size={15} />
+          {advance.isPending ? "Sending..." : "Let's Go! 🎉"}
+        </button>
+        <button
+          onClick={onClose}
+          className="mt-2 w-full rounded-xl py-2.5 text-sm transition-opacity hover:opacity-80"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Save & close
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -106,7 +106,7 @@ function CrewMemberRow({
   const rsvpCfg = m.rsvp_status ? RSVP_LABEL[m.rsvp_status] : null;
   const editable = canEdit && !isMe && m.role !== "Owner";
   const canActOnPlanner = isOwner && !isMe && m.role === "Planner";
-  const canPromoteToCoplanner = isOwner && !isMe && m.role === "Member" && !m.isGuest && !isPlannerRow;
+  const canPromoteToCoplanner = isOwner && !isMe && m.role === "Member" && !isPlannerRow && !!m.user?.email;
   const hasTextChanges = editName.trim() !== m.displayName || editEmail.trim() !== (m.user?.email ?? "");
 
   const handleSave = async () => {
@@ -236,7 +236,7 @@ function CrewMemberRow({
                 className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
                 style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
               >
-                Move to rest of crew
+                Remove as planner
               </button>
             )}
             {/* Crew row: promote to co-planner */}
@@ -247,7 +247,7 @@ function CrewMemberRow({
                 className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
                 style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
               >
-                Make co-planner
+                Make planner
               </button>
             )}
             {/* Remove (X) */}
@@ -591,17 +591,31 @@ export function CrewTab({ trip, canEdit }: TabProps) {
         </div>
       )}
 
-      {/* ── CO-PLANNERS section ── */}
+      {/* ── PLANNERS section ── */}
       <div>
+        {/* Search above header — owner only */}
+        {isOwner && (
+          <div className="mb-2">
+            <CrewSearchInput
+              tripId={tripId}
+              defaultRole="Planner"
+              defaultStatus="draft"
+              allowGhost={false}
+              allowInvite
+              showSearchIcon
+              placeholder="Search by email..."
+              frequentTripmates={[]}
+              onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
+            />
+          </div>
+        )}
         <h2
-          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          className="mb-1 text-xs font-semibold uppercase tracking-wider"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
-          Co-planners
+          Planners
         </h2>
-
-        {/* Owner rows first */}
-        {plannersSorted.filter((m) => m.role === "Owner").map((m, i) => {
+        {plannersSorted.map((m, i) => {
           const isMe = m.user_id === currentUser?.id;
           return (
             <CrewMemberRow
@@ -621,52 +635,6 @@ export function CrewTab({ trip, canEdit }: TabProps) {
             />
           );
         })}
-
-        {/* Get some help — between owner and planners, owner only */}
-        {isOwner && (
-          <div className="mt-3 pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
-            <p className="mb-2 text-[11px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
-              Get some help
-            </p>
-            <CrewSearchInput
-              tripId={tripId}
-              defaultRole="Planner"
-              defaultStatus="draft"
-              allowGhost={false}
-              allowInvite
-              showSearchIcon
-              placeholder="Search by email..."
-              frequentTripmates={[]}
-              onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-            />
-          </div>
-        )}
-
-        {/* Planner rows */}
-        {plannersSorted.filter((m) => m.role === "Planner").length > 0 && (
-          <div className="mt-2">
-            {plannersSorted.filter((m) => m.role === "Planner").map((m, i) => {
-              const isMe = m.user_id === currentUser?.id;
-              return (
-                <CrewMemberRow
-                  key={m.memberId}
-                  member={m}
-                  tripId={tripId}
-                  canEdit={canEdit}
-                  isOwner={isOwner}
-                  isMe={isMe}
-                  index={i}
-                  isExpanded={false}
-                  showRsvpStatus={showRsvpStatus}
-                  stage={stage}
-                  isPlannerRow
-                  onToggle={() => {}}
-                  onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
-                />
-              );
-            })}
-          </div>
-        )}
       </div>
 
       {/* ── REST OF THE CREW section ── */}
@@ -680,7 +648,7 @@ export function CrewTab({ trip, canEdit }: TabProps) {
 
         {/* Name + email add for crew members */}
         {canEdit && (
-          <div className="mb-4">
+          <div className="mb-2">
             <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
               Start adding the names and emails of everyone you&apos;re planning to invite. Nothing is set in stone — you can always add, remove, or update people later.
             </p>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -593,28 +593,32 @@ export function CrewTab({ trip, canEdit }: TabProps) {
 
       {/* ── PLANNERS section ── */}
       <div>
-        {/* Search above header — owner only */}
-        {isOwner && (
-          <div className="mb-2">
-            <CrewSearchInput
-              tripId={tripId}
-              defaultRole="Planner"
-              defaultStatus="draft"
-              allowGhost={false}
-              allowInvite
-              showSearchIcon
-              placeholder="Search by email..."
-              frequentTripmates={[]}
-              onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-            />
-          </div>
-        )}
         <h2
           className="mb-1 text-xs font-semibold uppercase tracking-wider"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
           Planners
         </h2>
+        {isOwner && (
+          <>
+            <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+              Invite friends who are good at planning to join the early conversations — they&apos;ll be able to add ideas, vote, and help shape the trip before it&apos;s official.
+            </p>
+            <div className="mb-2">
+              <CrewSearchInput
+                tripId={tripId}
+                defaultRole="Planner"
+                defaultStatus="draft"
+                allowGhost={false}
+                allowInvite
+                showSearchIcon
+                placeholder="Search by email..."
+                frequentTripmates={[]}
+                onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
+              />
+            </div>
+          </>
+        )}
         {plannersSorted.map((m, i) => {
           const isMe = m.user_id === currentUser?.id;
           return (

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -106,6 +106,7 @@ function CrewMemberRow({
   const rsvpCfg = m.rsvp_status ? RSVP_LABEL[m.rsvp_status] : null;
   const editable = canEdit && !isMe && m.role !== "Owner";
   const canActOnPlanner = isOwner && !isMe && m.role === "Planner";
+  const canPromoteToCoplanner = isOwner && !isMe && m.role === "Member" && !m.isGuest && !isPlannerRow;
   const hasTextChanges = editName.trim() !== m.displayName || editEmail.trim() !== (m.user?.email ?? "");
 
   const handleSave = async () => {
@@ -236,6 +237,17 @@ function CrewMemberRow({
                 style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
               >
                 Move to rest of crew
+              </button>
+            )}
+            {/* Crew row: promote to co-planner */}
+            {canPromoteToCoplanner && (
+              <button
+                onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Planner" }); }}
+                disabled={updateRole.isPending}
+                className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
+                style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+              >
+                Make co-planner
               </button>
             )}
             {/* Remove (X) */}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Ghost, Mail, Send, X } from "lucide-react";
+import { CrewSearchInput } from "@/components/CrewSearchInput";
 import { UserAvatar } from "@/components/UserAvatar";
 import { useTheme } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
@@ -538,21 +539,16 @@ export function CrewTab({ trip, canEdit }: TabProps) {
   };
 
   const stage = trip.stage ?? "idea";
+  const showRsvpStatus = stage === "going";
 
   // Count pending members who have an email (can actually be nudged)
   const pendingWithEmailCount = members.filter(
     (m) => (m as { rsvp_status?: string | null }).rsvp_status == null && !!m.user?.email
   ).length;
 
-  // Stage-aware config
-  const sectionLabel = stage === "idea" ? "CO-PLANNERS" : "CREW";
-  const helperText =
-    stage === "idea"
-      ? "Add anyone you're thinking of inviting. Make them a planner if you want their help deciding where to go."
-      : stage === "planning"
-        ? "Building your roster. Add everyone you're considering — you'll send the official RSVP when you're ready."
-        : null;
-  const showRsvpStatus = stage === "going";
+  // Split members into planners and crew
+  const plannersSorted = sorted.filter((m) => m.role === "Owner" || m.role === "Planner");
+  const crewSorted = sorted.filter((m) => m.role !== "Owner" && m.role !== "Planner");
 
   return (
     <div className="space-y-4 px-4">
@@ -566,7 +562,7 @@ export function CrewTab({ trip, canEdit }: TabProps) {
         />
       )}
 
-      {/* Header row — nudge button (going stage only) */}
+      {/* Nudge button (going stage only) */}
       {canEdit && showRsvpStatus && pendingWithEmailCount > 0 && (
         <div className="flex items-center justify-center">
           <button
@@ -585,96 +581,139 @@ export function CrewTab({ trip, canEdit }: TabProps) {
         </div>
       )}
 
-      {/* Stage-aware helper text */}
-      {helperText && (
-        <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          {helperText}
-        </p>
-      )}
-
-      {/* Inline add row */}
-      {canEdit && (
-        <div className="flex gap-2">
-          <input
-            value={addName}
-            onChange={(e) => setAddName(e.target.value)}
-            placeholder="Name"
-            className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
-            style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-            onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
-          />
-          <input
-            value={addEmail}
-            onChange={(e) => setAddEmail(e.target.value)}
-            placeholder="Email (optional)"
-            type="email"
-            className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
-            style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-            onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
-          />
-          <button
-            onClick={handleAdd}
-            disabled={!addName.trim() || isAdding}
-            className="flex-shrink-0 rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-40"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-          >
-            {isAdding ? "..." : "Add"}
-          </button>
-        </div>
-      )}
-
-      {/* Member list */}
-      <h2
-        className="mt-6 mb-1 text-xs font-semibold uppercase tracking-wider"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        {sectionLabel}
-      </h2>
-
-      {/* RSVP headcount summary (GOING/NOW stage) */}
-      {showRsvpStatus && (() => {
-        const inC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status === "in").length;
-        const maybeC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status === "maybe").length;
-        const outC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status === "out").length;
-        const pendC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status == null).length;
-        return (
-          <p
-            className="mb-3 inline-block rounded-full px-3 py-1.5 text-[13px]"
-            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
-          >
-            {inC} in · {maybeC} maybe · {pendC} pending · {outC} out
-          </p>
-        );
-      })()}
-
+      {/* ── CO-PLANNERS section ── */}
       <div>
-        {sorted.map((m, i) => {
-          const isMe = m.user_id === currentUser?.id;
-          return (
-            <CrewMemberRow
-              key={m.memberId}
-              member={m}
+        <h2
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Co-planners
+        </h2>
+
+        <div>
+          {plannersSorted.map((m, i) => {
+            const isMe = m.user_id === currentUser?.id;
+            return (
+              <CrewMemberRow
+                key={m.memberId}
+                member={m}
+                tripId={tripId}
+                canEdit={canEdit}
+                isOwner={isOwner}
+                isMe={isMe}
+                index={i}
+                isExpanded={expandedId === m.user_id}
+                showRsvpStatus={showRsvpStatus}
+                stage={stage}
+                onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
+                onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+              />
+            );
+          })}
+        </div>
+
+        {/* Email-find add for planners — owner only */}
+        {isOwner && (
+          <div className="mt-2">
+            <CrewSearchInput
               tripId={tripId}
-              canEdit={canEdit}
-              isOwner={isOwner}
-              isMe={isMe}
-              index={i}
-              isExpanded={expandedId === m.user_id}
-              showRsvpStatus={showRsvpStatus}
-              stage={stage}
-              onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
-              onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+              defaultRole="Planner"
+              defaultStatus="draft"
+              allowGhost={false}
+              allowInvite
+              showSearchIcon
+              placeholder="Find by email to add a co-planner..."
+              frequentTripmates={[]}
+              onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
             />
-          );
-        })}
+          </div>
+        )}
       </div>
 
-      {members.length === 0 && (
-        <p className="py-8 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          No members yet. Add someone above to get started.
-        </p>
-      )}
+      {/* ── CREW section ── */}
+      <div className="pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+        <h2
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Crew
+        </h2>
 
+        {/* RSVP headcount summary (GOING/NOW stage) */}
+        {showRsvpStatus && (() => {
+          const inC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status === "in").length;
+          const maybeC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status === "maybe").length;
+          const outC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status === "out").length;
+          const pendC = members.filter((m) => (m as { rsvp_status?: string | null }).rsvp_status == null).length;
+          return (
+            <p
+              className="mb-3 inline-block rounded-full px-3 py-1.5 text-[13px]"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+            >
+              {inC} in · {maybeC} maybe · {pendC} pending · {outC} out
+            </p>
+          );
+        })()}
+
+        <div>
+          {crewSorted.map((m, i) => {
+            const isMe = m.user_id === currentUser?.id;
+            return (
+              <CrewMemberRow
+                key={m.memberId}
+                member={m}
+                tripId={tripId}
+                canEdit={canEdit}
+                isOwner={isOwner}
+                isMe={isMe}
+                index={i}
+                isExpanded={expandedId === m.user_id}
+                showRsvpStatus={showRsvpStatus}
+                stage={stage}
+                onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
+                onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+              />
+            );
+          })}
+        </div>
+
+        {crewSorted.length === 0 && !canEdit && (
+          <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+            No crew members yet.
+          </p>
+        )}
+
+        {/* Name + email add for crew members */}
+        {canEdit && (
+          <div className="mt-2 flex gap-2">
+            <input
+              value={addName}
+              onChange={(e) => setAddName(e.target.value)}
+              placeholder="Name"
+              className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
+              style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+              onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+            />
+            <input
+              value={addEmail}
+              onChange={(e) => setAddEmail(e.target.value)}
+              placeholder="Email (optional)"
+              type="email"
+              className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
+              style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+              onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+            />
+            <button
+              onClick={handleAdd}
+              disabled={!addName.trim() || isAdding}
+              className="flex-shrink-0 rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-40"
+              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            >
+              {isAdding ? "..." : "Add"}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Ghost, Mail, Send, X } from "lucide-react";
+import { Ghost, Send, X } from "lucide-react";
 import { CrewSearchInput } from "@/components/CrewSearchInput";
 import { UserAvatar } from "@/components/UserAvatar";
 import { useTheme } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
-import { PlanningRow, type ArcCardState } from "../components/PlanningRow";
 import type { TabProps } from "./types";
 
 // ── RSVP helpers ──────────────────────────────────────────────────────────
@@ -411,81 +410,6 @@ function CrewMemberRow({
   );
 }
 
-// ── WriteInvitationPanel ─────────────────────────────────────────────────
-
-function WriteInvitationPanel({
-  tripId,
-  aboutMessage,
-  isOpen,
-  onToggle,
-}: {
-  tripId: string;
-  aboutMessage?: string | null;
-  isOpen: boolean;
-  onToggle: () => void;
-}) {
-  const utils = trpc.useUtils();
-  const [draft, setDraft] = useState(aboutMessage ?? "");
-  const [saving, setSaving] = useState(false);
-
-  const updateMessage = trpc.trips.updateAboutMessage.useMutation({
-    onSuccess() {
-      setSaving(false);
-      utils.trips.getById.invalidate({ tripId });
-    },
-    onError() {
-      setSaving(false);
-    },
-  });
-
-  const hasDraft = !!(draft.trim());
-  const state: ArcCardState = "none";
-  const note = hasDraft ? "Draft saved" : "Not written yet";
-
-  const handleBlur = () => {
-    const trimmed = draft.trim();
-    if (trimmed === (aboutMessage?.trim() ?? "")) return;
-    setSaving(true);
-    updateMessage.mutate({ tripId, aboutMessage: trimmed });
-  };
-
-  return (
-    <PlanningRow
-      icon={<Mail size={16} />}
-      label="Write Invitation"
-      note={note}
-      noteWarn={hasDraft}
-      state={state}
-      isOpen={isOpen}
-      onToggle={onToggle}
-    >
-      <div className="space-y-2">
-        <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          Write a message to your crew — this goes out by email when you make the trip official.
-        </p>
-        <textarea
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={handleBlur}
-          placeholder="Hey crew, here's the plan..."
-          rows={4}
-          className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            borderColor: "var(--color-bt-border)",
-            color: "var(--color-bt-text)",
-          }}
-        />
-        {saving && (
-          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-            Saving…
-          </p>
-        )}
-      </div>
-    </PlanningRow>
-  );
-}
-
 // ── CrewTab ───────────────────────────────────────────────────────────────
 
 export function CrewTab({ trip, canEdit }: TabProps) {
@@ -498,7 +422,6 @@ export function CrewTab({ trip, canEdit }: TabProps) {
   const [addEmail, setAddEmail] = useState("");
   const [isAdding, setIsAdding] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [invitationOpen, setInvitationOpen] = useState(false);
 
   const createGhost = trpc.ghostCrew.create.useMutation();
   const inviteByEmail = trpc.tripMembers.inviteByEmail.useMutation();
@@ -552,16 +475,6 @@ export function CrewTab({ trip, canEdit }: TabProps) {
 
   return (
     <div className="space-y-4 px-4">
-      {/* ── Write Invitation — owner only ── */}
-      {isOwner && (
-        <WriteInvitationPanel
-          tripId={tripId}
-          aboutMessage={trip.about_message}
-          isOpen={invitationOpen}
-          onToggle={() => setInvitationOpen((v) => !v)}
-        />
-      )}
-
       {/* Nudge button (going stage only) */}
       {canEdit && showRsvpStatus && pendingWithEmailCount > 0 && (
         <div className="flex items-center justify-center">

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -7,7 +7,6 @@ import { UserAvatar } from "@/components/UserAvatar";
 import { useTheme } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
-import { RoleBadge } from "@/components/RoleBadge";
 import { PlanningRow, type ArcCardState } from "../components/PlanningRow";
 import type { TabProps } from "./types";
 
@@ -24,12 +23,6 @@ function _rsvpSortKey(rsvpStatus: string | null): number {
   if (rsvpStatus === null || rsvpStatus === undefined) return 2; // pending after maybe, before out
   return RSVP_SORT_ORDER[rsvpStatus] ?? 2;
 }
-
-const ROLE_COLOR: Record<string, string> = {
-  Owner:   "var(--color-bt-accent)",
-  Planner: "var(--color-bt-ready)",
-  Member:  "var(--color-bt-text-dim)",
-};
 
 const ROLE_ORDER: Record<string, number> = { Owner: 0, Planner: 1, Member: 2 };
 
@@ -110,7 +103,6 @@ function CrewMemberRow({
   };
 
   const display = m.displayName;
-  const _roleColor = ROLE_COLOR[m.role] ?? "var(--color-bt-text-dim)";
   const rsvpCfg = m.rsvp_status ? RSVP_LABEL[m.rsvp_status] : null;
   const editable = canEdit && !isMe && m.role !== "Owner";
   const canActOnPlanner = isOwner && !isMe && m.role === "Planner";
@@ -196,18 +188,9 @@ function CrewMemberRow({
           ) : null}
         </div>
 
-        {/* ── Right side: fixed 3-column layout ───────────────────────────── */}
-        {/* Col 1 (badge) | Col 2 (vote/status) | Col 3 (delete) — widths are */}
-        {/* fixed so every row aligns regardless of content.                   */}
+        {/* ── Right side: status + actions ─────────────────────────────────── */}
         <div className="flex flex-shrink-0 items-center">
-          {/* Col 1: role badge */}
-          <div className="flex w-[68px] flex-shrink-0 justify-center">
-            {!m.isGuest && (m.role === "Owner" || m.role === "Planner") && (
-              <RoleBadge role={m.role} />
-            )}
-          </div>
-
-          {/* Col 2: vote chip (going stage), invite status (planning), hidden (idea) */}
+          {/* vote chip (going stage), invite status (planning), hidden (idea) */}
           {stage !== "idea" && (
           <div className="flex w-[64px] flex-shrink-0 justify-center">
             {showRsvpStatus ? (() => {
@@ -244,7 +227,7 @@ function CrewMemberRow({
 
           {/* Col 3: actions */}
           <div className="flex flex-shrink-0 items-center gap-1">
-            {/* Planner row: demote to Member */}
+            {/* Planner row: move to rest of crew */}
             {isPlannerRow && canActOnPlanner && (
               <button
                 onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Member" }); }}
@@ -252,7 +235,7 @@ function CrewMemberRow({
                 className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
                 style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
               >
-                Demote
+                Move to rest of crew
               </button>
             )}
             {/* Remove (X) */}
@@ -598,12 +581,29 @@ export function CrewTab({ trip, canEdit }: TabProps) {
 
       {/* ── CO-PLANNERS section ── */}
       <div>
-        <h2
-          className="mb-2 text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Co-planners
-        </h2>
+        <div className="mb-2 flex items-center gap-3">
+          <h2
+            className="flex-shrink-0 text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Co-planners
+          </h2>
+          {isOwner && (
+            <div className="flex-1">
+              <CrewSearchInput
+                tripId={tripId}
+                defaultRole="Planner"
+                defaultStatus="draft"
+                allowGhost={false}
+                allowInvite
+                showSearchIcon
+                placeholder="Search by email..."
+                frequentTripmates={[]}
+                onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
+              />
+            </div>
+          )}
+        </div>
 
         <div>
           {plannersSorted.map((m, i) => {
@@ -628,31 +628,15 @@ export function CrewTab({ trip, canEdit }: TabProps) {
           })}
         </div>
 
-        {/* Email-find add for planners — owner only */}
-        {isOwner && (
-          <div className="mt-2">
-            <CrewSearchInput
-              tripId={tripId}
-              defaultRole="Planner"
-              defaultStatus="draft"
-              allowGhost={false}
-              allowInvite
-              showSearchIcon
-              placeholder="Find by email to add a co-planner..."
-              frequentTripmates={[]}
-              onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-            />
-          </div>
-        )}
       </div>
 
-      {/* ── CREW section ── */}
+      {/* ── REST OF THE CREW section ── */}
       <div className="pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
         <h2
           className="mb-2 text-xs font-semibold uppercase tracking-wider"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
-          Crew
+          Rest of the crew
         </h2>
 
         {/* RSVP headcount summary (GOING/NOW stage) */}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -58,6 +58,7 @@ function CrewMemberRow({
   index,
   showRsvpStatus,
   stage,
+  isPlannerRow,
   onToggle,
   onUpdated,
 }: {
@@ -70,6 +71,7 @@ function CrewMemberRow({
   index: number;
   showRsvpStatus: boolean;
   stage: string;
+  isPlannerRow?: boolean;
   onToggle: () => void;
   onUpdated: () => void;
 }) {
@@ -111,6 +113,7 @@ function CrewMemberRow({
   const _roleColor = ROLE_COLOR[m.role] ?? "var(--color-bt-text-dim)";
   const rsvpCfg = m.rsvp_status ? RSVP_LABEL[m.rsvp_status] : null;
   const editable = canEdit && !isMe && m.role !== "Owner";
+  const canActOnPlanner = isOwner && !isMe && m.role === "Planner";
   const hasTextChanges = editName.trim() !== m.displayName || editEmail.trim() !== (m.user?.email ?? "");
 
   const handleSave = async () => {
@@ -158,9 +161,9 @@ function CrewMemberRow({
         className="flex items-center gap-3 py-2.5 px-1 -mx-1 rounded"
         style={{
           background: rsvpCfg && !m.isGuest ? `${rsvpCfg.color}0a` : undefined,
-          cursor: editable ? "pointer" : undefined,
+          cursor: editable && !isPlannerRow ? "pointer" : undefined,
         }}
-        onClick={editable ? onToggle : undefined}
+        onClick={editable && !isPlannerRow ? onToggle : undefined}
       >
         {/* Avatar */}
         {m.isGuest ? (
@@ -239,8 +242,20 @@ function CrewMemberRow({
           </div>
           )}
 
-          {/* Col 3: delete */}
-          <div className="flex w-7 flex-shrink-0 justify-center">
+          {/* Col 3: actions */}
+          <div className="flex flex-shrink-0 items-center gap-1">
+            {/* Planner row: demote to Member */}
+            {isPlannerRow && canActOnPlanner && (
+              <button
+                onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Member" }); }}
+                disabled={updateRole.isPending}
+                className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
+                style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+              >
+                Demote
+              </button>
+            )}
+            {/* Remove (X) */}
             {editable && (
               <button
                 onClick={(e) => { e.stopPropagation(); setConfirmRemove(true); }}
@@ -281,8 +296,8 @@ function CrewMemberRow({
         </div>
       )}
 
-      {/* ── Expanded edit panel ──────────────────────────────────────────── */}
-      {isExpanded && editable && (
+      {/* ── Expanded edit panel — crew only, not for planner rows ─────────── */}
+      {isExpanded && editable && !isPlannerRow && (
         <div
           className="space-y-2 rounded-lg px-3 py-2.5 mb-1"
           style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
@@ -602,10 +617,11 @@ export function CrewTab({ trip, canEdit }: TabProps) {
                 isOwner={isOwner}
                 isMe={isMe}
                 index={i}
-                isExpanded={expandedId === m.user_id}
+                isExpanded={false}
                 showRsvpStatus={showRsvpStatus}
                 stage={stage}
-                onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
+                isPlannerRow
+                onToggle={() => {}}
                 onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
               />
             );

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -581,53 +581,80 @@ export function CrewTab({ trip, canEdit }: TabProps) {
 
       {/* ── CO-PLANNERS section ── */}
       <div>
-        <div className="mb-2 flex items-center gap-3">
-          <h2
-            className="flex-shrink-0 text-xs font-semibold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Co-planners
-          </h2>
-          {isOwner && (
-            <div className="flex-1">
-              <CrewSearchInput
-                tripId={tripId}
-                defaultRole="Planner"
-                defaultStatus="draft"
-                allowGhost={false}
-                allowInvite
-                showSearchIcon
-                placeholder="Search by email..."
-                frequentTripmates={[]}
-                onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-              />
-            </div>
-          )}
-        </div>
+        <h2
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Co-planners
+        </h2>
 
-        <div>
-          {plannersSorted.map((m, i) => {
-            const isMe = m.user_id === currentUser?.id;
-            return (
-              <CrewMemberRow
-                key={m.memberId}
-                member={m}
-                tripId={tripId}
-                canEdit={canEdit}
-                isOwner={isOwner}
-                isMe={isMe}
-                index={i}
-                isExpanded={false}
-                showRsvpStatus={showRsvpStatus}
-                stage={stage}
-                isPlannerRow
-                onToggle={() => {}}
-                onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
-              />
-            );
-          })}
-        </div>
+        {/* Owner rows first */}
+        {plannersSorted.filter((m) => m.role === "Owner").map((m, i) => {
+          const isMe = m.user_id === currentUser?.id;
+          return (
+            <CrewMemberRow
+              key={m.memberId}
+              member={m}
+              tripId={tripId}
+              canEdit={canEdit}
+              isOwner={isOwner}
+              isMe={isMe}
+              index={i}
+              isExpanded={false}
+              showRsvpStatus={showRsvpStatus}
+              stage={stage}
+              isPlannerRow
+              onToggle={() => {}}
+              onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+            />
+          );
+        })}
 
+        {/* Get some help — between owner and planners, owner only */}
+        {isOwner && (
+          <div className="mt-3 pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+            <p className="mb-2 text-[11px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
+              Get some help
+            </p>
+            <CrewSearchInput
+              tripId={tripId}
+              defaultRole="Planner"
+              defaultStatus="draft"
+              allowGhost={false}
+              allowInvite
+              showSearchIcon
+              placeholder="Search by email..."
+              frequentTripmates={[]}
+              onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
+            />
+          </div>
+        )}
+
+        {/* Planner rows */}
+        {plannersSorted.filter((m) => m.role === "Planner").length > 0 && (
+          <div className="mt-2">
+            {plannersSorted.filter((m) => m.role === "Planner").map((m, i) => {
+              const isMe = m.user_id === currentUser?.id;
+              return (
+                <CrewMemberRow
+                  key={m.memberId}
+                  member={m}
+                  tripId={tripId}
+                  canEdit={canEdit}
+                  isOwner={isOwner}
+                  isMe={isMe}
+                  index={i}
+                  isExpanded={false}
+                  showRsvpStatus={showRsvpStatus}
+                  stage={stage}
+                  isPlannerRow
+                  onToggle={() => {}}
+                  onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+                />
+              );
+            })}
+          </div>
+        )}
       </div>
 
       {/* ── REST OF THE CREW section ── */}
@@ -638,6 +665,42 @@ export function CrewTab({ trip, canEdit }: TabProps) {
         >
           Rest of the crew
         </h2>
+
+        {/* Name + email add for crew members */}
+        {canEdit && (
+          <div className="mb-4">
+            <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+              Start adding the names and emails of everyone you&apos;re planning to invite. Nothing is set in stone — you can always add, remove, or update people later.
+            </p>
+            <div className="flex gap-2">
+              <input
+                value={addName}
+                onChange={(e) => setAddName(e.target.value)}
+                placeholder="Name"
+                className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
+                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+              />
+              <input
+                value={addEmail}
+                onChange={(e) => setAddEmail(e.target.value)}
+                placeholder="Email (optional)"
+                type="email"
+                className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
+                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
+              />
+              <button
+                onClick={handleAdd}
+                disabled={!addName.trim() || isAdding}
+                className="flex-shrink-0 rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-40"
+                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+              >
+                {isAdding ? "..." : "Add"}
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* RSVP headcount summary (GOING/NOW stage) */}
         {showRsvpStatus && (() => {
@@ -681,37 +744,6 @@ export function CrewTab({ trip, canEdit }: TabProps) {
           <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
             No crew members yet.
           </p>
-        )}
-
-        {/* Name + email add for crew members */}
-        {canEdit && (
-          <div className="mt-2 flex gap-2">
-            <input
-              value={addName}
-              onChange={(e) => setAddName(e.target.value)}
-              placeholder="Name"
-              className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
-              style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-              onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
-            />
-            <input
-              value={addEmail}
-              onChange={(e) => setAddEmail(e.target.value)}
-              placeholder="Email (optional)"
-              type="email"
-              className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
-              style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-              onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
-            />
-            <button
-              onClick={handleAdd}
-              disabled={!addName.trim() || isAdding}
-              className="flex-shrink-0 rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-40"
-              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-            >
-              {isAdding ? "..." : "Add"}
-            </button>
-          </div>
         )}
       </div>
     </div>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -642,7 +642,7 @@ export function CrewTab({ trip, canEdit }: TabProps) {
       </div>
 
       {/* ── REST OF THE CREW section ── */}
-      <div className="pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+      <div className="pt-4">
         <h2
           className="mb-2 text-xs font-semibold uppercase tracking-wider"
           style={{ color: "var(--color-bt-text-dim)" }}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -191,10 +191,10 @@ function CrewMemberRow({
 
         {/* ── Right side: status + actions ─────────────────────────────────── */}
         <div className="flex flex-shrink-0 items-center">
-          {/* vote chip (going stage), invite status (planning), hidden (idea) */}
-          {stage !== "idea" && (
+          {/* RSVP chip — going stage only */}
+          {showRsvpStatus && (
           <div className="flex w-[64px] flex-shrink-0 justify-center">
-            {showRsvpStatus ? (() => {
+            {(() => {
               const rsvp = m.rsvp_status;
               const cfg = rsvp ? RSVP_LABEL[rsvp] : null;
               return cfg ? (
@@ -212,17 +212,7 @@ function CrewMemberRow({
                   Pending
                 </span>
               );
-            })() : m.role !== "Owner" ? (
-              m.status === "draft" ? (
-                <span className="text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
-                  Not invited
-                </span>
-              ) : m.status === "invited" ? (
-                <span className="text-xs" style={{ color: "var(--color-bt-ready)" }}>
-                  Invited
-                </span>
-              ) : null
-            ) : null}
+            })()}
           </div>
           )}
 


### PR DESCRIPTION
## Summary

- **Shared `AddPropertySheet`** — unified modal for adding/editing lodging in both idea and planning stages; URL-first with manual mode, https auto-prefix, Google Places autocomplete, platform detection, and an Optional section (Sleeps, Price, Thoughts, Address, Dates)
- **LodgingCard redesign** — matches schedule item layout; single content row, notes/address/dates on subsequent lines, confirm toggle with optimistic update, listing link in bottom-right of actions column
- **Idea stage lodging** — "LODGING IDEAS" label, up to 4 columns on desktop, Add button below header when empty / inline when options exist
- **Travel modal** — Flight + Airport combined on one line under Flying tab; flight number removed
- **Crew page restructure** — split into PLANNERS (email search + blurb + planner list with promote/demote inline) and REST OF THE CREW (explainer copy + name/email form + member list); role badges removed; Invited/Not invited hidden until going stage
- **Write Invitation modal** — button at top of right sidebar opens a modal with textarea (auto-saves) and embedded Let's Go button; removed from Crew tab and NextStepsPanel

## Test plan

- [ ] Add a lodging option via URL paste and via manual mode (both idea and planning stages)
- [ ] Edit and delete a lodging option; confirm/unconfirm (planning stage)
- [ ] Add a planner via email search; promote a crew member to planner; demote back
- [ ] Add crew members by name with and without email
- [ ] Open Write Invitation modal, draft a message, verify auto-save, click Let's Go (requires locked date)
- [ ] Verify flying tab shows Flight + Airport on one line with no flight number field
- [ ] Verify PLANNERS label shows on both idea stage panel and crew tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)