### PR TITLE
refactor(home): move destination/dates edit controls to trip settings

### DIFF
--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -114,7 +114,6 @@ export function DatesPlanningRow({
   const [directEnd, setDirectEnd] = useState("");
 
   // Modals and confirm dialogs
-  const [showChangeDates, setShowChangeDates] = useState(false);
   const [showSelectDateModal, setShowSelectDateModal] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
 
@@ -995,7 +994,6 @@ export function DatesPlanningRow({
     // For poll-set dates: go straight back to poll draft state (no modal needed).
     // For direct-set dates: open the change-dates modal.
     if (datesLocked) {
-      const fromPoll = trip.date_set_method === "poll";
       return (
         <div className="space-y-2">
           <p
@@ -1008,20 +1006,6 @@ export function DatesPlanningRow({
             {nightsBetween(trip.start_date!, trip.end_date!)} night
             {nightsBetween(trip.start_date!, trip.end_date!) !== 1 ? "s" : ""}
           </p>
-          {isOwner && (
-            <button
-              onClick={
-                fromPoll
-                  ? () => unlockDates.mutate({ tripId })
-                  : () => setShowChangeDates(true)
-              }
-              disabled={fromPoll && unlockDates.isPending}
-              className="text-xs font-medium transition-opacity disabled:opacity-50"
-              style={{ color: "var(--color-bt-accent)" }}
-            >
-              {fromPoll && unlockDates.isPending ? "Going back…" : "Change dates →"}
-            </button>
-          )}
         </div>
       );
     }
@@ -1051,6 +1035,16 @@ export function DatesPlanningRow({
 
             {/* Date pickers + action button */}
             {renderDatePickerRow(pollState === "draft" ? "poll" : "set")}
+
+            {/* Note: dates can be changed later from trip settings */}
+            {pollState !== "draft" && (
+              <p
+                className="mt-2 text-xs"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Once set, dates can only be changed from the trip settings.
+              </p>
+            )}
 
             {/* Poll the crew — only in null (direct) mode */}
             {pollState === null && (
@@ -1093,37 +1087,6 @@ export function DatesPlanningRow({
         {renderBody()}
       </PlanningRow>
 
-      {/* Change dates modal (opens from the locked-dates card) */}
-      {showChangeDates && (
-        <ChangeDatesModal
-          tripId={tripId}
-          initialStart={trip.start_date ?? ""}
-          initialEnd={trip.end_date ?? ""}
-          method={trip.date_set_method ?? "direct"}
-          onClose={() => setShowChangeDates(false)}
-          onSubmit={(startDate, endDate) => {
-            lockDates.mutate(
-              {
-                tripId,
-                startDate,
-                endDate,
-                method: trip.date_set_method ?? "direct",
-              },
-              {
-                onSuccess() {
-                  setShowChangeDates(false);
-                },
-              }
-            );
-          }}
-          isPending={lockDates.isPending}
-          onClear={() => {
-            unlockDates.mutate({ tripId }, { onSuccess() { setShowChangeDates(false); } });
-          }}
-          isClearPending={unlockDates.isPending}
-        />
-      )}
-
       {/* Select date modal — pick a winning window from the poll */}
       {showSelectDateModal && (
         <SelectDateModal
@@ -1164,112 +1127,6 @@ export function DatesPlanningRow({
   );
 }
 
-// ── ChangeDatesModal ─────────────────────────────────────────────────────
-
-function ChangeDatesModal({
-  tripId: _tripId,
-  initialStart,
-  initialEnd,
-  onClose,
-  onSubmit,
-  isPending,
-  onClear,
-  isClearPending,
-}: {
-  tripId: string;
-  initialStart: string;
-  initialEnd: string;
-  method: "direct" | "poll";
-  onClose: () => void;
-  onSubmit: (startDate: string, endDate: string) => void;
-  isPending: boolean;
-  onClear: () => void;
-  isClearPending: boolean;
-}) {
-  useModalBackButton(onClose);
-  const [startDate, setStartDate] = useState(initialStart);
-  const [endDate, setEndDate] = useState(initialEnd);
-  const canSubmit = !!startDate && !!endDate && startDate < endDate && !isPending;
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
-      style={{ background: "var(--color-bt-overlay)" }}
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-[400px] rounded-t-2xl p-6 lg:rounded-2xl"
-        style={{ background: "var(--color-bt-card)" }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2
-          className="text-lg font-semibold"
-          style={{ color: "var(--color-bt-text)" }}
-        >
-          Change dates
-        </h2>
-
-        <div className="mt-4 flex items-center gap-2">
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="min-w-0 flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
-          />
-          <input
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-            className="min-w-0 flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
-          />
-        </div>
-
-        <button
-          onClick={() => onSubmit(startDate, endDate)}
-          disabled={!canSubmit}
-          className="mt-4 w-full rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
-          style={{
-            background: "var(--color-bt-accent)",
-            color: "var(--color-bt-base)",
-          }}
-        >
-          {isPending ? "Updating..." : "Update dates"}
-        </button>
-
-        <button
-          onClick={onClear}
-          disabled={isClearPending || isPending}
-          className="mt-2 w-full rounded-xl border py-2.5 text-sm font-medium transition-opacity hover:opacity-80 disabled:opacity-40"
-          style={{
-            borderColor: "var(--color-bt-danger-border)",
-            color: "var(--color-bt-danger)",
-          }}
-        >
-          {isClearPending ? "Clearing..." : "Clear dates"}
-        </button>
-
-        <button
-          onClick={onClose}
-          className="mt-2 w-full rounded-xl py-2.5 text-sm transition-opacity hover:opacity-80"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  );
-}
-
 // ── SelectDateModal ──────────────────────────────────────────────────────
 
 function SelectDateModal({
@@ -1294,7 +1151,7 @@ function SelectDateModal({
         className="w-full max-w-sm rounded-t-2xl p-5 lg:rounded-2xl"
         style={{ background: "var(--color-bt-card)" }}
       >
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-2 flex items-center justify-between">
           <p
             className="text-base font-semibold"
             style={{ color: "var(--color-bt-text)" }}
@@ -1310,6 +1167,12 @@ function SelectDateModal({
             <X size={16} />
           </button>
         </div>
+        <p
+          className="mb-4 text-xs"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Once selected, dates can only be changed from the trip settings.
+        </p>
         <div className="space-y-2">
           {windows.map((w) => {
             const nights = nightsBetween(w.start_date, w.end_date);

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { MoreHorizontal, Lock, HelpCircle, X, MessageCircle, Send, Mail } from "lucide-react";
+import { Settings, Lock, HelpCircle, X, MessageCircle, Send, Mail } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useTripRole } from "@/hooks/useTripRole";
 import { TripBottomNav, type TabId } from "@/components/BottomNav";
@@ -185,7 +185,7 @@ export default function TripDetailPage() {
       style={{ color: "var(--color-bt-text-dim)" }}
       aria-label="Trip settings"
     >
-      <MoreHorizontal size={18} />
+      <Settings size={18} />
     </button>
   ) : null;
 
@@ -406,6 +406,7 @@ export default function TripDetailPage() {
         <TripSettingsModal
           tripId={tripId}
           tripName={trip.title}
+          trip={trip}
           viewerRole={role}
           onClose={() => setShowSettings(false)}
         />

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -500,6 +500,10 @@ function SetDestinationModal({
           </p>
         )}
 
+        <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+          Once set, the destination can only be changed from the trip settings.
+        </p>
+
         <button
           onClick={handleSave}
           disabled={lock.isPending || !title.trim()}
@@ -1110,15 +1114,6 @@ function PlanningSection({
                 </span>
               )}
             </p>
-            {canEdit && stage === "planning" && (
-              <button
-                onClick={() => setShowChangeDest(true)}
-                className="text-xs font-medium"
-                style={{ color: "var(--color-bt-accent)" }}
-              >
-                Change destination →
-              </button>
-            )}
           </div>
         ) : (
           /* No destination set */
@@ -1600,7 +1595,7 @@ export function HomeTab({
           )}
 
           {/* ── Itinerary panel — read-only confirmed-only timeline ── */}
-          {stage !== "idea" && (
+          {stage !== "idea" && stage !== "planning" && (
             <ItineraryPanel
               tripId={trip.id}
               tripStartDate={trip.start_date}

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -10,15 +10,20 @@ import {
   Trash2,
   ChevronRight,
   Lock,
+  MapPin,
+  Calendar,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { RoleBadge } from "@/components/RoleBadge";
+import { formatDateRangeCompact } from "@/lib/dates";
 import type { TripRole } from "@/server/middleware";
+import type { TripData } from "@/app/trips/[tripId]/tabs/types";
 
 interface TripSettingsModalProps {
   tripId: string;
   tripName: string;
+  trip?: TripData;
   onClose: () => void;
   viewerRole: TripRole;
 }
@@ -26,6 +31,7 @@ interface TripSettingsModalProps {
 export function TripSettingsModal({
   tripId,
   tripName,
+  trip,
   onClose,
   viewerRole,
 }: TripSettingsModalProps) {
@@ -55,6 +61,56 @@ export function TripSettingsModal({
   }, [renameSuccess]);
 
   const nameChanged = newName.trim() !== tripName && newName.trim().length > 0;
+
+  // ── Destination / Dates edit state (planning stage only) ─────────────
+  const stage = trip?.stage ?? "idea";
+  const canEditPlan = stage === "planning" && (viewerRole === "Owner" || viewerRole === "Planner");
+  const destinationLocked = !!trip?.locked_destination_title;
+  const datesLocked = !!(trip?.start_date && trip?.end_date);
+  const datesFromPoll = trip?.date_set_method === "poll";
+
+  const [destExpanded, setDestExpanded] = useState(false);
+  const [destDraft, setDestDraft] = useState(trip?.locked_destination_title ?? "");
+  const [datesExpanded, setDatesExpanded] = useState(false);
+  const [startDraft, setStartDraft] = useState(trip?.start_date ?? "");
+  const [endDraft, setEndDraft] = useState(trip?.end_date ?? "");
+
+  const changeDestinationMutation = trpc.trips.changeDestination.useMutation({
+    onSuccess: () => {
+      utils.trips.getById.invalidate({ tripId });
+      utils.trips.list.invalidate();
+      utils.datePoll.get.invalidate({ tripId });
+      setDestExpanded(false);
+    },
+  });
+
+  const lockDatesMutation = trpc.trips.lockDates.useMutation({
+    onSuccess: () => {
+      utils.trips.getById.invalidate({ tripId });
+      utils.datePoll.get.invalidate({ tripId });
+      setDatesExpanded(false);
+    },
+  });
+
+  const unlockDatesMutation = trpc.datePoll.unlock.useMutation({
+    onSuccess: () => {
+      utils.trips.getById.invalidate({ tripId });
+      utils.datePoll.get.invalidate({ tripId });
+      setDatesExpanded(false);
+    },
+  });
+
+  const canSaveDest =
+    destDraft.trim().length > 0 &&
+    destDraft.trim() !== (trip?.locked_destination_title ?? "") &&
+    !changeDestinationMutation.isPending;
+
+  const canSaveDates =
+    !!startDraft &&
+    !!endDraft &&
+    startDraft < endDraft &&
+    (startDraft !== (trip?.start_date ?? "") || endDraft !== (trip?.end_date ?? "")) &&
+    !lockDatesMutation.isPending;
 
   // ── Transfer ownership state ─────────────────────────────────────────
   const [transferExpanded, setTransferExpanded] = useState(false);
@@ -174,6 +230,269 @@ export function TripSettingsModal({
             {/* Divider */}
             <div
               className="my-4"
+              style={{ height: 1, background: "var(--color-bt-border)" }}
+            />
+          </>
+        )}
+
+        {/* ── Section: Trip plan (planning stage only) ───────────────── */}
+        {canEditPlan && (destinationLocked || datesLocked) && (
+          <>
+            <p
+              className="mb-3 text-[11px] font-medium uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)", letterSpacing: "0.08em" }}
+            >
+              Trip plan
+            </p>
+
+            <div className="mb-4 space-y-2">
+              {/* Change destination */}
+              {destinationLocked && (
+                <div>
+                  <button
+                    data-testid="settings-change-destination-btn"
+                    onClick={() => {
+                      setDestExpanded(!destExpanded);
+                      setDatesExpanded(false);
+                      setTransferExpanded(false);
+                      setSaveConfirming(false);
+                      setDestDraft(trip?.locked_destination_title ?? "");
+                    }}
+                    className="flex w-full items-center gap-3 rounded-xl border px-3 py-2.5"
+                    style={{
+                      background: "var(--color-bt-card-raised)",
+                      borderColor: "var(--color-bt-border)",
+                    }}
+                  >
+                    <div
+                      className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
+                      style={{ background: "rgba(45,212,191,0.12)" }}
+                    >
+                      <MapPin size={16} style={{ color: "var(--color-bt-accent)" }} />
+                    </div>
+                    <div className="min-w-0 flex-1 text-left">
+                      <p className="text-sm" style={{ color: "var(--color-bt-text)" }}>
+                        Change destination
+                      </p>
+                      <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                        {trip?.locked_destination_title}
+                      </p>
+                    </div>
+                    <ChevronRight
+                      size={16}
+                      style={{
+                        color: "var(--color-bt-text-dim)",
+                        transform: destExpanded ? "rotate(90deg)" : undefined,
+                        transition: "transform 150ms",
+                      }}
+                    />
+                  </button>
+
+                  {destExpanded && (
+                    <div
+                      className="mt-2 space-y-2 rounded-xl border p-3"
+                      style={{ borderColor: "var(--color-bt-border)" }}
+                    >
+                      <div
+                        className="flex items-start gap-2 rounded-lg px-3 py-2"
+                        style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
+                      >
+                        <span style={{ color: "var(--color-bt-warning)" }}>⚠</span>
+                        <p className="text-xs" style={{ color: "var(--color-bt-warning)" }}>
+                          Changing the destination will reset any date poll responses.
+                        </p>
+                      </div>
+                      <input
+                        data-testid="settings-destination-input"
+                        value={destDraft}
+                        onChange={(e) => setDestDraft(e.target.value)}
+                        placeholder="New destination"
+                        className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+                        style={{
+                          background: "var(--color-bt-card-raised)",
+                          borderColor: "var(--color-bt-border)",
+                          color: "var(--color-bt-text)",
+                        }}
+                      />
+                      <button
+                        data-testid="settings-save-destination-btn"
+                        disabled={!canSaveDest}
+                        onClick={() =>
+                          changeDestinationMutation.mutate({
+                            tripId,
+                            destination: destDraft.trim(),
+                          })
+                        }
+                        className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+                        style={{
+                          background: "var(--color-bt-accent)",
+                          color: "var(--color-bt-base)",
+                        }}
+                      >
+                        {changeDestinationMutation.isPending ? "Updating…" : "Update destination"}
+                      </button>
+                      <button
+                        onClick={() => setDestExpanded(false)}
+                        className="w-full rounded-xl border py-2 text-sm"
+                        style={{
+                          borderColor: "var(--color-bt-border)",
+                          color: "var(--color-bt-text-dim)",
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Change dates */}
+              {datesLocked && (
+                <div>
+                  <button
+                    data-testid="settings-change-dates-btn"
+                    onClick={() => {
+                      setDatesExpanded(!datesExpanded);
+                      setDestExpanded(false);
+                      setTransferExpanded(false);
+                      setSaveConfirming(false);
+                      setStartDraft(trip?.start_date ?? "");
+                      setEndDraft(trip?.end_date ?? "");
+                    }}
+                    className="flex w-full items-center gap-3 rounded-xl border px-3 py-2.5"
+                    style={{
+                      background: "var(--color-bt-card-raised)",
+                      borderColor: "var(--color-bt-border)",
+                    }}
+                  >
+                    <div
+                      className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
+                      style={{ background: "rgba(96,165,250,0.12)" }}
+                    >
+                      <Calendar size={16} style={{ color: "#60a5fa" }} />
+                    </div>
+                    <div className="min-w-0 flex-1 text-left">
+                      <p className="text-sm" style={{ color: "var(--color-bt-text)" }}>
+                        Change dates
+                      </p>
+                      <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                        {formatDateRangeCompact(trip?.start_date ?? null, trip?.end_date ?? null)}
+                      </p>
+                    </div>
+                    <ChevronRight
+                      size={16}
+                      style={{
+                        color: "var(--color-bt-text-dim)",
+                        transform: datesExpanded ? "rotate(90deg)" : undefined,
+                        transition: "transform 150ms",
+                      }}
+                    />
+                  </button>
+
+                  {datesExpanded && (
+                    <div
+                      className="mt-2 space-y-2 rounded-xl border p-3"
+                      style={{ borderColor: "var(--color-bt-border)" }}
+                    >
+                      {datesFromPoll ? (
+                        <>
+                          <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                            These dates came from a crew poll. Going back will reopen the poll so the
+                            crew can vote again.
+                          </p>
+                          <button
+                            data-testid="settings-reopen-poll-btn"
+                            disabled={unlockDatesMutation.isPending}
+                            onClick={() => unlockDatesMutation.mutate({ tripId })}
+                            className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-40"
+                            style={{
+                              background: "var(--color-bt-accent)",
+                              color: "var(--color-bt-base)",
+                            }}
+                          >
+                            {unlockDatesMutation.isPending ? "Reopening…" : "Reopen poll"}
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="date"
+                              data-testid="settings-start-date-input"
+                              value={startDraft}
+                              onChange={(e) => setStartDraft(e.target.value)}
+                              className="min-w-0 flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
+                              style={{
+                                background: "var(--color-bt-card-raised)",
+                                borderColor: "var(--color-bt-border)",
+                                color: "var(--color-bt-text)",
+                              }}
+                            />
+                            <input
+                              type="date"
+                              data-testid="settings-end-date-input"
+                              value={endDraft}
+                              onChange={(e) => setEndDraft(e.target.value)}
+                              className="min-w-0 flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
+                              style={{
+                                background: "var(--color-bt-card-raised)",
+                                borderColor: "var(--color-bt-border)",
+                                color: "var(--color-bt-text)",
+                              }}
+                            />
+                          </div>
+                          <button
+                            data-testid="settings-save-dates-btn"
+                            disabled={!canSaveDates}
+                            onClick={() =>
+                              lockDatesMutation.mutate({
+                                tripId,
+                                startDate: startDraft,
+                                endDate: endDraft,
+                                method: "direct",
+                              })
+                            }
+                            className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+                            style={{
+                              background: "var(--color-bt-accent)",
+                              color: "var(--color-bt-base)",
+                            }}
+                          >
+                            {lockDatesMutation.isPending ? "Updating…" : "Update dates"}
+                          </button>
+                          <button
+                            data-testid="settings-clear-dates-btn"
+                            disabled={unlockDatesMutation.isPending || lockDatesMutation.isPending}
+                            onClick={() => unlockDatesMutation.mutate({ tripId })}
+                            className="w-full rounded-xl border py-2 text-sm font-medium transition-opacity disabled:opacity-40"
+                            style={{
+                              borderColor: "var(--color-bt-danger-border)",
+                              color: "var(--color-bt-danger)",
+                            }}
+                          >
+                            {unlockDatesMutation.isPending ? "Clearing…" : "Clear dates"}
+                          </button>
+                        </>
+                      )}
+                      <button
+                        onClick={() => setDatesExpanded(false)}
+                        className="w-full rounded-xl border py-2 text-sm"
+                        style={{
+                          borderColor: "var(--color-bt-border)",
+                          color: "var(--color-bt-text-dim)",
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Divider */}
+            <div
+              className="mb-4"
               style={{ height: 1, background: "var(--color-bt-border)" }}
             />
           </>


### PR DESCRIPTION
- Remove "Change destination" button from the locked Destination panel on the
  home tab; remove "Change dates" button from the Dates Selected panel.
- Add a Trip plan section to TripSettingsModal (planning stage + Owner/Planner
  only) with inline editors for destination and dates, including the existing
  "reset poll responses" warning and poll-reopen / clear-dates paths.
- Add blurbs to SetDestinationModal, the inline Set dates row, and
  SelectDateModal explaining that future changes must be made via trip
  settings.
- Swap the trip settings trigger icon from MoreHorizontal to Settings for a
  more administrative feel.
- Hide the ItineraryPanel on the home tab during the planning stage.