### PR TITLE
feat(action-center): date poll phase 1 UX polish

### DIFF
--- a/src/app/trips/[tripId]/components/ConfirmDatesModal.tsx
+++ b/src/app/trips/[tripId]/components/ConfirmDatesModal.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { Calendar } from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { parseLocalDate } from "@/lib/dates";
+
+export interface ConfirmDatesModalProps {
+  startDate: string;
+  endDate: string;
+  /**
+   * True when the dates come from selecting a poll window directly (not manual
+   * entry). In this case poll data is always preserved and no warning is shown.
+   */
+  fromPollWindow?: boolean;
+  /** Whether a date poll is currently active. */
+  hasPoll: boolean;
+  /**
+   * Existing poll windows. Used to detect an exact match against manually-
+   * entered dates so we can offer to preserve votes.
+   */
+  pollWindows?: Array<{ id: string; start_date: string; end_date: string }>;
+  isPending: boolean;
+  /** Called with true if poll data should be kept, false if it should clear. */
+  onConfirm: (preservePoll: boolean) => void;
+  onCancel: () => void;
+}
+
+function formatLong(d: string): string {
+  return parseLocalDate(d).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function ConfirmDatesModal({
+  startDate,
+  endDate,
+  fromPollWindow = false,
+  hasPoll,
+  pollWindows = [],
+  isPending,
+  onConfirm,
+  onCancel,
+}: ConfirmDatesModalProps) {
+  // Only relevant for manual-entry: check if the typed dates exactly match a
+  // poll window so we can offer to preserve votes.
+  const matchingWindow = !fromPollWindow
+    ? (pollWindows.find(
+        (w) => w.start_date === startDate && w.end_date === endDate
+      ) ?? null)
+    : null;
+
+  // Default preserve=true when there's a match, false otherwise.
+  const [preservePoll, setPreservePoll] = useState(matchingWindow !== null);
+
+  useModalBackButton(onCancel);
+
+  const showPreservedNote = fromPollWindow;
+  const showPreserveToggle = hasPoll && !fromPollWindow && matchingWindow !== null;
+  const showClearWarning = hasPoll && !fromPollWindow && matchingWindow === null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-6"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={(e) => e.target === e.currentTarget && onCancel()}
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl p-5"
+        style={{ background: "var(--color-bt-card)" }}
+      >
+        {/* Title */}
+        <p className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          Set trip dates
+        </p>
+
+        {/* Date range chip */}
+        <div
+          className="mt-3 flex items-center gap-2.5 rounded-xl px-3 py-2.5"
+          style={{ background: "var(--color-bt-card-raised)" }}
+        >
+          <Calendar
+            size={15}
+            style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+          />
+          <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
+            {formatLong(startDate)}
+            <span style={{ color: "var(--color-bt-text-dim)" }}> – </span>
+            {formatLong(endDate)}
+          </p>
+        </div>
+
+        <p className="mt-2 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+          You can change this anytime from Trip Settings.
+        </p>
+
+        {/* Poll-window path: always preserves data, show confirmation note */}
+        {showPreservedNote && (
+          <div
+            className="mt-3 rounded-xl px-3 py-2.5"
+            style={{
+              background: "var(--color-bt-accent-faint)",
+              border: "1px solid var(--color-bt-accent-border)",
+            }}
+          >
+            <p className="text-[12px]" style={{ color: "var(--color-bt-text)" }}>
+              Poll data and votes will be preserved.
+            </p>
+          </div>
+        )}
+
+        {/* Manual-entry path, matching window: offer preserve toggle */}
+        {showPreserveToggle && (
+          <div
+            className="mt-3 space-y-2 rounded-xl px-3 py-2.5"
+            style={{
+              background: "var(--color-bt-accent-faint)",
+              border: "1px solid var(--color-bt-accent-border)",
+            }}
+          >
+            <p className="text-[12px] font-medium" style={{ color: "var(--color-bt-text)" }}>
+              These dates match a poll option.
+            </p>
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={preservePoll}
+                onChange={(e) => setPreservePoll(e.target.checked)}
+                style={{ accentColor: "var(--color-bt-accent)" }}
+              />
+              <span className="text-[12px]" style={{ color: "var(--color-bt-text)" }}>
+                Preserve poll votes
+              </span>
+            </label>
+          </div>
+        )}
+
+        {/* Manual-entry path, no match, poll active: warn about clearing */}
+        {showClearWarning && (
+          <div
+            className="mt-3 flex items-start gap-2 rounded-xl px-3 py-2.5"
+            style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
+          >
+            <span style={{ color: "var(--color-bt-warning)", flexShrink: 0 }}>⚠</span>
+            <p className="text-[12px]" style={{ color: "var(--color-bt-warning)" }}>
+              This will clear the poll and all votes.
+            </p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-4 flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-xl py-2.5 text-sm font-medium"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(fromPollWindow || preservePoll)}
+            disabled={isPending}
+            className="flex-1 rounded-xl py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-base)",
+            }}
+          >
+            Set dates
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -1104,6 +1104,107 @@ export function DatesPanel({
     );
   }
 
+  // ── Poll-active owner view — flat non-collapsible header row ────────────
+  // Matches the lodging empty-state pattern: icon · title/subtitle · action
+  // button inline on the right. No body, no chevron, no collapse handler.
+  if (pollMode && isOwner && !datesLocked) {
+    return (
+      <div
+        className="rounded-xl border"
+        style={{
+          background: "var(--color-bt-card)",
+          borderColor: "var(--color-bt-border)",
+          boxShadow: "var(--shadow-card)",
+        }}
+      >
+        <div className="flex items-center gap-3 px-4 py-3.5">
+          {/* Icon */}
+          <div
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+            style={{ background: "var(--color-bt-card-raised)" }}
+          >
+            <Calendar size={16} style={{ color: "var(--color-bt-accent)" }} />
+          </div>
+
+          {/* Title + subtitle */}
+          <div className="min-w-0 flex-1">
+            <div
+              className="text-sm font-semibold"
+              style={{ color: "var(--color-bt-accent)" }}
+            >
+              Poll Open
+            </div>
+            <div
+              className="mt-0.5 text-xs"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Poll open · {windows.length} option{windows.length !== 1 ? "s" : ""}
+            </div>
+          </div>
+
+          {/* Cancel button — hidden when confirm row is showing */}
+          {!showCancelConfirm && (
+            <button
+              type="button"
+              onClick={() => setShowCancelConfirm(true)}
+              className="shrink-0 rounded-xl px-3 py-1.5 text-xs font-semibold"
+              style={{
+                border: "1.5px dashed var(--color-bt-warning)",
+                color: "var(--color-bt-warning)",
+                background: "transparent",
+              }}
+            >
+              Nevermind — cancel poll
+            </button>
+          )}
+        </div>
+
+        {/* Inline confirmation — below header row, inside same card */}
+        {showCancelConfirm && (
+          <div className="flex items-center justify-between gap-3 px-4 pb-3 pt-0">
+            <span
+              className="text-xs"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              This will clear all votes. Are you sure?
+            </span>
+            <div className="flex shrink-0 gap-2">
+              {/* Ghost small */}
+              <button
+                type="button"
+                onClick={() => setShowCancelConfirm(false)}
+                className="rounded-xl px-3 py-1.5 text-xs font-semibold"
+                style={{
+                  background: "transparent",
+                  color: "var(--color-bt-text-dim)",
+                  border: "0.5px solid var(--color-bt-border)",
+                }}
+              >
+                Keep poll
+              </button>
+              {/* Danger small */}
+              <button
+                type="button"
+                onClick={() => {
+                  setPollActive.mutate({ tripId, pollMode: false });
+                  setShowCancelConfirm(false);
+                }}
+                disabled={setPollActive.isPending}
+                className="rounded-xl px-3 py-1.5 text-xs font-semibold"
+                style={{
+                  background: "var(--color-bt-danger)",
+                  color: "var(--color-bt-base)",
+                }}
+              >
+                {setPollActive.isPending ? "Cancelling…" : "Yes, cancel"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <>
       <PlanningRow

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useRef, useMemo, useState } from "react";
 import { Calendar } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { parseLocalDate, formatDateRangeCompact } from "@/lib/dates";
@@ -74,7 +74,6 @@ export function DatesPanel({
     { tripId },
     { enabled: isOwner && !datesLocked }
   );
-  const windowCount = poll?.windows.length ?? 0;
   const pollWindows = (poll?.windows ?? []) as Array<{
     id: string;
     start_date: string;
@@ -87,10 +86,14 @@ export function DatesPanel({
   const [directStart, setDirectStart] = useState("");
   const [directEnd, setDirectEnd] = useState("");
 
-  // Sync mode with server state (e.g. poll cancelled from another session)
-  useEffect(() => {
+  // Sync mode with server state during render (e.g. poll cancelled from another
+  // session). Calling setState during render is the React-recommended alternative
+  // to useEffect + setState for derived state that depends on a changing prop.
+  const prevPollModeRef = useRef(pollMode);
+  if (prevPollModeRef.current !== pollMode) {
+    prevPollModeRef.current = pollMode;
     setMode(pollMode ? "poll" : "set");
-  }, [pollMode]);
+  }
 
   // ── Mutations ──────────────────────────────────────────────────────────
 

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -285,49 +285,51 @@ export function DatesPanel({
         {/* ── Set Dates content: pickers + two-stage confirm ─────────────── */}
         {mode === "set" && (
           <div className="space-y-3">
-            <div className="space-y-1">
-              <label
-                className="text-[11px] font-semibold uppercase tracking-wider"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Start date
-              </label>
-              <input
-                type="date"
-                value={directStart}
-                onChange={(e) => {
-                  setDirectStart(e.target.value);
-                  setShowSetConfirm(false);
-                }}
-                className="w-full rounded-xl px-3 py-2.5 text-sm"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  border: "1px solid var(--color-bt-border)",
-                  color: "var(--color-bt-text)",
-                }}
-              />
-            </div>
-            <div className="space-y-1">
-              <label
-                className="text-[11px] font-semibold uppercase tracking-wider"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                End date
-              </label>
-              <input
-                type="date"
-                value={directEnd}
-                onChange={(e) => {
-                  setDirectEnd(e.target.value);
-                  setShowSetConfirm(false);
-                }}
-                className="w-full rounded-xl px-3 py-2.5 text-sm"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  border: "1px solid var(--color-bt-border)",
-                  color: "var(--color-bt-text)",
-                }}
-              />
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <label
+                  className="text-[11px] font-semibold uppercase tracking-wider"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  Start date
+                </label>
+                <input
+                  type="date"
+                  value={directStart}
+                  onChange={(e) => {
+                    setDirectStart(e.target.value);
+                    setShowSetConfirm(false);
+                  }}
+                  className="w-full rounded-xl px-3 py-2.5 text-sm"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    border: "1px solid var(--color-bt-border)",
+                    color: "var(--color-bt-text)",
+                  }}
+                />
+              </div>
+              <div className="space-y-1">
+                <label
+                  className="text-[11px] font-semibold uppercase tracking-wider"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  End date
+                </label>
+                <input
+                  type="date"
+                  value={directEnd}
+                  onChange={(e) => {
+                    setDirectEnd(e.target.value);
+                    setShowSetConfirm(false);
+                  }}
+                  className="w-full rounded-xl px-3 py-2.5 text-sm"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    border: "1px solid var(--color-bt-border)",
+                    color: "var(--color-bt-text)",
+                  }}
+                />
+              </div>
             </div>
 
             {/* Two-stage confirm message */}

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -6,6 +6,7 @@ import { trpc } from "@/lib/trpc-client";
 import { parseLocalDate, formatDateRangeCompact } from "@/lib/dates";
 import { PlanningRow, type ArcCardState } from "./PlanningRow";
 import { DatePollCard } from "../tabs/components/DatePollCard";
+import { ConfirmDatesModal } from "./ConfirmDatesModal";
 import type { TripData } from "../tabs/types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -44,17 +45,13 @@ function formatLongDate(d: string): string {
 /**
  * DatesPanel — owner-only admin surface for trip dates.
  *
- * Three states (owner, !datesLocked):
- *   1. idle/set:    segmented control on "Set Dates" — pickers revealed below
- *   2. poll:        segmented control on "Poll the Crew" — DatePollCard below
+ * Two modes (owner, !datesLocked):
+ *   1. set:   segmented control on "Pick your Dates" — pickers + Set button below
+ *   2. poll:  segmented control on "Poll the Crew" — DatePollCard below
  *
- * Switching to "Poll the Crew" segment fires setPollMode(true) if not already.
- * Setting dates with an active poll cascades: lockDates + setPollMode(false).
- * The Set button is two-stage: first click shows a confirmation message,
- * second click executes. Confirm message is context-aware (poll active vs not).
- *
- * DatesPanel is owner-only. Non-owners see DatePollCard directly from
- * ActionCenter; DatesPanel returns null for them.
+ * Pressing Set opens ConfirmDatesModal which handles the poll-clear/preserve
+ * logic before committing. DatesPanel is owner-only. Non-owners see
+ * DatePollCard directly from ActionCenter.
  */
 export function DatesPanel({
   trip,
@@ -62,7 +59,7 @@ export function DatesPanel({
   isOwner,
   isOpen: _isOpen,
   onToggle: _onToggle,
-  onTabChange: _onTabChange,
+  onTabChange,
 }: DatesPanelProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
@@ -70,17 +67,23 @@ export function DatesPanel({
   const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;
 
-  // Header "N options" text needs the live window count. tRPC dedupes
-  // this against DatePollCard's identical query, so no extra network cost.
+  // Fetch poll data whenever a poll might be active so we can check for
+  // window matches in the ConfirmDatesModal. tRPC dedupes this against
+  // DatePollCard's identical query, so no extra network cost.
   const { data: poll } = trpc.datePoll.get.useQuery(
     { tripId },
-    { enabled: pollMode && isOwner }
+    { enabled: isOwner && !datesLocked }
   );
   const windowCount = poll?.windows.length ?? 0;
+  const pollWindows = (poll?.windows ?? []) as Array<{
+    id: string;
+    start_date: string;
+    end_date: string;
+  }>;
 
-  // Local UI state — segmented control selection + date picker values
+  // Local UI state
   const [mode, setMode] = useState<"set" | "poll">(pollMode ? "poll" : "set");
-  const [showSetConfirm, setShowSetConfirm] = useState(false);
+  const [showDatesModal, setShowDatesModal] = useState(false);
   const [directStart, setDirectStart] = useState("");
   const [directEnd, setDirectEnd] = useState("");
 
@@ -114,7 +117,7 @@ export function DatesPanel({
     onSuccess() {
       setDirectStart("");
       setDirectEnd("");
-      setShowSetConfirm(false);
+      setShowDatesModal(false);
     },
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
@@ -153,32 +156,36 @@ export function DatesPanel({
 
   const headerNote = useMemo(() => {
     if (datesLocked) return formatDateRangeCompact(trip.start_date, trip.end_date);
-    if (pollMode) return `Poll open · ${windowCount} option${windowCount !== 1 ? "s" : ""}`;
-    return "";
-  }, [datesLocked, pollMode, windowCount, trip.start_date, trip.end_date]);
+    return "TBD";
+  }, [datesLocked, trip.start_date, trip.end_date]);
 
   // ── Actions ────────────────────────────────────────────────────────────
 
-  const handleSetDatesConfirm = () => {
+  /**
+   * Called by ConfirmDatesModal. preservePoll=true means the user chose to keep
+   * existing poll windows (only possible when the dates match a poll window).
+   */
+  const handleConfirmDates = (preservePoll: boolean) => {
     if (!directStart || !directEnd || directStart >= directEnd) return;
-    // If a poll is active, cascade clear it alongside locking dates
-    if (pollMode) {
+    // Clear windows unless the user explicitly chose to preserve them
+    if (pollMode && !preservePoll) {
       setPollActive.mutate({ tripId, pollMode: false });
     }
     lockDates.mutate({ tripId, startDate: directStart, endDate: directEnd });
   };
 
   const handleSelectPollSegment = () => {
+    const savedY = window.scrollY;
     setMode("poll");
-    setShowSetConfirm(false);
-    if (!pollMode) {
-      setPollActive.mutate({ tripId, pollMode: true });
-    }
+    requestAnimationFrame(() => window.scrollTo({ top: savedY, behavior: "instant" }));
+    // Poll only activates server-side when the first date window is added
+    // (handled inside DatePollCard). Nothing to mutate here.
   };
 
   const handleSelectSetSegment = () => {
+    const savedY = window.scrollY;
     setMode("set");
-    setShowSetConfirm(false);
+    requestAnimationFrame(() => window.scrollTo({ top: savedY, behavior: "instant" }));
   };
 
   // ── Render ─────────────────────────────────────────────────────────────
@@ -218,75 +225,91 @@ export function DatesPanel({
   // Owner, not-locked — segmented control state machine.
   const valid = !!directStart && !!directEnd && directStart < directEnd;
 
-  const confirmMessage = pollMode
-    ? "This will lock these dates and clear the poll. Are you sure?"
-    : "Lock these dates?";
-
   return (
-    <PlanningRow
-      icon={<Calendar size={16} />}
-      label={headerLabel}
-      note={headerNote}
-      warnState={pollMode}
-      state={state}
-      isOpen={true}
-      onToggle={() => {}}
-      noExpand={true}
-    >
-      <div className="space-y-3">
-        {/* ── Segmented control: Set Dates | Poll the Crew ──────────────── */}
-        <div
-          className="flex overflow-hidden rounded-xl"
-          style={{ border: "1px solid var(--color-bt-border)" }}
-        >
-          <button
-            type="button"
-            onClick={handleSelectSetSegment}
-            className="flex flex-1 items-center justify-center py-2.5 text-sm font-medium transition-colors"
-            style={
-              mode === "set"
-                ? {
-                    background: "var(--color-bt-card-float)",
-                    color: "var(--color-bt-text)",
-                  }
-                : {
-                    background: "transparent",
-                    color: "var(--color-bt-text-dim)",
-                  }
-            }
-          >
-            Set Dates
-          </button>
+    <>
+      <PlanningRow
+        icon={<Calendar size={16} />}
+        label={headerLabel}
+        note={headerNote}
+        state={state}
+        isOpen={true}
+        onToggle={() => {}}
+        noExpand={true}
+      >
+        <div className="space-y-3">
+          {/* ── Segmented control: Pick your Dates | Poll the Crew ─────── */}
           <div
-            className="w-px self-stretch"
-            style={{ background: "var(--color-bt-border)" }}
-          />
-          <button
-            type="button"
-            onClick={handleSelectPollSegment}
-            disabled={setPollActive.isPending}
-            className="flex flex-1 items-center justify-center py-2.5 text-sm font-medium transition-colors"
-            style={
-              mode === "poll"
-                ? {
-                    background: "var(--color-bt-card-float)",
-                    color: "var(--color-bt-text)",
-                  }
-                : {
-                    background: "transparent",
-                    color: "var(--color-bt-text-dim)",
-                  }
-            }
+            className="flex overflow-hidden rounded-xl"
+            style={{ border: "1px solid var(--color-bt-border)" }}
           >
-            Poll the Crew
-          </button>
-        </div>
+            <button
+              type="button"
+              onClick={handleSelectSetSegment}
+              className="flex flex-1 items-center justify-center py-2.5 text-sm font-medium transition-colors"
+              style={
+                mode === "set"
+                  ? {
+                      background: "var(--color-bt-card-float)",
+                      color: "var(--color-bt-text)",
+                    }
+                  : {
+                      background: "transparent",
+                      color: "var(--color-bt-text-dim)",
+                    }
+              }
+            >
+              Pick your Dates
+            </button>
+            <div
+              className="w-px self-stretch"
+              style={{ background: "var(--color-bt-border)" }}
+            />
+            <button
+              type="button"
+              onClick={handleSelectPollSegment}
+              disabled={setPollActive.isPending}
+              className="flex flex-1 items-center justify-center gap-1.5 py-2.5 text-sm font-medium transition-colors"
+              style={
+                mode === "poll"
+                  ? {
+                      background: "var(--color-bt-card-float)",
+                      color: "var(--color-bt-text)",
+                    }
+                  : {
+                      background: "transparent",
+                      color: "var(--color-bt-text-dim)",
+                    }
+              }
+            >
+              Poll the Crew
+              {pollMode && (
+                <span
+                  className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+                  style={{
+                    background: "var(--color-bt-accent)",
+                    color: "var(--color-bt-base)",
+                  }}
+                >
+                  Active
+                </span>
+              )}
+            </button>
+          </div>
 
-        {/* ── Set Dates content: pickers + two-stage confirm ─────────────── */}
-        {mode === "set" && (
-          <div className="space-y-3">
-            <div className="grid grid-cols-2 gap-2">
-              <div className="space-y-1">
+          {/* ── Tab blurb ─────────────────────────────────────────────── */}
+          <p
+            className="text-[12px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {mode === "set"
+              ? "Already know the dates? Lock them in directly."
+              : `Not sure yet? Propose a few options and let your crew vote on what works.${pollMode ? " Here\u2019s your message to them \u2014 feel free to update it as needed." : ""}`}
+          </p>
+
+          {/* ── Pick your Dates content: pickers + Set button in one row ─ */}
+          {mode === "set" && (
+            <div className="flex items-end gap-3">
+              <div className="flex-1 space-y-1">
                 <label
                   className="text-[11px] font-semibold uppercase tracking-wider"
                   style={{ color: "var(--color-bt-text-dim)" }}
@@ -296,10 +319,7 @@ export function DatesPanel({
                 <input
                   type="date"
                   value={directStart}
-                  onChange={(e) => {
-                    setDirectStart(e.target.value);
-                    setShowSetConfirm(false);
-                  }}
+                  onChange={(e) => setDirectStart(e.target.value)}
                   className="w-full rounded-xl px-3 py-2.5 text-sm"
                   style={{
                     background: "var(--color-bt-card-raised)",
@@ -308,7 +328,7 @@ export function DatesPanel({
                   }}
                 />
               </div>
-              <div className="space-y-1">
+              <div className="flex-1 space-y-1">
                 <label
                   className="text-[11px] font-semibold uppercase tracking-wider"
                   style={{ color: "var(--color-bt-text-dim)" }}
@@ -318,10 +338,7 @@ export function DatesPanel({
                 <input
                   type="date"
                   value={directEnd}
-                  onChange={(e) => {
-                    setDirectEnd(e.target.value);
-                    setShowSetConfirm(false);
-                  }}
+                  onChange={(e) => setDirectEnd(e.target.value)}
                   className="w-full rounded-xl px-3 py-2.5 text-sm"
                   style={{
                     background: "var(--color-bt-card-raised)",
@@ -330,44 +347,46 @@ export function DatesPanel({
                   }}
                 />
               </div>
-            </div>
-
-            {/* Two-stage confirm message */}
-            {showSetConfirm && valid && (
-              <p
-                className="text-xs leading-snug"
-                style={{ color: "var(--color-bt-warning)" }}
+              <button
+                type="button"
+                disabled={!valid || lockDates.isPending}
+                onClick={() => setShowDatesModal(true)}
+                className="flex-shrink-0 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity"
+                style={{
+                  background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                  color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+                  opacity: valid ? 1 : 0.6,
+                  cursor: valid ? "pointer" : "not-allowed",
+                }}
               >
-                {confirmMessage}
-              </p>
-            )}
+                Set
+              </button>
+            </div>
+          )}
 
-            <button
-              type="button"
-              disabled={!valid || lockDates.isPending}
-              onClick={() => {
-                if (!showSetConfirm) {
-                  setShowSetConfirm(true);
-                } else {
-                  handleSetDatesConfirm();
-                }
-              }}
-              className="w-full rounded-xl py-2.5 text-sm font-semibold transition-opacity"
-              style={{
-                background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-                color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
-                opacity: valid ? 1 : 0.6,
-                cursor: valid ? "pointer" : "not-allowed",
-              }}
-            >
-              {lockDates.isPending ? "Setting…" : "Set dates"}
-            </button>
-          </div>
-        )}
+          {/* ── Poll the Crew content: DatePollCard ───────────────────────── */}
+          {mode === "poll" && (
+            <DatePollCard
+              trip={trip}
+              isOwner={true}
+              onManageCrew={onTabChange ? () => onTabChange("crew") : undefined}
+            />
+          )}
+        </div>
+      </PlanningRow>
 
-        {/* ── Poll the Crew content: DatePollCard ───────────────────────── */}
-        {mode === "poll" && <DatePollCard trip={trip} isOwner={true} />}
-      </div>
-    </PlanningRow>
+      {/* Confirmation modal */}
+      {showDatesModal && valid && (
+        <ConfirmDatesModal
+          startDate={directStart}
+          endDate={directEnd}
+          hasPoll={pollMode}
+          pollWindows={pollWindows}
+          isPending={lockDates.isPending}
+          onConfirm={handleConfirmDates}
+          onCancel={() => setShowDatesModal(false)}
+        />
+      )}
+    </>
   );
 }

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -12,7 +12,7 @@ import type { TripData } from "../tabs/types";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
-interface DatesPlanningRowProps {
+interface DatesPanelProps {
   trip: TripData;
   canEdit: boolean;
   isOwner: boolean;
@@ -75,14 +75,14 @@ function sortWindows(ws: PollWindow[]): PollWindow[] {
 
 // ── Component ────────────────────────────────────────────────────────────
 
-export function DatesPlanningRow({
+export function DatesPanel({
   trip,
   canEdit,
   isOwner,
   isOpen,
   onToggle: _onToggle,
   onTabChange,
-}: DatesPlanningRowProps) {
+}: DatesPanelProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Calendar, Plus, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
-import { UserAvatar } from "@/components/UserAvatar";
 import { parseLocalDate, formatDateRangeCompact } from "@/lib/dates";
 import { PlanningRow, type ArcCardState } from "./PlanningRow";
 import type { TripData } from "../tabs/types";
@@ -20,8 +18,6 @@ interface DatesPanelProps {
   onToggle: () => void;
   onTabChange?: (tab: string) => void;
 }
-
-type Answer = "yes" | "no" | "maybe";
 
 interface PollWindow {
   id: string;
@@ -50,18 +46,6 @@ function formatLongDate(d: string): string {
   });
 }
 
-function formatGridLabel(start: string, end: string): string {
-  const s = parseLocalDate(start).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
-  const e = parseLocalDate(end).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
-  return `${s}–${e}`;
-}
-
 function sortWindows(ws: PollWindow[]): PollWindow[] {
   return ws.slice().sort((a, b) => {
     if (a.start_date !== b.start_date) return a.start_date < b.start_date ? -1 : 1;
@@ -77,15 +61,14 @@ function sortWindows(ws: PollWindow[]): PollWindow[] {
 
 export function DatesPanel({
   trip,
-  canEdit,
+  canEdit: _canEdit,
   isOwner,
   isOpen,
   onToggle: _onToggle,
-  onTabChange,
+  onTabChange: _onTabChange,
 }: DatesPanelProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
-  const currentUser = useCurrentUser();
 
   // Refresh votes every 30 s while the owner has the panel open and the poll
   // is active — lets them watch responses come in without a manual reload.
@@ -105,7 +88,6 @@ export function DatesPanel({
 
   const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;
-  const hasWindows = windows.length > 0;
 
   // Manual date picker state — shared between the empty/idle state and the
   // "Change dates" modal. The poll-builder uses the same state so typing a
@@ -219,137 +201,6 @@ export function DatesPanel({
     },
   });
 
-  const removeWindowM = trpc.datePoll.removeWindow.useMutation({
-    async onMutate(vars) {
-      await utils.datePoll.get.cancel({ tripId });
-      const prev = utils.datePoll.get.getData({ tripId });
-      utils.datePoll.get.setData({ tripId }, (old) =>
-        old
-          ? { ...old, windows: old.windows.filter((w) => w.id !== vars.windowId) }
-          : old
-      );
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
-    },
-    onSettled() {
-      utils.datePoll.get.invalidate({ tripId });
-    },
-  });
-
-  const voteSelf = trpc.datePoll.castDateVote.useMutation({
-    async onMutate(vars) {
-      await utils.datePoll.get.cancel({ tripId });
-      const prev = utils.datePoll.get.getData({ tripId });
-      utils.datePoll.get.setData({ tripId }, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          windows: old.windows.map((w) => {
-            if (w.id !== vars.windowId) return w;
-            // Null answer = delete the vote
-            if (vars.answer === null) {
-              return {
-                ...w,
-                votes: w.votes.filter((v) => v.user_id !== currentUser?.id),
-              };
-            }
-            const existing = w.votes.find((v) => v.user_id === currentUser?.id);
-            if (existing?.answer === vars.answer) {
-              return {
-                ...w,
-                votes: w.votes.filter((v) => v.user_id !== currentUser?.id),
-              };
-            }
-            if (existing) {
-              return {
-                ...w,
-                votes: w.votes.map((v) =>
-                  v.user_id === currentUser?.id
-                    ? { ...v, answer: vars.answer as string }
-                    : v
-                ),
-              };
-            }
-            return {
-              ...w,
-              votes: [
-                ...w.votes,
-                {
-                  window_id: vars.windowId,
-                  user_id: currentUser?.id ?? "",
-                  answer: vars.answer,
-                  created_at: new Date().toISOString(),
-                },
-              ],
-            };
-          }),
-        };
-      });
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
-    },
-    onSettled() {
-      utils.datePoll.get.invalidate({ tripId });
-    },
-  });
-
-  const voteForMember = trpc.datePoll.castVoteForMember.useMutation({
-    async onMutate(vars) {
-      await utils.datePoll.get.cancel({ tripId });
-      const prev = utils.datePoll.get.getData({ tripId });
-      utils.datePoll.get.setData({ tripId }, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          windows: old.windows.map((w) => {
-            if (w.id !== vars.windowId) return w;
-            // Null answer = clear this member's vote.
-            if (vars.answer === null) {
-              return {
-                ...w,
-                votes: w.votes.filter((v) => v.user_id !== vars.userId),
-              };
-            }
-            const existing = w.votes.find((v) => v.user_id === vars.userId);
-            if (existing) {
-              return {
-                ...w,
-                votes: w.votes.map((v) =>
-                  v.user_id === vars.userId
-                    ? { ...v, answer: vars.answer as string }
-                    : v
-                ),
-              };
-            }
-            return {
-              ...w,
-              votes: [
-                ...w.votes,
-                {
-                  window_id: vars.windowId,
-                  user_id: vars.userId,
-                  answer: vars.answer as string,
-                  created_at: new Date().toISOString(),
-                },
-              ],
-            };
-          }),
-        };
-      });
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
-    },
-    onSettled() {
-      utils.datePoll.get.invalidate({ tripId });
-    },
-  });
-
   const lockWindow = trpc.datePoll.lockDateWindow.useMutation({
     async onMutate(vars) {
       await utils.trips.getById.cancel({ tripId });
@@ -437,11 +288,6 @@ export function DatesPanel({
     return "";
   }, [datesLocked, isOwner, pollMode, windows.length, trip.start_date, trip.end_date]);
 
-  const anyVotes = useMemo(
-    () => windows.some((w) => w.votes.length > 0),
-    [windows]
-  );
-
   // ── Actions ────────────────────────────────────────────────────────────
 
   const handleSetDates = () => {
@@ -473,10 +319,6 @@ export function DatesPanel({
 
   const handlePollTheCrew = () => {
     setPollActive.mutate({ tripId, pollMode: true });
-  };
-
-  const handleNevermind = () => {
-    setPollActive.mutate({ tripId, pollMode: false });
   };
 
   // ── Body renderers ─────────────────────────────────────────────────────
@@ -534,429 +376,6 @@ export function DatesPanel({
     );
   }
 
-  function renderWindowTextRows() {
-    if (!hasWindows) return null;
-    return (
-      <div className="mb-2 space-y-1.5">
-        {windows.map((w) => {
-          const nights = nightsBetween(w.start_date, w.end_date);
-          return (
-            <div key={w.id} className="flex items-center gap-2">
-              <div
-                className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  border: "1px solid var(--color-bt-border)",
-                  color: "var(--color-bt-text)",
-                }}
-              >
-                {formatLongDate(w.start_date)} – {formatLongDate(w.end_date)}
-                <span style={{ color: "var(--color-bt-text-dim)" }}>
-                  {" "}
-                  · {nights} night{nights !== 1 ? "s" : ""}
-                </span>
-              </div>
-              {canEdit && !pollMode && (
-                <button
-                  onClick={() =>
-                    removeWindowM.mutate({ tripId, windowId: w.id })
-                  }
-                  disabled={removeWindowM.isPending}
-                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl transition-colors"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    color: "var(--color-bt-text-dim)",
-                  }}
-                  aria-label="Remove date from poll"
-                >
-                  <X size={16} />
-                </button>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  function handleGridVote(userId: string, windowId: string, next: Answer) {
-    if (!userId) return;
-    if (userId === currentUser?.id) {
-      voteSelf.mutate({ tripId, windowId, answer: next });
-    } else if (isOwner) {
-      voteForMember.mutate({ tripId, windowId, userId, answer: next });
-    }
-  }
-
-  function renderPollGrid() {
-    return (
-      <div className="mt-5 space-y-3">
-        <div className="flex items-center justify-between">
-          <p
-            className="text-xs font-semibold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Polling
-          </p>
-          <div className="flex items-center gap-3">
-            {isOwner && anyVotes && (
-              <button
-                onClick={() => setConfirmReset(true)}
-                className="text-xs font-medium"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Reset votes ↻
-              </button>
-            )}
-            <button
-              onClick={() => onTabChange?.("crew")}
-              className="text-xs font-medium"
-              style={{ color: "var(--color-bt-accent)" }}
-            >
-              Manage crew →
-            </button>
-          </div>
-        </div>
-
-        <div
-          className="overflow-hidden overflow-x-auto rounded-xl"
-          style={{ background: "var(--color-bt-card-raised)" }}
-        >
-          <div
-            className="grid"
-            style={{
-              minWidth: `${100 + windows.length * 96}px`,
-              gridTemplateColumns: hasWindows
-                ? `auto repeat(${windows.length}, 1fr)`
-                : "1fr",
-            }}
-          >
-            {/* Header row — Select date button (or empty message) + per-window date label */}
-            <div
-              className="sticky top-0 z-10 flex items-center justify-center px-2 py-2"
-              style={{ background: "var(--color-bt-card-raised)" }}
-            >
-              {hasWindows ? (
-                <span
-                  className="text-[11px] font-semibold uppercase tracking-wider"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  Crew
-                </span>
-              ) : (
-                <span
-                  className="text-xs italic"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  No dates added yet
-                </span>
-              )}
-            </div>
-            {windows.map((w) => (
-              <div
-                key={w.id}
-                className="sticky top-0 z-10 flex items-center justify-center px-2 py-2 text-center"
-                style={{ background: "var(--color-bt-card-raised)" }}
-              >
-                <p
-                  className="text-[12px] font-semibold leading-none"
-                  style={{ color: "var(--color-bt-text)" }}
-                >
-                  {formatGridLabel(w.start_date, w.end_date)}
-                </p>
-              </div>
-            ))}
-
-            {/* Member rows — always visible so the crew list appears immediately */}
-            {members.map((m, rowIdx) => {
-                const rowBg =
-                  rowIdx % 2 === 0
-                    ? "var(--color-bt-state-fill)"
-                    : "transparent";
-                const isMe = m.user_id === currentUser?.id;
-                const isInteractive =
-                  !!m.user_id && (isMe || isOwner);
-                return (
-                  <Fragment key={m.user_id ?? rowIdx}>
-                    <div
-                      className="flex min-w-0 items-center gap-2 px-3 py-2"
-                      style={{ background: rowBg }}
-                    >
-                      <UserAvatar name={m.displayName} avatarUrl={null} size="sm" />
-                      <span
-                        className="truncate text-[13px]"
-                        style={{ color: "var(--color-bt-text)" }}
-                      >
-                        {m.displayName}
-                        {isMe && (
-                          <span
-                            className="text-[11px]"
-                            style={{ color: "var(--color-bt-text-dim)" }}
-                          >
-                            {" "}
-                            (you)
-                          </span>
-                        )}
-                      </span>
-                    </div>
-                    {windows.map((w) => {
-                      const vote = w.votes.find((v) => v.user_id === m.user_id);
-                      const answer = (vote?.answer ?? null) as Answer | null;
-                      return (
-                        <div
-                          key={w.id}
-                          className="flex items-center justify-center gap-0.5 px-1 py-2"
-                          style={{ background: rowBg }}
-                        >
-                          {(["yes", "maybe", "no"] as const).map((type) => {
-                            const active = answer === type;
-                            const bg =
-                              type === "yes"
-                                ? "var(--color-bt-vote-yes)"
-                                : type === "maybe"
-                                ? "var(--color-bt-vote-maybe)"
-                                : "var(--color-bt-vote-no)";
-                            const labels = { yes: "✓", maybe: "~", no: "✗" };
-                            return (
-                              <button
-                                key={type}
-                                disabled={!isInteractive}
-                                onClick={() =>
-                                  handleGridVote(m.user_id!, w.id, type)
-                                }
-                                className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-bold transition-all"
-                                style={
-                                  active
-                                    ? {
-                                        background: bg,
-                                        color: "var(--color-bt-vote-yes-text)",
-                                      }
-                                    : {
-                                        background: "transparent",
-                                        color: "var(--color-bt-text-dim)",
-                                        border:
-                                          "1px dashed var(--color-bt-border)",
-                                        cursor: isInteractive
-                                          ? "pointer"
-                                          : "default",
-                                      }
-                                }
-                              >
-                                {labels[type]}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      );
-                    })}
-                  </Fragment>
-                );
-              })}
-          </div>
-        </div>
-
-        {canEdit && (
-          <>
-            {/* Lifecycle buttons — open/close poll + reset */}
-            <div className="flex gap-2">
-              {(
-                [
-                  {
-                    label: "Open Poll",
-                    enabled: !pollMode && hasWindows,
-                    onClick: () => setPollActive.mutate({ tripId, pollMode: true }),
-                  },
-                  {
-                    label: "Close Poll",
-                    enabled: pollMode,
-                    onClick: () => setPollActive.mutate({ tripId, pollMode: false }),
-                  },
-                ] as const
-              ).map(({ label, enabled, onClick }) => (
-                <button
-                  key={label}
-                  onClick={enabled ? onClick : undefined}
-                  className="flex-1 rounded-xl py-2.5 text-sm font-medium transition-opacity"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    color: "var(--color-bt-text)",
-                    border: "1px solid var(--color-bt-border)",
-                    opacity: enabled ? 1 : 0.35,
-                    cursor: enabled ? "pointer" : "not-allowed",
-                    pointerEvents: enabled ? undefined : "none",
-                  }}
-                >
-                  {label}
-                </button>
-              ))}
-
-              {/* Select date — always-on escape valve, far right */}
-              {hasWindows && (
-                <button
-                  onClick={() => setShowSelectDateModal(true)}
-                  className="flex-1 rounded-xl py-2.5 text-sm font-medium transition-opacity"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    color: "var(--color-bt-accent)",
-                    border: "1px solid var(--color-bt-accent-border)",
-                  }}
-                >
-                  Select date
-                </button>
-              )}
-            </div>
-
-            <button
-              onClick={handleNevermind}
-              className="w-full rounded-xl py-3 text-sm font-medium transition-colors"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                color: "var(--color-bt-text-dim)",
-              }}
-            >
-              Nevermind, Set Dates Manually
-            </button>
-          </>
-        )}
-      </div>
-    );
-  }
-
-  function renderMemberPollView() {
-    return (
-      <div className="space-y-4">
-        <p
-          className="text-[13px] leading-relaxed"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          {ownerDisplayName} is asking for everyone&apos;s input — please
-          mark your availability for the dates below.
-        </p>
-
-        <div
-          className="overflow-hidden overflow-x-auto rounded-xl"
-          style={{ background: "var(--color-bt-card-raised)" }}
-        >
-          <div
-            className="grid"
-            style={{
-              minWidth: `${100 + windows.length * 96}px`,
-              gridTemplateColumns: `auto repeat(${windows.length}, 1fr)`,
-            }}
-          >
-            {/* Header row */}
-            <div
-              className="sticky top-0 z-10 flex items-center justify-center px-2 py-2"
-              style={{ background: "var(--color-bt-card-raised)" }}
-            />
-            {windows.map((w) => (
-              <div
-                key={w.id}
-                className="sticky top-0 z-10 flex items-center justify-center px-2 py-2 text-center"
-                style={{ background: "var(--color-bt-card-raised)" }}
-              >
-                <p
-                  className="text-[12px] font-semibold leading-none"
-                  style={{ color: "var(--color-bt-text)" }}
-                >
-                  {formatGridLabel(w.start_date, w.end_date)}
-                </p>
-              </div>
-            ))}
-
-            {/* Member rows — only the current user's votes are interactive */}
-            {members.map((m, rowIdx) => {
-              const rowBg =
-                rowIdx % 2 === 0
-                  ? "var(--color-bt-state-fill)"
-                  : "transparent";
-              const isMe = m.user_id === currentUser?.id;
-              const rowOpacity = isMe ? 1 : 0.25;
-              return (
-                <Fragment key={m.user_id ?? rowIdx}>
-                  <div
-                    className="flex min-w-0 items-center gap-2 px-3 py-2"
-                    style={{ background: rowBg, opacity: isMe ? 1 : rowOpacity }}
-                  >
-                    <UserAvatar name={m.displayName} avatarUrl={null} size="sm" />
-                    <span
-                      className="truncate text-[13px]"
-                      style={{ color: "var(--color-bt-text)" }}
-                    >
-                      {m.displayName}
-                      {isMe && (
-                        <span
-                          className="text-[11px]"
-                          style={{ color: "var(--color-bt-text-dim)" }}
-                        >
-                          {" "}
-                          (you)
-                        </span>
-                      )}
-                    </span>
-                  </div>
-                  {windows.map((w) => {
-                    const vote = w.votes.find((v) => v.user_id === m.user_id);
-                    const answer = (vote?.answer ?? null) as Answer | null;
-                    return (
-                      <div
-                        key={w.id}
-                        className="flex items-center justify-center gap-0.5 px-1 py-2"
-                        style={{ background: rowBg, opacity: isMe ? 1 : rowOpacity }}
-                      >
-                        {(["yes", "maybe", "no"] as const).map((type) => {
-                          const active = answer === type;
-                          const bg =
-                            type === "yes"
-                              ? "var(--color-bt-vote-yes)"
-                              : type === "maybe"
-                              ? "var(--color-bt-vote-maybe)"
-                              : "var(--color-bt-vote-no)";
-                          const labels = { yes: "✓", maybe: "~", no: "✗" };
-                          return (
-                            <button
-                              key={type}
-                              disabled={!isMe}
-                              onClick={() => {
-                                if (isMe && m.user_id) {
-                                  voteSelf.mutate({
-                                    tripId,
-                                    windowId: w.id,
-                                    answer: type,
-                                  });
-                                }
-                              }}
-                              className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-bold transition-all"
-                              style={
-                                active
-                                  ? {
-                                      background: bg,
-                                      color: "var(--color-bt-vote-yes-text)",
-                                    }
-                                  : {
-                                      background: "transparent",
-                                      color: "var(--color-bt-text-dim)",
-                                      border: "1px dashed var(--color-bt-border)",
-                                      cursor: isMe ? "pointer" : "default",
-                                    }
-                              }
-                            >
-                              {labels[type]}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    );
-                  })}
-                </Fragment>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   function renderBody() {
     // Locked view: show the range and a Change dates → button.
     // For poll-set dates: go straight back to poll draft state (no modal needed).
@@ -978,11 +397,9 @@ export function DatesPanel({
       );
     }
 
-    // Non-owner view: simplified poll-only panel (Planners and Members alike)
-    if (!isOwner) {
-      if (pollMode && hasWindows) return renderMemberPollView();
-      return null;
-    }
+    // DatesPanel is owner-only (ActionCenter hides it from non-owners —
+    // they see DatePollCard directly). Defensive null for any other path.
+    if (!isOwner) return null;
 
     // Owner view — input row visible whenever poll is not yet open
     const showInputRow = !pollMode;

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -116,6 +116,8 @@ export function DatesPanel({
   // Modals and confirm dialogs
   const [showSelectDateModal, setShowSelectDateModal] = useState(false);
   const [confirmReset, setConfirmReset] = useState(false);
+  // Inline cancel-poll confirmation (no modal — renders below the cancel button)
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
 
   // ── Mutations (optimistic updates from main's rewrite) ────────────────
 
@@ -1024,8 +1026,80 @@ export function DatesPanel({
           </>
         )}
 
-        {/* Polling grid — visible whenever poll mode is on */}
-        {pollMode && renderPollGrid()}
+        {/* Poll-active state — date pickers grayed out + amber cancel button */}
+        {pollMode && (
+          <div className="mt-3 space-y-3">
+            {/* Date pickers — visible but non-interactive to show the direct
+                entry path is temporarily unavailable while the poll is open */}
+            <div style={{ opacity: 0.4, pointerEvents: "none" }}>
+              {renderDatePickerRow("set")}
+              <p
+                className="mt-2 text-xs"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Once set, dates can only be changed from the trip settings.
+              </p>
+            </div>
+
+            {/* Amber dashed cancel button — caution, not primary action */}
+            <button
+              type="button"
+              onClick={() => setShowCancelConfirm((v) => !v)}
+              className="flex w-full items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
+              style={{
+                border: "1.5px dashed var(--color-bt-warning)",
+                color: "var(--color-bt-warning)",
+                background: "transparent",
+              }}
+            >
+              <X size={14} />
+              Nevermind — cancel poll, set dates instead
+            </button>
+
+            {/* Inline confirmation row — no modal, renders directly below */}
+            {showCancelConfirm && (
+              <div className="flex items-center justify-between px-1 pt-1">
+                <span
+                  className="text-xs"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  This will clear all votes. Are you sure?
+                </span>
+                <div className="flex gap-2">
+                  {/* Ghost small */}
+                  <button
+                    type="button"
+                    onClick={() => setShowCancelConfirm(false)}
+                    className="rounded-xl px-3 py-1.5 text-xs font-medium"
+                    style={{
+                      background: "transparent",
+                      color: "var(--color-bt-text-dim)",
+                      border: "0.5px solid var(--color-bt-border)",
+                    }}
+                  >
+                    Keep poll
+                  </button>
+                  {/* Danger small */}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setPollActive.mutate({ tripId, pollMode: false });
+                      setShowCancelConfirm(false);
+                    }}
+                    disabled={setPollActive.isPending}
+                    className="rounded-xl px-3 py-1.5 text-xs font-semibold"
+                    style={{
+                      background: "var(--color-bt-danger)",
+                      color: "white",
+                    }}
+                  >
+                    {setPollActive.isPending ? "Cancelling…" : "Yes, cancel"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Calendar, Plus, X } from "lucide-react";
+import { Calendar, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { parseLocalDate, formatDateRangeCompact } from "@/lib/dates";
 import { PlanningRow, type ArcCardState } from "./PlanningRow";
+import { DatePollCard } from "../tabs/components/DatePollCard";
 import type { TripData } from "../tabs/types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -17,13 +17,6 @@ interface DatesPanelProps {
   isOpen: boolean;
   onToggle: () => void;
   onTabChange?: (tab: string) => void;
-}
-
-interface PollWindow {
-  id: string;
-  start_date: string;
-  end_date: string;
-  votes: { user_id: string; answer: string }[];
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -46,62 +39,56 @@ function formatLongDate(d: string): string {
   });
 }
 
-function sortWindows(ws: PollWindow[]): PollWindow[] {
-  return ws.slice().sort((a, b) => {
-    if (a.start_date !== b.start_date) return a.start_date < b.start_date ? -1 : 1;
-    const aDur =
-      parseLocalDate(a.end_date).getTime() - parseLocalDate(a.start_date).getTime();
-    const bDur =
-      parseLocalDate(b.end_date).getTime() - parseLocalDate(b.start_date).getTime();
-    return aDur - bDur;
-  });
-}
-
 // ── Component ────────────────────────────────────────────────────────────
 
+/**
+ * DatesPanel — owner-only admin surface for trip dates.
+ *
+ * Three states (owner, !datesLocked):
+ *   1. idle:       two buttons — "Set Dates" and "Poll the Crew"
+ *   2. setDates:   pickers revealed below the buttons (local UI only)
+ *   3. pollMode:   Set Dates disabled; Poll the Crew becomes
+ *                  "Nevermind — cancel poll". Crew availability grid
+ *                  (DatePollCard) renders below.
+ *
+ * Clicking "Poll the Crew" in idle → flips server pollMode=true → state 3.
+ * Clicking "Nevermind — cancel poll" in state 3 → flips pollMode=false +
+ * clears vote/window data (server-side cascade) → back to state 1.
+ * Clicking "Set Dates" → toggles local pickers (state 2).
+ * Entering valid dates + clicking Set → lockDates → locked view.
+ *
+ * DatesPanel is owner-only. Non-owners see DatePollCard directly from
+ * ActionCenter; DatesPanel returns null for them.
+ */
 export function DatesPanel({
   trip,
   canEdit: _canEdit,
   isOwner,
-  isOpen,
+  isOpen: _isOpen,
   onToggle: _onToggle,
   onTabChange: _onTabChange,
 }: DatesPanelProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
 
-  // Refresh votes every 30 s while the owner has the panel open and the poll
-  // is active — lets them watch responses come in without a manual reload.
-  const liveVotePolling =
-    isOwner && isOpen && !!trip.poll_mode && !trip.start_date;
-
-  const { data: poll } = trpc.datePoll.get.useQuery(
-    { tripId },
-    { refetchInterval: liveVotePolling ? 30_000 : false }
-  );
-  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
-
-  const windows = useMemo(
-    () => sortWindows((poll?.windows ?? []) as PollWindow[]),
-    [poll?.windows]
-  );
-
   const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;
 
-  // Manual date picker state — shared between the empty/idle state and the
-  // "Change dates" modal. The poll-builder uses the same state so typing a
-  // range and hitting "Add to poll" bypasses any second input row.
+  // Header "N options" text needs the live window count. tRPC dedupes
+  // this against DatePollCard's identical query, so no extra network cost.
+  const { data: poll } = trpc.datePoll.get.useQuery(
+    { tripId },
+    { enabled: pollMode && isOwner }
+  );
+  const windowCount = poll?.windows.length ?? 0;
+
+  // Local UI — whether the date pickers are revealed. Reset whenever the
+  // user hands control to the poll flow.
+  const [showPickers, setShowPickers] = useState(false);
   const [directStart, setDirectStart] = useState("");
   const [directEnd, setDirectEnd] = useState("");
 
-  // Modals and confirm dialogs
-  const [showSelectDateModal, setShowSelectDateModal] = useState(false);
-  const [confirmReset, setConfirmReset] = useState(false);
-  // Inline cancel-poll confirmation (no modal — renders below the cancel button)
-  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
-
-  // ── Mutations (optimistic updates from main's rewrite) ────────────────
+  // ── Mutations ──────────────────────────────────────────────────────────
 
   const lockDates = trpc.trips.lockDates.useMutation({
     async onMutate(vars) {
@@ -126,6 +113,7 @@ export function DatesPanel({
     onSuccess() {
       setDirectStart("");
       setDirectEnd("");
+      setShowPickers(false);
     },
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
@@ -138,12 +126,7 @@ export function DatesPanel({
       await utils.trips.getById.cancel({ tripId });
       const prevTrip = utils.trips.getById.getData({ tripId });
       utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
-        old
-          ? {
-              ...old,
-              poll_mode: vars.pollMode,
-            }
-          : old
+        old ? { ...old, poll_mode: vars.pollMode } : old
       );
       return { prevTrip };
     },
@@ -153,100 +136,6 @@ export function DatesPanel({
     },
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
-    },
-  });
-
-  const addWindow = trpc.datePoll.addWindow.useMutation({
-    async onMutate(vars) {
-      await utils.datePoll.get.cancel({ tripId });
-      const prev = utils.datePoll.get.getData({ tripId });
-      utils.datePoll.get.setData({ tripId }, (old) => {
-        const newWindow = {
-          id: vars.id,
-          trip_id: tripId,
-          start_date: vars.startDate,
-          end_date: vars.endDate,
-          created_at: new Date().toISOString(),
-          votes: [] as { window_id: string; user_id: string; answer: string; created_at: string }[],
-        };
-        if (!old) {
-          return {
-            lockedWindowId: null,
-            notifySent: false,
-            pollMode: true,
-            windows: [newWindow],
-          };
-        }
-        const merged = [...old.windows, newWindow];
-        merged.sort((a, b) => {
-          if (a.start_date !== b.start_date)
-            return a.start_date < b.start_date ? -1 : 1;
-          const aDur =
-            parseLocalDate(a.end_date).getTime() -
-            parseLocalDate(a.start_date).getTime();
-          const bDur =
-            parseLocalDate(b.end_date).getTime() -
-            parseLocalDate(b.start_date).getTime();
-          return aDur - bDur;
-        });
-        return { ...old, windows: merged };
-      });
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
-    },
-    onSettled() {
-      utils.datePoll.get.invalidate({ tripId });
-    },
-  });
-
-  const lockWindow = trpc.datePoll.lockDateWindow.useMutation({
-    async onMutate(vars) {
-      await utils.trips.getById.cancel({ tripId });
-      const prevTrip = utils.trips.getById.getData({ tripId });
-      // Find the window dates from the local poll cache
-      const pollData = utils.datePoll.get.getData({ tripId });
-      const win = pollData?.windows.find((w) => w.id === vars.windowId);
-      if (win) {
-        utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
-          old
-            ? {
-                ...old,
-                start_date: win.start_date,
-                end_date: win.end_date,
-                poll_mode: false,
-              }
-            : old
-        );
-      }
-      return { prevTrip };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prevTrip !== undefined)
-        utils.trips.getById.setData({ tripId }, ctx.prevTrip);
-    },
-    onSettled() {
-      utils.datePoll.get.invalidate({ tripId });
-      utils.trips.getById.invalidate({ tripId });
-    },
-  });
-
-  const resetVotes = trpc.datePoll.resetPoll.useMutation({
-    async onMutate() {
-      await utils.datePoll.get.cancel({ tripId });
-      const prev = utils.datePoll.get.getData({ tripId });
-      utils.datePoll.get.setData({ tripId }, (old) =>
-        old
-          ? { ...old, windows: old.windows.map((w) => ({ ...w, votes: [] })) }
-          : old
-      );
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
-    },
-    onSettled() {
       utils.datePoll.get.invalidate({ tripId });
     },
   });
@@ -259,129 +148,53 @@ export function DatesPanel({
     ? "inProgress"
     : "none";
 
-  const ownerDisplayName = useMemo(() => {
-    const owner = members.find((m) => m.role === "Owner");
-    return owner?.displayName ?? "Your organizer";
-  }, [members]);
-
-  const headerLabel = datesLocked
-    ? "Dates Selected"
-    : pollMode
-    ? isOwner
-      ? "Poll Open"
-      : `Dates TBD: ${ownerDisplayName} is working on it`
-    : isOwner
-    ? "Set Dates"
-    : `Dates TBD: ${ownerDisplayName} is working on it`;
+  const headerLabel = datesLocked ? "Dates Selected" : "Dates";
 
   const headerNote = useMemo(() => {
-    if (datesLocked) {
-      return formatDateRangeCompact(trip.start_date, trip.end_date);
-    }
-    if (!isOwner) {
-      return pollMode
-        ? `Poll open · ${windows.length} option${windows.length !== 1 ? "s" : ""}`
-        : "";
-    }
-    if (pollMode)
-      return `Poll open · ${windows.length} option${windows.length !== 1 ? "s" : ""}`;
+    if (datesLocked) return formatDateRangeCompact(trip.start_date, trip.end_date);
+    if (pollMode) return `Poll open · ${windowCount} option${windowCount !== 1 ? "s" : ""}`;
     return "";
-  }, [datesLocked, isOwner, pollMode, windows.length, trip.start_date, trip.end_date]);
+  }, [datesLocked, pollMode, windowCount, trip.start_date, trip.end_date]);
 
   // ── Actions ────────────────────────────────────────────────────────────
 
   const handleSetDates = () => {
     if (!directStart || !directEnd || directStart >= directEnd) return;
-    lockDates.mutate({
-      tripId,
-      startDate: directStart,
-      endDate: directEnd,
-    });
-  };
-
-  const handleAddToPoll = () => {
-    if (!directStart || !directEnd || directStart >= directEnd) return;
-    addWindow.mutate(
-      {
-        tripId,
-        id: crypto.randomUUID(),
-        startDate: directStart,
-        endDate: directEnd,
-      },
-      {
-        onSuccess() {
-          setDirectStart("");
-          setDirectEnd("");
-        },
-      }
-    );
+    lockDates.mutate({ tripId, startDate: directStart, endDate: directEnd });
   };
 
   const handlePollTheCrew = () => {
+    setShowPickers(false);
     setPollActive.mutate({ tripId, pollMode: true });
   };
 
-  // ── Body renderers ─────────────────────────────────────────────────────
+  const handleCancelPoll = () => {
+    setPollActive.mutate({ tripId, pollMode: false });
+  };
 
-  function renderDatePickerRow(buttonMode: "set" | "poll") {
-    const valid = !!directStart && !!directEnd && directStart < directEnd;
-    const busy =
-      buttonMode === "set" ? lockDates.isPending : addWindow.isPending;
-    const label =
-      buttonMode === "set"
-        ? lockDates.isPending
-          ? "Setting…"
-          : "Set dates"
-        : addWindow.isPending
-        ? "Adding…"
-        : "Add to poll";
+  const handleToggleSetDates = () => {
+    if (pollMode) return; // disabled while poll active
+    setShowPickers((v) => !v);
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  // Non-owner: DatesPanel doesn't render for them. ActionCenter surfaces
+  // the DatePollCard directly for non-owners.
+  if (!isOwner) return null;
+
+  // Locked: read-only range display.
+  if (datesLocked) {
     return (
-      <div className="flex items-center gap-2">
-        <input
-          type="date"
-          value={directStart}
-          onChange={(e) => setDirectStart(e.target.value)}
-          className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            border: "1px solid var(--color-bt-border)",
-            color: "var(--color-bt-text)",
-          }}
-        />
-        <input
-          type="date"
-          value={directEnd}
-          onChange={(e) => setDirectEnd(e.target.value)}
-          className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            border: "1px solid var(--color-bt-border)",
-            color: "var(--color-bt-text)",
-          }}
-        />
-        <button
-          disabled={!valid || busy}
-          onClick={buttonMode === "set" ? handleSetDates : handleAddToPoll}
-          className="flex-shrink-0 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity"
-          style={{
-            background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-            color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
-            opacity: valid ? 1 : 0.6,
-            cursor: valid ? "pointer" : "not-allowed",
-          }}
-        >
-          {label}
-        </button>
-      </div>
-    );
-  }
-
-  function renderBody() {
-    // Locked view: show the range and a Change dates → button.
-    // For poll-set dates: go straight back to poll draft state (no modal needed).
-    // For direct-set dates: open the change-dates modal.
-    if (datesLocked) {
-      return (
+      <PlanningRow
+        icon={<Calendar size={16} />}
+        label={headerLabel}
+        note={headerNote}
+        state={state}
+        isOpen={true}
+        onToggle={() => {}}
+        noExpand={true}
+      >
         <div className="space-y-2">
           <p
             className="text-sm font-medium"
@@ -394,75 +207,66 @@ export function DatesPanel({
             {nightsBetween(trip.start_date!, trip.end_date!) !== 1 ? "s" : ""}
           </p>
         </div>
-      );
-    }
+      </PlanningRow>
+    );
+  }
 
-    // DatesPanel is owner-only (ActionCenter hides it from non-owners —
-    // they see DatePollCard directly). Defensive null for any other path.
-    if (!isOwner) return null;
+  // Owner, not-locked — two-button state machine.
+  const valid = !!directStart && !!directEnd && directStart < directEnd;
 
-    // Owner view — input row visible whenever poll is not yet open
-    const showInputRow = !pollMode;
+  return (
+    <PlanningRow
+      icon={<Calendar size={16} />}
+      label={headerLabel}
+      note={headerNote}
+      warnState={pollMode}
+      state={state}
+      isOpen={true}
+      onToggle={() => {}}
+      noExpand={true}
+    >
+      <div className="space-y-3">
+        {/* ── Button row: Set Dates + Poll the Crew / Cancel ──────────── */}
+        <div className="flex gap-2">
+          {/* Set Dates — disabled while poll is active. When pickers are
+              open in idle mode we tint it accent to signal "you're here". */}
+          <button
+            type="button"
+            onClick={handleToggleSetDates}
+            disabled={pollMode}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
+            style={
+              pollMode
+                ? {
+                    border: "1.5px dashed var(--color-bt-border)",
+                    color: "var(--color-bt-text-dim)",
+                    background: "transparent",
+                    opacity: 0.5,
+                    cursor: "not-allowed",
+                  }
+                : showPickers
+                ? {
+                    background: "var(--color-bt-accent)",
+                    color: "var(--color-bt-base)",
+                    border: "1.5px solid var(--color-bt-accent)",
+                  }
+                : {
+                    border: "1.5px dashed var(--color-bt-accent)",
+                    color: "var(--color-bt-accent)",
+                    background: "transparent",
+                  }
+            }
+          >
+            Set Dates
+          </button>
 
-    return (
-      <div className="space-y-0">
-        {showInputRow && (
-          <>
-            <p
-              className="mb-3 text-[13px]"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              When are you going?
-            </p>
-
-            {/* Date pickers + action button */}
-            {renderDatePickerRow("set")}
-
-            <p
-              className="mt-2 text-xs"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              Once set, dates can only be changed from the trip settings.
-            </p>
-
-            {/* Poll the crew — direct mode escape to poll flow */}
-            <div className="mt-3 flex gap-2">
-              <button
-                onClick={handlePollTheCrew}
-                className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
-                style={{
-                  border: "1.5px dashed var(--color-bt-accent)",
-                  color: "var(--color-bt-accent)",
-                  background: "transparent",
-                }}
-              >
-                <Plus size={14} />
-                Poll the crew
-              </button>
-            </div>
-          </>
-        )}
-
-        {/* Poll-active state — date pickers grayed out + amber cancel button */}
-        {pollMode && (
-          <div className="mt-3 space-y-3">
-            {/* Date pickers — visible but non-interactive to show the direct
-                entry path is temporarily unavailable while the poll is open */}
-            <div style={{ opacity: 0.4, pointerEvents: "none" }}>
-              {renderDatePickerRow("set")}
-              <p
-                className="mt-2 text-xs"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Once set, dates can only be changed from the trip settings.
-              </p>
-            </div>
-
-            {/* Amber dashed cancel button — caution, not primary action */}
+          {/* Poll the Crew / Nevermind — cancel poll */}
+          {pollMode ? (
             <button
               type="button"
-              onClick={() => setShowCancelConfirm((v) => !v)}
-              className="flex w-full items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
+              onClick={handleCancelPoll}
+              disabled={setPollActive.isPending}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
               style={{
                 border: "1.5px dashed var(--color-bt-warning)",
                 color: "var(--color-bt-warning)",
@@ -470,406 +274,70 @@ export function DatesPanel({
               }}
             >
               <X size={14} />
-              Nevermind — cancel poll, set dates instead
+              {setPollActive.isPending ? "Cancelling…" : "Nevermind — cancel poll"}
             </button>
-
-            {/* Inline confirmation row — no modal, renders directly below */}
-            {showCancelConfirm && (
-              <div className="flex items-center justify-between px-1 pt-1">
-                <span
-                  className="text-xs"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  This will clear all votes. Are you sure?
-                </span>
-                <div className="flex gap-2">
-                  {/* Ghost small */}
-                  <button
-                    type="button"
-                    onClick={() => setShowCancelConfirm(false)}
-                    className="rounded-xl px-3 py-1.5 text-xs font-medium"
-                    style={{
-                      background: "transparent",
-                      color: "var(--color-bt-text-dim)",
-                      border: "0.5px solid var(--color-bt-border)",
-                    }}
-                  >
-                    Keep poll
-                  </button>
-                  {/* Danger small */}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setPollActive.mutate({ tripId, pollMode: false });
-                      setShowCancelConfirm(false);
-                    }}
-                    disabled={setPollActive.isPending}
-                    className="rounded-xl px-3 py-1.5 text-xs font-semibold"
-                    style={{
-                      background: "var(--color-bt-danger)",
-                      color: "white",
-                    }}
-                  >
-                    {setPollActive.isPending ? "Cancelling…" : "Yes, cancel"}
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // ── Poll-active owner view — flat non-collapsible header row ────────────
-  // Matches the lodging empty-state pattern: icon · title/subtitle · action
-  // button inline on the right. No body, no chevron, no collapse handler.
-  if (pollMode && isOwner && !datesLocked) {
-    return (
-      <div
-        className="rounded-xl border"
-        style={{
-          background: "var(--color-bt-card)",
-          borderColor: "var(--color-bt-border)",
-          boxShadow: "var(--shadow-card)",
-        }}
-      >
-        <div className="flex items-center gap-3 px-4 py-3.5">
-          {/* Icon */}
-          <div
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
-            style={{ background: "var(--color-bt-card-raised)" }}
-          >
-            <Calendar size={16} style={{ color: "var(--color-bt-accent)" }} />
-          </div>
-
-          {/* Title + subtitle */}
-          <div className="min-w-0 flex-1">
-            <div
-              className="text-sm font-semibold"
-              style={{ color: "var(--color-bt-accent)" }}
-            >
-              Poll Open
-            </div>
-            <div
-              className="mt-0.5 text-xs"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              Poll open · {windows.length} option{windows.length !== 1 ? "s" : ""}
-            </div>
-          </div>
-
-          {/* Cancel button — hidden when confirm row is showing */}
-          {!showCancelConfirm && (
+          ) : (
             <button
               type="button"
-              onClick={() => setShowCancelConfirm(true)}
-              className="shrink-0 rounded-xl px-3 py-1.5 text-xs font-semibold"
+              onClick={handlePollTheCrew}
+              disabled={setPollActive.isPending}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
               style={{
-                border: "1.5px dashed var(--color-bt-warning)",
-                color: "var(--color-bt-warning)",
+                border: "1.5px dashed var(--color-bt-accent)",
+                color: "var(--color-bt-accent)",
                 background: "transparent",
               }}
             >
-              Nevermind — cancel poll
+              Poll the Crew
             </button>
           )}
         </div>
 
-        {/* Inline confirmation — below header row, inside same card */}
-        {showCancelConfirm && (
-          <div className="flex items-center justify-between gap-3 px-4 pb-3 pt-0">
-            <span
-              className="text-xs"
-              style={{ color: "var(--color-bt-text-dim)" }}
+        {/* ── Expanded: date pickers (idle + Set Dates clicked) ─────────── */}
+        {showPickers && !pollMode && (
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              value={directStart}
+              onChange={(e) => setDirectStart(e.target.value)}
+              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+            <input
+              type="date"
+              value={directEnd}
+              onChange={(e) => setDirectEnd(e.target.value)}
+              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+            <button
+              type="button"
+              disabled={!valid || lockDates.isPending}
+              onClick={handleSetDates}
+              className="flex-shrink-0 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity"
+              style={{
+                background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+                opacity: valid ? 1 : 0.6,
+                cursor: valid ? "pointer" : "not-allowed",
+              }}
             >
-              This will clear all votes. Are you sure?
-            </span>
-            <div className="flex shrink-0 gap-2">
-              {/* Ghost small */}
-              <button
-                type="button"
-                onClick={() => setShowCancelConfirm(false)}
-                className="rounded-xl px-3 py-1.5 text-xs font-semibold"
-                style={{
-                  background: "transparent",
-                  color: "var(--color-bt-text-dim)",
-                  border: "0.5px solid var(--color-bt-border)",
-                }}
-              >
-                Keep poll
-              </button>
-              {/* Danger small */}
-              <button
-                type="button"
-                onClick={() => {
-                  setPollActive.mutate({ tripId, pollMode: false });
-                  setShowCancelConfirm(false);
-                }}
-                disabled={setPollActive.isPending}
-                className="rounded-xl px-3 py-1.5 text-xs font-semibold"
-                style={{
-                  background: "var(--color-bt-danger)",
-                  color: "var(--color-bt-base)",
-                }}
-              >
-                {setPollActive.isPending ? "Cancelling…" : "Yes, cancel"}
-              </button>
-            </div>
+              {lockDates.isPending ? "Setting…" : "Set"}
+            </button>
           </div>
         )}
+
+        {/* ── Expanded: crew availability (poll active) ─────────────────── */}
+        {pollMode && <DatePollCard trip={trip} isOwner={true} />}
       </div>
-    );
-  }
-
-  return (
-    <>
-      <PlanningRow
-        icon={<Calendar size={16} />}
-        label={headerLabel}
-        note={headerNote}
-        warnState={pollMode}
-        state={state}
-        isOpen={true}
-        onToggle={() => {}}
-        noExpand={true}
-      >
-        {renderBody()}
-      </PlanningRow>
-
-      {/* Select date modal — pick a winning window from the poll */}
-      {showSelectDateModal && (
-        <SelectDateModal
-          windows={windows}
-          pending={lockWindow.isPending}
-          onClose={() => setShowSelectDateModal(false)}
-          onSelect={(w) =>
-            lockWindow.mutate(
-              { tripId, windowId: w.id },
-              {
-                onSuccess() {
-                  setShowSelectDateModal(false);
-                },
-              }
-            )
-          }
-        />
-      )}
-
-      {/* Confirm reset votes dialog */}
-      {confirmReset && (
-        <ConfirmDialog
-          title="Reset poll votes?"
-          body="Date options will be kept but all votes will be cleared. The crew will need to vote again."
-          cancelLabel="Cancel"
-          confirmLabel={resetVotes.isPending ? "Resetting…" : "Reset votes"}
-          confirmDanger
-          onCancel={() => setConfirmReset(false)}
-          onConfirm={() =>
-            resetVotes.mutate(
-              { tripId },
-              { onSuccess: () => setConfirmReset(false) }
-            )
-          }
-        />
-      )}
-    </>
-  );
-}
-
-// ── SelectDateModal ──────────────────────────────────────────────────────
-
-function SelectDateModal({
-  windows,
-  pending,
-  onClose,
-  onSelect,
-}: {
-  windows: PollWindow[];
-  pending: boolean;
-  onClose: () => void;
-  onSelect: (w: PollWindow) => void;
-}) {
-  useModalBackButton(onClose);
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
-      style={{ background: "var(--color-bt-overlay)" }}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
-    >
-      <div
-        className="w-full max-w-sm rounded-t-2xl p-5 lg:rounded-2xl"
-        style={{ background: "var(--color-bt-card)" }}
-      >
-        <div className="mb-2 flex items-center justify-between">
-          <p
-            className="text-base font-semibold"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            Pick a date
-          </p>
-          <button
-            onClick={onClose}
-            className="flex h-7 w-7 items-center justify-center rounded-lg"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            aria-label="Close"
-          >
-            <X size={16} />
-          </button>
-        </div>
-        <p
-          className="mb-4 text-xs"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Once selected, dates can only be changed from the trip settings.
-        </p>
-        <div className="space-y-2">
-          {windows.map((w) => {
-            const nights = nightsBetween(w.start_date, w.end_date);
-            const yesCount = w.votes.filter((v) => v.answer === "yes").length;
-            const maybeCount = w.votes.filter((v) => v.answer === "maybe").length;
-            const noCount = w.votes.filter((v) => v.answer === "no").length;
-            return (
-              <div
-                key={w.id}
-                className="flex items-center justify-between gap-3 rounded-xl px-4 py-3"
-                style={{ background: "var(--color-bt-card-raised)" }}
-              >
-                <div className="min-w-0 flex-1">
-                  <p
-                    className="text-sm font-semibold leading-tight"
-                    style={{ color: "var(--color-bt-text)" }}
-                  >
-                    {formatLongDate(w.start_date)} – {formatLongDate(w.end_date)}
-                  </p>
-                  <p
-                    className="mt-0.5 text-xs"
-                    style={{ color: "var(--color-bt-text-dim)" }}
-                  >
-                    {nights} night{nights !== 1 ? "s" : ""}
-                  </p>
-                  {yesCount + maybeCount + noCount > 0 && (
-                    <div className="mt-1.5 flex items-center gap-2">
-                      {yesCount > 0 && (
-                        <span
-                          className="rounded-full px-1.5 py-0.5 text-[11px] font-semibold"
-                          style={{
-                            background: "var(--color-bt-vote-yes)",
-                            color: "var(--color-bt-vote-yes-text)",
-                          }}
-                        >
-                          ✓ {yesCount}
-                        </span>
-                      )}
-                      {maybeCount > 0 && (
-                        <span
-                          className="rounded-full px-1.5 py-0.5 text-[11px] font-semibold"
-                          style={{
-                            background: "var(--color-bt-vote-maybe)",
-                            color: "var(--color-bt-vote-yes-text)",
-                          }}
-                        >
-                          ~ {maybeCount}
-                        </span>
-                      )}
-                      {noCount > 0 && (
-                        <span
-                          className="rounded-full px-1.5 py-0.5 text-[11px] font-semibold"
-                          style={{
-                            background: "var(--color-bt-vote-no)",
-                            color: "var(--color-bt-vote-yes-text)",
-                          }}
-                        >
-                          ✗ {noCount}
-                        </span>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <button
-                  disabled={pending}
-                  onClick={() => onSelect(w)}
-                  className="flex-shrink-0 rounded-xl px-4 py-2 text-sm font-semibold"
-                  style={{
-                    background: "var(--color-bt-accent)",
-                    color: "var(--color-bt-base)",
-                  }}
-                >
-                  {pending ? "…" : "Select"}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── ConfirmDialog ────────────────────────────────────────────────────────
-
-function ConfirmDialog({
-  title,
-  body,
-  cancelLabel,
-  confirmLabel,
-  confirmDanger,
-  onCancel,
-  onConfirm,
-}: {
-  title: string;
-  body: string;
-  cancelLabel: string;
-  confirmLabel: string;
-  confirmDanger?: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  useModalBackButton(onCancel);
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center px-6"
-      style={{ background: "var(--color-bt-overlay)" }}
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
-    >
-      <div
-        className="w-full max-w-sm rounded-2xl p-5"
-        style={{ background: "var(--color-bt-card)" }}
-      >
-        <p
-          className="text-base font-semibold"
-          style={{ color: "var(--color-bt-text)" }}
-        >
-          {title}
-        </p>
-        <p className="mt-1 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          {body}
-        </p>
-        <div className="mt-4 flex gap-3">
-          <button
-            onClick={onCancel}
-            className="flex-1 rounded-xl py-2.5 text-sm font-medium"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              color: "var(--color-bt-text)",
-            }}
-          >
-            {cancelLabel}
-          </button>
-          <button
-            onClick={onConfirm}
-            className="flex-1 rounded-xl py-2.5 text-sm font-semibold"
-            style={{
-              background: confirmDanger
-                ? "var(--color-bt-danger)"
-                : "var(--color-bt-accent)",
-              color: "var(--color-bt-base)",
-            }}
-          >
-            {confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
+    </PlanningRow>
   );
 }

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -284,8 +284,14 @@ export function DatesPanel({
 
         {/* ── Set Dates content: pickers + two-stage confirm ─────────────── */}
         {mode === "set" && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label
+                className="text-[11px] font-semibold uppercase tracking-wider"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Start date
+              </label>
               <input
                 type="date"
                 value={directStart}
@@ -293,13 +299,21 @@ export function DatesPanel({
                   setDirectStart(e.target.value);
                   setShowSetConfirm(false);
                 }}
-                className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+                className="w-full rounded-xl px-3 py-2.5 text-sm"
                 style={{
                   background: "var(--color-bt-card-raised)",
                   border: "1px solid var(--color-bt-border)",
                   color: "var(--color-bt-text)",
                 }}
               />
+            </div>
+            <div className="space-y-1">
+              <label
+                className="text-[11px] font-semibold uppercase tracking-wider"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                End date
+              </label>
               <input
                 type="date"
                 value={directEnd}
@@ -307,33 +321,13 @@ export function DatesPanel({
                   setDirectEnd(e.target.value);
                   setShowSetConfirm(false);
                 }}
-                className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+                className="w-full rounded-xl px-3 py-2.5 text-sm"
                 style={{
                   background: "var(--color-bt-card-raised)",
                   border: "1px solid var(--color-bt-border)",
                   color: "var(--color-bt-text)",
                 }}
               />
-              <button
-                type="button"
-                disabled={!valid || lockDates.isPending}
-                onClick={() => {
-                  if (!showSetConfirm) {
-                    setShowSetConfirm(true);
-                  } else {
-                    handleSetDatesConfirm();
-                  }
-                }}
-                className="flex-shrink-0 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity"
-                style={{
-                  background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-                  color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
-                  opacity: valid ? 1 : 0.6,
-                  cursor: valid ? "pointer" : "not-allowed",
-                }}
-              >
-                {lockDates.isPending ? "Setting…" : "Set"}
-              </button>
             </div>
 
             {/* Two-stage confirm message */}
@@ -345,6 +339,27 @@ export function DatesPanel({
                 {confirmMessage}
               </p>
             )}
+
+            <button
+              type="button"
+              disabled={!valid || lockDates.isPending}
+              onClick={() => {
+                if (!showSetConfirm) {
+                  setShowSetConfirm(true);
+                } else {
+                  handleSetDatesConfirm();
+                }
+              }}
+              className="w-full rounded-xl py-2.5 text-sm font-semibold transition-opacity"
+              style={{
+                background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+                opacity: valid ? 1 : 0.6,
+                cursor: valid ? "pointer" : "not-allowed",
+              }}
+            >
+              {lockDates.isPending ? "Setting…" : "Set dates"}
+            </button>
           </div>
         )}
 

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Calendar } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { parseLocalDate, formatDateRangeCompact } from "@/lib/dates";
@@ -80,20 +80,14 @@ export function DatesPanel({
     end_date: string;
   }>;
 
-  // Local UI state
+  // Local UI state — initialized from server pollMode so the correct tab is
+  // shown on mount. The server-derived ACTIVE badge and empty-state grid handle
+  // any external state changes (e.g. poll cancelled from another session)
+  // without needing a synchronization effect.
   const [mode, setMode] = useState<"set" | "poll">(pollMode ? "poll" : "set");
   const [showDatesModal, setShowDatesModal] = useState(false);
   const [directStart, setDirectStart] = useState("");
   const [directEnd, setDirectEnd] = useState("");
-
-  // Sync mode with server state during render (e.g. poll cancelled from another
-  // session). Calling setState during render is the React-recommended alternative
-  // to useEffect + setState for derived state that depends on a changing prop.
-  const prevPollModeRef = useRef(pollMode);
-  if (prevPollModeRef.current !== pollMode) {
-    prevPollModeRef.current = pollMode;
-    setMode(pollMode ? "poll" : "set");
-  }
 
   // ── Mutations ──────────────────────────────────────────────────────────
 

--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { Calendar, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Calendar } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { parseLocalDate, formatDateRangeCompact } from "@/lib/dates";
 import { PlanningRow, type ArcCardState } from "./PlanningRow";
@@ -45,17 +45,13 @@ function formatLongDate(d: string): string {
  * DatesPanel — owner-only admin surface for trip dates.
  *
  * Three states (owner, !datesLocked):
- *   1. idle:       two buttons — "Set Dates" and "Poll the Crew"
- *   2. setDates:   pickers revealed below the buttons (local UI only)
- *   3. pollMode:   Set Dates disabled; Poll the Crew becomes
- *                  "Nevermind — cancel poll". Crew availability grid
- *                  (DatePollCard) renders below.
+ *   1. idle/set:    segmented control on "Set Dates" — pickers revealed below
+ *   2. poll:        segmented control on "Poll the Crew" — DatePollCard below
  *
- * Clicking "Poll the Crew" in idle → flips server pollMode=true → state 3.
- * Clicking "Nevermind — cancel poll" in state 3 → flips pollMode=false +
- * clears vote/window data (server-side cascade) → back to state 1.
- * Clicking "Set Dates" → toggles local pickers (state 2).
- * Entering valid dates + clicking Set → lockDates → locked view.
+ * Switching to "Poll the Crew" segment fires setPollMode(true) if not already.
+ * Setting dates with an active poll cascades: lockDates + setPollMode(false).
+ * The Set button is two-stage: first click shows a confirmation message,
+ * second click executes. Confirm message is context-aware (poll active vs not).
  *
  * DatesPanel is owner-only. Non-owners see DatePollCard directly from
  * ActionCenter; DatesPanel returns null for them.
@@ -82,11 +78,16 @@ export function DatesPanel({
   );
   const windowCount = poll?.windows.length ?? 0;
 
-  // Local UI — whether the date pickers are revealed. Reset whenever the
-  // user hands control to the poll flow.
-  const [showPickers, setShowPickers] = useState(false);
+  // Local UI state — segmented control selection + date picker values
+  const [mode, setMode] = useState<"set" | "poll">(pollMode ? "poll" : "set");
+  const [showSetConfirm, setShowSetConfirm] = useState(false);
   const [directStart, setDirectStart] = useState("");
   const [directEnd, setDirectEnd] = useState("");
+
+  // Sync mode with server state (e.g. poll cancelled from another session)
+  useEffect(() => {
+    setMode(pollMode ? "poll" : "set");
+  }, [pollMode]);
 
   // ── Mutations ──────────────────────────────────────────────────────────
 
@@ -113,7 +114,7 @@ export function DatesPanel({
     onSuccess() {
       setDirectStart("");
       setDirectEnd("");
-      setShowPickers(false);
+      setShowSetConfirm(false);
     },
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
@@ -158,23 +159,26 @@ export function DatesPanel({
 
   // ── Actions ────────────────────────────────────────────────────────────
 
-  const handleSetDates = () => {
+  const handleSetDatesConfirm = () => {
     if (!directStart || !directEnd || directStart >= directEnd) return;
+    // If a poll is active, cascade clear it alongside locking dates
+    if (pollMode) {
+      setPollActive.mutate({ tripId, pollMode: false });
+    }
     lockDates.mutate({ tripId, startDate: directStart, endDate: directEnd });
   };
 
-  const handlePollTheCrew = () => {
-    setShowPickers(false);
-    setPollActive.mutate({ tripId, pollMode: true });
+  const handleSelectPollSegment = () => {
+    setMode("poll");
+    setShowSetConfirm(false);
+    if (!pollMode) {
+      setPollActive.mutate({ tripId, pollMode: true });
+    }
   };
 
-  const handleCancelPoll = () => {
-    setPollActive.mutate({ tripId, pollMode: false });
-  };
-
-  const handleToggleSetDates = () => {
-    if (pollMode) return; // disabled while poll active
-    setShowPickers((v) => !v);
+  const handleSelectSetSegment = () => {
+    setMode("set");
+    setShowSetConfirm(false);
   };
 
   // ── Render ─────────────────────────────────────────────────────────────
@@ -211,8 +215,12 @@ export function DatesPanel({
     );
   }
 
-  // Owner, not-locked — two-button state machine.
+  // Owner, not-locked — segmented control state machine.
   const valid = !!directStart && !!directEnd && directStart < directEnd;
+
+  const confirmMessage = pollMode
+    ? "This will lock these dates and clear the poll. Are you sure?"
+    : "Lock these dates?";
 
   return (
     <PlanningRow
@@ -226,117 +234,122 @@ export function DatesPanel({
       noExpand={true}
     >
       <div className="space-y-3">
-        {/* ── Button row: Set Dates + Poll the Crew / Cancel ──────────── */}
-        <div className="flex gap-2">
-          {/* Set Dates — disabled while poll is active. When pickers are
-              open in idle mode we tint it accent to signal "you're here". */}
+        {/* ── Segmented control: Set Dates | Poll the Crew ──────────────── */}
+        <div
+          className="flex overflow-hidden rounded-xl"
+          style={{ border: "1px solid var(--color-bt-border)" }}
+        >
           <button
             type="button"
-            onClick={handleToggleSetDates}
-            disabled={pollMode}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
+            onClick={handleSelectSetSegment}
+            className="flex flex-1 items-center justify-center py-2.5 text-sm font-medium transition-colors"
             style={
-              pollMode
+              mode === "set"
                 ? {
-                    border: "1.5px dashed var(--color-bt-border)",
-                    color: "var(--color-bt-text-dim)",
-                    background: "transparent",
-                    opacity: 0.5,
-                    cursor: "not-allowed",
-                  }
-                : showPickers
-                ? {
-                    background: "var(--color-bt-accent)",
-                    color: "var(--color-bt-base)",
-                    border: "1.5px solid var(--color-bt-accent)",
+                    background: "var(--color-bt-card-float)",
+                    color: "var(--color-bt-text)",
                   }
                 : {
-                    border: "1.5px dashed var(--color-bt-accent)",
-                    color: "var(--color-bt-accent)",
                     background: "transparent",
+                    color: "var(--color-bt-text-dim)",
                   }
             }
           >
             Set Dates
           </button>
-
-          {/* Poll the Crew / Nevermind — cancel poll */}
-          {pollMode ? (
-            <button
-              type="button"
-              onClick={handleCancelPoll}
-              disabled={setPollActive.isPending}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
-              style={{
-                border: "1.5px dashed var(--color-bt-warning)",
-                color: "var(--color-bt-warning)",
-                background: "transparent",
-              }}
-            >
-              <X size={14} />
-              {setPollActive.isPending ? "Cancelling…" : "Nevermind — cancel poll"}
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={handlePollTheCrew}
-              disabled={setPollActive.isPending}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-3 text-sm font-medium transition-colors"
-              style={{
-                border: "1.5px dashed var(--color-bt-accent)",
-                color: "var(--color-bt-accent)",
-                background: "transparent",
-              }}
-            >
-              Poll the Crew
-            </button>
-          )}
+          <div
+            className="w-px self-stretch"
+            style={{ background: "var(--color-bt-border)" }}
+          />
+          <button
+            type="button"
+            onClick={handleSelectPollSegment}
+            disabled={setPollActive.isPending}
+            className="flex flex-1 items-center justify-center py-2.5 text-sm font-medium transition-colors"
+            style={
+              mode === "poll"
+                ? {
+                    background: "var(--color-bt-card-float)",
+                    color: "var(--color-bt-text)",
+                  }
+                : {
+                    background: "transparent",
+                    color: "var(--color-bt-text-dim)",
+                  }
+            }
+          >
+            Poll the Crew
+          </button>
         </div>
 
-        {/* ── Expanded: date pickers (idle + Set Dates clicked) ─────────── */}
-        {showPickers && !pollMode && (
-          <div className="flex items-center gap-2">
-            <input
-              type="date"
-              value={directStart}
-              onChange={(e) => setDirectStart(e.target.value)}
-              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-            <input
-              type="date"
-              value={directEnd}
-              onChange={(e) => setDirectEnd(e.target.value)}
-              className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-            <button
-              type="button"
-              disabled={!valid || lockDates.isPending}
-              onClick={handleSetDates}
-              className="flex-shrink-0 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity"
-              style={{
-                background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-                color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
-                opacity: valid ? 1 : 0.6,
-                cursor: valid ? "pointer" : "not-allowed",
-              }}
-            >
-              {lockDates.isPending ? "Setting…" : "Set"}
-            </button>
+        {/* ── Set Dates content: pickers + two-stage confirm ─────────────── */}
+        {mode === "set" && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <input
+                type="date"
+                value={directStart}
+                onChange={(e) => {
+                  setDirectStart(e.target.value);
+                  setShowSetConfirm(false);
+                }}
+                className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  border: "1px solid var(--color-bt-border)",
+                  color: "var(--color-bt-text)",
+                }}
+              />
+              <input
+                type="date"
+                value={directEnd}
+                onChange={(e) => {
+                  setDirectEnd(e.target.value);
+                  setShowSetConfirm(false);
+                }}
+                className="min-w-0 flex-1 rounded-xl px-3 py-2.5 text-sm"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  border: "1px solid var(--color-bt-border)",
+                  color: "var(--color-bt-text)",
+                }}
+              />
+              <button
+                type="button"
+                disabled={!valid || lockDates.isPending}
+                onClick={() => {
+                  if (!showSetConfirm) {
+                    setShowSetConfirm(true);
+                  } else {
+                    handleSetDatesConfirm();
+                  }
+                }}
+                className="flex-shrink-0 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity"
+                style={{
+                  background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                  color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
+                  opacity: valid ? 1 : 0.6,
+                  cursor: valid ? "pointer" : "not-allowed",
+                }}
+              >
+                {lockDates.isPending ? "Setting…" : "Set"}
+              </button>
+            </div>
+
+            {/* Two-stage confirm message */}
+            {showSetConfirm && valid && (
+              <p
+                className="text-xs leading-snug"
+                style={{ color: "var(--color-bt-warning)" }}
+              >
+                {confirmMessage}
+              </p>
+            )}
           </div>
         )}
 
-        {/* ── Expanded: crew availability (poll active) ─────────────────── */}
-        {pollMode && <DatePollCard trip={trip} isOwner={true} />}
+        {/* ── Poll the Crew content: DatePollCard ───────────────────────── */}
+        {mode === "poll" && <DatePollCard trip={trip} isOwner={true} />}
       </div>
     </PlanningRow>
   );

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ExternalLink, MapPin, Plus, Trash2, Hotel, Pencil, Home, Clock } from "lucide-react";
+import { ExternalLink, MapPin, Trash2, Hotel, Pencil, Clock } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { PlanningRow, type ArcCardState } from "./PlanningRow";
 import { AddPropertySheet, detectPlatform, extractDomain, isValidUrl, type PropertyFormValues } from "./AddPropertySheet";
@@ -334,6 +334,73 @@ export function LodgingPanel({
 
   const state: ArcCardState = confirmedCount > 0 ? "inProgress" : totalCount > 0 ? "inProgress" : "none";
 
+  // ── Empty state — flat non-collapsible header row ─────────────────────
+  if (lodgingItems.length === 0) {
+    return (
+      <>
+        <div
+          className="rounded-xl border"
+          style={{
+            background: "var(--color-bt-card)",
+            borderColor: "var(--color-bt-border)",
+            boxShadow: "var(--shadow-card)",
+          }}
+        >
+          <div className="flex items-center gap-3 px-4 py-3.5">
+            {/* Icon */}
+            <div
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+              style={{ background: "var(--color-bt-card-raised)" }}
+            >
+              <Hotel size={16} style={{ color: "var(--color-bt-text-dim)" }} />
+            </div>
+
+            {/* Title + subtitle */}
+            <div className="min-w-0 flex-1">
+              <div
+                className="text-sm font-semibold"
+                style={{ color: "var(--color-bt-text)" }}
+              >
+                Lodging
+              </div>
+              <div
+                className="mt-0.5 text-xs"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Where are you staying?
+              </div>
+            </div>
+
+            {/* Add button — secondary small, canEdit only */}
+            {canEdit && (
+              <button
+                onClick={() => setShowAddLodging(true)}
+                className="shrink-0 rounded-xl px-3 py-1.5 text-xs font-semibold"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  color: "var(--color-bt-text)",
+                  border: "0.5px solid var(--color-bt-border)",
+                }}
+              >
+                + Add property
+              </button>
+            )}
+          </div>
+        </div>
+
+        {showAddLodging && (
+          <AddPropertySheet
+            showAddressAndDates
+            isPending={createItem.isPending}
+            onSubmit={handleCreate}
+            onClose={() => setShowAddLodging(false)}
+          />
+        )}
+      </>
+    );
+  }
+
+  // ── Has properties — collapsible PlanningRow ───────────────────────────
   return (
     <>
       <PlanningRow
@@ -345,46 +412,36 @@ export function LodgingPanel({
         onToggle={onToggle}
         noExpand={true}
       >
-        <div>
-          <p className="mb-3 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            Add the places you&apos;re thinking of staying at. Once you decide on the
-            perfect one, lock it in and remove the others.
-          </p>
+        <div className="flex flex-col gap-2">
+          {lodgingItems.map((item) => (
+            <LodgingCard
+              key={item.id}
+              item={item}
+              canEdit={canEdit}
+              onEdit={() => setEditingItem(item)}
+              onRemove={() => removeItem.mutate({ tripId, itemId: item.id })}
+              onConfirmToggle={() =>
+                item.is_confirmed
+                  ? unconfirmItem.mutate({ tripId, itemId: item.id })
+                  : confirmItem.mutate({ tripId, itemId: item.id })
+              }
+              removing={removeItem.isPending}
+            />
+          ))}
 
+          {/* Add property — dashed/add style, bottom of list, canEdit only */}
           {canEdit && (
             <button
               onClick={() => setShowAddLodging(true)}
-              className="mb-3 flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+              className="w-full rounded-xl py-2.5 text-sm font-medium"
               style={{
-                background: "var(--color-bt-card-raised)",
-                color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-border)",
+                border: "1.5px dashed var(--color-bt-accent)",
+                color: "var(--color-bt-accent)",
+                background: "transparent",
               }}
             >
-              <Home size={14} />
-              <Plus size={12} />
-              Add property
+              + Add property
             </button>
-          )}
-
-          {lodgingItems.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {lodgingItems.map((item) => (
-                <LodgingCard
-                  key={item.id}
-                  item={item}
-                  canEdit={canEdit}
-                  onEdit={() => setEditingItem(item)}
-                  onRemove={() => removeItem.mutate({ tripId, itemId: item.id })}
-                  onConfirmToggle={() =>
-                    item.is_confirmed
-                      ? unconfirmItem.mutate({ tripId, itemId: item.id })
-                      : confirmItem.mutate({ tripId, itemId: item.id })
-                  }
-                  removing={removeItem.isPending}
-                />
-              ))}
-            </div>
           )}
         </div>
       </PlanningRow>

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -25,7 +25,7 @@ import { getTripStatus } from "@/components/StatusBadge";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import IdeaZonePanel from "../components/IdeaZonePanel";
-import { DatesPlanningRow } from "../components/DatesPlanningRow";
+import { DatesPanel } from "../components/DatesPanel";
 import { ActionCenter } from "./components/ActionCenter";
 import { LodgingPanel } from "../components/LodgingPanel";
 import { TravelPanel } from "../components/TravelPanel";
@@ -769,7 +769,7 @@ function PlanningSection({
       {/* ── Dates — Owner-only admin surface. Non-owners use the  ── */}
       {/*    DatePollCard in ActionCenter. Hidden once locked.     ── */}
       {!(trip.start_date && trip.end_date) && isOwner && (
-        <DatesPlanningRow
+        <DatesPanel
           trip={trip}
           canEdit={canEdit}
           isOwner={isOwner}
@@ -1034,7 +1034,7 @@ export function HomeTab({
           )}
 
           {/* ── Action Center — everyone sees their active tasks in   ── */}
-          {/*    idea + planning stages (matches DatesPlanningRow gate) ── */}
+          {/*    idea + planning stages (matches DatesPanel gate)        ── */}
           {(stage === "idea" || stage === "planning") && (
             <ActionCenter trip={trip} isOwner={!!isOwner} />
           )}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -25,7 +25,6 @@ import { getTripStatus } from "@/components/StatusBadge";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import IdeaZonePanel from "../components/IdeaZonePanel";
-import { DatesPanel } from "../components/DatesPanel";
 import { ActionCenter } from "./components/ActionCenter";
 import { LodgingPanel } from "../components/LodgingPanel";
 import { TravelPanel } from "../components/TravelPanel";
@@ -766,18 +765,6 @@ function PlanningSection({
         Planning
       </p>
 
-      {/* ── Dates — Owner-only admin surface. Non-owners use the  ── */}
-      {/*    DatePollCard in ActionCenter. Hidden once locked.     ── */}
-      {!(trip.start_date && trip.end_date) && isOwner && (
-        <DatesPanel
-          trip={trip}
-          canEdit={canEdit}
-          isOwner={isOwner}
-          isOpen={true}
-          onToggle={() => {}}
-          onTabChange={onTabChange}
-        />
-      )}
       {/* ── Lodging — always expanded ── */}
       <LodgingPanel
         tripId={trip.id}
@@ -1036,7 +1023,7 @@ export function HomeTab({
           {/* ── Action Center — everyone sees their active tasks in   ── */}
           {/*    idea + planning stages (matches DatesPanel gate)        ── */}
           {(stage === "idea" || stage === "planning") && (
-            <ActionCenter trip={trip} isOwner={!!isOwner} />
+            <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} />
           )}
 
           {/* ── Planning rows — gated by stage + canEdit ──────────── */}

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -3,34 +3,35 @@
 import { Sparkles } from "lucide-react";
 import type { TripData } from "../types";
 import { DatePollCard } from "./DatePollCard";
+import { DatesPanel } from "../../components/DatesPanel";
 
 export interface ActionCenterProps {
   trip: TripData;
   isOwner: boolean;
+  canEdit: boolean;
+  onTabChange?: (tab: string) => void;
 }
 
 /**
- * ActionCenter — member-facing "what needs your attention" surface shown
- * during the IDEA and PLANNING stages.
+ * ActionCenter — the single "what needs your attention" surface shown
+ * during the PLANNING stage. Three clean states:
  *
- * Mirrors DatesPanel's visibility contract: the date poll can be
- * open in either stage, so ActionCenter must surface DatePollCard in both
- * or non-owners would have no way to see / vote on the poll.
+ * 1. datesLocked = true  → "You're all set" idle state
+ * 2. datesLocked = false, pollMode = false
+ *      → DatesPanel (date pickers + Poll the crew button)
+ * 3. datesLocked = false, pollMode = true
+ *      → DatesPanel (collapsed flat row + cancel button)
+ *        + DatePollCard below it
  *
- * When no card has anything actionable to surface (e.g. dates are locked
- * and there's no poll in progress), we render a soft placeholder instead
- * of unmounting the whole section — the user asked us to avoid the
- * "panels vanish" transition whiplash.
- *
- * Future cards (RsvpCard, TravelCard) slot in alongside DatePollCard.
+ * DatesPanel is removed from PlanningSection; it lives here exclusively.
+ * Future cards (RsvpCard, TravelCard) slot in alongside the dates surface.
  */
-export function ActionCenter({ trip, isOwner }: ActionCenterProps) {
+export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
   if (stage !== "idea" && stage !== "planning") return null;
 
+  const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;
-  // Future: also roll up RsvpCard / TravelCard "has action?" flags here.
-  const hasActionableCard = pollMode;
 
   return (
     <section className="space-y-3">
@@ -40,9 +41,28 @@ export function ActionCenter({ trip, isOwner }: ActionCenterProps) {
       >
         Action Center
       </p>
-      {pollMode && <DatePollCard trip={trip} isOwner={isOwner} />}
-      {!hasActionableCard && <ActionCenterIdle isOwner={isOwner} />}
-      {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
+
+      {datesLocked ? (
+        // Dates locked — nothing to do
+        <ActionCenterIdle isOwner={isOwner} />
+      ) : (
+        <>
+          {/* DatesPanel always renders when dates are not locked */}
+          <DatesPanel
+            trip={trip}
+            canEdit={canEdit}
+            isOwner={isOwner}
+            isOpen={true}
+            onToggle={() => {}}
+            onTabChange={onTabChange}
+          />
+
+          {/* DatePollCard slides in below when the poll is active */}
+          {pollMode && <DatePollCard trip={trip} isOwner={isOwner} />}
+
+          {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
+        </>
+      )}
     </section>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -59,7 +59,11 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCent
       ) : pollMode ? (
         // Non-owner view: DatesPanel is hidden entirely — the DatePollCard
         // is the only surface they need to see / interact with.
-        <DatePollCard trip={trip} isOwner={isOwner} />
+        <DatePollCard
+          trip={trip}
+          isOwner={isOwner}
+          onManageCrew={canEdit && onTabChange ? () => onTabChange("crew") : undefined}
+        />
       ) : (
         // Non-owner, no poll yet — host hasn't started anything.
         <ActionCenterIdle isOwner={isOwner} />

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -46,19 +46,16 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCent
         // Dates locked — nothing to do
         <ActionCenterIdle isOwner={isOwner} />
       ) : isOwner ? (
-        <>
-          {/* Owner view: DatesPanel is the admin surface. When the poll is
-              active the DatePollCard (crew availability) appears below it. */}
-          <DatesPanel
-            trip={trip}
-            canEdit={canEdit}
-            isOwner={isOwner}
-            isOpen={true}
-            onToggle={() => {}}
-            onTabChange={onTabChange}
-          />
-          {pollMode && <DatePollCard trip={trip} isOwner={isOwner} />}
-        </>
+        // Owner view: DatesPanel is a two-button state machine that
+        // internally expands to embed DatePollCard when the poll is active.
+        <DatesPanel
+          trip={trip}
+          canEdit={canEdit}
+          isOwner={isOwner}
+          isOpen={true}
+          onToggle={() => {}}
+          onTabChange={onTabChange}
+        />
       ) : pollMode ? (
         // Non-owner view: DatesPanel is hidden entirely — the DatePollCard
         // is the only surface they need to see / interact with.

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -13,7 +13,7 @@ export interface ActionCenterProps {
  * ActionCenter — member-facing "what needs your attention" surface shown
  * during the IDEA and PLANNING stages.
  *
- * Mirrors DatesPlanningRow's visibility contract: the date poll can be
+ * Mirrors DatesPanel's visibility contract: the date poll can be
  * open in either stage, so ActionCenter must surface DatePollCard in both
  * or non-owners would have no way to see / vote on the poll.
  *

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -45,9 +45,10 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCent
       {datesLocked ? (
         // Dates locked — nothing to do
         <ActionCenterIdle isOwner={isOwner} />
-      ) : (
+      ) : isOwner ? (
         <>
-          {/* DatesPanel always renders when dates are not locked */}
+          {/* Owner view: DatesPanel is the admin surface. When the poll is
+              active the DatePollCard (crew availability) appears below it. */}
           <DatesPanel
             trip={trip}
             canEdit={canEdit}
@@ -56,13 +57,18 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCent
             onToggle={() => {}}
             onTabChange={onTabChange}
           />
-
-          {/* DatePollCard slides in below when the poll is active */}
           {pollMode && <DatePollCard trip={trip} isOwner={isOwner} />}
-
-          {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
         </>
+      ) : pollMode ? (
+        // Non-owner view: DatesPanel is hidden entirely — the DatePollCard
+        // is the only surface they need to see / interact with.
+        <DatePollCard trip={trip} isOwner={isOwner} />
+      ) : (
+        // Non-owner, no poll yet — host hasn't started anything.
+        <ActionCenterIdle isOwner={isOwner} />
       )}
+
+      {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
     </section>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -490,8 +490,8 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           <div
             className="flex items-center gap-2 rounded-xl px-3 py-2.5"
             style={{
-              background: "var(--color-bt-state-fill)",
-              border: "1px solid var(--color-bt-border)",
+              background: "var(--color-bt-accent-faint)",
+              border: "1px solid var(--color-bt-accent-border)",
             }}
           >
             <ThumbsUp

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -13,10 +13,13 @@ import {
   type PollWindow,
   type VoteAnswer,
 } from "./DatePollGrid";
+import { ConfirmDatesModal } from "../../components/ConfirmDatesModal";
 
 export interface DatePollCardProps {
   trip: TripData;
   isOwner: boolean;
+  /** Owner / planner only — shown as "Manage →" in the Crew column header. */
+  onManageCrew?: () => void;
 }
 
 const DEFAULT_POLL_NOTE =
@@ -44,7 +47,7 @@ function sortWindows(ws: PollWindow[]): PollWindow[] {
  *   a reset is performed, or new members have joined since the last notify.
  * - All-voted banner: thumbs-up shown to any user once they've responded to every window.
  */
-export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
+export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps) {
   const tripId = trip.id;
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
@@ -52,15 +55,19 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const [showAddDateModal, setShowAddDateModal] = useState(false);
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  // Pending window to lock — set when owner clicks "Select this date";
+  // cleared when the ConfirmDatesModal is confirmed or cancelled.
+  const [pendingLockWindowId, setPendingLockWindowId] = useState<string | null>(null);
 
   // Re-notify state:
   // hasFiredNotify latches true on success so refetch races can't re-enable
-  // the button. It's only cleared when one of the three re-enable criteria
-  // fire (addWindow, resetPoll, or new members joined).
+  // the button. Cleared only when a re-enable event fires (new date / reset).
   const [hasFiredNotify, setHasFiredNotify] = useState(false);
-  const [memberCountAtNotify, setMemberCountAtNotify] = useState<number | null>(null);
-  // Human-readable reason shown next to the button when it re-enables.
-  const [renotifyReason, setRenotifyReason] = useState<string | null>(null);
+  // Track the member IDs present at the time of last notification so we can
+  // identify newly-added members for targeted re-notification.
+  const [memberIdsAtNotify, setMemberIdsAtNotify] = useState<string[] | null>(null);
+  // "new-date" | "reset" | null — drives the button label copy.
+  const [renotifyReason, setRenotifyReason] = useState<"new-date" | "reset" | null>(null);
 
   // Poll note editor
   const [editingNote, setEditingNote] = useState(false);
@@ -78,20 +85,31 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const datesLocked = !!(trip.start_date && trip.end_date);
   const notifySent = !!poll?.notifySent;
 
-  // Button is disabled when notifySent (server) OR hasFiredNotify (local latch).
-  // Either condition alone is enough to disable — this prevents refetch races
-  // from re-enabling after the user clicks Notify.
-  // Re-enabled explicitly when: addWindow fires, resetPoll fires, or new members joined.
-  const hasNewMembers =
-    memberCountAtNotify !== null && members.length > memberCountAtNotify;
-  const canNotify = !(notifySent || hasFiredNotify) || hasNewMembers;
+  // Identify members who joined after the last crew-wide notification.
+  // newMemberIds is non-empty only after at least one full notify has been sent.
+  const newMemberIds: string[] = memberIdsAtNotify !== null
+    ? members
+        .filter((m) => m.user_id && !memberIdsAtNotify.includes(m.user_id))
+        .map((m) => m.user_id!)
+    : [];
+  const hasNewMembers = newMemberIds.length > 0;
 
-  // Set reason when new members trigger re-enable (server cases set it in onSuccess).
-  useEffect(() => {
-    if (hasNewMembers && !renotifyReason) {
-      setRenotifyReason("A new crew member joined since the last notification");
-    }
-  }, [hasNewMembers, renotifyReason]);
+  // Button is disabled when notifySent (server) OR hasFiredNotify (local latch).
+  // Re-enabled explicitly when: addWindow fires, resetPoll fires, or new members joined.
+  const canNotify = !(notifySent || hasFiredNotify) || hasNewMembers || renotifyReason !== null;
+
+  // Derive the button label from the current re-notify context.
+  // renotifyReason (new date / reset) takes priority over new members because
+  // those events mean we want to notify everyone, not just the new members.
+  const notifyButtonLabel = !canNotify
+    ? "Crew notified"
+    : renotifyReason === "new-date"
+    ? "Notify crew about the new date"
+    : renotifyReason === "reset"
+    ? "Notify crew again"
+    : hasNewMembers
+    ? "Notify new crew members"
+    : "Notify crew";
 
   const pollNote = poll?.pollNote ?? null;
   const displayNote = pollNote ?? DEFAULT_POLL_NOTE;
@@ -256,7 +274,12 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     },
     onSuccess() {
       setHasFiredNotify(false);
-      setRenotifyReason("A new date option was added");
+      if (notifySent || hasFiredNotify) {
+        setRenotifyReason("new-date");
+      }
+      if (!trip.poll_mode) {
+        activatePoll.mutate({ tripId, pollMode: true });
+      }
     },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -326,7 +349,9 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     },
     onSuccess() {
       setHasFiredNotify(true);
-      setMemberCountAtNotify(members.length);
+      setMemberIdsAtNotify(
+        members.map((m) => m.user_id!).filter(Boolean)
+      );
       setRenotifyReason(null);
     },
     onSettled() {
@@ -355,7 +380,58 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     onSuccess() {
       setShowResetConfirm(false);
       setHasFiredNotify(false);
-      setRenotifyReason("Votes were reset");
+      setRenotifyReason("reset");
+    },
+    onSettled() {
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  // Ends (kills) the poll — clears all windows + votes, sets poll_mode = false.
+  const endPoll = trpc.datePoll.setPollMode.useMutation({
+    async onMutate() {
+      await utils.trips.getById.cancel({ tripId });
+      const prevTrip = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old ? { ...old, poll_mode: false } : old
+      );
+      return { prevTrip };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prevTrip !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prevTrip);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  // Activates the poll (poll_mode = true) the first time a date window is added.
+  const activatePoll = trpc.datePoll.setPollMode.useMutation({
+    async onMutate() {
+      await utils.trips.getById.cancel({ tripId });
+      const prevTrip = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old ? { ...old, poll_mode: true } : old
+      );
+      return { prevTrip };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prevTrip !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prevTrip);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+    },
+  });
+
+  const notifyNewMembersM = trpc.datePoll.notifyNewMembers.useMutation({
+    onSuccess() {
+      // Absorb notified members into the tracked set so they're no longer "new"
+      setMemberIdsAtNotify(
+        members.map((m) => m.user_id!).filter(Boolean)
+      );
     },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -417,79 +493,81 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   return (
     <>
       <div className="space-y-2">
-        {/* ── Poll note: owner-editable, non-owner read-only ─────────────── */}
-        {editingNote ? (
-          <div className="space-y-1.5">
-            <textarea
-              ref={noteTextareaRef}
-              value={noteValue}
-              onChange={(e) => setNoteValue(e.target.value)}
-              rows={3}
-              maxLength={500}
-              placeholder={DEFAULT_POLL_NOTE}
-              className="w-full resize-none rounded-xl px-3 py-2.5 text-[13px] leading-snug"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-accent)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setEditingNote(false)}
-                className="flex-1 rounded-xl py-2 text-[13px] font-medium"
+        {/* ── Poll note: only shown once at least one date has been added ── */}
+        {windows.length > 0 && (
+          editingNote ? (
+            <div className="space-y-1.5">
+              <textarea
+                ref={noteTextareaRef}
+                value={noteValue}
+                onChange={(e) => setNoteValue(e.target.value)}
+                rows={3}
+                maxLength={500}
+                placeholder={DEFAULT_POLL_NOTE}
+                className="w-full resize-none rounded-xl px-3 py-2.5 text-[13px] leading-snug"
                 style={{
                   background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text-dim)",
-                  border: "1px solid var(--color-bt-border)",
+                  border: "1px solid var(--color-bt-accent)",
+                  color: "var(--color-bt-text)",
                 }}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleSaveNote}
-                disabled={updatePollNote.isPending}
-                className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
-                style={{
-                  background: "var(--color-bt-accent)",
-                  color: "var(--color-bt-base)",
-                }}
-              >
-                {updatePollNote.isPending ? "Saving…" : "Save"}
-              </button>
+              />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setEditingNote(false)}
+                  className="flex-1 rounded-xl py-2 text-[13px] font-medium"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-border)",
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSaveNote}
+                  disabled={updatePollNote.isPending}
+                  className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
+                  style={{
+                    background: "var(--color-bt-accent)",
+                    color: "var(--color-bt-base)",
+                  }}
+                >
+                  {updatePollNote.isPending ? "Saving…" : "Save"}
+                </button>
+              </div>
             </div>
-          </div>
-        ) : (
-          <div
-            className="flex items-start gap-2 rounded-xl px-3 py-2.5"
-            style={{
-              background: "var(--color-bt-accent-faint)",
-              border: "1px solid var(--color-bt-accent-border)",
-            }}
-          >
-            <p
-              className="flex-1 text-[12px] leading-snug"
+          ) : (
+            <div
+              className="flex items-start gap-2 rounded-xl px-3 py-2.5"
               style={{
-                color: pollNote ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
-                fontStyle: pollNote ? "normal" : "italic",
+                background: "var(--color-bt-accent-faint)",
+                border: "1px solid var(--color-bt-accent-border)",
               }}
             >
-              {displayNote}
-            </p>
-            {isOwner && (
-              <button
-                type="button"
-                onClick={handleStartEditNote}
-                className="flex-shrink-0 rounded-md p-1 transition-opacity hover:opacity-70"
-                style={{ color: "var(--color-bt-accent)" }}
-                aria-label="Edit note"
+              <p
+                className="flex-1 text-[12px] leading-snug"
+                style={{
+                  color: pollNote ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+                  fontStyle: pollNote ? "normal" : "italic",
+                }}
               >
-                <Pencil size={12} />
-              </button>
-            )}
-          </div>
+                {displayNote}
+              </p>
+              {isOwner && (
+                <button
+                  type="button"
+                  onClick={handleStartEditNote}
+                  className="flex-shrink-0 rounded-md p-1 transition-opacity hover:opacity-70"
+                  style={{ color: "var(--color-bt-accent)" }}
+                  aria-label="Edit note"
+                >
+                  <Pencil size={12} />
+                </button>
+              )}
+            </div>
+          )
         )}
 
         {/* ── Date poll grid ─────────────────────────────────────────────── */}
@@ -502,16 +580,17 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           onAddDateWindow={isOwner ? () => setShowAddDateModal(true) : undefined}
           onLockDateWindow={
             isOwner
-              ? (windowId) => lockWindow.mutate({ tripId, windowId })
+              ? (windowId) => setPendingLockWindowId(windowId)
               : undefined
           }
           onRemoveDateWindow={
             isOwner ? (windowId) => setConfirmRemoveId(windowId) : undefined
           }
+          onManageCrew={onManageCrew}
         />
 
-        {/* ── All-voted confirmation ─────────────────────────────────────── */}
-        {allWindowsVoted && (
+        {/* ── All-voted confirmation (non-owners only) ──────────────────── */}
+        {allWindowsVoted && !isOwner && (
           <div
             className="flex items-center gap-2 rounded-xl px-3 py-2.5"
             style={{
@@ -532,86 +611,111 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           </div>
         )}
 
-        {/* ── Re-notify reason ──────────────────────────────────────────── */}
-        {isOwner && canNotify && renotifyReason && (
-          <p
-            className="text-[11px] leading-snug"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            ↻ {renotifyReason}
-          </p>
-        )}
-
-        {/* ── Owner footer: Notify + Reset ───────────────────────────────── */}
-        {isOwner && (
+        {/* ── Owner footer: Notify + Reset (only once dates exist) ─────── */}
+        {windows.length > 0 && isOwner && (
           <div className="flex items-center gap-2 pt-1">
-            <button
-              type="button"
-              onClick={() => notifyCrew.mutate({ tripId })}
-              disabled={!canNotify || notifyCrew.isPending}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                color: canNotify
-                  ? "var(--color-bt-accent)"
-                  : "var(--color-bt-text-dim)",
-                border: "1px solid var(--color-bt-border)",
-                opacity: canNotify ? 1 : 0.6,
-                cursor: canNotify ? "pointer" : "default",
-              }}
-            >
-              <Bell size={13} />
-              {canNotify ? "Notify crew" : "Crew notified"}
-            </button>
-            {anyVotes && (
-              showResetConfirm ? (
-                /* Confirmation replaces the Reset button in-place */
-                <div className="flex flex-shrink-0 gap-1.5">
-                  <button
-                    type="button"
-                    onClick={() => setShowResetConfirm(false)}
-                    className="rounded-xl px-3 py-2 text-[13px] font-medium"
-                    style={{
-                      background: "var(--color-bt-card-raised)",
-                      color: "var(--color-bt-text-dim)",
-                      border: "1px solid var(--color-bt-border)",
-                    }}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => resetPoll.mutate({ tripId })}
-                    disabled={resetPoll.isPending}
-                    className="rounded-xl px-3 py-2 text-[13px] font-semibold"
-                    style={{
-                      background: "var(--color-bt-danger)",
-                      color: "var(--color-bt-base)",
-                    }}
-                  >
-                    {resetPoll.isPending ? "Clearing…" : "Clear votes?"}
-                  </button>
-                </div>
-              ) : (
+            {showResetConfirm ? (
+              /* Notify hides; three confirm buttons fill the row */
+              <>
                 <button
                   type="button"
-                  onClick={() => setShowResetConfirm(true)}
-                  className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
+                  onClick={() => setShowResetConfirm(false)}
+                  className="flex-1 rounded-xl py-2 text-[13px] font-medium"
                   style={{
                     background: "var(--color-bt-card-raised)",
                     color: "var(--color-bt-text-dim)",
                     border: "1px solid var(--color-bt-border)",
                   }}
-                  aria-label="Reset votes"
                 >
-                  <RotateCcw size={13} />
-                  Reset
+                  Cancel
                 </button>
-              )
+                <button
+                  type="button"
+                  onClick={() => resetPoll.mutate({ tripId })}
+                  disabled={resetPoll.isPending}
+                  className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
+                  style={{ background: "var(--color-bt-danger)", color: "var(--color-bt-base)" }}
+                >
+                  {resetPoll.isPending ? "Clearing…" : "Clear votes?"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => endPoll.mutate({ tripId, pollMode: false })}
+                  disabled={endPoll.isPending}
+                  className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
+                  style={{ background: "var(--color-bt-danger)", color: "var(--color-bt-base)" }}
+                >
+                  {endPoll.isPending ? "Clearing…" : "Clear poll?"}
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!canNotify) return;
+                    if (hasNewMembers && !renotifyReason) {
+                      notifyNewMembersM.mutate({ tripId, userIds: newMemberIds });
+                    } else {
+                      notifyCrew.mutate({ tripId });
+                    }
+                  }}
+                  disabled={!canNotify || notifyCrew.isPending || notifyNewMembersM.isPending}
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: canNotify ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-border)",
+                    opacity: canNotify ? 1 : 0.6,
+                    cursor: canNotify ? "pointer" : "default",
+                  }}
+                >
+                  <Bell size={13} />
+                  {notifyButtonLabel}
+                </button>
+                {anyVotes && (
+                  <button
+                    type="button"
+                    onClick={() => setShowResetConfirm(true)}
+                    className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
+                    style={{
+                      background: "var(--color-bt-card-raised)",
+                      color: "var(--color-bt-text-dim)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
+                    aria-label="Reset votes"
+                  >
+                    <RotateCcw size={13} />
+                    Reset
+                  </button>
+                )}
+              </>
             )}
           </div>
         )}
       </div>
+
+      {/* Confirm dates modal — shown when owner clicks "Select this date" */}
+      {(() => {
+        const win = pendingLockWindowId
+          ? windows.find((w) => w.id === pendingLockWindowId) ?? null
+          : null;
+        if (!win) return null;
+        return (
+          <ConfirmDatesModal
+            startDate={win.start_date}
+            endDate={win.end_date}
+            fromPollWindow={true}
+            hasPoll={true}
+            isPending={lockWindow.isPending}
+            onConfirm={() => {
+              lockWindow.mutate({ tripId, windowId: win.id });
+              setPendingLockWindowId(null);
+            }}
+            onCancel={() => setPendingLockWindowId(null)}
+          />
+        );
+      })()}
 
       {/* Add date window modal */}
       {showAddDateModal && (

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -534,66 +534,52 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
               <Bell size={13} />
               {notifySent && !hasNewMembers ? "Crew notified" : "Notify crew"}
             </button>
-            {anyVotes && !showResetConfirm && (
-              <button
-                type="button"
-                onClick={() => setShowResetConfirm(true)}
-                className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text-dim)",
-                  border: "1px solid var(--color-bt-border)",
-                }}
-                aria-label="Reset votes"
-              >
-                <RotateCcw size={13} />
-                Reset
-              </button>
+            {anyVotes && (
+              showResetConfirm ? (
+                /* Confirmation replaces the Reset button in-place */
+                <div className="flex flex-shrink-0 gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => setShowResetConfirm(false)}
+                    className="rounded-xl px-3 py-2 text-[13px] font-medium"
+                    style={{
+                      background: "var(--color-bt-card-raised)",
+                      color: "var(--color-bt-text-dim)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => resetPoll.mutate({ tripId })}
+                    disabled={resetPoll.isPending}
+                    className="rounded-xl px-3 py-2 text-[13px] font-semibold"
+                    style={{
+                      background: "var(--color-bt-danger)",
+                      color: "var(--color-bt-base)",
+                    }}
+                  >
+                    {resetPoll.isPending ? "Clearing…" : "Clear votes?"}
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowResetConfirm(true)}
+                  className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-border)",
+                  }}
+                  aria-label="Reset votes"
+                >
+                  <RotateCcw size={13} />
+                  Reset
+                </button>
+              )
             )}
-          </div>
-        )}
-
-        {/* ── Reset confirmation inline ──────────────────────────────────── */}
-        {isOwner && showResetConfirm && (
-          <div
-            className="flex items-center justify-between gap-3 rounded-xl px-3 py-2.5"
-            style={{
-              background: "var(--color-bt-state-fill)",
-              border: "1px solid var(--color-bt-border)",
-            }}
-          >
-            <p
-              className="text-[12px] leading-snug"
-              style={{ color: "var(--color-bt-text)" }}
-            >
-              Clear everyone&apos;s date preferences?
-            </p>
-            <div className="flex flex-shrink-0 gap-2">
-              <button
-                type="button"
-                onClick={() => setShowResetConfirm(false)}
-                className="rounded-lg px-3 py-1.5 text-[12px] font-medium"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text-dim)",
-                  border: "1px solid var(--color-bt-border)",
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => resetPoll.mutate({ tripId })}
-                disabled={resetPoll.isPending}
-                className="rounded-lg px-3 py-1.5 text-[12px] font-semibold"
-                style={{
-                  background: "var(--color-bt-danger)",
-                  color: "var(--color-bt-base)",
-                }}
-              >
-                {resetPoll.isPending ? "Clearing…" : "Yes, clear"}
-              </button>
-            </div>
           </div>
         )}
       </div>

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Bell, Pencil, RotateCcw, ThumbsUp, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -59,6 +59,8 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   // fire (addWindow, resetPoll, or new members joined).
   const [hasFiredNotify, setHasFiredNotify] = useState(false);
   const [memberCountAtNotify, setMemberCountAtNotify] = useState<number | null>(null);
+  // Human-readable reason shown next to the button when it re-enables.
+  const [renotifyReason, setRenotifyReason] = useState<string | null>(null);
 
   // Poll note editor
   const [editingNote, setEditingNote] = useState(false);
@@ -83,6 +85,13 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const hasNewMembers =
     memberCountAtNotify !== null && members.length > memberCountAtNotify;
   const canNotify = !(notifySent || hasFiredNotify) || hasNewMembers;
+
+  // Set reason when new members trigger re-enable (server cases set it in onSuccess).
+  useEffect(() => {
+    if (hasNewMembers && !renotifyReason) {
+      setRenotifyReason("A new crew member joined since the last notification");
+    }
+  }, [hasNewMembers, renotifyReason]);
 
   const pollNote = poll?.pollNote ?? null;
   const displayNote = pollNote ?? DEFAULT_POLL_NOTE;
@@ -246,8 +255,8 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
       if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
     },
     onSuccess() {
-      // Clear the notify latch so the button re-enables for the new date option.
       setHasFiredNotify(false);
+      setRenotifyReason("A new date option was added");
     },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -318,6 +327,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     onSuccess() {
       setHasFiredNotify(true);
       setMemberCountAtNotify(members.length);
+      setRenotifyReason(null);
     },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -345,6 +355,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     onSuccess() {
       setShowResetConfirm(false);
       setHasFiredNotify(false);
+      setRenotifyReason("Votes were reset");
     },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -519,6 +530,16 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
               Thanks for the feedback, we&apos;ll be selecting a date soon!
             </p>
           </div>
+        )}
+
+        {/* ── Re-notify reason ──────────────────────────────────────────── */}
+        {isOwner && canNotify && renotifyReason && (
+          <p
+            className="text-[11px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            ↻ {renotifyReason}
+          </p>
         )}
 
         {/* ── Owner footer: Notify + Reset ───────────────────────────────── */}

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -443,7 +443,13 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
             </div>
           </div>
         ) : (
-          <div className="flex items-start gap-1.5">
+          <div
+            className="flex items-start gap-2 rounded-xl px-3 py-2.5"
+            style={{
+              background: "var(--color-bt-accent-faint)",
+              border: "1px solid var(--color-bt-accent-border)",
+            }}
+          >
             <p
               className="flex-1 text-[12px] leading-snug"
               style={{
@@ -458,7 +464,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
                 type="button"
                 onClick={handleStartEditNote}
                 className="flex-shrink-0 rounded-md p-1 transition-opacity hover:opacity-70"
-                style={{ color: "var(--color-bt-text-dim)" }}
+                style={{ color: "var(--color-bt-accent)" }}
                 aria-label="Edit note"
               >
                 <Pencil size={12} />
@@ -490,8 +496,8 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           <div
             className="flex items-center gap-2 rounded-xl px-3 py-2.5"
             style={{
-              background: "var(--color-bt-accent-faint)",
-              border: "1px solid var(--color-bt-accent-border)",
+              background: "var(--color-bt-state-fill)",
+              border: "1px solid var(--color-bt-border)",
             }}
           >
             <ThumbsUp

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -326,12 +326,6 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           the "panel inside panel" visual nesting. Matches DatesPanel's
           internal poll-grid pattern: small uppercase header + grid. */}
       <div className="space-y-2">
-        <p
-          className="text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Crew Availability
-        </p>
         <DatePollGrid
           dateWindows={windows}
           members={pollMembers}

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { Bell, RotateCcw, X } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Bell, Pencil, RotateCcw, ThumbsUp, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
@@ -19,6 +19,9 @@ export interface DatePollCardProps {
   isOwner: boolean;
 }
 
+const DEFAULT_POLL_NOTE =
+  "Vote on each date option — ✓ if it works, ~ if maybe, ✕ if you can't make it.";
+
 function sortWindows(ws: PollWindow[]): PollWindow[] {
   return ws.slice().sort((a, b) => {
     if (a.start_date !== b.start_date) return a.start_date < b.start_date ? -1 : 1;
@@ -32,10 +35,14 @@ function sortWindows(ws: PollWindow[]): PollWindow[] {
 
 /**
  * DatePollCard — the member-facing (and owner-operable) surface for the
- * date poll. Wraps ActionCard + DatePollGrid. Shows resolved chip when
- * dates are locked. Footer actions (Notify crew / Reset) are owner-only;
- * non-owners see a read-only poll with interactive cells only on their
- * own row.
+ * date poll. Footer actions (Notify crew / Reset) are owner-only.
+ *
+ * Features:
+ * - Poll note: owner-editable instructional text shown to all crew above the grid.
+ * - Reset confirmation: two-step confirm before clearing all votes.
+ * - Smart re-notify: Notify button re-enables after a new date is added,
+ *   a reset is performed, or new members have joined since the last notify.
+ * - All-voted banner: thumbs-up shown to any user once they've responded to every window.
  */
 export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const tripId = trip.id;
@@ -44,6 +51,16 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
 
   const [showAddDateModal, setShowAddDateModal] = useState(false);
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+
+  // Re-notify: track member count at time of last notify so we can detect
+  // new joiners client-side. Server handles the addWindow + resetPoll cases.
+  const [memberCountAtNotify, setMemberCountAtNotify] = useState<number | null>(null);
+
+  // Poll note editor
+  const [editingNote, setEditingNote] = useState(false);
+  const [noteValue, setNoteValue] = useState<string>("");
+  const noteTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const { data: poll } = trpc.datePoll.get.useQuery({ tripId });
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
@@ -56,6 +73,17 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const datesLocked = !!(trip.start_date && trip.end_date);
   const notifySent = !!poll?.notifySent;
 
+  // Re-notify is allowed when:
+  //   1. Notify hasn't been sent yet, OR
+  //   2. New members joined since the last notify (client-only detection), OR
+  //   3. notify_sent was reset by addWindow or resetPoll (server-driven, picked up via refetch)
+  const hasNewMembers =
+    memberCountAtNotify !== null && members.length > memberCountAtNotify;
+  const canNotify = !notifySent || hasNewMembers;
+
+  const pollNote = poll?.pollNote ?? null;
+  const displayNote = pollNote ?? DEFAULT_POLL_NOTE;
+
   const pollMembers: PollMember[] = useMemo(
     () =>
       members.map((m) => ({
@@ -65,6 +93,13 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
       })),
     [members]
   );
+
+  // Has the current user voted on every available window?
+  const allWindowsVoted =
+    windows.length > 0 &&
+    windows.every((w) =>
+      w.votes.some((v) => v.user_id === currentUser?.id && v.answer != null)
+    );
 
   // ── Mutations ──────────────────────────────────────────────────────────
 
@@ -130,7 +165,6 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           ...old,
           windows: old.windows.map((w) => {
             if (w.id !== vars.windowId) return w;
-            // Null answer = clear that member's vote.
             if (vars.answer === null) {
               return {
                 ...w,
@@ -195,11 +229,13 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           return {
             lockedWindowId: null,
             notifySent: false,
+            pollNote: null,
             pollMode: true,
             windows: [newWindow],
           };
         }
-        return { ...old, windows: [...old.windows, newWindow] };
+        // Optimistically reset notifySent so the button re-enables immediately.
+        return { ...old, notifySent: false, windows: [...old.windows, newWindow] };
       });
       return { prev };
     },
@@ -272,6 +308,10 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     onError(_e, _v, ctx) {
       if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
     },
+    onSuccess() {
+      // Snapshot current member count so we can detect new joiners
+      setMemberCountAtNotify(members.length);
+    },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
     },
@@ -283,7 +323,11 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
       const prev = utils.datePoll.get.getData({ tripId });
       utils.datePoll.get.setData({ tripId }, (old) =>
         old
-          ? { ...old, windows: old.windows.map((w) => ({ ...w, votes: [] })) }
+          ? {
+              ...old,
+              notifySent: false,
+              windows: old.windows.map((w) => ({ ...w, votes: [] })),
+            }
           : old
       );
       return { prev };
@@ -291,15 +335,34 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     onError(_e, _v, ctx) {
       if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
     },
+    onSuccess() {
+      setShowResetConfirm(false);
+    },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
     },
   });
 
-  // When dates are locked, the date poll is not an action surface — the
-  // ActionCenter renders its own "nothing needed right now" placeholder
-  // (which will also cover future resolved-stage cards like RSVP / travel).
-  // Returning null here keeps DatePollCard a pure poll-mode component.
+  const updatePollNote = trpc.datePoll.updatePollNote.useMutation({
+    async onMutate(vars) {
+      await utils.datePoll.get.cancel({ tripId });
+      const prev = utils.datePoll.get.getData({ tripId });
+      utils.datePoll.get.setData({ tripId }, (old) =>
+        old ? { ...old, pollNote: vars.note } : old
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
+    },
+    onSuccess() {
+      setEditingNote(false);
+    },
+    onSettled() {
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
   if (datesLocked) return null;
 
   // ── Poll-open view ─────────────────────────────────────────────────────
@@ -308,10 +371,8 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     if (userId === currentUser?.id) {
       castVote.mutate({ tripId, windowId, answer });
     } else if (isOwner) {
-      // Owner voting on behalf of another crew member.
       voteForMember.mutate({ tripId, windowId, userId, answer });
     }
-    // Non-owner clicks on another member's cell are blocked at the grid level.
   };
 
   const anyVotes = windows.some((w) => w.votes.length > 0);
@@ -320,12 +381,93 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     ? windows.find((w) => w.id === confirmRemoveId) ?? null
     : null;
 
+  const handleSaveNote = () => {
+    const trimmed = noteValue.trim();
+    updatePollNote.mutate({ tripId, note: trimmed || null });
+  };
+
+  const handleStartEditNote = () => {
+    setNoteValue(pollNote ?? "");
+    setEditingNote(true);
+    setTimeout(() => {
+      noteTextareaRef.current?.focus();
+      noteTextareaRef.current?.select();
+    }, 0);
+  };
+
   return (
     <>
-      {/* Panel-less container — sits directly under DatesPanel so we avoid
-          the "panel inside panel" visual nesting. Matches DatesPanel's
-          internal poll-grid pattern: small uppercase header + grid. */}
       <div className="space-y-2">
+        {/* ── Poll note: owner-editable, non-owner read-only ─────────────── */}
+        {editingNote ? (
+          <div className="space-y-1.5">
+            <textarea
+              ref={noteTextareaRef}
+              value={noteValue}
+              onChange={(e) => setNoteValue(e.target.value)}
+              rows={3}
+              maxLength={500}
+              placeholder={DEFAULT_POLL_NOTE}
+              className="w-full resize-none rounded-xl px-3 py-2.5 text-[13px] leading-snug"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-accent)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setEditingNote(false)}
+                className="flex-1 rounded-xl py-2 text-[13px] font-medium"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  color: "var(--color-bt-text-dim)",
+                  border: "1px solid var(--color-bt-border)",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveNote}
+                disabled={updatePollNote.isPending}
+                className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
+                style={{
+                  background: "var(--color-bt-accent)",
+                  color: "var(--color-bt-base)",
+                }}
+              >
+                {updatePollNote.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start gap-1.5">
+            <p
+              className="flex-1 text-[12px] leading-snug"
+              style={{
+                color: pollNote ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+                fontStyle: pollNote ? "normal" : "italic",
+              }}
+            >
+              {displayNote}
+            </p>
+            {isOwner && (
+              <button
+                type="button"
+                onClick={handleStartEditNote}
+                className="flex-shrink-0 rounded-md p-1 transition-opacity hover:opacity-70"
+                style={{ color: "var(--color-bt-text-dim)" }}
+                aria-label="Edit note"
+              >
+                <Pencil size={12} />
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* ── Date poll grid ─────────────────────────────────────────────── */}
         <DatePollGrid
           dateWindows={windows}
           members={pollMembers}
@@ -343,31 +485,53 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
           }
         />
 
+        {/* ── All-voted confirmation ─────────────────────────────────────── */}
+        {allWindowsVoted && (
+          <div
+            className="flex items-center gap-2 rounded-xl px-3 py-2.5"
+            style={{
+              background: "var(--color-bt-state-fill)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            <ThumbsUp
+              size={14}
+              style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+            />
+            <p
+              className="text-[12px] leading-snug"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              You&apos;ve voted on all date options — nice!
+            </p>
+          </div>
+        )}
+
+        {/* ── Owner footer: Notify + Reset ───────────────────────────────── */}
         {isOwner && (
           <div className="flex items-center gap-2 pt-1">
             <button
               type="button"
               onClick={() => notifyCrew.mutate({ tripId })}
-              disabled={notifySent || notifyCrew.isPending}
+              disabled={!canNotify || notifyCrew.isPending}
               className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
               style={{
                 background: "var(--color-bt-card-raised)",
-                color: notifySent
-                  ? "var(--color-bt-text-dim)"
-                  : "var(--color-bt-accent)",
+                color: canNotify
+                  ? "var(--color-bt-accent)"
+                  : "var(--color-bt-text-dim)",
                 border: "1px solid var(--color-bt-border)",
-                opacity: notifySent ? 0.6 : 1,
-                cursor: notifySent ? "default" : "pointer",
+                opacity: canNotify ? 1 : 0.6,
+                cursor: canNotify ? "pointer" : "default",
               }}
             >
               <Bell size={13} />
-              {notifySent ? "Crew notified" : "Notify crew"}
+              {notifySent && !hasNewMembers ? "Crew notified" : "Notify crew"}
             </button>
-            {anyVotes && (
+            {anyVotes && !showResetConfirm && (
               <button
                 type="button"
-                onClick={() => resetPoll.mutate({ tripId })}
-                disabled={resetPoll.isPending}
+                onClick={() => setShowResetConfirm(true)}
                 className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
                 style={{
                   background: "var(--color-bt-card-raised)",
@@ -380,6 +544,50 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
                 Reset
               </button>
             )}
+          </div>
+        )}
+
+        {/* ── Reset confirmation inline ──────────────────────────────────── */}
+        {isOwner && showResetConfirm && (
+          <div
+            className="flex items-center justify-between gap-3 rounded-xl px-3 py-2.5"
+            style={{
+              background: "var(--color-bt-state-fill)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            <p
+              className="text-[12px] leading-snug"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              Clear everyone&apos;s date preferences?
+            </p>
+            <div className="flex flex-shrink-0 gap-2">
+              <button
+                type="button"
+                onClick={() => setShowResetConfirm(false)}
+                className="rounded-lg px-3 py-1.5 text-[12px] font-medium"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  color: "var(--color-bt-text-dim)",
+                  border: "1px solid var(--color-bt-border)",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => resetPoll.mutate({ tripId })}
+                disabled={resetPoll.isPending}
+                className="rounded-lg px-3 py-1.5 text-[12px] font-semibold"
+                style={{
+                  background: "var(--color-bt-danger)",
+                  color: "var(--color-bt-base)",
+                }}
+              >
+                {resetPoll.isPending ? "Clearing…" : "Yes, clear"}
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -678,7 +678,7 @@ function AddDateWindowModal({
             <X size={16} />
           </button>
         </div>
-        <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-2">
           <div className="space-y-1">
             <label
               className="text-[11px] font-semibold uppercase tracking-wider"

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -53,8 +53,11 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
 
-  // Re-notify: track member count at time of last notify so we can detect
-  // new joiners client-side. Server handles the addWindow + resetPoll cases.
+  // Re-notify state:
+  // hasFiredNotify latches true on success so refetch races can't re-enable
+  // the button. It's only cleared when one of the three re-enable criteria
+  // fire (addWindow, resetPoll, or new members joined).
+  const [hasFiredNotify, setHasFiredNotify] = useState(false);
   const [memberCountAtNotify, setMemberCountAtNotify] = useState<number | null>(null);
 
   // Poll note editor
@@ -73,13 +76,13 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
   const datesLocked = !!(trip.start_date && trip.end_date);
   const notifySent = !!poll?.notifySent;
 
-  // Re-notify is allowed when:
-  //   1. Notify hasn't been sent yet, OR
-  //   2. New members joined since the last notify (client-only detection), OR
-  //   3. notify_sent was reset by addWindow or resetPoll (server-driven, picked up via refetch)
+  // Button is disabled when notifySent (server) OR hasFiredNotify (local latch).
+  // Either condition alone is enough to disable — this prevents refetch races
+  // from re-enabling after the user clicks Notify.
+  // Re-enabled explicitly when: addWindow fires, resetPoll fires, or new members joined.
   const hasNewMembers =
     memberCountAtNotify !== null && members.length > memberCountAtNotify;
-  const canNotify = !notifySent || hasNewMembers;
+  const canNotify = !(notifySent || hasFiredNotify) || hasNewMembers;
 
   const pollNote = poll?.pollNote ?? null;
   const displayNote = pollNote ?? DEFAULT_POLL_NOTE;
@@ -242,6 +245,10 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     onError(_e, _v, ctx) {
       if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
     },
+    onSuccess() {
+      // Clear the notify latch so the button re-enables for the new date option.
+      setHasFiredNotify(false);
+    },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
     },
@@ -309,7 +316,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
       if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
     },
     onSuccess() {
-      // Snapshot current member count so we can detect new joiners
+      setHasFiredNotify(true);
       setMemberCountAtNotify(members.length);
     },
     onSettled() {
@@ -337,6 +344,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
     },
     onSuccess() {
       setShowResetConfirm(false);
+      setHasFiredNotify(false);
     },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
@@ -532,7 +540,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
               }}
             >
               <Bell size={13} />
-              {notifySent && !hasNewMembers ? "Crew notified" : "Notify crew"}
+              {canNotify ? "Notify crew" : "Crew notified"}
             </button>
             {anyVotes && (
               showResetConfirm ? (

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Bell, Pencil, RotateCcw, ThumbsUp, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -20,7 +20,7 @@ export interface DatePollCardProps {
 }
 
 const DEFAULT_POLL_NOTE =
-  "Vote on each date option — ✓ if it works, ~ if maybe, ✕ if you can't make it.";
+  "We're trying to get a feel for everyone's availability before locking in a date — let us know what you think about these options.";
 
 function sortWindows(ws: PollWindow[]): PollWindow[] {
   return ws.slice().sort((a, b) => {

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Calendar, Bell, RotateCcw, X } from "lucide-react";
+import { Bell, RotateCcw, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { parseLocalDate } from "@/lib/dates";
 import type { TripData } from "../types";
-import { ActionCard } from "./ActionCard";
 import {
   DatePollGrid,
   type PollMember,
@@ -323,71 +322,73 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
 
   return (
     <>
-      <ActionCard
-        icon={<Calendar size={16} />}
-        title="Pick your dates"
-        subtitle={isOwner ? "Tap any cell to vote on behalf of a crew member" : "Tap your row to cast a vote"}
-        isResolved={false}
-      >
-        <div className="space-y-3">
-          <DatePollGrid
-            dateWindows={windows}
-            members={pollMembers}
-            currentUserId={currentUser?.id ?? ""}
-            isOwner={isOwner}
-            onVote={handleVote}
-            onAddDateWindow={isOwner ? () => setShowAddDateModal(true) : undefined}
-            onLockDateWindow={
-              isOwner
-                ? (windowId) => lockWindow.mutate({ tripId, windowId })
-                : undefined
-            }
-            onRemoveDateWindow={
-              isOwner ? (windowId) => setConfirmRemoveId(windowId) : undefined
-            }
-          />
+      {/* Panel-less container — sits directly under DatesPanel so we avoid
+          the "panel inside panel" visual nesting. Matches DatesPanel's
+          internal poll-grid pattern: small uppercase header + grid. */}
+      <div className="space-y-2">
+        <p
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Crew Availability
+        </p>
+        <DatePollGrid
+          dateWindows={windows}
+          members={pollMembers}
+          currentUserId={currentUser?.id ?? ""}
+          isOwner={isOwner}
+          onVote={handleVote}
+          onAddDateWindow={isOwner ? () => setShowAddDateModal(true) : undefined}
+          onLockDateWindow={
+            isOwner
+              ? (windowId) => lockWindow.mutate({ tripId, windowId })
+              : undefined
+          }
+          onRemoveDateWindow={
+            isOwner ? (windowId) => setConfirmRemoveId(windowId) : undefined
+          }
+        />
 
-          {isOwner && (
-            <div className="flex items-center gap-2">
+        {isOwner && (
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => notifyCrew.mutate({ tripId })}
+              disabled={notifySent || notifyCrew.isPending}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                color: notifySent
+                  ? "var(--color-bt-text-dim)"
+                  : "var(--color-bt-accent)",
+                border: "1px solid var(--color-bt-border)",
+                opacity: notifySent ? 0.6 : 1,
+                cursor: notifySent ? "default" : "pointer",
+              }}
+            >
+              <Bell size={13} />
+              {notifySent ? "Crew notified" : "Notify crew"}
+            </button>
+            {anyVotes && (
               <button
                 type="button"
-                onClick={() => notifyCrew.mutate({ tripId })}
-                disabled={notifySent || notifyCrew.isPending}
-                className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-opacity"
+                onClick={() => resetPoll.mutate({ tripId })}
+                disabled={resetPoll.isPending}
+                className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
                 style={{
                   background: "var(--color-bt-card-raised)",
-                  color: notifySent
-                    ? "var(--color-bt-text-dim)"
-                    : "var(--color-bt-accent)",
+                  color: "var(--color-bt-text-dim)",
                   border: "1px solid var(--color-bt-border)",
-                  opacity: notifySent ? 0.6 : 1,
-                  cursor: notifySent ? "default" : "pointer",
                 }}
+                aria-label="Reset votes"
               >
-                <Bell size={13} />
-                {notifySent ? "Crew notified" : "Notify crew"}
+                <RotateCcw size={13} />
+                Reset
               </button>
-              {anyVotes && (
-                <button
-                  type="button"
-                  onClick={() => resetPoll.mutate({ tripId })}
-                  disabled={resetPoll.isPending}
-                  className="flex items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    color: "var(--color-bt-text-dim)",
-                    border: "1px solid var(--color-bt-border)",
-                  }}
-                  aria-label="Reset votes"
-                >
-                  <RotateCcw size={13} />
-                  Reset
-                </button>
-              )}
-            </div>
-          )}
-        </div>
-      </ActionCard>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Add date window modal */}
       {showAddDateModal && (

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -516,7 +516,7 @@ export function DatePollCard({ trip, isOwner }: DatePollCardProps) {
               className="text-[12px] leading-snug"
               style={{ color: "var(--color-bt-text)" }}
             >
-              You&apos;ve voted on all date options — nice!
+              Thanks for the feedback, we&apos;ll be selecting a date soon!
             </p>
           </div>
         )}

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -678,35 +678,45 @@ function AddDateWindowModal({
             <X size={16} />
           </button>
         </div>
-        <p
-          className="mb-4 text-xs"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Pick a start and end date for a new window the crew can vote on.
-        </p>
-        <div className="space-y-2">
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="w-full rounded-xl px-3 py-2.5 text-sm"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              border: "1px solid var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
-          />
-          <input
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-            className="w-full rounded-xl px-3 py-2.5 text-sm"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              border: "1px solid var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
-          />
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label
+              className="text-[11px] font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Start date
+            </label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full rounded-xl px-3 py-2.5 text-sm"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+          </div>
+          <div className="space-y-1">
+            <label
+              className="text-[11px] font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              End date
+            </label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-full rounded-xl px-3 py-2.5 text-sm"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            />
+          </div>
         </div>
         <div className="mt-4 flex gap-2">
           <button

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -309,7 +309,7 @@ export function DatePollGrid({
                 const answer = (vote?.answer ?? null) as VoteAnswer;
                 const isColumnHighlighted = openPopoverId === w.id;
                 const cellBg = isColumnHighlighted
-                  ? "rgba(45, 212, 191, 0.07)"
+                  ? "var(--color-bt-accent-faint)"
                   : rowBg;
                 const interactive = isMe || isOwner;
                 const handleSet = (next: VoteAnswer) => {
@@ -403,7 +403,7 @@ function ColumnHeader({
   canEdit: boolean;
   onToggle: (anchorRect: DOMRect) => void;
 }) {
-  const bg = isActive ? "rgba(45, 212, 191, 0.07)" : "var(--color-bt-card)";
+  const bg = isActive ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)";
   if (!canEdit) {
     return (
       <div

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -142,201 +142,216 @@ export function DatePollGrid({
   const openPopoverId = openPopover?.id ?? null;
 
   const hasWindows = dateWindows.length > 0;
-  const gridMinWidth = NAME_COL_MIN_WIDTH + dateWindows.length * COLUMN_WIDTH;
+  const showAddColumn = isOwner && !!onAddDateWindow;
+  const gridMinWidth =
+    NAME_COL_MIN_WIDTH +
+    dateWindows.length * COLUMN_WIDTH +
+    (showAddColumn ? ADD_COL_WIDTH : 0);
 
-  // Empty-state short-circuit: when there are no date windows, rendering
-  // member rows inside the grid causes layout to jumble (the grid template
-  // has a placeholder column, but each row only contributes the name cell,
-  // so names flow across the extra column). Swap to a single-line empty
-  // banner until the first window is added.
+  // Empty-state short-circuit: no date windows yet. Keep a single-row
+  // banner layout so member rows don't flow across undefined columns.
   if (!hasWindows) {
     return (
-      <div className="flex">
+      <div
+        className="overflow-hidden rounded-xl"
+        style={{ background: "var(--color-bt-card-raised)" }}
+      >
         <div
-          className="min-w-0 flex-1 rounded-xl px-4 py-6 text-center"
-          style={{ background: "var(--color-bt-card)" }}
+          className="grid"
+          style={{
+            gridTemplateColumns: showAddColumn
+              ? `1fr ${ADD_COL_WIDTH}px`
+              : "1fr",
+          }}
         >
-          <span
-            className="text-[13px] italic"
-            style={{ color: "var(--color-bt-text-dim)" }}
+          <div
+            className="flex items-center justify-center px-4 py-6 text-center"
           >
-            {isOwner
-              ? "No dates added yet — tap the + to propose a date option."
-              : "No dates added yet — the host hasn't proposed any options."}
-          </span>
+            <span
+              className="text-[13px] italic"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              {isOwner
+                ? "No dates added yet — tap the + to propose a date option."
+                : "No dates added yet — the host hasn't proposed any options."}
+            </span>
+          </div>
+          {showAddColumn && (
+            <button
+              type="button"
+              onClick={onAddDateWindow}
+              className="flex items-center justify-center transition-colors hover:bg-[var(--color-bt-card)]"
+              style={{
+                background: "transparent",
+                borderLeft: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-accent)",
+              }}
+              aria-label="Add date option"
+            >
+              <CalendarPlus size={20} />
+            </button>
+          )}
         </div>
-        {isOwner && onAddDateWindow && (
-          <button
-            type="button"
-            onClick={onAddDateWindow}
-            className="group relative ml-2 flex flex-shrink-0 items-center justify-center self-stretch rounded-xl transition-colors hover:bg-[var(--color-bt-card-raised)]"
-            style={{
-              width: `${ADD_COL_WIDTH}px`,
-              background: "transparent",
-              border: "1.5px dashed var(--color-bt-border)",
-              color: "var(--color-bt-accent)",
-            }}
-            aria-label="Add date option"
-          >
-            <CalendarPlus size={22} />
-          </button>
-        )}
       </div>
     );
   }
 
   return (
-    <div className="flex">
-      {/* ── scrollable grid ────────────────────────────────────────────── */}
+    <div
+      className="overflow-x-auto rounded-xl"
+      style={{ background: "var(--color-bt-card-raised)" }}
+    >
       <div
-        className="min-w-0 flex-1 overflow-x-auto rounded-xl"
-        style={{ background: "var(--color-bt-card)" }}
+        className="grid"
+        style={{
+          minWidth: `${gridMinWidth}px`,
+          // Name column auto-fits content (no truncate) with a minimum width.
+          // Date columns flex. Trailing narrow column hosts the + button.
+          gridTemplateColumns: `minmax(${NAME_COL_MIN_WIDTH}px, max-content) repeat(${dateWindows.length}, minmax(${COLUMN_WIDTH}px, 1fr))${showAddColumn ? ` ${ADD_COL_WIDTH}px` : ""}`,
+        }}
       >
+        {/* Header: name column */}
         <div
-          className="grid"
+          className="sticky left-0 z-[3] flex items-center px-3 py-2.5"
           style={{
-            minWidth: `${gridMinWidth}px`,
-            // Name column auto-fits content (no truncate) with a minimum width.
-            // Date columns use a fixed min then flex to share space.
-            gridTemplateColumns: `minmax(${NAME_COL_MIN_WIDTH}px, max-content) repeat(${dateWindows.length}, minmax(${COLUMN_WIDTH}px, 1fr))`,
+            background: "var(--color-bt-card-raised)",
+            borderBottom: "1px solid var(--color-bt-border)",
           }}
         >
-          {/* Header: name column */}
-          <div
-            className="sticky left-0 z-[3] flex items-center px-3 py-2.5"
-            style={{
-              background: "var(--color-bt-card)",
-              borderBottom: "1px solid var(--color-bt-border)",
-            }}
+          <span
+            className="text-[11px] font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
           >
-            <span
-              className="text-[11px] font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              Crew
-            </span>
-          </div>
-
-          {/* Header: per-window label + popover trigger */}
-          {dateWindows.map((w) => {
-            const isActive = openPopoverId === w.id;
-            return (
-              <ColumnHeader
-                key={w.id}
-                label={formatColumnLabel(w.start_date, w.end_date)}
-                isActive={isActive}
-                canEdit={isOwner}
-                onToggle={(btnRect) => {
-                  if (openPopoverId === w.id) {
-                    setOpenPopover(null);
-                    return;
-                  }
-                  setOpenPopover({
-                    id: w.id,
-                    anchorLeft: btnRect.left,
-                    anchorBottom: btnRect.bottom,
-                    anchorCenter: btnRect.left + btnRect.width / 2,
-                  });
-                }}
-              />
-            );
-          })}
-
-          {/* Member rows */}
-          {members.map((m, rowIdx) => {
-            const rowBg =
-              rowIdx % 2 === 0
-                ? "var(--color-bt-card)"
-                : "var(--color-bt-state-fill)";
-            const isMe = m.user_id === currentUserId;
-            // Only the owner can see / interact with other members' rows.
-            // Planners and Members see their own row clearly and others dimmed
-            // (and non-operational).
-            const rowDimmed = !isMe && !isOwner;
-            return (
-              <div key={m.user_id ?? rowIdx} className="contents">
-                <div
-                  className="sticky left-0 z-[2] flex items-center gap-2 whitespace-nowrap px-3 py-2"
-                  style={{ background: rowBg }}
-                >
-                  <UserAvatar name={m.displayName} avatarUrl={m.avatarUrl ?? null} size="sm" />
-                  <span
-                    className="text-[13px]"
-                    style={{ color: "var(--color-bt-text)" }}
-                  >
-                    {m.displayName}
-                    {isMe && (
-                      <span
-                        className="text-[11px]"
-                        style={{ color: "var(--color-bt-text-dim)" }}
-                      >
-                        {" "}
-                        (you)
-                      </span>
-                    )}
-                  </span>
-                </div>
-                {dateWindows.map((w) => {
-                  const vote = w.votes.find((v) => v.user_id === m.user_id);
-                  const answer = (vote?.answer ?? null) as VoteAnswer;
-                  const isColumnHighlighted = openPopoverId === w.id;
-                  const cellBg = isColumnHighlighted
-                    ? "rgba(45, 212, 191, 0.07)"
-                    : rowBg;
-                  const interactive = isMe || isOwner;
-                  const handleSet = (next: VoteAnswer) => {
-                    if (!m.user_id || !interactive) return;
-                    onVote(w.id, next, m.user_id);
-                  };
-                  return (
-                    <div
-                      key={w.id}
-                      className="flex items-center justify-center px-1 py-2"
-                      style={{ background: cellBg }}
-                    >
-                      {useTripletLayout ? (
-                        <VoteTriplet
-                          answer={answer}
-                          interactive={interactive}
-                          dimmed={rowDimmed}
-                          onSet={handleSet}
-                        />
-                      ) : (
-                        <VoteButton
-                          answer={answer}
-                          interactive={interactive}
-                          dimmed={rowDimmed}
-                          onClick={() => handleSet(cycleAnswer(answer))}
-                        />
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* ── add-column sibling (outside scroll) ───────────────────────── */}
-      {isOwner && onAddDateWindow && (
-        <button
-          type="button"
-          onClick={onAddDateWindow}
-          className="group relative ml-2 flex flex-shrink-0 items-center justify-center self-stretch rounded-xl transition-colors hover:bg-[var(--color-bt-card-raised)]"
-          style={{
-            width: `${ADD_COL_WIDTH}px`,
-            background: "transparent",
-            border: "1.5px dashed var(--color-bt-border)",
-            color: "var(--color-bt-accent)",
-          }}
-          aria-label="Add date option"
-        >
-          <span className="relative flex items-center justify-center">
-            <CalendarPlus size={22} />
+            Crew
           </span>
-        </button>
-      )}
+        </div>
+
+        {/* Header: per-window label + popover trigger */}
+        {dateWindows.map((w) => {
+          const isActive = openPopoverId === w.id;
+          return (
+            <ColumnHeader
+              key={w.id}
+              label={formatColumnLabel(w.start_date, w.end_date)}
+              isActive={isActive}
+              canEdit={isOwner}
+              onToggle={(btnRect) => {
+                if (openPopoverId === w.id) {
+                  setOpenPopover(null);
+                  return;
+                }
+                setOpenPopover({
+                  id: w.id,
+                  anchorLeft: btnRect.left,
+                  anchorBottom: btnRect.bottom,
+                  anchorCenter: btnRect.left + btnRect.width / 2,
+                });
+              }}
+            />
+          );
+        })}
+
+        {/* Header: add-date column (trailing narrow + button) */}
+        {showAddColumn && (
+          <button
+            type="button"
+            onClick={onAddDateWindow}
+            className="flex items-center justify-center transition-colors hover:bg-[var(--color-bt-card)]"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              borderLeft: "1px solid var(--color-bt-border)",
+              borderBottom: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-accent)",
+            }}
+            aria-label="Add date option"
+          >
+            <CalendarPlus size={20} />
+          </button>
+        )}
+
+        {/* Member rows */}
+        {members.map((m, rowIdx) => {
+          // Match DatesPanel row striping: state-fill on even, transparent
+          // on odd (revealing the card-raised container).
+          const rowBg =
+            rowIdx % 2 === 0 ? "var(--color-bt-state-fill)" : "transparent";
+          const isMe = m.user_id === currentUserId;
+          // Only the owner can see / interact with other members' rows.
+          // Planners and Members see their own row clearly and others dimmed
+          // (and non-operational).
+          const rowDimmed = !isMe && !isOwner;
+          return (
+            <div key={m.user_id ?? rowIdx} className="contents">
+              <div
+                className="sticky left-0 z-[2] flex items-center gap-2 whitespace-nowrap px-3 py-2"
+                style={{ background: rowBg }}
+              >
+                <UserAvatar name={m.displayName} avatarUrl={m.avatarUrl ?? null} size="sm" />
+                <span
+                  className="text-[13px]"
+                  style={{ color: "var(--color-bt-text)" }}
+                >
+                  {m.displayName}
+                  {isMe && (
+                    <span
+                      className="text-[11px]"
+                      style={{ color: "var(--color-bt-text-dim)" }}
+                    >
+                      {" "}
+                      (you)
+                    </span>
+                  )}
+                </span>
+              </div>
+              {dateWindows.map((w) => {
+                const vote = w.votes.find((v) => v.user_id === m.user_id);
+                const answer = (vote?.answer ?? null) as VoteAnswer;
+                const isColumnHighlighted = openPopoverId === w.id;
+                const cellBg = isColumnHighlighted
+                  ? "rgba(45, 212, 191, 0.07)"
+                  : rowBg;
+                const interactive = isMe || isOwner;
+                const handleSet = (next: VoteAnswer) => {
+                  if (!m.user_id || !interactive) return;
+                  onVote(w.id, next, m.user_id);
+                };
+                return (
+                  <div
+                    key={w.id}
+                    className="flex items-center justify-center px-1 py-2"
+                    style={{ background: cellBg }}
+                  >
+                    {useTripletLayout ? (
+                      <VoteTriplet
+                        answer={answer}
+                        interactive={interactive}
+                        dimmed={rowDimmed}
+                        onSet={handleSet}
+                      />
+                    ) : (
+                      <VoteButton
+                        answer={answer}
+                        interactive={interactive}
+                        dimmed={rowDimmed}
+                        onClick={() => handleSet(cycleAnswer(answer))}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+              {/* Empty cell under the add-date column — keeps grid aligned */}
+              {showAddColumn && (
+                <div
+                  style={{
+                    background: rowBg,
+                    borderLeft: "1px solid var(--color-bt-border)",
+                  }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
 
       {/* ── column header popover ─────────────────────────────────────── */}
       {openPopover && isOwner && (
@@ -564,32 +579,34 @@ function voteVisual(answer: VoteAnswer): {
   border: string;
   text: string;
 } {
+  // Solid-fill palette matching the DatesPanel pattern — easier to read
+  // at a glance than the translucent tint version.
   if (answer === "yes") {
     return {
-      background: "rgba(0, 212, 170, 0.18)",
-      color: "var(--color-bt-vote-yes)",
-      border: "1px solid rgba(0, 212, 170, 0.3)",
+      background: "var(--color-bt-vote-yes)",
+      color: "var(--color-bt-vote-yes-text)",
+      border: "none",
       text: "✓",
     };
   }
   if (answer === "maybe") {
     return {
-      background: "rgba(245, 158, 11, 0.18)",
-      color: "var(--color-bt-warning)",
-      border: "1px solid var(--color-bt-warning-border)",
+      background: "var(--color-bt-vote-maybe)",
+      color: "var(--color-bt-vote-yes-text)",
+      border: "none",
       text: "~",
     };
   }
   if (answer === "no") {
     return {
-      background: "rgba(239, 68, 68, 0.18)",
-      color: "var(--color-bt-danger)",
-      border: "1px solid var(--color-bt-danger-border)",
+      background: "var(--color-bt-vote-no)",
+      color: "var(--color-bt-vote-yes-text)",
+      border: "none",
       text: "✕",
     };
   }
   return {
-    background: "var(--color-bt-card-raised)",
+    background: "transparent",
     color: "var(--color-bt-text-dim)",
     border: "1px dashed var(--color-bt-border)",
     text: "?",

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -307,8 +307,7 @@ export function DatePollGrid({
               {dateWindows.map((w) => {
                 const vote = w.votes.find((v) => v.user_id === m.user_id);
                 const answer = (vote?.answer ?? null) as VoteAnswer;
-                const cellBg =
-                  openPopoverId === w.id ? "var(--color-bt-state-stroke)" : rowBg;
+                const isColumnActive = openPopoverId === w.id;
                 const interactive = isMe || isOwner;
                 const handleSet = (next: VoteAnswer) => {
                   if (!m.user_id || !interactive) return;
@@ -317,9 +316,15 @@ export function DatePollGrid({
                 return (
                   <div
                     key={w.id}
-                    className="flex items-center justify-center px-1 py-2"
-                    style={{ background: cellBg }}
+                    className="relative flex items-center justify-center px-1 py-2"
+                    style={{ background: rowBg }}
                   >
+                    {isColumnActive && (
+                      <div
+                        className="absolute inset-0 pointer-events-none"
+                        style={{ background: "var(--color-bt-state-stroke)" }}
+                      />
+                    )}
                     {useTripletLayout ? (
                       <VoteTriplet
                         answer={answer}
@@ -401,16 +406,21 @@ function ColumnHeader({
   canEdit: boolean;
   onToggle: (anchorRect: DOMRect) => void;
 }) {
-  const headerBg = isActive ? "var(--color-bt-state-stroke)" : "var(--color-bt-card)";
   if (!canEdit) {
     return (
       <div
-        className="flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
+        className="relative flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
         style={{
-          background: headerBg,
+          background: "var(--color-bt-card)",
           borderBottom: "1px solid var(--color-bt-border)",
         }}
       >
+        {isActive && (
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{ background: "var(--color-bt-state-stroke)" }}
+          />
+        )}
         <span
           className="text-[12px] font-semibold leading-none"
           style={{ color: "var(--color-bt-text)" }}
@@ -422,12 +432,18 @@ function ColumnHeader({
   }
   return (
     <div
-      className="flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
+      className="relative flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
       style={{
-        background: headerBg,
+        background: "var(--color-bt-card)",
         borderBottom: "1px solid var(--color-bt-border)",
       }}
     >
+      {isActive && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{ background: "var(--color-bt-state-stroke)" }}
+        />
+      )}
       <span
         className="text-[12px] font-semibold leading-none"
         style={{ color: "var(--color-bt-text)" }}

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -400,7 +400,7 @@ function ColumnHeader({
   canEdit: boolean;
   onToggle: (anchorRect: DOMRect) => void;
 }) {
-  const headerBg = "var(--color-bt-card)";
+  const headerBg = isActive ? "var(--color-bt-state-fill)" : "var(--color-bt-card)";
   if (!canEdit) {
     return (
       <div

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -214,7 +214,7 @@ export function DatePollGrid({
         <div
           className="sticky left-0 z-[3] flex items-center px-3 py-2.5"
           style={{
-            background: "var(--color-bt-card-raised)",
+            background: "var(--color-bt-card)",
             borderBottom: "1px solid var(--color-bt-border)",
           }}
         >
@@ -258,7 +258,7 @@ export function DatePollGrid({
             onClick={onAddDateWindow}
             className="flex items-center justify-center transition-colors hover:bg-[var(--color-bt-card)]"
             style={{
-              background: "var(--color-bt-card-raised)",
+              background: "var(--color-bt-card)",
               borderLeft: "1px solid var(--color-bt-border)",
               borderBottom: "1px solid var(--color-bt-border)",
               color: "var(--color-bt-accent)",
@@ -271,10 +271,11 @@ export function DatePollGrid({
 
         {/* Member rows */}
         {members.map((m, rowIdx) => {
-          // Match DatesPanel row striping: state-fill on even, transparent
-          // on odd (revealing the card-raised container).
+          // Row striping: state-fill on even rows, card-raised on odd rows.
+          // Explicit background on both so dark-mode contrast is preserved —
+          // transparent would make the cell invisible against the container.
           const rowBg =
-            rowIdx % 2 === 0 ? "var(--color-bt-state-fill)" : "transparent";
+            rowIdx % 2 === 0 ? "var(--color-bt-state-fill)" : "var(--color-bt-card-raised)";
           const isMe = m.user_id === currentUserId;
           // Only the owner can see / interact with other members' rows.
           // Planners and Members see their own row clearly and others dimmed

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -307,7 +307,8 @@ export function DatePollGrid({
               {dateWindows.map((w) => {
                 const vote = w.votes.find((v) => v.user_id === m.user_id);
                 const answer = (vote?.answer ?? null) as VoteAnswer;
-                const cellBg = rowBg;
+                const cellBg =
+                  openPopoverId === w.id ? "var(--color-bt-state-stroke)" : rowBg;
                 const interactive = isMe || isOwner;
                 const handleSet = (next: VoteAnswer) => {
                   if (!m.user_id || !interactive) return;
@@ -400,7 +401,7 @@ function ColumnHeader({
   canEdit: boolean;
   onToggle: (anchorRect: DOMRect) => void;
 }) {
-  const headerBg = isActive ? "var(--color-bt-state-fill)" : "var(--color-bt-card)";
+  const headerBg = isActive ? "var(--color-bt-state-stroke)" : "var(--color-bt-card)";
   if (!canEdit) {
     return (
       <div

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -307,10 +307,7 @@ export function DatePollGrid({
               {dateWindows.map((w) => {
                 const vote = w.votes.find((v) => v.user_id === m.user_id);
                 const answer = (vote?.answer ?? null) as VoteAnswer;
-                const isColumnHighlighted = openPopoverId === w.id;
-                const cellBg = isColumnHighlighted
-                  ? "var(--color-bt-accent-faint)"
-                  : rowBg;
+                const cellBg = rowBg;
                 const interactive = isMe || isOwner;
                 const handleSet = (next: VoteAnswer) => {
                   if (!m.user_id || !interactive) return;
@@ -403,13 +400,13 @@ function ColumnHeader({
   canEdit: boolean;
   onToggle: (anchorRect: DOMRect) => void;
 }) {
-  const bg = isActive ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)";
+  const headerBg = "var(--color-bt-card)";
   if (!canEdit) {
     return (
       <div
         className="flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
         style={{
-          background: bg,
+          background: headerBg,
           borderBottom: "1px solid var(--color-bt-border)",
         }}
       >
@@ -426,7 +423,7 @@ function ColumnHeader({
     <div
       className="flex flex-col items-center justify-center gap-1 px-2 py-2 text-center"
       style={{
-        background: bg,
+        background: headerBg,
         borderBottom: "1px solid var(--color-bt-border)",
       }}
     >
@@ -436,8 +433,13 @@ function ColumnHeader({
       >
         {label}
       </span>
+      {/* onMouseDown stops the outside-click handler from firing before
+          this click, which would cause the popover to close then immediately
+          re-open (stale closure race). With propagation stopped, the click
+          alone drives the toggle: same column closes, different column switches. */}
       <button
         type="button"
+        onMouseDown={(e) => e.stopPropagation()}
         onClick={(e) => onToggle(e.currentTarget.getBoundingClientRect())}
         className="rounded-md px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider leading-none transition-colors"
         style={{
@@ -451,7 +453,7 @@ function ColumnHeader({
             ? "1px solid var(--color-bt-accent)"
             : "1px solid var(--color-bt-accent-border)",
         }}
-        aria-label="Select this date"
+        aria-label={isActive ? "Deselect this date" : "Select this date"}
       >
         Select
       </button>

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -46,6 +46,8 @@ export interface DatePollGridProps {
   onAddDateWindow?: () => void;
   onRemoveDateWindow?: (id: string) => void;
   onLockDateWindow?: (id: string) => void;
+  /** Owner / planner only — navigates to the Crew tab when provided. */
+  onManageCrew?: () => void;
 }
 
 // Cycle: null → yes → maybe → no → null
@@ -100,6 +102,7 @@ export function DatePollGrid({
   onAddDateWindow,
   onRemoveDateWindow,
   onLockDateWindow,
+  onManageCrew,
 }: DatePollGridProps) {
   // On desktop with three or fewer date options the cell is wide enough to
   // render the three answer buttons side-by-side (yes / maybe / no) instead
@@ -156,42 +159,25 @@ export function DatePollGrid({
         className="overflow-hidden rounded-xl"
         style={{ background: "var(--color-bt-card-raised)" }}
       >
-        <div
-          className="grid"
-          style={{
-            gridTemplateColumns: showAddColumn
-              ? `1fr ${ADD_COL_WIDTH}px`
-              : "1fr",
-          }}
-        >
-          <div
-            className="flex items-center justify-center px-4 py-6 text-center"
+        {showAddColumn ? (
+          <button
+            type="button"
+            onClick={onAddDateWindow}
+            className="flex w-full items-center justify-center gap-2 py-5 text-[13px] font-medium transition-colors hover:opacity-80"
+            style={{ color: "var(--color-bt-accent)" }}
+            aria-label="Add date option"
           >
-            <span
-              className="text-[13px] italic"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              {isOwner
-                ? "No dates added yet — tap the + to propose a date option."
-                : "No dates added yet — the host hasn't proposed any options."}
-            </span>
-          </div>
-          {showAddColumn && (
-            <button
-              type="button"
-              onClick={onAddDateWindow}
-              className="flex items-center justify-center transition-colors hover:bg-[var(--color-bt-card)]"
-              style={{
-                background: "transparent",
-                borderLeft: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-accent)",
-              }}
-              aria-label="Add date option"
-            >
-              <CalendarPlus size={20} />
-            </button>
-          )}
-        </div>
+            <CalendarPlus size={16} />
+            Add your first date option
+          </button>
+        ) : (
+          <p
+            className="px-4 py-5 text-center text-[13px] italic"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            No date options added yet.
+          </p>
+        )}
       </div>
     );
   }
@@ -212,7 +198,7 @@ export function DatePollGrid({
       >
         {/* Header: name column */}
         <div
-          className="sticky left-0 z-[3] flex items-center px-3 py-2.5"
+          className="sticky left-0 z-[3] flex items-center gap-2 px-3 py-2.5"
           style={{
             background: "var(--color-bt-card)",
             borderBottom: "1px solid var(--color-bt-border)",
@@ -224,6 +210,16 @@ export function DatePollGrid({
           >
             Crew
           </span>
+          {onManageCrew && (
+            <button
+              type="button"
+              onClick={onManageCrew}
+              className="text-[10px] font-semibold transition-opacity hover:opacity-70"
+              style={{ color: "var(--color-bt-accent)" }}
+            >
+              Manage →
+            </button>
+          )}
         </div>
 
         {/* Header: per-window label + popover trigger */}

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -411,31 +411,47 @@ export function TripSettingsModal({
                       style={{ borderColor: "var(--color-bt-border)" }}
                     >
                       <>
-                          <div className="flex items-center gap-2">
-                            <input
-                              type="date"
-                              data-testid="settings-start-date-input"
-                              value={startDraft}
-                              onChange={(e) => setStartDraft(e.target.value)}
-                              className="min-w-0 flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
-                              style={{
-                                background: "var(--color-bt-card-raised)",
-                                borderColor: "var(--color-bt-border)",
-                                color: "var(--color-bt-text)",
-                              }}
-                            />
-                            <input
-                              type="date"
-                              data-testid="settings-end-date-input"
-                              value={endDraft}
-                              onChange={(e) => setEndDraft(e.target.value)}
-                              className="min-w-0 flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
-                              style={{
-                                background: "var(--color-bt-card-raised)",
-                                borderColor: "var(--color-bt-border)",
-                                color: "var(--color-bt-text)",
-                              }}
-                            />
+                          <div className="space-y-3">
+                            <div className="space-y-1">
+                              <label
+                                className="text-[11px] font-semibold uppercase tracking-wider"
+                                style={{ color: "var(--color-bt-text-dim)" }}
+                              >
+                                Start date
+                              </label>
+                              <input
+                                type="date"
+                                data-testid="settings-start-date-input"
+                                value={startDraft}
+                                onChange={(e) => setStartDraft(e.target.value)}
+                                className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+                                style={{
+                                  background: "var(--color-bt-card-raised)",
+                                  borderColor: "var(--color-bt-border)",
+                                  color: "var(--color-bt-text)",
+                                }}
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <label
+                                className="text-[11px] font-semibold uppercase tracking-wider"
+                                style={{ color: "var(--color-bt-text-dim)" }}
+                              >
+                                End date
+                              </label>
+                              <input
+                                type="date"
+                                data-testid="settings-end-date-input"
+                                value={endDraft}
+                                onChange={(e) => setEndDraft(e.target.value)}
+                                className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+                                style={{
+                                  background: "var(--color-bt-card-raised)",
+                                  borderColor: "var(--color-bt-border)",
+                                  color: "var(--color-bt-text)",
+                                }}
+                              />
+                            </div>
                           </div>
                           <button
                             data-testid="settings-save-dates-btn"

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -411,7 +411,7 @@ export function TripSettingsModal({
                       style={{ borderColor: "var(--color-bt-border)" }}
                     >
                       <>
-                          <div className="space-y-3">
+                          <div className="grid grid-cols-2 gap-2">
                             <div className="space-y-1">
                               <label
                                 className="text-[11px] font-semibold uppercase tracking-wider"

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -74,6 +74,14 @@ export function TripSettingsModal({
   const [startDraft, setStartDraft] = useState(trip?.start_date ?? "");
   const [endDraft, setEndDraft] = useState(trip?.end_date ?? "");
 
+  // Lazy-fetch poll data when the dates section is open so we know whether
+  // there are existing windows to return to.
+  const { data: pollData } = trpc.datePoll.get.useQuery(
+    { tripId },
+    { enabled: datesExpanded && isOwner && datesLocked }
+  );
+  const hasPollWindows = (pollData?.windows.length ?? 0) > 0;
+
   const changeDestinationMutation = trpc.trips.changeDestination.useMutation({
     onSuccess: () => {
       utils.trips.getById.invalidate({ tripId });
@@ -107,6 +115,7 @@ export function TripSettingsModal({
       utils.trips.getById.invalidate({ tripId });
       utils.datePoll.get.invalidate({ tripId });
       setDatesExpanded(false);
+      onClose();
     },
   });
 
@@ -181,7 +190,7 @@ export function TripSettingsModal({
         onClick={onClose}
       />
       <div
-        className="relative w-[340px] max-h-[85vh] overflow-y-auto rounded-xl p-5"
+        className="relative w-full max-w-[480px] max-h-[85vh] overflow-y-auto rounded-xl p-5"
         style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
       >
         {/* ── Header ────────────────────────────────────────────────── */}
@@ -471,18 +480,20 @@ export function TripSettingsModal({
                           >
                             {lockDatesMutation.isPending ? "Updating…" : "Update dates"}
                           </button>
-                          <button
-                            data-testid="settings-return-to-poll-btn"
-                            disabled={returnToPollPending || lockDatesMutation.isPending}
-                            onClick={handleReturnToPoll}
-                            className="w-full rounded-xl border py-2 text-sm font-medium transition-opacity disabled:opacity-40"
-                            style={{
-                              borderColor: "var(--color-bt-accent-border)",
-                              color: "var(--color-bt-accent)",
-                            }}
-                          >
-                            {returnToPollPending ? "Returning…" : "Return to poll"}
-                          </button>
+                          {hasPollWindows && (
+                            <button
+                              data-testid="settings-reopen-poll-btn"
+                              disabled={returnToPollPending || lockDatesMutation.isPending}
+                              onClick={handleReturnToPoll}
+                              className="w-full rounded-xl border py-2 text-sm font-medium transition-opacity disabled:opacity-40"
+                              style={{
+                                borderColor: "var(--color-bt-accent-border)",
+                                color: "var(--color-bt-accent)",
+                              }}
+                            >
+                              {returnToPollPending ? "Reopening…" : "Reopen poll"}
+                            </button>
+                          )}
                           <button
                             data-testid="settings-clear-dates-btn"
                             disabled={unlockDatesMutation.isPending || lockDatesMutation.isPending || returnToPollMutation.isPending}

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -41,10 +41,10 @@ export const datePollRouter = router({
         votesByWindow.set(v.window_id, arr);
       }
 
-      // Fetch locked_window_id + notify_sent from date_polls
+      // Fetch locked_window_id + notify_sent + poll_note from date_polls
       const { data: poll } = await ctx.supabase
         .from("date_polls")
-        .select("locked_window_id, notify_sent")
+        .select("locked_window_id, notify_sent, poll_note")
         .eq("trip_id", ctx.tripId)
         .maybeSingle();
 
@@ -58,6 +58,7 @@ export const datePollRouter = router({
       return {
         lockedWindowId: poll?.locked_window_id ?? null,
         notifySent: poll?.notify_sent ?? false,
+        pollNote: poll?.poll_note ?? null,
         pollMode: trip?.poll_mode ?? false,
         windows: (windows ?? []).map((w) => ({
           ...w,
@@ -97,6 +98,12 @@ export const datePollRouter = router({
           message: `Failed to add date window: ${error.message}`,
         });
       }
+
+      // Reset notify_sent so the owner can re-notify after adding a new option.
+      await ctx.supabase
+        .from("date_polls")
+        .update({ notify_sent: false })
+        .eq("trip_id", ctx.tripId);
 
       return data;
     }),
@@ -792,6 +799,36 @@ export const datePollRouter = router({
           { trip_id: ctx.tripId, open: true, notify_sent: true },
           { onConflict: "trip_id" }
         );
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
+  // updatePollNote — Owner: set the free-text note shown to crew at the top
+  // of the date poll. Pass null to clear it (UI falls back to default text).
+  // -----------------------------------------------------------------------
+  updatePollNote: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        note: z.string().max(500).nullable(),
+      })
+    )
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from("date_polls")
+        .upsert(
+          { trip_id: ctx.tripId, open: true, poll_note: input.note },
+          { onConflict: "trip_id" }
+        );
+
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to update poll note: ${error.message}`,
+        });
+      }
 
       return { success: true };
     }),

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -100,10 +100,14 @@ export const datePollRouter = router({
       }
 
       // Reset notify_sent so the owner can re-notify after adding a new option.
+      // Use upsert so the row is created here if setPollMode(true) hasn't run yet
+      // (first-window-activates-poll flow).
       await ctx.supabase
         .from("date_polls")
-        .update({ notify_sent: false })
-        .eq("trip_id", ctx.tripId);
+        .upsert(
+          { trip_id: ctx.tripId, notify_sent: false },
+          { onConflict: "trip_id" }
+        );
 
       return data;
     }),
@@ -799,6 +803,57 @@ export const datePollRouter = router({
           { trip_id: ctx.tripId, open: true, notify_sent: true },
           { onConflict: "trip_id" }
         );
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
+  // notifyNewMembers — Owner or Planner: send a date_poll_started notification
+  // to a specific set of member user IDs (e.g. members who joined after the
+  // initial crew notification). Does NOT flip notify_sent — that flag tracks
+  // whether the whole crew has been notified; targeted re-sends don't change it.
+  // -----------------------------------------------------------------------
+  notifyNewMembers: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        userIds: z.array(z.string()).min(1),
+      })
+    )
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { data: tripData } = await ctx.supabase
+          .from("trips")
+          .select("title")
+          .eq("id", ctx.tripId)
+          .single();
+
+        const { data: actorData } = await ctx.supabase
+          .from("users")
+          .select("name, nickname")
+          .eq("id", ctx.user!.id)
+          .single();
+
+        const { createNotification } = await import("./notifications");
+        for (const userId of input.userIds) {
+          // Skip the actor themselves just in case
+          if (userId === ctx.user!.id) continue;
+          await createNotification(ctx.supabase, {
+            tripId: ctx.tripId,
+            actorId: ctx.user!.id,
+            recipientId: userId,
+            type: "date_poll_started",
+            payload: {
+              owner_name: actorData?.nickname ?? actorData?.name ?? "The organizer",
+              trip_name: tripData?.title ?? "the trip",
+              trip_id: ctx.tripId,
+            },
+          });
+        }
+      } catch {
+        // Notification failure shouldn't block the response
+      }
 
       return { success: true };
     }),

--- a/src/server/routers/datePoll.ts
+++ b/src/server/routers/datePoll.ts
@@ -644,7 +644,19 @@ export const datePollRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // setPollMode — Owner or Planner: flip trips.poll_mode on or off
+  // setPollMode — Owner or Planner: flip trips.poll_mode on or off.
+  //
+  // When pollMode = false (cancel poll):
+  //   1. Delete all date_poll_votes for this trip's windows (child rows first)
+  //   2. Delete all date_windows for this trip
+  //   3. Reset notify_sent = false on the date_polls record
+  //   4. Flip poll_mode = false on trips
+  //
+  // This matches the spec's cancelPoll semantics — all poll data is cleared
+  // so the owner starts fresh if they re-open a poll later.
+  //
+  // When pollMode = true (open poll): just flip the flag and ensure a
+  // date_polls row exists (no data to clear).
   // -----------------------------------------------------------------------
   setPollMode: authedProcedure
     .input(
@@ -655,6 +667,53 @@ export const datePollRouter = router({
     )
     .use(requireTripRole("Planner"))
     .mutation(async ({ ctx, input }) => {
+      if (!input.pollMode) {
+        // ── Cancel poll: clear all data, children before parents ──────────
+
+        // 1. Collect the window IDs for this trip so we can delete votes.
+        const { data: windows } = await ctx.supabase
+          .from("date_windows")
+          .select("id")
+          .eq("trip_id", ctx.tripId);
+
+        const windowIds = (windows ?? []).map((w) => w.id);
+
+        // 2. Delete all votes that reference those windows.
+        if (windowIds.length > 0) {
+          const { error: votesErr } = await ctx.supabase
+            .from("date_poll_votes")
+            .delete()
+            .in("window_id", windowIds);
+
+          if (votesErr) {
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: `Failed to clear poll votes: ${votesErr.message}`,
+            });
+          }
+        }
+
+        // 3. Delete the date windows themselves.
+        const { error: windowsErr } = await ctx.supabase
+          .from("date_windows")
+          .delete()
+          .eq("trip_id", ctx.tripId);
+
+        if (windowsErr) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: `Failed to clear date windows: ${windowsErr.message}`,
+          });
+        }
+
+        // 4. Reset notify_sent so the Notify button re-enables next time.
+        await ctx.supabase
+          .from("date_polls")
+          .update({ notify_sent: false, open: false })
+          .eq("trip_id", ctx.tripId);
+      }
+
+      // 5. Flip poll_mode on the trip (both open and cancel paths).
       const { error } = await ctx.supabase
         .from("trips")
         .update({ poll_mode: input.pollMode })
@@ -667,7 +726,8 @@ export const datePollRouter = router({
         });
       }
 
-      // Ensure a date_polls row exists so notify_sent can be read/written.
+      // When opening a poll, ensure a date_polls row exists so
+      // notify_sent can be read/written without a separate insert.
       if (input.pollMode) {
         await ctx.supabase
           .from("date_polls")

--- a/src/server/routers/trips.test.ts
+++ b/src/server/routers/trips.test.ts
@@ -439,6 +439,67 @@ describe("datePoll router — setPollMode", () => {
       caller.datePoll.setPollMode({ tripId: pollTripId, pollMode: true })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
+
+  it("setPollMode(false) — clears date windows, votes, and resets notify_sent", async () => {
+    // Fresh trip so we don't collide with other tests in this describe block.
+    const clearTripId = `test-poll-cancel-${Date.now()}`;
+    const caller = ctx.caller();
+    await caller.trips.create({ id: clearTripId, title: "Cancel Poll Test" });
+    ctx.trackTrip(clearTripId);
+    await ctx.admin
+      .from("trips")
+      .update({ stage: "planning", locked_destination_title: "Test Dest" })
+      .eq("id", clearTripId);
+
+    // Open the poll.
+    await caller.datePoll.setPollMode({ tripId: clearTripId, pollMode: true });
+
+    // Add 2 date windows.
+    const w1 = `w1-${Date.now()}`;
+    const w2 = `w2-${Date.now()}`;
+    await caller.datePoll.addWindow({ tripId: clearTripId, id: w1, startDate: "2026-10-01", endDate: "2026-10-04" });
+    await caller.datePoll.addWindow({ tripId: clearTripId, id: w2, startDate: "2026-11-01", endDate: "2026-11-05" });
+
+    // Add the shared member user to this trip so they can vote.
+    await ctx.addTripMember(clearTripId, "member", "Member");
+
+    // Cast 3 votes (owner votes on both windows; member votes on one).
+    await caller.datePoll.castDateVote({ tripId: clearTripId, windowId: w1, answer: "yes" });
+    await caller.datePoll.castDateVote({ tripId: clearTripId, windowId: w2, answer: "maybe" });
+    const memberCaller = ctx.callerAs("member");
+    await memberCaller.datePoll.castDateVote({ tripId: clearTripId, windowId: w1, answer: "no" });
+
+    // Confirm data exists before cancel.
+    let poll = await caller.datePoll.get({ tripId: clearTripId });
+    expect(poll.windows.length).toBe(2);
+    const totalVotesBefore = poll.windows.reduce((sum, w) => sum + w.votes.length, 0);
+    expect(totalVotesBefore).toBe(3);
+
+    // Cancel the poll — setPollMode(false) should clear everything.
+    await caller.datePoll.setPollMode({ tripId: clearTripId, pollMode: false });
+
+    // Verify windows are gone.
+    poll = await caller.datePoll.get({ tripId: clearTripId });
+    expect(poll.windows.length).toBe(0);
+
+    // Verify votes are gone (direct DB check via admin).
+    const { count: voteCount } = await ctx.admin
+      .from("date_poll_votes")
+      .select("window_id", { count: "exact", head: true })
+      .in("window_id", [w1, w2]);
+    expect(voteCount).toBe(0);
+
+    // Verify notify_sent was reset.
+    expect(poll.notifySent).toBe(false);
+
+    // Verify poll_mode is false on the trip.
+    const { data: tripRow } = await ctx.admin
+      .from("trips")
+      .select("poll_mode")
+      .eq("id", clearTripId)
+      .single();
+    expect(tripRow?.poll_mode).toBe(false);
+  });
 });
 
 // ── setOwnerAlert ──────────────────────────────────────────────────────

--- a/supabase/migrations/20260417000000_046_date_poll_note.sql
+++ b/supabase/migrations/20260417000000_046_date_poll_note.sql
@@ -1,0 +1,9 @@
+-- 046: date poll owner note
+--
+-- Adds a free-text note column to date_polls so the trip owner can provide
+-- context to crew members (e.g. "we're leaning toward Option 2 because of
+-- cheaper flights, but Option 1 works if people prefer that weekend").
+-- The column is nullable; the UI shows default instructional text when null.
+
+ALTER TABLE date_polls
+  ADD COLUMN IF NOT EXISTS poll_note text;


### PR DESCRIPTION
## Summary

- **ConfirmDatesModal** — new shared modal for both date-setting flows (Pick your Dates + Poll the Crew); handles poll-clear/preserve logic including offering to keep poll data when selected dates match an existing poll window
- **Lazy poll activation** — `poll_mode` stays `false` until the first date window is added; switching to the Poll tab no longer fires a mutation
- **DatesPanel UX** — scroll position preserved on segment switch; segment renamed to "Pick your Dates"; Set button moved inline with date pickers; tab blurbs added for context (poll blurb includes message hint only when poll is active); ACTIVE badge on Poll the Crew tab; header note simplified to "TBD"
- **Reset flow** — Reset button expands inline to Cancel / Clear votes? / Clear poll?
- **Smart re-notify** — Notify button label adapts: "Notify crew about the new date" / "Notify crew again" / "Notify new crew members"; new members notified individually via `notifyNewMembers` endpoint
- **Grid polish** — "Manage →" link in Crew column header for owners and planners; empty state redesigned with owner CTA; "Thanks for the feedback" banner hidden for owners; poll note + footer gated on at least one window existing
- **TripSettingsModal** — fixed hardcoded `w-[340px]` → responsive `w-full max-w-[480px]`; "Return to poll" renamed to "Reopen poll" and now closes the modal on success
- **Server** — `addWindow` uses upsert so the `date_polls` row is created on first window add; new `notifyNewMembers` endpoint for targeted member notifications

## Test plan

- [ ] Owner: Pick your Dates → Set → ConfirmDatesModal appears → confirm locks dates
- [ ] Owner: Pick your Dates → Set when poll is active → modal offers to clear or preserve poll
- [ ] Owner: Poll the Crew → add first date option → poll activates, ACTIVE badge appears
- [ ] Owner: Reset → Cancel / Clear votes? / Clear poll? inline confirm works
- [ ] Owner: Notify crew → button label updates after adding date / reset / new member
- [ ] Owner: Crew column "Manage →" navigates to Crew tab
- [ ] Planner: Crew column "Manage →" navigates to Crew tab; members do not see it
- [ ] Owner: "Thanks for the feedback" banner not shown; non-owner sees it after voting all
- [ ] TripSettingsModal: widens on desktop; "Reopen poll" closes modal after success
- [ ] tsc --noEmit passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)