### PR TITLE
feat: add itinerary panel to home tab

### DIFF
--- a/e2e/itinerary-panel.spec.ts
+++ b/e2e/itinerary-panel.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Smoke tests for the Itinerary Panel on the Home tab.
+ *
+ * The aggregation/sorting/bucketing logic is exhaustively tested in the
+ * Vitest unit suite (`src/app/trips/[tripId]/components/itinerary.test.ts`).
+ * These tests verify the route loads without runtime errors after the panel
+ * was added to HomeTab.
+ */
+test.describe("Itinerary Panel smoke", () => {
+  test("trip detail page loads (or redirects to login) without crashing", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/trips/test-trip-id");
+
+    // Either we hit the trip page or we are bounced to login — both are fine
+    // as long as there are no uncaught exceptions from the panel render.
+    await page.waitForLoadState("networkidle");
+    expect(errors).toEqual([]);
+  });
+
+  test("login page loads without errors after itinerary panel changes", async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/login");
+    await expect(page.getByText("BuddyTrip")).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/app/trips/[tripId]/components/ItineraryPanel.tsx
+++ b/src/app/trips/[tripId]/components/ItineraryPanel.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Calendar,
+  Clock,
+  Flag,
+  Home,
+  Hotel,
+  Plane,
+  Sparkles,
+} from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { parseLocalDate, fmtTime12 } from "@/lib/dates";
+import { UserAvatar } from "@/components/UserAvatar";
+import {
+  buildItinerary,
+  groupByDay,
+  bucketDays,
+  isHappeningNow,
+  todayLocalISO,
+  dayNumber,
+  type ItineraryEvent,
+  type ItineraryDay,
+} from "./itinerary";
+
+// ── Props ─────────────────────────────────────────────────────────────────
+
+export interface ItineraryPanelProps {
+  tripId: string;
+  tripStartDate?: string | null;
+  /** Trip stage from `trip.stage` ("idea" | "planning" | "going" | …). */
+  stage: string;
+  /** Effective trip status (`getTripStatus(trip)`) — "future" | "now" | "past" | … */
+  status: string;
+  onTabChange?: (tab: string) => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function dayHeaderText(date: string): string {
+  return parseLocalDate(date).toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function shortDayHeaderText(date: string): string {
+  return parseLocalDate(date).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function eventTimeLabel(time: string | null): string {
+  return time ? fmtTime12(time) : "All day";
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+
+function EventIcon({ event }: { event: ItineraryEvent }) {
+  const sizeStyle = {
+    width: 32,
+    height: 32,
+    background: "var(--color-bt-card-raised)",
+    color: "var(--color-bt-text-dim)",
+  };
+  const wrap = (icon: React.ReactNode) => (
+    <div
+      className="flex flex-shrink-0 items-center justify-center rounded-full"
+      style={sizeStyle}
+      aria-hidden
+    >
+      {icon}
+    </div>
+  );
+
+  switch (event.kind) {
+    case "schedule":
+      return wrap(
+        event.itemType === "golf" ? <Flag size={14} /> : <Clock size={14} />
+      );
+    case "lodging-checkin":
+      return wrap(<Home size={14} />);
+    case "lodging-checkout":
+      return wrap(<Hotel size={14} />);
+    case "arrival":
+      return (
+        <UserAvatar
+          name={event.displayName}
+          avatarUrl={null}
+          size="md"
+        />
+      );
+  }
+}
+
+function HappeningNowPill() {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider"
+      style={{
+        background: "var(--color-bt-warning-faint)",
+        color: "var(--color-bt-warning)",
+        border: "1px solid var(--color-bt-warning)",
+      }}
+    >
+      <span
+        className="inline-block h-1.5 w-1.5 animate-pulse rounded-full"
+        style={{ background: "var(--color-bt-warning)" }}
+      />
+      Happening now
+    </span>
+  );
+}
+
+function EventRow({
+  event,
+  highlightToday,
+}: {
+  event: ItineraryEvent;
+  highlightToday: boolean;
+}) {
+  const happeningNow = highlightToday && isHappeningNow(event.date, event.time);
+  const arrival = event.kind === "arrival";
+
+  return (
+    <div
+      className="flex items-start gap-3 rounded-xl px-3 py-2.5"
+      style={{
+        background: "var(--color-bt-card)",
+        border: highlightToday
+          ? "1px solid var(--color-bt-accent-border)"
+          : "1px solid var(--color-bt-border)",
+      }}
+    >
+      <EventIcon event={event} />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <span
+            className="text-xs font-semibold tabular-nums"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {eventTimeLabel(event.time)}
+          </span>
+          <span
+            className="text-sm font-medium"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            {event.title}
+          </span>
+          {happeningNow && <HappeningNowPill />}
+          {arrival && event.kind === "arrival" && (
+            <Plane
+              size={12}
+              style={{ color: "var(--color-bt-text-dim)" }}
+              aria-hidden
+            />
+          )}
+        </div>
+        {event.subtitle && (
+          <p
+            className="mt-0.5 truncate text-xs"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {event.subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DayHeader({
+  date,
+  variant,
+  tripStart,
+}: {
+  date: string;
+  variant: "today" | "upcoming" | "past";
+  tripStart?: string | null;
+}) {
+  if (variant === "today") {
+    return (
+      <div className="mb-2 flex items-center gap-2">
+        <Sparkles size={14} style={{ color: "var(--color-bt-accent)" }} />
+        <span
+          className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+            border: "1px solid var(--color-bt-accent-border)",
+          }}
+        >
+          Today
+        </span>
+        <span
+          className="text-xs font-medium"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {shortDayHeaderText(date)}
+        </span>
+      </div>
+    );
+  }
+
+  const dayNum = dayNumber(date, tripStart ?? null);
+  const prefix = dayNum != null ? `Day ${dayNum} — ` : "";
+  return (
+    <div className="mb-2 flex items-center gap-2">
+      <span
+        className="text-[11px] font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {prefix}
+        {dayHeaderText(date)}
+      </span>
+    </div>
+  );
+}
+
+function DayBlock({
+  day,
+  variant,
+  tripStart,
+}: {
+  day: ItineraryDay;
+  variant: "today" | "upcoming" | "past";
+  tripStart?: string | null;
+}) {
+  return (
+    <div>
+      <DayHeader date={day.date} variant={variant} tripStart={tripStart} />
+      <div className="space-y-1.5">
+        {day.events.map((e) => (
+          <EventRow
+            key={e.id}
+            event={e}
+            highlightToday={variant === "today"}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PanelShell({ children }: { children: React.ReactNode }) {
+  return (
+    <section
+      className="rounded-xl p-4"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      {children}
+    </section>
+  );
+}
+
+function PanelHeader() {
+  return (
+    <div className="mb-3 flex items-start gap-2">
+      <Calendar
+        size={16}
+        style={{ color: "var(--color-bt-text)" }}
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <h2
+          className="text-sm font-semibold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          Itinerary
+        </h2>
+        <p
+          className="text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Confirmed plans only — planners manage details in the Schedule tab.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="animate-pulse space-y-2">
+      <div
+        className="h-3 w-32 rounded"
+        style={{ background: "var(--color-bt-card-raised)" }}
+      />
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="h-12 rounded-xl"
+          style={{ background: "var(--color-bt-card-raised)" }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({
+  onTabChange,
+}: {
+  onTabChange?: (tab: string) => void;
+}) {
+  return (
+    <div
+      className="rounded-xl px-4 py-6 text-center"
+      style={{
+        background: "var(--color-bt-card-raised)",
+        border: "1px dashed var(--color-bt-border)",
+      }}
+    >
+      <Calendar
+        size={20}
+        className="mx-auto mb-1.5"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      />
+      <p
+        className="text-sm font-medium"
+        style={{ color: "var(--color-bt-text)" }}
+      >
+        Nothing confirmed yet.
+      </p>
+      <p
+        className="mt-0.5 text-xs"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Planners can confirm items in the Schedule tab.
+      </p>
+      {onTabChange && (
+        <button
+          type="button"
+          onClick={() => onTabChange("schedule")}
+          className="mt-2 text-xs font-medium underline-offset-2 hover:underline"
+          style={{ color: "var(--color-bt-accent)" }}
+        >
+          Open the Schedule tab
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────
+
+export function ItineraryPanel({
+  tripId,
+  tripStartDate,
+  stage,
+  status,
+  onTabChange,
+}: ItineraryPanelProps) {
+  // Hidden entirely during the idea stage.
+  const hidden = stage === "idea";
+
+  // Show the "still being worked on" copy during planning.
+  const planning = !hidden && stage === "planning" && status !== "now" && status !== "past";
+
+  // Always call hooks in the same order — but only render results outside the
+  // planning teaser.
+  const scheduleQuery = trpc.schedule.list.useQuery(
+    { tripId },
+    { enabled: !hidden }
+  );
+  const logisticsQuery = trpc.logistics.list.useQuery(
+    { tripId },
+    { enabled: !hidden }
+  );
+  const membersQuery = trpc.tripMembers.list.useQuery(
+    { tripId },
+    { enabled: !hidden }
+  );
+
+  const events = useMemo(() => {
+    if (hidden || planning) return [];
+    return buildItinerary({
+      scheduleItems: scheduleQuery.data ?? [],
+      logisticsItems: logisticsQuery.data ?? [],
+      members: membersQuery.data ?? [],
+    });
+  }, [
+    hidden,
+    planning,
+    scheduleQuery.data,
+    logisticsQuery.data,
+    membersQuery.data,
+  ]);
+
+  const buckets = useMemo(() => {
+    const days = groupByDay(events);
+    return bucketDays(days, todayLocalISO());
+  }, [events]);
+
+  if (hidden) return null;
+
+  if (planning) {
+    return (
+      <PanelShell>
+        <PanelHeader />
+        <div
+          className="rounded-xl px-4 py-5 text-center"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            border: "1px dashed var(--color-bt-border)",
+          }}
+        >
+          <p
+            className="text-sm font-medium"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            Your planners are still working on the schedule.
+          </p>
+          <p
+            className="mt-1 text-xs"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Confirmed items will show up here.
+          </p>
+        </div>
+      </PanelShell>
+    );
+  }
+
+  const isLoading =
+    scheduleQuery.isLoading ||
+    logisticsQuery.isLoading ||
+    membersQuery.isLoading;
+
+  return (
+    <PanelShell>
+      <PanelHeader />
+
+      {isLoading ? (
+        <LoadingSkeleton />
+      ) : events.length === 0 ? (
+        <EmptyState onTabChange={onTabChange} />
+      ) : (
+        <div className="space-y-4">
+          {/* Past — collapsed behind <details> */}
+          {buckets.past.length > 0 && (
+            <details className="group">
+              <summary
+                className="cursor-pointer select-none text-xs font-medium"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Earlier on this trip ({buckets.past.reduce((sum, d) => sum + d.events.length, 0)})
+              </summary>
+              <div
+                className="mt-2 space-y-4"
+                style={{ opacity: 0.55 }}
+              >
+                {buckets.past.map((day) => (
+                  <DayBlock
+                    key={day.date}
+                    day={day}
+                    variant="past"
+                    tripStart={tripStartDate}
+                  />
+                ))}
+              </div>
+            </details>
+          )}
+
+          {/* Today — flared */}
+          {buckets.today && (
+            <DayBlock
+              day={buckets.today}
+              variant="today"
+              tripStart={tripStartDate}
+            />
+          )}
+
+          {/* Upcoming */}
+          {buckets.upcoming.map((day) => (
+            <DayBlock
+              key={day.date}
+              day={day}
+              variant="upcoming"
+              tripStart={tripStartDate}
+            />
+          ))}
+        </div>
+      )}
+    </PanelShell>
+  );
+}

--- a/src/app/trips/[tripId]/components/itinerary.test.ts
+++ b/src/app/trips/[tripId]/components/itinerary.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildItinerary,
+  groupByDay,
+  bucketDays,
+  isHappeningNow,
+  todayLocalISO,
+  dayNumber,
+  type ItineraryScheduleItem,
+  type ItineraryLogisticsItem,
+  type ItineraryTripMember,
+} from "./itinerary";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function scheduleItem(
+  overrides: Partial<ItineraryScheduleItem> = {}
+): ItineraryScheduleItem {
+  return {
+    id: "s1",
+    item_type: "general",
+    title: "Breakfast",
+    detail: null,
+    scheduled_date: "2026-06-15",
+    scheduled_time: "08:00",
+    is_confirmed: true,
+    sort_order: 0,
+    course_name: null,
+    course_location: null,
+    ...overrides,
+  };
+}
+
+function lodgingItem(
+  overrides: Partial<ItineraryLogisticsItem> = {}
+): ItineraryLogisticsItem {
+  return {
+    id: "l1",
+    type: "lodging",
+    label: "Beach House",
+    property_name: "Sleeps 8",
+    address: "1 Ocean Dr",
+    check_in_time: "2026-06-15",
+    check_out_time: "2026-06-18",
+    is_confirmed: true,
+    ...overrides,
+  };
+}
+
+function member(
+  overrides: Partial<ItineraryTripMember> = {}
+): ItineraryTripMember {
+  return {
+    memberId: "u1",
+    displayName: "Alice",
+    travel_mode: "flying",
+    travel_detail: null,
+    flight_airline: "United",
+    flight_number: "UA123",
+    flight_arrival_time: "2026-06-15T15:30:00Z",
+    flight_airport: "ORD",
+    travel_shared: true,
+    user: null,
+    ...overrides,
+  };
+}
+
+// ── buildItinerary: filtering ─────────────────────────────────────────────
+
+describe("buildItinerary — filtering", () => {
+  it("excludes unconfirmed schedule items", () => {
+    const events = buildItinerary({
+      scheduleItems: [scheduleItem({ is_confirmed: false })],
+      logisticsItems: [],
+      members: [],
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it("excludes schedule items without a scheduled_date", () => {
+    const events = buildItinerary({
+      scheduleItems: [scheduleItem({ scheduled_date: null })],
+      logisticsItems: [],
+      members: [],
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it("excludes unconfirmed lodging", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [lodgingItem({ is_confirmed: false })],
+      members: [],
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it("excludes non-lodging logistics items", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [lodgingItem({ type: "transport" })],
+      members: [],
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it("excludes arrivals where travel_shared is false", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [],
+      members: [member({ travel_shared: false })],
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it("excludes arrivals without a flight_arrival_time", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [],
+      members: [member({ flight_arrival_time: null })],
+    });
+    expect(events).toHaveLength(0);
+  });
+});
+
+// ── buildItinerary: lodging splitting ─────────────────────────────────────
+
+describe("buildItinerary — lodging", () => {
+  it("emits separate check-in and check-out events", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [lodgingItem()],
+      members: [],
+    });
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toContain("lodging-checkin");
+    expect(kinds).toContain("lodging-checkout");
+    expect(events).toHaveLength(2);
+  });
+
+  it("skips check-in event when check_in_time is missing without throwing", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [lodgingItem({ check_in_time: null })],
+      members: [],
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("lodging-checkout");
+  });
+
+  it("skips check-out event when check_out_time is missing", () => {
+    const events = buildItinerary({
+      scheduleItems: [],
+      logisticsItems: [lodgingItem({ check_out_time: null })],
+      members: [],
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("lodging-checkin");
+  });
+});
+
+// ── Sorting ───────────────────────────────────────────────────────────────
+
+describe("buildItinerary — sorting", () => {
+  it("sorts by date ascending across days", () => {
+    const events = buildItinerary({
+      scheduleItems: [
+        scheduleItem({ id: "s1", scheduled_date: "2026-06-17", scheduled_time: "10:00" }),
+        scheduleItem({ id: "s2", scheduled_date: "2026-06-15", scheduled_time: "10:00" }),
+      ],
+      logisticsItems: [],
+      members: [],
+    });
+    expect(events.map((e) => e.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("orders same-day events: checkout < arrival < checkin < schedule (when times tie)", () => {
+    // All timeless / same time so kind priority is the deciding factor.
+    const events = buildItinerary({
+      scheduleItems: [
+        scheduleItem({ id: "s1", scheduled_time: null }),
+      ],
+      logisticsItems: [
+        lodgingItem({
+          id: "l1",
+          check_in_time: "2026-06-15",
+          check_out_time: "2026-06-15",
+        }),
+      ],
+      members: [
+        member({ memberId: "u1", flight_arrival_time: null }),
+      ],
+    });
+    // Arrival skipped (no time), so we should see checkout, checkin, schedule.
+    expect(events.map((e) => e.kind)).toEqual([
+      "lodging-checkout",
+      "lodging-checkin",
+      "schedule",
+    ]);
+  });
+
+  it("breaks schedule ties by sort_order", () => {
+    const events = buildItinerary({
+      scheduleItems: [
+        scheduleItem({ id: "s1", scheduled_time: "10:00", sort_order: 5 }),
+        scheduleItem({ id: "s2", scheduled_time: "10:00", sort_order: 1 }),
+      ],
+      logisticsItems: [],
+      members: [],
+    });
+    expect(events.map((e) => e.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("places null-time events after timed events on the same day", () => {
+    const events = buildItinerary({
+      scheduleItems: [
+        scheduleItem({ id: "s_null", scheduled_time: null }),
+        scheduleItem({ id: "s_timed", scheduled_time: "09:00" }),
+      ],
+      logisticsItems: [],
+      members: [],
+    });
+    expect(events.map((e) => e.id)).toEqual(["s_timed", "s_null"]);
+  });
+});
+
+// ── groupByDay / bucketDays ───────────────────────────────────────────────
+
+describe("groupByDay & bucketDays", () => {
+  it("groups events by date and sorts the day buckets", () => {
+    const events = buildItinerary({
+      scheduleItems: [
+        scheduleItem({ id: "s1", scheduled_date: "2026-06-15" }),
+        scheduleItem({ id: "s2", scheduled_date: "2026-06-17" }),
+        scheduleItem({ id: "s3", scheduled_date: "2026-06-15", scheduled_time: "12:00" }),
+      ],
+      logisticsItems: [],
+      members: [],
+    });
+    const days = groupByDay(events);
+    expect(days.map((d) => d.date)).toEqual(["2026-06-15", "2026-06-17"]);
+    expect(days[0].events).toHaveLength(2);
+    expect(days[1].events).toHaveLength(1);
+  });
+
+  it("buckets days into past, today, upcoming relative to a fixed today", () => {
+    const days = groupByDay(
+      buildItinerary({
+        scheduleItems: [
+          scheduleItem({ id: "p", scheduled_date: "2026-06-14" }),
+          scheduleItem({ id: "t", scheduled_date: "2026-06-15" }),
+          scheduleItem({ id: "u", scheduled_date: "2026-06-16" }),
+        ],
+        logisticsItems: [],
+        members: [],
+      })
+    );
+    const buckets = bucketDays(days, "2026-06-15");
+    expect(buckets.past.map((d) => d.date)).toEqual(["2026-06-14"]);
+    expect(buckets.today?.date).toBe("2026-06-15");
+    expect(buckets.upcoming.map((d) => d.date)).toEqual(["2026-06-16"]);
+  });
+});
+
+// ── isHappeningNow ────────────────────────────────────────────────────────
+
+describe("isHappeningNow", () => {
+  const baseNow = new Date(2026, 5, 15, 12, 0, 0); // June 15, 2026, 12:00 local
+
+  it("returns true within ±60 minutes", () => {
+    expect(isHappeningNow("2026-06-15", "11:30", baseNow)).toBe(true);
+    expect(isHappeningNow("2026-06-15", "12:30", baseNow)).toBe(true);
+    expect(isHappeningNow("2026-06-15", "12:00", baseNow)).toBe(true);
+  });
+
+  it("returns false outside ±60 minutes", () => {
+    expect(isHappeningNow("2026-06-15", "10:30", baseNow)).toBe(false);
+    expect(isHappeningNow("2026-06-15", "13:30", baseNow)).toBe(false);
+  });
+
+  it("returns false on a different day", () => {
+    expect(isHappeningNow("2026-06-16", "12:00", baseNow)).toBe(false);
+  });
+
+  it("returns false when time is null (we don't know when in the day)", () => {
+    expect(isHappeningNow("2026-06-15", null, baseNow)).toBe(false);
+  });
+});
+
+// ── Misc helpers ──────────────────────────────────────────────────────────
+
+describe("todayLocalISO", () => {
+  it("returns a YYYY-MM-DD string in local time", () => {
+    const result = todayLocalISO(new Date(2026, 5, 15, 23, 59));
+    expect(result).toBe("2026-06-15");
+  });
+});
+
+describe("dayNumber", () => {
+  it("returns 1 for the trip start date", () => {
+    expect(dayNumber("2026-06-15", "2026-06-15")).toBe(1);
+  });
+
+  it("counts subsequent days correctly", () => {
+    expect(dayNumber("2026-06-17", "2026-06-15")).toBe(3);
+  });
+
+  it("returns null when tripStart is missing", () => {
+    expect(dayNumber("2026-06-15", null)).toBeNull();
+  });
+});

--- a/src/app/trips/[tripId]/components/itinerary.ts
+++ b/src/app/trips/[tripId]/components/itinerary.ts
@@ -1,0 +1,319 @@
+/**
+ * Itinerary aggregation utilities.
+ *
+ * Takes the trip's confirmed schedule items, confirmed lodging items, and
+ * shared member arrivals, and produces a unified, sorted timeline of typed
+ * events used by the Home tab's ItineraryPanel.
+ *
+ * Pure functions only — no React, no tRPC. Easy to unit-test.
+ */
+
+// ── Input shapes (subset of router responses) ─────────────────────────────
+
+export interface ItineraryScheduleItem {
+  id: string;
+  item_type: "general" | "golf";
+  title: string;
+  detail?: string | null;
+  scheduled_date?: string | null; // YYYY-MM-DD
+  scheduled_time?: string | null; // HH:MM
+  is_confirmed: boolean;
+  sort_order: number;
+  course_name?: string | null;
+  course_location?: string | null;
+}
+
+export interface ItineraryLogisticsItem {
+  id: string;
+  type: "lodging" | "transport" | "general";
+  label: string;
+  property_name?: string | null;
+  address?: string | null;
+  /** Stored as text; treated as YYYY-MM-DD by the rest of the app. */
+  check_in_time?: string | null;
+  check_out_time?: string | null;
+  is_confirmed?: boolean | null;
+}
+
+export interface ItineraryTripMember {
+  memberId: string;
+  displayName: string;
+  travel_mode?: "driving" | "flying" | "other" | null;
+  travel_detail?: string | null;
+  flight_airline?: string | null;
+  flight_number?: string | null;
+  flight_arrival_time?: string | null; // ISO timestamptz
+  flight_airport?: string | null;
+  travel_shared?: boolean | null;
+  user?: { name?: string | null; nickname?: string | null } | null;
+}
+
+// ── Output shape ──────────────────────────────────────────────────────────
+
+export type ItineraryEvent =
+  | {
+      kind: "schedule";
+      id: string;
+      date: string;
+      time: string | null;
+      title: string;
+      subtitle?: string | null;
+      itemType: "general" | "golf";
+      sortOrder: number;
+    }
+  | {
+      kind: "lodging-checkin" | "lodging-checkout";
+      id: string;
+      date: string;
+      time: null;
+      title: string;
+      subtitle?: string | null;
+    }
+  | {
+      kind: "arrival";
+      id: string;
+      date: string;
+      time: string | null;
+      title: string;
+      subtitle?: string | null;
+      memberId: string;
+      displayName: string;
+    };
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/** Today's date in the user's local timezone, as YYYY-MM-DD. */
+export function todayLocalISO(now: Date = new Date()): string {
+  // 'en-CA' produces ISO-shaped date strings (YYYY-MM-DD).
+  return now.toLocaleDateString("en-CA");
+}
+
+/**
+ * Parse the date portion of a YYYY-MM-DD or full ISO timestamp.
+ * Returns the YYYY-MM-DD portion in the user's local timezone.
+ */
+function localDateOfTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  return d.toLocaleDateString("en-CA");
+}
+
+/** Parse the local HH:MM portion of a full ISO timestamp. */
+function localTimeOfTimestamp(iso: string): string | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+/** Looks like a YYYY-MM-DD date string. */
+function isDateString(s: string | null | undefined): s is string {
+  return typeof s === "string" && /^\d{4}-\d{2}-\d{2}/.test(s);
+}
+
+// ── Core: buildItinerary ──────────────────────────────────────────────────
+
+export function buildItinerary(input: {
+  scheduleItems: ItineraryScheduleItem[];
+  logisticsItems: ItineraryLogisticsItem[];
+  members: ItineraryTripMember[];
+}): ItineraryEvent[] {
+  const events: ItineraryEvent[] = [];
+
+  // ── 1. Confirmed schedule items ──
+  for (const item of input.scheduleItems) {
+    if (!item.is_confirmed) continue;
+    if (!isDateString(item.scheduled_date)) continue;
+
+    const subtitleParts: string[] = [];
+    if (item.item_type === "golf" && item.course_name) {
+      subtitleParts.push(item.course_name);
+      if (item.course_location) subtitleParts.push(item.course_location);
+    } else if (item.detail) {
+      subtitleParts.push(item.detail);
+    }
+
+    events.push({
+      kind: "schedule",
+      id: item.id,
+      date: item.scheduled_date.slice(0, 10),
+      time: item.scheduled_time ? item.scheduled_time.slice(0, 5) : null,
+      title: item.title,
+      subtitle: subtitleParts.join(" · ") || null,
+      itemType: item.item_type,
+      sortOrder: item.sort_order,
+    });
+  }
+
+  // ── 2. Confirmed lodging — emit check-in + check-out events ──
+  for (const item of input.logisticsItems) {
+    if (item.type !== "lodging") continue;
+    if (!item.is_confirmed) continue;
+
+    const name = item.property_name ?? item.label ?? "Lodging";
+    const subtitle = item.address ?? null;
+
+    if (isDateString(item.check_in_time)) {
+      events.push({
+        kind: "lodging-checkin",
+        id: `${item.id}-checkin`,
+        date: item.check_in_time.slice(0, 10),
+        time: null,
+        title: `Check in: ${item.label || name}`,
+        subtitle,
+      });
+    }
+    if (isDateString(item.check_out_time)) {
+      events.push({
+        kind: "lodging-checkout",
+        id: `${item.id}-checkout`,
+        date: item.check_out_time.slice(0, 10),
+        time: null,
+        title: `Check out: ${item.label || name}`,
+        subtitle,
+      });
+    }
+  }
+
+  // ── 3. Shared member arrivals ──
+  for (const m of input.members) {
+    if (!m.travel_shared) continue;
+    if (!m.flight_arrival_time) continue;
+
+    const date = localDateOfTimestamp(m.flight_arrival_time);
+    const time = localTimeOfTimestamp(m.flight_arrival_time);
+
+    let subtitle: string | null = null;
+    if (m.travel_mode === "flying") {
+      const flight = [m.flight_airline, m.flight_number].filter(Boolean).join(" ");
+      const parts: string[] = [];
+      if (flight) parts.push(flight);
+      if (m.flight_airport) parts.push(`arriving ${m.flight_airport}`);
+      subtitle = parts.join(" · ") || null;
+    } else if (m.travel_detail) {
+      subtitle = m.travel_detail;
+    }
+
+    events.push({
+      kind: "arrival",
+      id: `arrival-${m.memberId}`,
+      date,
+      time,
+      title: `${m.displayName} arrives`,
+      subtitle,
+      memberId: m.memberId,
+      displayName: m.displayName,
+    });
+  }
+
+  events.sort(compareEvents);
+  return events;
+}
+
+// ── Sorting ───────────────────────────────────────────────────────────────
+
+const KIND_PRIORITY: Record<ItineraryEvent["kind"], number> = {
+  "lodging-checkout": 0,
+  arrival: 1,
+  "lodging-checkin": 2,
+  schedule: 3,
+};
+
+function compareEvents(a: ItineraryEvent, b: ItineraryEvent): number {
+  if (a.date !== b.date) return a.date < b.date ? -1 : 1;
+
+  // Null times sort *after* timed events on the same day.
+  if (a.time !== b.time) {
+    if (a.time === null) return 1;
+    if (b.time === null) return -1;
+    return a.time < b.time ? -1 : 1;
+  }
+
+  const kindDelta = KIND_PRIORITY[a.kind] - KIND_PRIORITY[b.kind];
+  if (kindDelta !== 0) return kindDelta;
+
+  if (a.kind === "schedule" && b.kind === "schedule") {
+    return a.sortOrder - b.sortOrder;
+  }
+  return 0;
+}
+
+// ── Grouping ──────────────────────────────────────────────────────────────
+
+export interface ItineraryDay {
+  date: string;
+  events: ItineraryEvent[];
+}
+
+export function groupByDay(events: ItineraryEvent[]): ItineraryDay[] {
+  const map = new Map<string, ItineraryEvent[]>();
+  for (const e of events) {
+    const list = map.get(e.date);
+    if (list) list.push(e);
+    else map.set(e.date, [e]);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([date, events]) => ({ date, events }));
+}
+
+/** Bucket grouped days into past / today / upcoming. */
+export function bucketDays(
+  days: ItineraryDay[],
+  today: string = todayLocalISO()
+): { past: ItineraryDay[]; today: ItineraryDay | null; upcoming: ItineraryDay[] } {
+  const past: ItineraryDay[] = [];
+  const upcoming: ItineraryDay[] = [];
+  let todayDay: ItineraryDay | null = null;
+  for (const d of days) {
+    if (d.date < today) past.push(d);
+    else if (d.date === today) todayDay = d;
+    else upcoming.push(d);
+  }
+  return { past, today: todayDay, upcoming };
+}
+
+// ── Happening-now detection ───────────────────────────────────────────────
+
+/**
+ * Returns true when an event is within ±60 minutes of `now`. Events without a
+ * time component never qualify (we don't know when in the day they occur).
+ */
+export function isHappeningNow(
+  dateISO: string,
+  timeHHMM: string | null,
+  now: Date = new Date()
+): boolean {
+  if (!timeHHMM) return false;
+  const [hStr, mStr] = timeHHMM.split(":");
+  const h = parseInt(hStr, 10);
+  const m = parseInt(mStr, 10);
+  if (Number.isNaN(h) || Number.isNaN(m)) return false;
+
+  // Build a Date in local time at the given date + time.
+  const [yStr, moStr, dStr] = dateISO.split("-");
+  const eventDate = new Date(
+    parseInt(yStr, 10),
+    parseInt(moStr, 10) - 1,
+    parseInt(dStr, 10),
+    h,
+    m,
+    0,
+    0
+  );
+  if (Number.isNaN(eventDate.getTime())) return false;
+
+  const diffMs = Math.abs(eventDate.getTime() - now.getTime());
+  return diffMs <= 60 * 60 * 1000;
+}
+
+/** Compute the "Day N" label index for a date relative to a trip start date. */
+export function dayNumber(date: string, tripStart: string | null): number | null {
+  if (!tripStart) return null;
+  const [sy, sm, sd] = tripStart.slice(0, 10).split("-").map((n) => parseInt(n, 10));
+  const [dy, dm, dd] = date.slice(0, 10).split("-").map((n) => parseInt(n, 10));
+  const start = new Date(sy, sm - 1, sd, 12, 0, 0, 0).getTime();
+  const day = new Date(dy, dm - 1, dd, 12, 0, 0, 0).getTime();
+  return Math.floor((day - start) / 86400000) + 1;
+}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -36,6 +36,7 @@ import { DatesPlanningRow } from "../components/DatesPlanningRow";
 import { LodgingPanel } from "../components/LodgingPanel";
 import { TravelPanel } from "../components/TravelPanel";
 import { TravelEntryForm } from "../components/TravelEntryForm";
+import { ItineraryPanel } from "../components/ItineraryPanel";
 import type { TripDisplayStatus } from "@/lib/tripStatus";
 import type { TabProps, TripData } from "./types";
 
@@ -1596,6 +1597,17 @@ export function HomeTab({
           {/* ── GOING / NOW stage: RSVP panel ──────────────────────── */}
           {(stage === "going" || status === "now") && (
             <RsvpPanel tripId={trip.id} members={members} currentUserId={currentUser?.id ?? null} />
+          )}
+
+          {/* ── Itinerary panel — read-only confirmed-only timeline ── */}
+          {stage !== "idea" && (
+            <ItineraryPanel
+              tripId={trip.id}
+              tripStartDate={trip.start_date}
+              stage={stage}
+              status={status}
+              onTabChange={onTabChange}
+            />
           )}
 
           {/* ── Planning rows — gated by stage ────────────────────── */}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { EmptyState } from "@/components/EmptyState";
 import { trpc } from "@/lib/trpc-client";
-import { parseLocalDate } from "@/lib/dates";
+import { parseLocalDate, fmtTime12 } from "@/lib/dates";
 import { AddScheduleItemSheet } from "../components/AddScheduleItemSheet";
 import type { TabProps } from "./types";
 
@@ -84,14 +84,6 @@ function generateTripDays(start: string, end: string): string[] {
     cur.setDate(cur.getDate() + 1);
   }
   return days;
-}
-
-function fmtTime12(t: string): string {
-  const [hStr, mStr] = t.split(":");
-  const h = parseInt(hStr, 10);
-  const suffix = h >= 12 ? "PM" : "AM";
-  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
-  return `${h12}:${mStr} ${suffix}`;
 }
 
 function dayNumber(date: string, tripStart: string | null): number | null {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -77,3 +77,16 @@ export function formatDateRange(
   if (start) return `From ${fmt(start)}`;
   return `Until ${fmt(end!)}`;
 }
+
+/**
+ * Format an "HH:MM" 24-hour time string as 12-hour with AM/PM (e.g. "3:45 PM").
+ * Returns the input unchanged if it doesn't match the expected shape.
+ */
+export function fmtTime12(t: string): string {
+  const [hStr, mStr] = t.split(":");
+  const h = parseInt(hStr, 10);
+  if (Number.isNaN(h) || mStr === undefined) return t;
+  const suffix = h >= 12 ? "PM" : "AM";
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${h12}:${mStr} ${suffix}`;
+}


### PR DESCRIPTION
## Summary

Adds a read-only **Itinerary Panel** to the Home tab, visible to all trip roles. Aggregates confirmed schedule items, confirmed lodging check-in/check-out events, and shared member arrivals into a single sorted timeline grouped by day.

- **Today flare:** `Sparkles` icon + teal "Today" chip on the day header; accent border on today's event cards; amber pulsing "Happening now" pill for events within ±60 minutes of right now.
- **Past de-emphasis:** prior days collapse behind an "Earlier on this trip (N)" `<details>` toggle, dimmed to 55% opacity when expanded.
- **Stage gating:** hidden during `idea`; planning stage shows "still being worked on" copy; `going`/`now`/`past` render the full timeline.
- **Three data sources merged:** `schedule_items` (confirmed), `logistics_items` where `type='lodging' AND is_confirmed=true` (split into check-in + check-out events), and `trip_members` arrivals with `travel_shared=true`.

No DB migrations, no router changes — reuses `schedule.list`, `logistics.list`, and `tripMembers.list` queries.

## Files

- **New:** `src/app/trips/[tripId]/components/ItineraryPanel.tsx`, `itinerary.ts`, `itinerary.test.ts`, `e2e/itinerary-panel.spec.ts`
- **Modified:** `HomeTab.tsx` (mounts the panel above `PlanningSection`), `ScheduleTab.tsx` (uses shared helper), `src/lib/dates.ts` (exports `fmtTime12`)

## Test plan

- [x] `npx vitest run itinerary.test.ts` — 23/23 pass (filtering, lodging splitting, sort precedence `checkout < arrival < checkin < schedule`, null-time handling, `isHappeningNow` ±60min, `todayLocalISO`, `dayNumber`)
- [x] `npx tsc --noEmit` — no errors
- [x] ESLint clean on all new files
- [ ] Manual: open a going-stage trip → see today highlighted + past collapsed
- [ ] Manual: flip trip to planning stage → see "still being worked on" copy
- [ ] Manual: flip trip to idea stage → panel hidden
- [ ] Manual: unconfirm a schedule item → it disappears from the panel (still visible in Schedule tab for planners)