### PR TITLE
fix(DatePoll): feedback rounds 1-5 + empty-state, return-to-poll, idle ActionCenter

### DIFF
--- a/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
+++ b/src/app/trips/[tripId]/components/DatesPlanningRow.tsx
@@ -305,12 +305,21 @@ export function DatesPlanningRow({
           ...old,
           windows: old.windows.map((w) => {
             if (w.id !== vars.windowId) return w;
+            // Null answer = clear this member's vote.
+            if (vars.answer === null) {
+              return {
+                ...w,
+                votes: w.votes.filter((v) => v.user_id !== vars.userId),
+              };
+            }
             const existing = w.votes.find((v) => v.user_id === vars.userId);
             if (existing) {
               return {
                 ...w,
                 votes: w.votes.map((v) =>
-                  v.user_id === vars.userId ? { ...v, answer: vars.answer } : v
+                  v.user_id === vars.userId
+                    ? { ...v, answer: vars.answer as string }
+                    : v
                 ),
               };
             }
@@ -321,7 +330,7 @@ export function DatesPlanningRow({
                 {
                   window_id: vars.windowId,
                   user_id: vars.userId,
-                  answer: vars.answer,
+                  answer: vars.answer as string,
                   created_at: new Date().toISOString(),
                 },
               ],

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -1036,7 +1036,7 @@ export function HomeTab({
           {/* ── Action Center — everyone sees their active tasks in   ── */}
           {/*    idea + planning stages (matches DatesPlanningRow gate) ── */}
           {(stage === "idea" || stage === "planning") && (
-            <ActionCenter trip={trip} canEdit={canEditProp} isOwner={!!isOwner} />
+            <ActionCenter trip={trip} isOwner={!!isOwner} />
           )}
 
           {/* ── Planning rows — gated by stage + canEdit ──────────── */}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -766,9 +766,9 @@ function PlanningSection({
         Planning
       </p>
 
-      {/* ── Dates — hidden once locked (shown in header, edit in settings; ── */}
-      {/*    re-open a poll via settings → Reopen poll to revisit options) ── */}
-      {!(trip.start_date && trip.end_date) && (
+      {/* ── Dates — Owner-only admin surface. Non-owners use the  ── */}
+      {/*    DatePollCard in ActionCenter. Hidden once locked.     ── */}
+      {!(trip.start_date && trip.end_date) && isOwner && (
         <DatesPlanningRow
           trip={trip}
           canEdit={canEdit}
@@ -1035,7 +1035,7 @@ export function HomeTab({
 
           {/* ── Action Center — everyone sees their active tasks ──── */}
           {stage === "planning" && (
-            <ActionCenter trip={trip} canEdit={canEditProp} />
+            <ActionCenter trip={trip} canEdit={canEditProp} isOwner={!!isOwner} />
           )}
 
           {/* ── Planning rows — gated by stage + canEdit ──────────── */}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -1033,8 +1033,9 @@ export function HomeTab({
             />
           )}
 
-          {/* ── Action Center — everyone sees their active tasks ──── */}
-          {stage === "planning" && (
+          {/* ── Action Center — everyone sees their active tasks in   ── */}
+          {/*    idea + planning stages (matches DatesPlanningRow gate) ── */}
+          {(stage === "idea" || stage === "planning") && (
             <ActionCenter trip={trip} canEdit={canEditProp} isOwner={!!isOwner} />
           )}
 

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Sparkles } from "lucide-react";
 import type { TripData } from "../types";
 import { DatePollCard } from "./DatePollCard";
 
@@ -10,27 +11,26 @@ export interface ActionCenterProps {
 
 /**
  * ActionCenter — member-facing "what needs your attention" surface shown
- * above PlanningSection during the IDEA and PLANNING stages.
+ * during the IDEA and PLANNING stages.
  *
  * Mirrors DatesPlanningRow's visibility contract: the date poll can be
  * open in either stage, so ActionCenter must surface DatePollCard in both
- * or non-owners will have no way to see / vote on the poll.
+ * or non-owners would have no way to see / vote on the poll.
  *
- * Currently renders DatePollCard when the date poll is in progress or
- * dates have just been locked. Future cards (RsvpCard, TravelCard) will
- * follow the same shell pattern and plug in here.
+ * When no card has anything actionable to surface (e.g. dates are locked
+ * and there's no poll in progress), we render a soft placeholder instead
+ * of unmounting the whole section — the user asked us to avoid the
+ * "panels vanish" transition whiplash.
+ *
+ * Future cards (RsvpCard, TravelCard) slot in alongside DatePollCard.
  */
 export function ActionCenter({ trip, isOwner }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
   if (stage !== "idea" && stage !== "planning") return null;
 
-  const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;
-
-  // Only surface the date poll card when there's something to show.
-  const showDatePollCard = pollMode || datesLocked;
-
-  if (!showDatePollCard) return null;
+  // Future: also roll up RsvpCard / TravelCard "has action?" flags here.
+  const hasActionableCard = pollMode;
 
   return (
     <section className="space-y-3">
@@ -40,8 +40,52 @@ export function ActionCenter({ trip, isOwner }: ActionCenterProps) {
       >
         Action Center
       </p>
-      {showDatePollCard && <DatePollCard trip={trip} isOwner={isOwner} />}
+      {pollMode && <DatePollCard trip={trip} isOwner={isOwner} />}
+      {!hasActionableCard && <ActionCenterIdle isOwner={isOwner} />}
       {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
     </section>
+  );
+}
+
+/**
+ * Idle-state placeholder — shown when no card has a pending action.
+ * Kept small and low-contrast so it reads as "you're all set" rather
+ * than competing with real action cards when they appear later.
+ */
+function ActionCenterIdle({ isOwner }: { isOwner: boolean }) {
+  return (
+    <div
+      className="flex items-start gap-3 rounded-xl px-4 py-3.5 transition-opacity duration-300"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px dashed var(--color-bt-border)",
+      }}
+    >
+      <span
+        className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          color: "var(--color-bt-accent)",
+        }}
+      >
+        <Sparkles size={14} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p
+          className="text-[14px] font-semibold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          You&apos;re all set
+        </p>
+        <p
+          className="mt-0.5 text-[12px] leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {isOwner
+            ? "Nothing needed from the crew right now. New action cards will show up here as the trip progresses."
+            : "Nothing needed from you at the moment — we'll let you know when the host has something for you to respond to."}
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -6,6 +6,7 @@ import { DatePollCard } from "./DatePollCard";
 export interface ActionCenterProps {
   trip: TripData;
   canEdit: boolean;
+  isOwner: boolean;
 }
 
 /**
@@ -16,7 +17,7 @@ export interface ActionCenterProps {
  * dates have just been locked. Future cards (RsvpCard, TravelCard) will
  * follow the same shell pattern and plug in here.
  */
-export function ActionCenter({ trip, canEdit }: ActionCenterProps) {
+export function ActionCenter({ trip, canEdit, isOwner }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
   if (stage !== "planning") return null;
 
@@ -36,7 +37,9 @@ export function ActionCenter({ trip, canEdit }: ActionCenterProps) {
       >
         Action Center
       </p>
-      {showDatePollCard && <DatePollCard trip={trip} canEdit={canEdit} />}
+      {showDatePollCard && (
+        <DatePollCard trip={trip} canEdit={canEdit} isOwner={isOwner} />
+      )}
       {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
     </section>
   );

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -5,7 +5,6 @@ import { DatePollCard } from "./DatePollCard";
 
 export interface ActionCenterProps {
   trip: TripData;
-  canEdit: boolean;
   isOwner: boolean;
 }
 
@@ -21,7 +20,7 @@ export interface ActionCenterProps {
  * dates have just been locked. Future cards (RsvpCard, TravelCard) will
  * follow the same shell pattern and plug in here.
  */
-export function ActionCenter({ trip, canEdit, isOwner }: ActionCenterProps) {
+export function ActionCenter({ trip, isOwner }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
   if (stage !== "idea" && stage !== "planning") return null;
 
@@ -41,9 +40,7 @@ export function ActionCenter({ trip, canEdit, isOwner }: ActionCenterProps) {
       >
         Action Center
       </p>
-      {showDatePollCard && (
-        <DatePollCard trip={trip} canEdit={canEdit} isOwner={isOwner} />
-      )}
+      {showDatePollCard && <DatePollCard trip={trip} isOwner={isOwner} />}
       {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
     </section>
   );

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -11,7 +11,11 @@ export interface ActionCenterProps {
 
 /**
  * ActionCenter — member-facing "what needs your attention" surface shown
- * above PlanningSection during the PLANNING stage.
+ * above PlanningSection during the IDEA and PLANNING stages.
+ *
+ * Mirrors DatesPlanningRow's visibility contract: the date poll can be
+ * open in either stage, so ActionCenter must surface DatePollCard in both
+ * or non-owners will have no way to see / vote on the poll.
  *
  * Currently renders DatePollCard when the date poll is in progress or
  * dates have just been locked. Future cards (RsvpCard, TravelCard) will
@@ -19,7 +23,7 @@ export interface ActionCenterProps {
  */
 export function ActionCenter({ trip, canEdit, isOwner }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
-  if (stage !== "planning") return null;
+  if (stage !== "idea" && stage !== "planning") return null;
 
   const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -17,7 +17,6 @@ import {
 
 export interface DatePollCardProps {
   trip: TripData;
-  canEdit: boolean;
   isOwner: boolean;
 }
 
@@ -33,11 +32,13 @@ function sortWindows(ws: PollWindow[]): PollWindow[] {
 }
 
 /**
- * DatePollCard — the member-facing (and canEdit-viewable) surface for the
+ * DatePollCard — the member-facing (and owner-operable) surface for the
  * date poll. Wraps ActionCard + DatePollGrid. Shows resolved chip when
- * dates are locked. Footer actions (Notify crew / Reset) visible to canEdit.
+ * dates are locked. Footer actions (Notify crew / Reset) are owner-only;
+ * non-owners see a read-only poll with interactive cells only on their
+ * own row.
  */
-export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
+export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
@@ -261,6 +262,17 @@ export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
   });
 
   const notifyCrew = trpc.datePoll.notifyCrewPollOpen.useMutation({
+    async onMutate() {
+      await utils.datePoll.get.cancel({ tripId });
+      const prev = utils.datePoll.get.getData({ tripId });
+      utils.datePoll.get.setData({ tripId }, (old) =>
+        old ? { ...old, notifySent: true } : old
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
+    },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
     },
@@ -329,52 +341,45 @@ export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
             dateWindows={windows}
             members={pollMembers}
             currentUserId={currentUser?.id ?? ""}
-            canEdit={canEdit}
             isOwner={isOwner}
             onVote={handleVote}
-            onAddDateWindow={canEdit ? () => setShowAddDateModal(true) : undefined}
+            onAddDateWindow={isOwner ? () => setShowAddDateModal(true) : undefined}
             onLockDateWindow={
-              canEdit
+              isOwner
                 ? (windowId) => lockWindow.mutate({ tripId, windowId })
                 : undefined
             }
             onRemoveDateWindow={
-              canEdit ? (windowId) => setConfirmRemoveId(windowId) : undefined
+              isOwner ? (windowId) => setConfirmRemoveId(windowId) : undefined
             }
           />
 
-          {canEdit && (
+          {isOwner && (
             <div className="flex items-center gap-2">
-              {isOwner && (
-                <button
-                  type="button"
-                  onClick={() => notifyCrew.mutate({ tripId })}
-                  disabled={notifySent || notifyCrew.isPending}
-                  className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    color: notifySent
-                      ? "var(--color-bt-text-dim)"
-                      : "var(--color-bt-accent)",
-                    border: "1px solid var(--color-bt-border)",
-                    opacity: notifySent ? 0.6 : 1,
-                    cursor: notifySent ? "default" : "pointer",
-                  }}
-                >
-                  <Bell size={13} />
-                  {notifySent ? "Crew notified" : "Notify crew"}
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => notifyCrew.mutate({ tripId })}
+                disabled={notifySent || notifyCrew.isPending}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  color: notifySent
+                    ? "var(--color-bt-text-dim)"
+                    : "var(--color-bt-accent)",
+                  border: "1px solid var(--color-bt-border)",
+                  opacity: notifySent ? 0.6 : 1,
+                  cursor: notifySent ? "default" : "pointer",
+                }}
+              >
+                <Bell size={13} />
+                {notifySent ? "Crew notified" : "Notify crew"}
+              </button>
               {anyVotes && (
                 <button
                   type="button"
                   onClick={() => resetPoll.mutate({ tripId })}
                   disabled={resetPoll.isPending}
-                  className={
-                    isOwner
-                      ? "flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
-                      : "flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
-                  }
+                  className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
                   style={{
                     background: "var(--color-bt-card-raised)",
                     color: "var(--color-bt-text-dim)",

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -17,6 +17,7 @@ import {
 export interface DatePollCardProps {
   trip: TripData;
   canEdit: boolean;
+  isOwner: boolean;
 }
 
 function sortWindows(ws: PollWindow[]): PollWindow[] {
@@ -35,7 +36,7 @@ function sortWindows(ws: PollWindow[]): PollWindow[] {
  * date poll. Wraps ActionCard + DatePollGrid. Shows resolved chip when
  * dates are locked. Footer actions (Notify crew / Reset) visible to canEdit.
  */
-export function DatePollCard({ trip, canEdit }: DatePollCardProps) {
+export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
@@ -115,6 +116,59 @@ export function DatePollCard({ trip, canEdit }: DatePollCardProps) {
     },
   });
 
+  const voteForMember = trpc.datePoll.castVoteForMember.useMutation({
+    async onMutate(vars) {
+      await utils.datePoll.get.cancel({ tripId });
+      const prev = utils.datePoll.get.getData({ tripId });
+      utils.datePoll.get.setData({ tripId }, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          windows: old.windows.map((w) => {
+            if (w.id !== vars.windowId) return w;
+            // Null answer = clear that member's vote.
+            if (vars.answer === null) {
+              return {
+                ...w,
+                votes: w.votes.filter((v) => v.user_id !== vars.userId),
+              };
+            }
+            const existing = w.votes.find((v) => v.user_id === vars.userId);
+            if (existing) {
+              return {
+                ...w,
+                votes: w.votes.map((v) =>
+                  v.user_id === vars.userId
+                    ? { ...v, answer: vars.answer as string }
+                    : v
+                ),
+              };
+            }
+            return {
+              ...w,
+              votes: [
+                ...w.votes,
+                {
+                  window_id: vars.windowId,
+                  user_id: vars.userId,
+                  answer: vars.answer as string,
+                  created_at: new Date().toISOString(),
+                },
+              ],
+            };
+          }),
+        };
+      });
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
+    },
+    onSettled() {
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
   const notifyCrew = trpc.datePoll.notifyCrewPollOpen.useMutation({
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -155,8 +209,14 @@ export function DatePollCard({ trip, canEdit }: DatePollCardProps) {
 
   // ── Poll-open view ─────────────────────────────────────────────────────
 
-  const handleVote = (windowId: string, answer: VoteAnswer) => {
-    castVote.mutate({ tripId, windowId, answer });
+  const handleVote = (windowId: string, answer: VoteAnswer, userId: string) => {
+    if (userId === currentUser?.id) {
+      castVote.mutate({ tripId, windowId, answer });
+    } else if (isOwner) {
+      // Owner voting on behalf of another crew member.
+      voteForMember.mutate({ tripId, windowId, userId, answer });
+    }
+    // Non-owner clicks on another member's cell are blocked at the grid level.
   };
 
   const anyVotes = windows.some((w) => w.votes.length > 0);
@@ -165,7 +225,7 @@ export function DatePollCard({ trip, canEdit }: DatePollCardProps) {
     <ActionCard
       icon={<Calendar size={16} />}
       title="Pick your dates"
-      subtitle={canEdit ? "Tap a cell to vote on behalf of a member" : "Tap your row to cast a vote"}
+      subtitle={isOwner ? "Tap any cell to vote on behalf of a crew member" : "Tap your row to cast a vote"}
       isResolved={false}
     >
       <div className="space-y-3">
@@ -174,6 +234,7 @@ export function DatePollCard({ trip, canEdit }: DatePollCardProps) {
           members={pollMembers}
           currentUserId={currentUser?.id ?? ""}
           canEdit={canEdit}
+          isOwner={isOwner}
           onVote={handleVote}
         />
 

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
-import { Calendar, Bell, RotateCcw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Calendar, Bell, RotateCcw, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { formatDateRangeCompact, parseLocalDate } from "@/lib/dates";
 import type { TripData } from "../types";
 import { ActionCard } from "./ActionCard";
@@ -40,6 +41,9 @@ export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
+
+  const [showAddDateModal, setShowAddDateModal] = useState(false);
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
 
   const { data: poll } = trpc.datePoll.get.useQuery({ tripId });
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
@@ -169,6 +173,93 @@ export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
     },
   });
 
+  const addWindow = trpc.datePoll.addWindow.useMutation({
+    async onMutate(vars) {
+      await utils.datePoll.get.cancel({ tripId });
+      const prev = utils.datePoll.get.getData({ tripId });
+      utils.datePoll.get.setData({ tripId }, (old) => {
+        const newWindow = {
+          id: vars.id,
+          trip_id: tripId,
+          start_date: vars.startDate,
+          end_date: vars.endDate,
+          created_at: new Date().toISOString(),
+          votes: [] as {
+            window_id: string;
+            user_id: string;
+            answer: string;
+            created_at: string;
+          }[],
+        };
+        if (!old) {
+          return {
+            lockedWindowId: null,
+            notifySent: false,
+            pollMode: true,
+            windows: [newWindow],
+          };
+        }
+        return { ...old, windows: [...old.windows, newWindow] };
+      });
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
+    },
+    onSettled() {
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  const removeWindow = trpc.datePoll.removeWindow.useMutation({
+    async onMutate(vars) {
+      await utils.datePoll.get.cancel({ tripId });
+      const prev = utils.datePoll.get.getData({ tripId });
+      utils.datePoll.get.setData({ tripId }, (old) =>
+        old
+          ? { ...old, windows: old.windows.filter((w) => w.id !== vars.windowId) }
+          : old
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
+    },
+    onSettled() {
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  const lockWindow = trpc.datePoll.lockDateWindow.useMutation({
+    async onMutate(vars) {
+      await utils.trips.getById.cancel({ tripId });
+      const prevTrip = utils.trips.getById.getData({ tripId });
+      const pollData = utils.datePoll.get.getData({ tripId });
+      const win = pollData?.windows.find((w) => w.id === vars.windowId);
+      if (win) {
+        utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+          old
+            ? {
+                ...old,
+                start_date: win.start_date,
+                end_date: win.end_date,
+                poll_mode: false,
+              }
+            : old
+        );
+      }
+      return { prevTrip };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prevTrip !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prevTrip);
+    },
+    onSettled() {
+      utils.datePoll.get.invalidate({ tripId });
+      utils.trips.getById.invalidate({ tripId });
+    },
+  });
+
   const notifyCrew = trpc.datePoll.notifyCrewPollOpen.useMutation({
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -221,63 +312,292 @@ export function DatePollCard({ trip, canEdit, isOwner }: DatePollCardProps) {
 
   const anyVotes = windows.some((w) => w.votes.length > 0);
 
-  return (
-    <ActionCard
-      icon={<Calendar size={16} />}
-      title="Pick your dates"
-      subtitle={isOwner ? "Tap any cell to vote on behalf of a crew member" : "Tap your row to cast a vote"}
-      isResolved={false}
-    >
-      <div className="space-y-3">
-        <DatePollGrid
-          dateWindows={windows}
-          members={pollMembers}
-          currentUserId={currentUser?.id ?? ""}
-          canEdit={canEdit}
-          isOwner={isOwner}
-          onVote={handleVote}
-        />
+  const pendingRemoveWindow = confirmRemoveId
+    ? windows.find((w) => w.id === confirmRemoveId) ?? null
+    : null;
 
-        {canEdit && (
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => notifyCrew.mutate({ tripId })}
-              disabled={notifySent || notifyCrew.isPending}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                color: notifySent
-                  ? "var(--color-bt-text-dim)"
-                  : "var(--color-bt-accent)",
-                border: "1px solid var(--color-bt-border)",
-                opacity: notifySent ? 0.6 : 1,
-                cursor: notifySent ? "default" : "pointer",
-              }}
-            >
-              <Bell size={13} />
-              {notifySent ? "Crew notified" : "Notify crew"}
-            </button>
-            {anyVotes && (
-              <button
-                type="button"
-                onClick={() => resetPoll.mutate({ tripId })}
-                disabled={resetPoll.isPending}
-                className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text-dim)",
-                  border: "1px solid var(--color-bt-border)",
-                }}
-                aria-label="Reset votes"
-              >
-                <RotateCcw size={13} />
-                Reset
-              </button>
-            )}
-          </div>
-        )}
+  return (
+    <>
+      <ActionCard
+        icon={<Calendar size={16} />}
+        title="Pick your dates"
+        subtitle={isOwner ? "Tap any cell to vote on behalf of a crew member" : "Tap your row to cast a vote"}
+        isResolved={false}
+      >
+        <div className="space-y-3">
+          <DatePollGrid
+            dateWindows={windows}
+            members={pollMembers}
+            currentUserId={currentUser?.id ?? ""}
+            canEdit={canEdit}
+            isOwner={isOwner}
+            onVote={handleVote}
+            onAddDateWindow={canEdit ? () => setShowAddDateModal(true) : undefined}
+            onLockDateWindow={
+              canEdit
+                ? (windowId) => lockWindow.mutate({ tripId, windowId })
+                : undefined
+            }
+            onRemoveDateWindow={
+              canEdit ? (windowId) => setConfirmRemoveId(windowId) : undefined
+            }
+          />
+
+          {canEdit && (
+            <div className="flex items-center gap-2">
+              {isOwner && (
+                <button
+                  type="button"
+                  onClick={() => notifyCrew.mutate({ tripId })}
+                  disabled={notifySent || notifyCrew.isPending}
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: notifySent
+                      ? "var(--color-bt-text-dim)"
+                      : "var(--color-bt-accent)",
+                    border: "1px solid var(--color-bt-border)",
+                    opacity: notifySent ? 0.6 : 1,
+                    cursor: notifySent ? "default" : "pointer",
+                  }}
+                >
+                  <Bell size={13} />
+                  {notifySent ? "Crew notified" : "Notify crew"}
+                </button>
+              )}
+              {anyVotes && (
+                <button
+                  type="button"
+                  onClick={() => resetPoll.mutate({ tripId })}
+                  disabled={resetPoll.isPending}
+                  className={
+                    isOwner
+                      ? "flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
+                      : "flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
+                  }
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-border)",
+                  }}
+                  aria-label="Reset votes"
+                >
+                  <RotateCcw size={13} />
+                  Reset
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </ActionCard>
+
+      {/* Add date window modal */}
+      {showAddDateModal && (
+        <AddDateWindowModal
+          pending={addWindow.isPending}
+          onClose={() => setShowAddDateModal(false)}
+          onSubmit={(startDate, endDate) => {
+            addWindow.mutate(
+              {
+                tripId,
+                id: crypto.randomUUID(),
+                startDate,
+                endDate,
+              },
+              {
+                onSuccess() {
+                  setShowAddDateModal(false);
+                },
+              }
+            );
+          }}
+        />
+      )}
+
+      {/* Confirm remove dialog */}
+      {pendingRemoveWindow && (
+        <ConfirmDialog
+          title="Remove this date option?"
+          body="This will delete the option and any votes already cast for it."
+          cancelLabel="Cancel"
+          confirmLabel={removeWindow.isPending ? "Removing…" : "Remove"}
+          confirmDanger
+          onCancel={() => setConfirmRemoveId(null)}
+          onConfirm={() =>
+            removeWindow.mutate(
+              { tripId, windowId: pendingRemoveWindow.id },
+              { onSuccess: () => setConfirmRemoveId(null) }
+            )
+          }
+        />
+      )}
+    </>
+  );
+}
+
+// ── AddDateWindowModal ───────────────────────────────────────────────────
+
+function AddDateWindowModal({
+  pending,
+  onClose,
+  onSubmit,
+}: {
+  pending: boolean;
+  onClose: () => void;
+  onSubmit: (startDate: string, endDate: string) => void;
+}) {
+  useModalBackButton(onClose);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const valid = !!startDate && !!endDate && startDate < endDate;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="w-full max-w-sm rounded-t-2xl p-5 lg:rounded-2xl"
+        style={{ background: "var(--color-bt-card)" }}
+      >
+        <div className="mb-2 flex items-center justify-between">
+          <p
+            className="text-base font-semibold"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            Add a date option
+          </p>
+          <button
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-lg"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <p
+          className="mb-4 text-xs"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Pick a start and end date for a new window the crew can vote on.
+        </p>
+        <div className="space-y-2">
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="w-full rounded-xl px-3 py-2.5 text-sm"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="w-full rounded-xl px-3 py-2.5 text-sm"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+        </div>
+        <div className="mt-4 flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 rounded-xl py-2.5 text-sm font-medium"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!valid || pending}
+            onClick={() => valid && onSubmit(startDate, endDate)}
+            className="flex-1 rounded-xl py-2.5 text-sm font-semibold"
+            style={{
+              background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+              color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+              opacity: valid ? 1 : 0.6,
+              cursor: valid ? "pointer" : "not-allowed",
+            }}
+          >
+            {pending ? "Adding…" : "Add date"}
+          </button>
+        </div>
       </div>
-    </ActionCard>
+    </div>
+  );
+}
+
+// ── ConfirmDialog ────────────────────────────────────────────────────────
+
+function ConfirmDialog({
+  title,
+  body,
+  cancelLabel,
+  confirmLabel,
+  confirmDanger,
+  onCancel,
+  onConfirm,
+}: {
+  title: string;
+  body: string;
+  cancelLabel: string;
+  confirmLabel: string;
+  confirmDanger?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  useModalBackButton(onCancel);
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-6"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl p-5"
+        style={{ background: "var(--color-bt-card)" }}
+      >
+        <p className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          {title}
+        </p>
+        <p className="mt-1 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+          {body}
+        </p>
+        <div className="mt-4 flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-xl py-2.5 text-sm font-medium"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+            }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 rounded-xl py-2.5 text-sm font-semibold"
+            style={{
+              background: confirmDanger
+                ? "var(--color-bt-danger)"
+                : "var(--color-bt-accent)",
+              color: "var(--color-bt-base)",
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -5,7 +5,7 @@ import { Calendar, Bell, RotateCcw, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
-import { formatDateRangeCompact, parseLocalDate } from "@/lib/dates";
+import { parseLocalDate } from "@/lib/dates";
 import type { TripData } from "../types";
 import { ActionCard } from "./ActionCard";
 import {
@@ -297,18 +297,11 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     },
   });
 
-  // ── Resolved view ──────────────────────────────────────────────────────
-
-  if (datesLocked) {
-    return (
-      <ActionCard
-        icon={<Calendar size={16} />}
-        title="Dates locked"
-        isResolved
-        resolvedSummary={formatDateRangeCompact(trip.start_date, trip.end_date)}
-      />
-    );
-  }
+  // When dates are locked, the date poll is not an action surface — the
+  // ActionCenter renders its own "nothing needed right now" placeholder
+  // (which will also cover future resolved-stage cards like RSVP / travel).
+  // Returning null here keeps DatePollCard a pure poll-mode component.
+  if (datesLocked) return null;
 
   // ── Poll-open view ─────────────────────────────────────────────────────
 

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -33,8 +33,12 @@ export interface DatePollGridProps {
   dateWindows: PollWindow[];
   members: PollMember[];
   currentUserId: string;
+  /** Owner + Planner — controls column-header popover (lock/edit/remove). */
   canEdit: boolean;
-  onVote: (dateWindowId: string, answer: VoteAnswer) => void;
+  /** Owner only — controls vote-for-other-members. Non-owners can only vote in their own row. */
+  isOwner: boolean;
+  /** Fires with the target member's user_id. For non-owners this is always the current user. */
+  onVote: (dateWindowId: string, answer: VoteAnswer, userId: string) => void;
   // canEdit-only — optional so caller can omit for member-rendered grids
   onAddDateWindow?: () => void;
   onEditDateWindow?: (id: string) => void;
@@ -75,6 +79,7 @@ export function DatePollGrid({
   members,
   currentUserId,
   canEdit,
+  isOwner,
   onVote,
   onAddDateWindow,
   onEditDateWindow,
@@ -165,8 +170,10 @@ export function DatePollGrid({
                 ? "var(--color-bt-card)"
                 : "var(--color-bt-state-fill)";
             const isMe = m.user_id === currentUserId;
-            // Members see other rows dimmed; canEdit sees all rows clearly
-            const rowDimmed = !isMe && !canEdit;
+            // Only the owner can see / interact with other members' rows.
+            // Planners and Members see their own row clearly and others dimmed
+            // (and non-operational).
+            const rowDimmed = !isMe && !isOwner;
             return (
               <div key={m.user_id ?? rowIdx} className="contents">
                 <div
@@ -205,14 +212,12 @@ export function DatePollGrid({
                     >
                       <VoteButton
                         answer={answer}
-                        interactive={isMe || canEdit}
+                        interactive={isMe || isOwner}
                         dimmed={rowDimmed}
                         onClick={() => {
                           if (!m.user_id) return;
-                          if (isMe) {
-                            onVote(w.id, cycleAnswer(answer));
-                          } else if (canEdit) {
-                            onVote(w.id, cycleAnswer(answer));
+                          if (isMe || isOwner) {
+                            onVote(w.id, cycleAnswer(answer), m.user_id);
                           }
                         }}
                       />

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { CalendarPlus, Check, Lock, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { CalendarPlus, Check, CheckCircle2, Trash2 } from "lucide-react";
 import { parseLocalDate } from "@/lib/dates";
 import { UserAvatar } from "@/components/UserAvatar";
 
@@ -41,7 +41,6 @@ export interface DatePollGridProps {
   onVote: (dateWindowId: string, answer: VoteAnswer, userId: string) => void;
   // canEdit-only — optional so caller can omit for member-rendered grids
   onAddDateWindow?: () => void;
-  onEditDateWindow?: (id: string) => void;
   onRemoveDateWindow?: (id: string) => void;
   onLockDateWindow?: (id: string) => void;
 }
@@ -67,8 +66,8 @@ function formatColumnLabel(start: string, end: string): string {
 }
 
 const COLUMN_WIDTH = 88; // px, per-window column
-const NAME_COL_WIDTH = 96; // px, sticky name column
-const ADD_COL_WIDTH = 46; // px, always-visible add column
+const NAME_COL_MIN_WIDTH = 120; // px, sticky name column minimum — grows to fit names
+const ADD_COL_WIDTH = 54; // px, always-visible add column
 
 /**
  * Grid UI for the date poll. Pure rendering — emits callbacks for vote
@@ -82,7 +81,6 @@ export function DatePollGrid({
   isOwner,
   onVote,
   onAddDateWindow,
-  onEditDateWindow,
   onRemoveDateWindow,
   onLockDateWindow,
 }: DatePollGridProps) {
@@ -101,20 +99,22 @@ export function DatePollGrid({
     return () => window.removeEventListener("mousedown", handler);
   }, [openPopoverId]);
 
-  const gridMinWidth = NAME_COL_WIDTH + dateWindows.length * COLUMN_WIDTH;
+  const gridMinWidth = NAME_COL_MIN_WIDTH + dateWindows.length * COLUMN_WIDTH;
 
   return (
     <div className="flex">
       {/* ── scrollable grid ────────────────────────────────────────────── */}
       <div
-        className="min-w-0 flex-1 overflow-x-auto rounded-l-xl"
+        className="min-w-0 flex-1 overflow-x-auto rounded-xl"
         style={{ background: "var(--color-bt-card)" }}
       >
         <div
           className="grid"
           style={{
             minWidth: `${gridMinWidth}px`,
-            gridTemplateColumns: `${NAME_COL_WIDTH}px repeat(${Math.max(dateWindows.length, 1)}, minmax(${COLUMN_WIDTH}px, 1fr))`,
+            // Name column auto-fits content (no truncate) with a minimum width.
+            // Date columns use a fixed min then flex to share space.
+            gridTemplateColumns: `minmax(${NAME_COL_MIN_WIDTH}px, max-content) repeat(${Math.max(dateWindows.length, 1)}, minmax(${COLUMN_WIDTH}px, 1fr))`,
           }}
         >
           {/* Header: name column */}
@@ -177,12 +177,12 @@ export function DatePollGrid({
             return (
               <div key={m.user_id ?? rowIdx} className="contents">
                 <div
-                  className="sticky left-0 z-[2] flex min-w-0 items-center gap-2 px-3 py-2"
+                  className="sticky left-0 z-[2] flex items-center gap-2 whitespace-nowrap px-3 py-2"
                   style={{ background: rowBg }}
                 >
                   <UserAvatar name={m.displayName} avatarUrl={m.avatarUrl ?? null} size="sm" />
                   <span
-                    className="truncate text-[13px]"
+                    className="text-[13px]"
                     style={{ color: "var(--color-bt-text)" }}
                   >
                     {m.displayName}
@@ -235,17 +235,17 @@ export function DatePollGrid({
         <button
           type="button"
           onClick={onAddDateWindow}
-          className="flex flex-shrink-0 items-center justify-center rounded-r-xl transition-colors"
+          className="group relative ml-2 flex flex-shrink-0 items-center justify-center self-stretch rounded-xl transition-colors hover:bg-[var(--color-bt-card-raised)]"
           style={{
             width: `${ADD_COL_WIDTH}px`,
-            background: "var(--color-bt-card)",
-            borderLeft: "1px solid var(--color-bt-border)",
+            background: "transparent",
+            border: "1.5px dashed var(--color-bt-border)",
             color: "var(--color-bt-accent)",
           }}
           aria-label="Add date option"
         >
           <span className="relative flex items-center justify-center">
-            <CalendarPlus size={20} />
+            <CalendarPlus size={22} />
           </span>
         </button>
       )}
@@ -262,18 +262,10 @@ export function DatePollGrid({
           }}
         >
           <PopoverItem
-            icon={<Lock size={14} />}
-            label="Lock this date"
+            icon={<CheckCircle2 size={14} />}
+            label="Select this date"
             onClick={() => {
               onLockDateWindow?.(openPopoverId);
-              setOpenPopoverId(null);
-            }}
-          />
-          <PopoverItem
-            icon={<Pencil size={14} />}
-            label="Edit dates"
-            onClick={() => {
-              onEditDateWindow?.(openPopoverId);
               setOpenPopoverId(null);
             }}
           />
@@ -309,7 +301,7 @@ function ColumnHeader({
   if (!canEdit) {
     return (
       <div
-        className="flex items-center justify-center px-2 py-2.5 text-center"
+        className="flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
         style={{
           background: bg,
           borderBottom: "1px solid var(--color-bt-border)",
@@ -325,10 +317,8 @@ function ColumnHeader({
     );
   }
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className="flex items-center justify-center gap-1 px-2 py-2.5 text-center transition-colors"
+    <div
+      className="flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
       style={{
         background: bg,
         borderBottom: "1px solid var(--color-bt-border)",
@@ -340,14 +330,26 @@ function ColumnHeader({
       >
         {label}
       </span>
-      <MoreHorizontal
-        size={14}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="rounded-md px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider leading-none transition-colors"
         style={{
-          color: isActive ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-          opacity: isActive ? 1 : 0.4,
+          background: isActive
+            ? "var(--color-bt-accent)"
+            : "var(--color-bt-card-raised)",
+          color: isActive
+            ? "var(--color-bt-base)"
+            : "var(--color-bt-accent)",
+          border: isActive
+            ? "1px solid var(--color-bt-accent)"
+            : "1px solid var(--color-bt-accent-border)",
         }}
-      />
-    </button>
+        aria-label="Select this date"
+      >
+        Select
+      </button>
+    </div>
   );
 }
 

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -33,13 +33,16 @@ export interface DatePollGridProps {
   dateWindows: PollWindow[];
   members: PollMember[];
   currentUserId: string;
-  /** Owner + Planner — controls column-header popover (lock/edit/remove). */
-  canEdit: boolean;
-  /** Owner only — controls vote-for-other-members. Non-owners can only vote in their own row. */
+  /**
+   * Owner only. Controls every admin affordance on the grid: column
+   * popover (Select / Remove), add-date column, voting on behalf of other
+   * crew members, un-dimmed rendering of other rows. Non-owners see a
+   * read-only surface where only their own row is interactive.
+   */
   isOwner: boolean;
   /** Fires with the target member's user_id. For non-owners this is always the current user. */
   onVote: (dateWindowId: string, answer: VoteAnswer, userId: string) => void;
-  // canEdit-only — optional so caller can omit for member-rendered grids
+  // isOwner-only — optional so caller can omit for non-owner grids
   onAddDateWindow?: () => void;
   onRemoveDateWindow?: (id: string) => void;
   onLockDateWindow?: (id: string) => void;
@@ -73,17 +76,36 @@ const ADD_COL_WIDTH = 54; // px, always-visible add column
  * Grid UI for the date poll. Pure rendering — emits callbacks for vote
  * changes and column header actions. Caller wires mutations.
  */
+// Media query hook — tiny inline helper so we can branch the vote cell
+// layout on viewport width without pulling a dependency.
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia(query);
+    const onChange = () => setMatches(mq.matches);
+    onChange();
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, [query]);
+  return matches;
+}
+
 export function DatePollGrid({
   dateWindows,
   members,
   currentUserId,
-  canEdit,
   isOwner,
   onVote,
   onAddDateWindow,
   onRemoveDateWindow,
   onLockDateWindow,
 }: DatePollGridProps) {
+  // On desktop with three or fewer date options the cell is wide enough to
+  // render the three answer buttons side-by-side (yes / maybe / no) instead
+  // of the cycle single-button. Mobile always uses cycle mode.
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const useTripletLayout = isDesktop && dateWindows.length > 0 && dateWindows.length <= 3;
   // Popover state keeps the anchor rect so the menu can be positioned
   // directly beneath the column header button that opened it.
   const [openPopover, setOpenPopover] = useState<
@@ -174,7 +196,7 @@ export function DatePollGrid({
                   key={w.id}
                   label={formatColumnLabel(w.start_date, w.end_date)}
                   isActive={isActive}
-                  canEdit={canEdit}
+                  canEdit={isOwner}
                   onToggle={(btnRect) => {
                     if (openPopoverId === w.id) {
                       setOpenPopover(null);
@@ -233,23 +255,32 @@ export function DatePollGrid({
                   const cellBg = isColumnHighlighted
                     ? "rgba(45, 212, 191, 0.07)"
                     : rowBg;
+                  const interactive = isMe || isOwner;
+                  const handleSet = (next: VoteAnswer) => {
+                    if (!m.user_id || !interactive) return;
+                    onVote(w.id, next, m.user_id);
+                  };
                   return (
                     <div
                       key={w.id}
                       className="flex items-center justify-center px-1 py-2"
                       style={{ background: cellBg }}
                     >
-                      <VoteButton
-                        answer={answer}
-                        interactive={isMe || isOwner}
-                        dimmed={rowDimmed}
-                        onClick={() => {
-                          if (!m.user_id) return;
-                          if (isMe || isOwner) {
-                            onVote(w.id, cycleAnswer(answer), m.user_id);
-                          }
-                        }}
-                      />
+                      {useTripletLayout ? (
+                        <VoteTriplet
+                          answer={answer}
+                          interactive={interactive}
+                          dimmed={rowDimmed}
+                          onSet={handleSet}
+                        />
+                      ) : (
+                        <VoteButton
+                          answer={answer}
+                          interactive={interactive}
+                          dimmed={rowDimmed}
+                          onClick={() => handleSet(cycleAnswer(answer))}
+                        />
+                      )}
                     </div>
                   );
                 })}
@@ -260,7 +291,7 @@ export function DatePollGrid({
       </div>
 
       {/* ── add-column sibling (outside scroll) ───────────────────────── */}
-      {canEdit && onAddDateWindow && (
+      {isOwner && onAddDateWindow && (
         <button
           type="button"
           onClick={onAddDateWindow}
@@ -280,7 +311,7 @@ export function DatePollGrid({
       )}
 
       {/* ── column header popover ─────────────────────────────────────── */}
-      {openPopover && canEdit && (
+      {openPopover && isOwner && (
         <div
           ref={popoverRef}
           className="fixed z-50 -translate-x-1/2 rounded-xl p-1.5 shadow-lg"
@@ -414,6 +445,61 @@ function VoteButton({
     >
       {text}
     </button>
+  );
+}
+
+function VoteTriplet({
+  answer,
+  interactive,
+  dimmed,
+  onSet,
+}: {
+  answer: VoteAnswer;
+  interactive: boolean;
+  dimmed: boolean;
+  onSet: (next: VoteAnswer) => void;
+}) {
+  // Three side-by-side buttons. Clicking the active one clears the vote.
+  const options: { key: Exclude<VoteAnswer, null>; label: string }[] = [
+    { key: "yes", label: "✓" },
+    { key: "maybe", label: "~" },
+    { key: "no", label: "✕" },
+  ];
+  return (
+    <div
+      className="flex items-center gap-1"
+      style={{
+        opacity: dimmed ? 0.4 : 1,
+        pointerEvents: dimmed ? "none" : undefined,
+      }}
+    >
+      {options.map((opt) => {
+        const isActive = answer === opt.key;
+        const { background, color, border } = voteVisual(opt.key);
+        // Inactive pill uses the empty-state styling so it reads as "not picked"
+        // but still telegraphs what choice it represents via the glyph.
+        const inactive = voteVisual(null);
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            onClick={() => onSet(isActive ? null : opt.key)}
+            disabled={!interactive}
+            className="flex h-[28px] w-[28px] items-center justify-center rounded-lg text-[12px] font-bold transition-all"
+            style={{
+              background: isActive ? background : inactive.background,
+              color: isActive ? color : "var(--color-bt-text-dim)",
+              border: isActive ? border : inactive.border,
+              cursor: interactive ? "pointer" : "default",
+            }}
+            aria-label={`Vote: ${opt.key}`}
+            aria-pressed={isActive}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -84,20 +84,40 @@ export function DatePollGrid({
   onRemoveDateWindow,
   onLockDateWindow,
 }: DatePollGridProps) {
-  const [openPopoverId, setOpenPopoverId] = useState<string | null>(null);
+  // Popover state keeps the anchor rect so the menu can be positioned
+  // directly beneath the column header button that opened it.
+  const [openPopover, setOpenPopover] = useState<
+    | { id: string; anchorLeft: number; anchorBottom: number; anchorCenter: number }
+    | null
+  >(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
   // Close popover on outside click
   useEffect(() => {
-    if (!openPopoverId) return;
+    if (!openPopover) return;
     const handler = (e: MouseEvent) => {
       if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        setOpenPopoverId(null);
+        setOpenPopover(null);
       }
     };
     window.addEventListener("mousedown", handler);
     return () => window.removeEventListener("mousedown", handler);
-  }, [openPopoverId]);
+  }, [openPopover]);
+
+  // Close popover if the page / grid scrolls so it doesn't desync from the
+  // column it's anchored to.
+  useEffect(() => {
+    if (!openPopover) return;
+    const close = () => setOpenPopover(null);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [openPopover]);
+
+  const openPopoverId = openPopover?.id ?? null;
 
   const gridMinWidth = NAME_COL_MIN_WIDTH + dateWindows.length * COLUMN_WIDTH;
 
@@ -155,9 +175,18 @@ export function DatePollGrid({
                   label={formatColumnLabel(w.start_date, w.end_date)}
                   isActive={isActive}
                   canEdit={canEdit}
-                  onToggle={() =>
-                    setOpenPopoverId((prev) => (prev === w.id ? null : w.id))
-                  }
+                  onToggle={(btnRect) => {
+                    if (openPopoverId === w.id) {
+                      setOpenPopover(null);
+                      return;
+                    }
+                    setOpenPopover({
+                      id: w.id,
+                      anchorLeft: btnRect.left,
+                      anchorBottom: btnRect.bottom,
+                      anchorCenter: btnRect.left + btnRect.width / 2,
+                    });
+                  }}
                 />
               );
             })
@@ -251,11 +280,13 @@ export function DatePollGrid({
       )}
 
       {/* ── column header popover ─────────────────────────────────────── */}
-      {openPopoverId && canEdit && (
+      {openPopover && canEdit && (
         <div
           ref={popoverRef}
-          className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl p-1.5 shadow-lg"
+          className="fixed z-50 -translate-x-1/2 rounded-xl p-1.5 shadow-lg"
           style={{
+            top: `${openPopover.anchorBottom + 6}px`,
+            left: `${openPopover.anchorCenter}px`,
             background: "var(--color-bt-card-raised)",
             border: "1px solid var(--color-bt-border)",
             minWidth: "180px",
@@ -265,16 +296,16 @@ export function DatePollGrid({
             icon={<CheckCircle2 size={14} />}
             label="Select this date"
             onClick={() => {
-              onLockDateWindow?.(openPopoverId);
-              setOpenPopoverId(null);
+              onLockDateWindow?.(openPopover.id);
+              setOpenPopover(null);
             }}
           />
           <PopoverItem
             icon={<Trash2 size={14} />}
             label="Remove"
             onClick={() => {
-              onRemoveDateWindow?.(openPopoverId);
-              setOpenPopoverId(null);
+              onRemoveDateWindow?.(openPopover.id);
+              setOpenPopover(null);
             }}
             danger
           />
@@ -295,7 +326,7 @@ function ColumnHeader({
   label: string;
   isActive: boolean;
   canEdit: boolean;
-  onToggle: () => void;
+  onToggle: (anchorRect: DOMRect) => void;
 }) {
   const bg = isActive ? "rgba(45, 212, 191, 0.07)" : "var(--color-bt-card)";
   if (!canEdit) {
@@ -332,7 +363,7 @@ function ColumnHeader({
       </span>
       <button
         type="button"
-        onClick={onToggle}
+        onClick={(e) => onToggle(e.currentTarget.getBoundingClientRect())}
         className="rounded-md px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider leading-none transition-colors"
         style={{
           background: isActive

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -141,7 +141,49 @@ export function DatePollGrid({
 
   const openPopoverId = openPopover?.id ?? null;
 
+  const hasWindows = dateWindows.length > 0;
   const gridMinWidth = NAME_COL_MIN_WIDTH + dateWindows.length * COLUMN_WIDTH;
+
+  // Empty-state short-circuit: when there are no date windows, rendering
+  // member rows inside the grid causes layout to jumble (the grid template
+  // has a placeholder column, but each row only contributes the name cell,
+  // so names flow across the extra column). Swap to a single-line empty
+  // banner until the first window is added.
+  if (!hasWindows) {
+    return (
+      <div className="flex">
+        <div
+          className="min-w-0 flex-1 rounded-xl px-4 py-6 text-center"
+          style={{ background: "var(--color-bt-card)" }}
+        >
+          <span
+            className="text-[13px] italic"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {isOwner
+              ? "No dates added yet — tap the + to propose a date option."
+              : "No dates added yet — the host hasn't proposed any options."}
+          </span>
+        </div>
+        {isOwner && onAddDateWindow && (
+          <button
+            type="button"
+            onClick={onAddDateWindow}
+            className="group relative ml-2 flex flex-shrink-0 items-center justify-center self-stretch rounded-xl transition-colors hover:bg-[var(--color-bt-card-raised)]"
+            style={{
+              width: `${ADD_COL_WIDTH}px`,
+              background: "transparent",
+              border: "1.5px dashed var(--color-bt-border)",
+              color: "var(--color-bt-accent)",
+            }}
+            aria-label="Add date option"
+          >
+            <CalendarPlus size={22} />
+          </button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="flex">
@@ -156,7 +198,7 @@ export function DatePollGrid({
             minWidth: `${gridMinWidth}px`,
             // Name column auto-fits content (no truncate) with a minimum width.
             // Date columns use a fixed min then flex to share space.
-            gridTemplateColumns: `minmax(${NAME_COL_MIN_WIDTH}px, max-content) repeat(${Math.max(dateWindows.length, 1)}, minmax(${COLUMN_WIDTH}px, 1fr))`,
+            gridTemplateColumns: `minmax(${NAME_COL_MIN_WIDTH}px, max-content) repeat(${dateWindows.length}, minmax(${COLUMN_WIDTH}px, 1fr))`,
           }}
         >
           {/* Header: name column */}
@@ -176,43 +218,29 @@ export function DatePollGrid({
           </div>
 
           {/* Header: per-window label + popover trigger */}
-          {dateWindows.length === 0 ? (
-            <div
-              className="flex items-center justify-center px-3 py-2.5"
-              style={{ borderBottom: "1px solid var(--color-bt-border)" }}
-            >
-              <span
-                className="text-[12px] italic"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                No dates added yet
-              </span>
-            </div>
-          ) : (
-            dateWindows.map((w) => {
-              const isActive = openPopoverId === w.id;
-              return (
-                <ColumnHeader
-                  key={w.id}
-                  label={formatColumnLabel(w.start_date, w.end_date)}
-                  isActive={isActive}
-                  canEdit={isOwner}
-                  onToggle={(btnRect) => {
-                    if (openPopoverId === w.id) {
-                      setOpenPopover(null);
-                      return;
-                    }
-                    setOpenPopover({
-                      id: w.id,
-                      anchorLeft: btnRect.left,
-                      anchorBottom: btnRect.bottom,
-                      anchorCenter: btnRect.left + btnRect.width / 2,
-                    });
-                  }}
-                />
-              );
-            })
-          )}
+          {dateWindows.map((w) => {
+            const isActive = openPopoverId === w.id;
+            return (
+              <ColumnHeader
+                key={w.id}
+                label={formatColumnLabel(w.start_date, w.end_date)}
+                isActive={isActive}
+                canEdit={isOwner}
+                onToggle={(btnRect) => {
+                  if (openPopoverId === w.id) {
+                    setOpenPopover(null);
+                    return;
+                  }
+                  setOpenPopover({
+                    id: w.id,
+                    anchorLeft: btnRect.left,
+                    anchorBottom: btnRect.bottom,
+                    anchorCenter: btnRect.left + btnRect.width / 2,
+                  });
+                }}
+              />
+            );
+          })}
 
           {/* Member rows */}
           {members.map((m, rowIdx) => {

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -99,9 +99,10 @@ export function TripSettingsModal({
     },
   });
 
-  // Return-to-poll: flips poll_mode back on so the crew sees the poll UI
-  // again. Paired with unlock to drop the locked trip dates in one action.
-  const setPollModeMutation = trpc.datePoll.setPollMode.useMutation({
+  // Return-to-poll: clears trip dates, flips poll_mode back on, and
+  // reopens the poll row — all in one server call that preserves every
+  // existing window (including the formerly-locked one) and every vote.
+  const returnToPollMutation = trpc.datePoll.returnToPoll.useMutation({
     onSuccess: () => {
       utils.trips.getById.invalidate({ tripId });
       utils.datePoll.get.invalidate({ tripId });
@@ -109,21 +110,10 @@ export function TripSettingsModal({
     },
   });
 
-  const returnToPollPending =
-    unlockDatesMutation.isPending || setPollModeMutation.isPending;
+  const returnToPollPending = returnToPollMutation.isPending;
 
   const handleReturnToPoll = () => {
-    // Unlock dates first, then flip poll_mode on. Server order matters —
-    // unlock clears start/end + reopens the poll row; setPollMode flips
-    // the trip's poll_mode flag so the action center renders the grid.
-    unlockDatesMutation.mutate(
-      { tripId },
-      {
-        onSuccess: () => {
-          setPollModeMutation.mutate({ tripId, pollMode: true });
-        },
-      }
-    );
+    returnToPollMutation.mutate({ tripId });
   };
 
   const canSaveDest =
@@ -479,7 +469,7 @@ export function TripSettingsModal({
                           </button>
                           <button
                             data-testid="settings-clear-dates-btn"
-                            disabled={unlockDatesMutation.isPending || lockDatesMutation.isPending || setPollModeMutation.isPending}
+                            disabled={unlockDatesMutation.isPending || lockDatesMutation.isPending || returnToPollMutation.isPending}
                             onClick={() => unlockDatesMutation.mutate({ tripId })}
                             className="w-full rounded-xl border py-2 text-sm font-medium transition-opacity disabled:opacity-40"
                             style={{
@@ -487,7 +477,7 @@ export function TripSettingsModal({
                               color: "var(--color-bt-danger)",
                             }}
                           >
-                            {unlockDatesMutation.isPending && !setPollModeMutation.isPending ? "Clearing…" : "Clear dates"}
+                            {unlockDatesMutation.isPending ? "Clearing…" : "Clear dates"}
                           </button>
                       </>
                       <button

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -99,6 +99,33 @@ export function TripSettingsModal({
     },
   });
 
+  // Return-to-poll: flips poll_mode back on so the crew sees the poll UI
+  // again. Paired with unlock to drop the locked trip dates in one action.
+  const setPollModeMutation = trpc.datePoll.setPollMode.useMutation({
+    onSuccess: () => {
+      utils.trips.getById.invalidate({ tripId });
+      utils.datePoll.get.invalidate({ tripId });
+      setDatesExpanded(false);
+    },
+  });
+
+  const returnToPollPending =
+    unlockDatesMutation.isPending || setPollModeMutation.isPending;
+
+  const handleReturnToPoll = () => {
+    // Unlock dates first, then flip poll_mode on. Server order matters —
+    // unlock clears start/end + reopens the poll row; setPollMode flips
+    // the trip's poll_mode flag so the action center renders the grid.
+    unlockDatesMutation.mutate(
+      { tripId },
+      {
+        onSuccess: () => {
+          setPollModeMutation.mutate({ tripId, pollMode: true });
+        },
+      }
+    );
+  };
+
   const canSaveDest =
     destDraft.trim().length > 0 &&
     destDraft.trim() !== (trip?.locked_destination_title ?? "") &&
@@ -439,8 +466,20 @@ export function TripSettingsModal({
                             {lockDatesMutation.isPending ? "Updating…" : "Update dates"}
                           </button>
                           <button
+                            data-testid="settings-return-to-poll-btn"
+                            disabled={returnToPollPending || lockDatesMutation.isPending}
+                            onClick={handleReturnToPoll}
+                            className="w-full rounded-xl border py-2 text-sm font-medium transition-opacity disabled:opacity-40"
+                            style={{
+                              borderColor: "var(--color-bt-accent-border)",
+                              color: "var(--color-bt-accent)",
+                            }}
+                          >
+                            {returnToPollPending ? "Returning…" : "Return to poll"}
+                          </button>
+                          <button
                             data-testid="settings-clear-dates-btn"
-                            disabled={unlockDatesMutation.isPending || lockDatesMutation.isPending}
+                            disabled={unlockDatesMutation.isPending || lockDatesMutation.isPending || setPollModeMutation.isPending}
                             onClick={() => unlockDatesMutation.mutate({ tripId })}
                             className="w-full rounded-xl border py-2 text-sm font-medium transition-opacity disabled:opacity-40"
                             style={{
@@ -448,7 +487,7 @@ export function TripSettingsModal({
                               color: "var(--color-bt-danger)",
                             }}
                           >
-                            {unlockDatesMutation.isPending ? "Clearing…" : "Clear dates"}
+                            {unlockDatesMutation.isPending && !setPollModeMutation.isPending ? "Clearing…" : "Clear dates"}
                           </button>
                       </>
                       <button

--- a/src/server/routers/datePoll.test.ts
+++ b/src/server/routers/datePoll.test.ts
@@ -310,4 +310,66 @@ describe("datePoll router", () => {
       caller.datePoll.resetPoll({ tripId })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
+
+  // ── returnToPoll ────────────────────────────────────────────────────────
+
+  it("returnToPoll — preserves all windows and votes (even the locked one with zero votes)", async () => {
+    // Fresh trip + direct-lock (creates a single window with no votes) so we
+    // can prove returnToPoll does NOT delete it the way unlock would.
+    const rtTripId = await ctx.createTrip("Return To Poll Test");
+    const caller = ctx.caller();
+
+    await caller.trips.lockDates({
+      tripId: rtTripId,
+      startDate: "2026-09-01",
+      endDate: "2026-09-05",
+    });
+
+    // Confirm the window was created and dates are locked
+    let poll = await caller.datePoll.get({ tripId: rtTripId });
+    expect(poll.windows.length).toBe(1);
+    const directWindowId = poll.windows[0]!.id;
+
+    await caller.datePoll.returnToPoll({ tripId: rtTripId });
+
+    // Window should still be there (unlock would have deleted it)
+    poll = await caller.datePoll.get({ tripId: rtTripId });
+    expect(poll.windows.length).toBe(1);
+    expect(poll.windows[0]!.id).toBe(directWindowId);
+    expect(poll.lockedWindowId).toBeNull();
+    expect(poll.pollMode).toBe(true);
+
+    // Trip dates should be cleared
+    const trip = await caller.trips.getById({ tripId: rtTripId });
+    expect(trip.start_date).toBeNull();
+    expect(trip.end_date).toBeNull();
+  });
+
+  it("returnToPoll — preserves votes on non-locked windows", async () => {
+    // Use the main suite trip which has windows + votes from earlier tests.
+    const ownerCaller = ctx.caller();
+    const memberCaller = ctx.callerAs("member");
+
+    // Ensure at least one vote exists
+    await memberCaller.datePoll.castDateVote({ tripId, windowId, answer: "yes" });
+
+    // Lock then return to poll
+    await ownerCaller.datePoll.lockDateWindow({ tripId, windowId });
+    await ownerCaller.datePoll.returnToPoll({ tripId });
+
+    const poll = await ownerCaller.datePoll.get({ tripId });
+    const win = poll.windows.find((w) => w.id === windowId);
+    const memberUser = ctx.getUser("member");
+    const memberVote = win?.votes.find((v) => v.user_id === memberUser.id);
+    expect(memberVote?.answer).toBe("yes");
+    expect(poll.pollMode).toBe(true);
+    expect(poll.lockedWindowId).toBeNull();
+  });
+
+  it("returnToPoll — member cannot call", async () => {
+    const caller = ctx.callerAs("member");
+    await expect(
+      caller.datePoll.returnToPoll({ tripId })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
 });

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -590,6 +590,60 @@ export const datePollRouter = router({
     }),
 
   // -----------------------------------------------------------------------
+  // returnToPoll — Owner or Planner: clear locked dates AND reopen the
+  // poll (trips.poll_mode = true) while preserving every existing window
+  // and vote — including the formerly-locked window (even if it has zero
+  // votes, which unlock() would have deleted). This is the reverse of
+  // lockDateWindow: the crew lands back on the poll grid with their full
+  // history intact.
+  // -----------------------------------------------------------------------
+  returnToPoll: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx }) => {
+      // Clear the trip dates and flip poll_mode back on in a single update
+      // so the UI transitions in one render.
+      const { error: tripErr } = await ctx.supabase
+        .from("trips")
+        .update({
+          start_date: null,
+          end_date: null,
+          poll_mode: true,
+        })
+        .eq("id", ctx.tripId);
+
+      if (tripErr) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to return to poll: ${tripErr.message}`,
+        });
+      }
+
+      // Reopen the poll row — if it doesn't exist (direct-date-entry path),
+      // create one. We intentionally do NOT delete any date_windows so the
+      // previously-chosen window remains available as a voting option.
+      const { error: pollErr } = await ctx.supabase
+        .from("date_polls")
+        .upsert(
+          {
+            trip_id: ctx.tripId,
+            open: true,
+            locked_window_id: null,
+          },
+          { onConflict: "trip_id" }
+        );
+
+      if (pollErr) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to reopen date poll: ${pollErr.message}`,
+        });
+      }
+
+      return { ok: true };
+    }),
+
+  // -----------------------------------------------------------------------
   // setPollMode — Owner or Planner: flip trips.poll_mode on or off
   // -----------------------------------------------------------------------
   setPollMode: authedProcedure

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -338,7 +338,8 @@ export const datePollRouter = router({
         tripId: z.string(),
         windowId: z.string(),
         userId: z.string(),
-        answer: z.enum(["yes", "no", "maybe"]),
+        // Nullable — null clears the vote, mirroring castDateVote.
+        answer: z.enum(["yes", "no", "maybe"]).nullable(),
       })
     )
     .use(requireTripRole("Owner"))
@@ -356,6 +357,22 @@ export const datePollRouter = router({
           code: "NOT_FOUND",
           message: "User is not a member of this trip",
         });
+      }
+
+      // Null answer = clear the vote (delete row, mirrors castDateVote).
+      if (input.answer === null) {
+        const { error } = await ctx.supabase
+          .from("date_poll_votes")
+          .delete()
+          .eq("window_id", input.windowId)
+          .eq("user_id", input.userId);
+        if (error) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: `Failed to clear vote for member: ${error.message}`,
+          });
+        }
+        return { cleared: true };
       }
 
       const { data, error } = await ctx.supabase


### PR DESCRIPTION
## Summary

Follow-up fixes for the Action Center + Date Poll redesign landed in #220. Everything here came from visual feedback rounds against the merged baseline, bundled into one PR because they share the same files.

### Fixes

- **Empty-state grid jumble** — `DatePollGrid` short-circuits to a single-line banner when `dateWindows.length === 0`. The prior grid template left a placeholder column and each member row only contributed one cell, so crew names flowed across both columns ("all in one line").
- **Return-to-poll data loss** — new `datePoll.returnToPoll` tRPC procedure. Clears trip dates, flips `poll_mode=true`, reopens `date_polls`, and preserves every window (including the formerly-locked one with zero votes, which `unlock` would have deleted). Replaces the client-side `unlock + setPollMode` chain in `TripSettingsModal`. The reset button now reappears because votes survive the round-trip.
- **Jarring "Dates locked" panel** — `DatePollCard` returns `null` when dates are locked. `ActionCenter` renders an `ActionCenterIdle` placeholder (dashed border, Sparkles, friendly copy) so the panel doesn't vanish on lock transitions and future cards have an obvious slot.
- **Owner-only admin gates** — `DatePollCard` / `DatePollGrid` / `ActionCenter` drop `canEdit` in favor of `isOwner` as the single admin gate. Non-owners can't add dates, open the column popover, or reset votes.
- **Desktop triplet layout** — when `isDesktop && windows.length <= 3`, cells render three side-by-side Y/M/N pills (`VoteTriplet`). Otherwise the single cycling `VoteButton` stays.
- **Optimistic notify-crew** — `notifyCrew` now flips `notifySent` in `onMutate` with rollback on error.
- **Column popover anchoring** — popover is positioned by `getBoundingClientRect` of the Select button rather than centered on the viewport.
- **Visibility parity** — `ActionCenter` renders in both `idea` and `planning` stages to match `DatesPlanningRow`.
- **Owner-on-behalf voting** — grid's `onVote` now carries `userId`; owners route to `castVoteForMember`, everyone else to `castDateVote`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/server/routers/datePoll.test.ts` — 24/24 pass (3 new `returnToPoll` cases covering direct-lock preservation, vote preservation, role gate)
- [ ] Owner: open poll, add 2 windows, vote, lock a window, open Trip Settings → Change dates → Return to poll. Verify windows + votes intact and reset button visible.
- [ ] Owner: lock dates directly (no poll) → Return to poll → verify the single window survives (the bug this PR fixes).
- [ ] Non-owner: verify read-only poll view, no popover, no add/reset buttons, only own-row is interactive.
- [ ] Desktop with ≤3 windows: confirm triplet pill layout. Mobile + dense polls fall back to cycle button.
- [ ] Dates locked: confirm "You're all set" idle card appears instead of "Dates locked" chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)