### PR TITLE
feat(action-center): opt-in RSVP/Travel toggles + invitation surface

### DIFF
--- a/src/app/trips/[tripId]/components/TravelEntryForm.tsx
+++ b/src/app/trips/[tripId]/components/TravelEntryForm.tsx
@@ -97,7 +97,7 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
     }
 
     return (
-      <div className="mt-3 flex items-center gap-2">
+      <div className="flex items-center gap-2">
         {currentTravel?.travel_mode === "flying" ? (
           <Plane size={14} style={{ color: "var(--color-bt-accent)" }} />
         ) : (
@@ -120,19 +120,7 @@ export function TravelEntryForm({ tripId, currentTravel, onSave }: TravelEntryFo
 
   // Edit form
   return (
-    <div className="mt-4">
-      <div
-        className="mb-3"
-        style={{ borderTop: "1px solid var(--color-bt-border)" }}
-      />
-      <p
-        className="mb-2 text-[13px] leading-relaxed"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        You said you&apos;re in — can you share your travel plans so the crew
-        can coordinate?
-      </p>
-
+    <div>
       {/* Travel mode pills */}
       <p
         className="mb-1.5 text-xs font-medium"

--- a/src/app/trips/[tripId]/components/TripInvitationModal.tsx
+++ b/src/app/trips/[tripId]/components/TripInvitationModal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { Send, Sparkles } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+
+export interface TripInvitationModalProps {
+  tripId: string;
+  trip: {
+    title?: string | null;
+    about_message?: string | null;
+    locked_destination_title?: string | null;
+    start_date?: string | null;
+    end_date?: string | null;
+  };
+  onClose: () => void;
+}
+
+/**
+ * TripInvitationModal — opened from the going-stage Action Center "Write
+ * invitation" button. Lets the owner compose / edit the invitation message
+ * the crew sees on their RSVP surface. Distinct from TripSummaryModal,
+ * which is the planning→going recap/advance gate.
+ */
+export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationModalProps) {
+  useModalBackButton(onClose);
+  const utils = trpc.useUtils();
+
+  const [message, setMessage] = useState(trip.about_message ?? "");
+
+  const update = trpc.trips.updateAboutMessage.useMutation({
+    onSuccess() {
+      utils.trips.getById.invalidate({ tripId });
+      onClose();
+    },
+  });
+
+  const handleSave = () => {
+    update.mutate({ tripId, aboutMessage: message.trim() || null });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[560px] rounded-t-2xl p-6 lg:rounded-2xl"
+        style={{ background: "var(--color-bt-card)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-1 flex items-center gap-2">
+          <Sparkles size={16} style={{ color: "var(--color-bt-accent)" }} />
+          <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            Trip Invitation
+          </h2>
+        </div>
+        <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+          Tell the crew what this trip is about. This message shows up alongside
+          their RSVP so they know what they&apos;re saying yes to.
+        </p>
+
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Three days in Charlotte, golf every morning, BBQ most evenings. Bring clubs and a jacket for the cold front coming through."
+          rows={6}
+          className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            borderColor: "var(--color-bt-border)",
+            color: "var(--color-bt-text)",
+          }}
+          data-testid="trip-invitation-message-input"
+        />
+
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-xl py-3 text-sm font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-text-dim)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={update.isPending}
+            data-testid="trip-invitation-save-btn"
+            className="flex flex-1 items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-base)",
+              border: "1px solid var(--color-bt-accent)",
+            }}
+          >
+            <Send size={14} />
+            {update.isPending ? "Saving…" : "Save invitation"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -25,6 +25,7 @@ import { ChatDrawer } from "./components/ChatDrawer";
 import { STAGE_CONTENT } from "./components/StageContextBar";
 import { QuickInfoSection } from "./components/QuickInfoSection";
 import { TripSummaryModal } from "./components/TripSummaryModal";
+import { TripInvitationModal } from "./components/TripInvitationModal";
 import { TwoColumnLayout } from "./components/TwoColumnLayout";
 import { SidebarForStage } from "./components/SidebarForStage";
 import { QuickInfoDrawer } from "./components/QuickInfoSection";
@@ -39,6 +40,7 @@ export default function TripDetailPage() {
   const [compUnlocked, setCompUnlocked] = useState(false);
   const [showHelpSheet, setShowHelpSheet] = useState(false);
   const [showInvitationModal, setShowInvitationModal] = useState(false);
+  const [showWriteInvitationModal, setShowWriteInvitationModal] = useState(false);
   const [toast, setToast] = useState<{ message: string; variant: "warning" } | null>(null);
   const [showChatDrawer, setShowChatDrawer] = useState(false);
   const [showQuickInfoDrawer, setShowQuickInfoDrawer] = useState(false);
@@ -362,6 +364,7 @@ export default function TripDetailPage() {
                     onTabChange={(tab) => setActiveTab(tab as TabId)}
                     onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
                     onOpenChat={() => setShowChatDrawer(true)}
+                    onWriteInvitation={() => setShowWriteInvitationModal(true)}
                   />
                 )}
                 {activeTab === "schedule" && (
@@ -412,6 +415,15 @@ export default function TripDetailPage() {
           trip={trip}
           onClose={() => setShowInvitationModal(false)}
           onAdvanced={() => setShowInvitationModal(false)}
+        />
+      )}
+
+      {/* ── Trip Invitation modal (going-stage owner write-invitation CTA) ── */}
+      {showWriteInvitationModal && trip && (
+        <TripInvitationModal
+          tripId={tripId}
+          trip={trip}
+          onClose={() => setShowWriteInvitationModal(false)}
         />
       )}
 

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -12,7 +12,6 @@ import { getTripStatus } from "@/components/StatusBadge";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import IdeaZonePanel from "../components/IdeaZonePanel";
 import { ActionCenter } from "./components/ActionCenter";
-import { TravelPanel } from "../components/TravelPanel";
 import { ItineraryPanel } from "../components/ItineraryPanel";
 import type { TripDisplayStatus } from "@/lib/tripStatus";
 import type { TabProps, TripData } from "./types";
@@ -288,33 +287,6 @@ function CompetitionPanel({
   return null;
 }
 
-// ── Travel Section ───────────────────────────────────────────────────────
-// Was PlanningSection, used to hold Lodging + Travel. Lodging moved to
-// its own tab; this now just wraps the Travel panel with a section
-// header. Only rendered in going/now/past.
-
-function TravelSection({ trip }: { trip: TripData }) {
-  const [travelOpen, setTravelOpen] = useState(false);
-
-  return (
-    <section className="space-y-2">
-      <p
-        className="text-xs font-semibold uppercase tracking-wider"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        Travel
-      </p>
-
-      <TravelPanel
-        tripId={trip.id}
-        isOpen={travelOpen}
-        onToggle={() => setTravelOpen((v) => !v)}
-      />
-    </section>
-  );
-}
-
-
 // ── HomeTab ──────────────────────────────────────────────────────────────
 
 export function HomeTab({
@@ -324,15 +296,13 @@ export function HomeTab({
   onTabChange,
   onEnableComp,
   onOpenChat,
-}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void }) {
+  onWriteInvitation,
+}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void }) {
   const { data: ideas = [] } = trpc.ideas.list.useQuery({ tripId: trip.id });
   const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId: trip.id });
 
   const status = getTripStatus(trip);
   const _isCompleted = status === "past";
-  const isLocked = !!trip.locked_destination_title;
-  const _isExploring = !!trip.comparison_mode && !isLocked;
-  const isBlank = !trip.comparison_mode && !isLocked;
   const stage = trip.stage ?? "idea";
 
   // IDEA stage: render IdeaZonePanel only — no planning rows
@@ -355,7 +325,7 @@ export function HomeTab({
       {/*    the RSVP card. Rendered first so it stays visible        ── */}
       {/*    above the itinerary once the trip is going.              ── */}
       {(stage === "idea" || stage === "planning" || stage === "going") && (
-        <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} />
+        <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} onWriteInvitation={onWriteInvitation} />
       )}
 
       {/* ── Itinerary panel — read-only confirmed-only timeline ── */}
@@ -373,12 +343,7 @@ export function HomeTab({
       {/*    Schedule). Home deliberately doesn't render it anymore so ── */}
       {/*    the main flow stays focused on status + itinerary.        ── */}
 
-      {/* ── GOING/NOW: Travel section — logistics stays editable ── */}
-      {(stage === "going" || status === "now" || status === "past") && (isBlank || isLocked) && (
-        <TravelSection trip={trip} />
-      )}
-
-      {/* Competition panel — only in READY stage and beyond */}
+{/* Competition panel — only in READY stage and beyond */}
       {stage !== "idea" && stage !== "planning" && (
         <CompetitionPanel
           trip={trip}

--- a/src/app/trips/[tripId]/tabs/components/ActionCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCard.tsx
@@ -4,8 +4,8 @@ import { Check, Pencil } from "lucide-react";
 import type { ReactNode } from "react";
 
 export interface ActionCardProps {
-  icon: ReactNode;
-  title: string;
+  icon?: ReactNode;
+  title?: string;
   subtitle?: string;
   isResolved: boolean;
   resolvedSummary?: string;
@@ -94,37 +94,41 @@ export function ActionCard({
         boxShadow: "var(--shadow-raised)",
       }}
     >
-      <div
-        className="flex items-center gap-2.5 px-4 py-3.5"
-        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
-      >
-        <span
-          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            color: "var(--color-bt-accent)",
-          }}
+      {title && (
+        <div
+          className="flex items-center gap-2.5 px-4 py-3.5"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
         >
-          {icon}
-        </span>
-        <div className="min-w-0 flex-1">
-          <p
-            className="text-[14px] font-semibold leading-tight"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            {title}
-          </p>
-          {subtitle && (
-            <p
-              className="truncate text-[12px]"
-              style={{ color: "var(--color-bt-text-dim)" }}
+          {icon && (
+            <span
+              className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                color: "var(--color-bt-accent)",
+              }}
             >
-              {subtitle}
-            </p>
+              {icon}
+            </span>
           )}
+          <div className="min-w-0 flex-1">
+            <p
+              className="text-[14px] font-semibold leading-tight"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {title}
+            </p>
+            {subtitle && (
+              <p
+                className="truncate text-[12px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {subtitle}
+              </p>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="px-4 pb-4 pt-3">{children}</div>
+      )}
+      <div className="px-4 pb-4 pt-4">{children}</div>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -11,6 +11,7 @@ export interface ActionCenterProps {
   isOwner: boolean;
   canEdit: boolean;
   onTabChange?: (tab: string) => void;
+  onWriteInvitation?: () => void;
 }
 
 /**
@@ -27,7 +28,7 @@ export interface ActionCenterProps {
  * DatesPanel is removed from PlanningSection; it lives here exclusively.
  * Future cards (RsvpCard, TravelCard) slot in alongside the dates surface.
  */
-export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCenterProps) {
+export function ActionCenter({ trip, isOwner, canEdit, onTabChange, onWriteInvitation }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
   if (stage !== "idea" && stage !== "planning" && stage !== "going") return null;
 
@@ -46,7 +47,7 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange }: ActionCent
         >
           Action Center
         </p>
-        <RsvpActionCard tripId={trip.id} />
+        <RsvpActionCard trip={trip} isOwner={isOwner} onWriteInvitation={onWriteInvitation} />
       </section>
     );
   }

--- a/src/app/trips/[tripId]/tabs/components/RsvpActionCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/RsvpActionCard.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { Check, Minus, Plane, X } from "lucide-react";
+import { useState } from "react";
+import { Check, Mail, Minus, Pencil, RotateCcw, Send, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { formatDateRange } from "@/lib/dates";
+import type { TripData } from "../types";
 import { TravelEntryForm } from "../../components/TravelEntryForm";
 import { ActionCard } from "./ActionCard";
 
@@ -31,21 +34,48 @@ const RSVP_OPTIONS = [
 ];
 
 export interface RsvpActionCardProps {
-  tripId: string;
+  trip: TripData;
+  isOwner?: boolean;
+  onWriteInvitation?: () => void;
 }
 
 /**
- * RsvpActionCard — the going-stage Action Center surface that asks
- * "Are you in?". Uses the shared ActionCard shell. Keeps the yes/maybe/no
- * selector always visible so users can toggle their answer at any time;
- * when the viewer picks "in", the TravelEntryForm expands inside the card
- * so they can record how they're getting there.
+ * RsvpActionCard — the going-stage Action Center body.
+ *
+ * Structure (top → bottom):
+ *   1. Owner toggle row — inline switches that enable/disable the RSVP
+ *      and Travel sections for everyone on the trip. Keeps the card
+ *      compact when the owner doesn't want either.
+ *   2. Invitation — always shown. Canned short-and-sweet default
+ *      generated from trip.title / locked_destination / date range;
+ *      once the owner has edited it, the edited text takes over.
+ *      Owner sees Edit + Send + "Default invite" (reset) actions.
+ *   3. RSVP section — only when trip.rsvp_enabled. Members vote in /
+ *      maybe / out; owner sees the tallies.
+ *   4. Travel section — only when trip.travel_enabled.
  */
-export function RsvpActionCard({ tripId }: RsvpActionCardProps) {
+export function RsvpActionCard({ trip, isOwner = false, onWriteInvitation }: RsvpActionCardProps) {
+  const tripId = trip.id;
   const currentUser = useCurrentUser();
   const utils = trpc.useUtils();
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
 
+  const rsvpEnabled = !!trip.rsvp_enabled;
+  const travelEnabled = !!trip.travel_enabled;
+
+  // ── Canned invitation default ────────────────────────────────────────
+  const destination = trip.locked_destination_title?.trim() || trip.location?.trim() || "";
+  const dateRange = formatDateRange(trip.start_date, trip.end_date);
+  const cannedInvitation = buildCannedInvitation({
+    title: trip.title,
+    destination,
+    dateRange,
+  });
+  const savedMessage = trip.about_message?.trim() || "";
+  const invitationText = savedMessage || cannedInvitation;
+  const isUsingDefault = !savedMessage;
+
+  // ── Mutations ────────────────────────────────────────────────────────
   const setRsvp = trpc.tripMembers.setRsvpStatus.useMutation({
     async onMutate(vars) {
       await utils.tripMembers.list.cancel({ tripId });
@@ -65,6 +95,36 @@ export function RsvpActionCard({ tripId }: RsvpActionCardProps) {
     },
   });
 
+  const updateSettings = trpc.trips.updateActionCenterSettings.useMutation({
+    async onMutate(vars) {
+      await utils.trips.getById.cancel({ tripId });
+      const prev = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: unknown) => {
+        if (!old) return old;
+        const trip = old as Record<string, unknown>;
+        return {
+          ...trip,
+          ...(vars.rsvpEnabled !== undefined ? { rsvp_enabled: vars.rsvpEnabled } : {}),
+          ...(vars.travelEnabled !== undefined ? { travel_enabled: vars.travelEnabled } : {}),
+        } as typeof old;
+      });
+      return { prev };
+    },
+    onError(_err, _vars, context) {
+      if (context?.prev) utils.trips.getById.setData({ tripId }, context.prev);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+    },
+  });
+
+  const resetInvitation = trpc.trips.updateAboutMessage.useMutation({
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+    },
+  });
+
+  // ── Viewer + tallies ─────────────────────────────────────────────────
   const myMember = members.find((m) => m.user_id === currentUser?.id);
   const myRsvp = (myMember as { rsvp_status?: string | null } | undefined)?.rsvp_status ?? null;
 
@@ -80,57 +140,212 @@ export function RsvpActionCard({ tripId }: RsvpActionCardProps) {
   const pendingCount = members.filter(
     (m) => (m as { rsvp_status?: string | null }).rsvp_status == null
   ).length;
+  const rsvpSummary = `${inCount} in · ${maybeCount} maybe · ${outCount} out · ${pendingCount} pending`;
 
-  const summary = `${inCount} in · ${maybeCount} maybe · ${outCount} out · ${pendingCount} pending`;
-
-  const title =
-    myRsvp === "in"
-      ? "You're in — tell the crew how you're getting there"
-      : myRsvp === "maybe"
-        ? "You're a maybe — change your mind any time"
-        : myRsvp === "out"
-          ? "You're out — change your mind any time"
-          : "Are you in?";
+  // When RSVP collection is off the travel form can't be keyed off
+  // myRsvp — treat everyone as eligible instead so the form still shows.
+  const canShowTravel =
+    travelEnabled && (isOwner || !rsvpEnabled || myRsvp === "in" || myRsvp === "maybe");
 
   return (
-    <ActionCard
-      icon={<Plane size={14} />}
-      title={title}
-      subtitle={myRsvp == null ? "Let the crew know your RSVP." : undefined}
-      isResolved={false}
-    >
-      <div className="flex gap-2">
-        {RSVP_OPTIONS.map((opt) => {
-          const isSelected = myRsvp === opt.value;
-          const Icon = opt.icon;
-          return (
+    <ActionCard isResolved={false}>
+      {/* ── Owner toggle row ──────────────────────────────────────────── */}
+      {isOwner && (
+        <div
+          className="mb-4 flex flex-col gap-2 rounded-lg px-3 py-2.5"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            border: "1px solid var(--color-bt-border)",
+          }}
+        >
+          <ToggleRow
+            label="Collect RSVPs"
+            checked={rsvpEnabled}
+            onChange={(v) => updateSettings.mutate({ tripId, rsvpEnabled: v })}
+            testid="toggle-rsvp-enabled"
+          />
+          <ToggleRow
+            label="Share travel info"
+            checked={travelEnabled}
+            onChange={(v) => updateSettings.mutate({ tripId, travelEnabled: v })}
+            testid="toggle-travel-enabled"
+          />
+        </div>
+      )}
+
+      {/* ── Invitation section (always visible) ──────────────────────── */}
+      <p
+        className="mb-2 text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Invitation
+      </p>
+      {isOwner ? (
+        <p
+          className="mb-3 text-[13px] leading-relaxed"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {isUsingDefault
+            ? "We drafted a short invite from your trip details. Edit it, or send it as-is."
+            : "Your custom invite is what the crew will see."}
+        </p>
+      ) : (
+        <p
+          className="mb-3 text-[13px] leading-relaxed"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          A note from your host on what this trip is about.
+        </p>
+      )}
+
+      <div
+        className="rounded-xl px-4 py-3 text-[13px] leading-relaxed whitespace-pre-wrap"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+          color: "var(--color-bt-text)",
+        }}
+        data-testid="invitation-message"
+      >
+        {invitationText}
+      </div>
+
+      {isOwner && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onWriteInvitation}
+            disabled={!onWriteInvitation}
+            data-testid="invitation-edit-btn"
+            className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-accent)",
+              border: "1px solid var(--color-bt-accent)",
+            }}
+          >
+            <Pencil size={13} />
+            Edit
+          </button>
+          <button
+            type="button"
+            data-testid="invitation-send-btn"
+            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-sm font-semibold transition-opacity hover:opacity-90"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-base)",
+              border: "1px solid var(--color-bt-accent)",
+            }}
+          >
+            <Send size={13} />
+            Send invitation
+          </button>
+          {!isUsingDefault && (
             <button
-              key={opt.value}
-              onClick={() => {
-                if (isSelected) return;
-                setRsvp.mutate({ tripId, rsvpStatus: opt.value });
-              }}
-              disabled={setRsvp.isPending}
-              data-testid={`rsvp-action-btn-${opt.value}`}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all disabled:opacity-50"
+              type="button"
+              onClick={() => resetInvitation.mutate({ tripId, aboutMessage: null })}
+              disabled={resetInvitation.isPending}
+              data-testid="invitation-reset-btn"
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
               style={{
-                background: isSelected ? opt.selectedBg : "var(--color-bt-card-raised)",
-                color: isSelected ? opt.selectedText : "var(--color-bt-text)",
-                border: isSelected ? "none" : "1px solid var(--color-bt-border)",
+                background: "transparent",
+                color: "var(--color-bt-text-dim)",
+                border: "1px solid var(--color-bt-border)",
               }}
             >
-              <Icon size={14} />
-              {opt.label}
+              <RotateCcw size={13} />
+              Default invite
             </button>
-          );
-        })}
-      </div>
-      <p className="mt-3 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-        {summary}
-      </p>
+          )}
+        </div>
+      )}
 
-      {myRsvp === "in" && (
-        <div className="mt-3 border-t pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
+      {/* ── RSVP section (opt-in) ───────────────────────────────────── */}
+      {rsvpEnabled && (
+        <div className="mt-4 border-t pt-4" style={{ borderColor: "var(--color-bt-border)" }}>
+          <p
+            className="mb-2 text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            RSVP
+          </p>
+          {isOwner ? (
+            <>
+              <p
+                className="mb-2 text-[13px] leading-relaxed"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Here&apos;s where the crew stands.
+              </p>
+              <p className="flex items-center gap-1.5 text-[13px]" style={{ color: "var(--color-bt-text)" }}>
+                <Mail size={13} style={{ color: "var(--color-bt-text-dim)" }} />
+                {rsvpSummary}
+              </p>
+            </>
+          ) : (
+            <>
+              <p
+                className="mb-3 text-[13px] leading-relaxed"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {myRsvp == null
+                  ? "Let the crew know if you're in — you can change your mind any time."
+                  : myRsvp === "in"
+                    ? "You're in. Change your answer below any time."
+                    : myRsvp === "maybe"
+                      ? "You're a maybe. Flip to in or out whenever you know."
+                      : "You're out. Change your mind any time."}
+              </p>
+              <div className="flex gap-2">
+                {RSVP_OPTIONS.map((opt) => {
+                  const isSelected = myRsvp === opt.value;
+                  const Icon = opt.icon;
+                  return (
+                    <button
+                      key={opt.value}
+                      onClick={() => {
+                        if (isSelected) return;
+                        setRsvp.mutate({ tripId, rsvpStatus: opt.value });
+                      }}
+                      disabled={setRsvp.isPending}
+                      data-testid={`rsvp-action-btn-${opt.value}`}
+                      className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all disabled:opacity-50"
+                      style={{
+                        background: isSelected ? opt.selectedBg : "var(--color-bt-card-raised)",
+                        color: isSelected ? opt.selectedText : "var(--color-bt-text)",
+                        border: isSelected ? "none" : "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      <Icon size={14} />
+                      {opt.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* ── Travel section (opt-in) ─────────────────────────────────── */}
+      {canShowTravel && (
+        <div className="mt-4 border-t pt-4" style={{ borderColor: "var(--color-bt-border)" }}>
+          <p
+            className="mb-2 text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Travel
+          </p>
+          <p
+            className="mb-3 text-[13px] leading-relaxed"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {isOwner
+              ? "You're the host — share your travel plans so the crew can coordinate."
+              : myRsvp === "maybe"
+                ? "You said you're a maybe — share any tentative travel plans so the crew can coordinate."
+                : "Share your travel plans so the crew can coordinate."}
+          </p>
           <TravelEntryForm
             tripId={tripId}
             currentTravel={
@@ -140,5 +355,70 @@ export function RsvpActionCard({ tripId }: RsvpActionCardProps) {
         </div>
       )}
     </ActionCard>
+  );
+}
+
+// ── Canned invitation builder ────────────────────────────────────────────
+// Short-and-sweet single-paragraph message built from the bits we already
+// know. Falls back gracefully when a field is missing.
+function buildCannedInvitation({
+  title,
+  destination,
+  dateRange,
+}: {
+  title: string;
+  destination: string;
+  dateRange: string;
+}): string {
+  const headline = title || destination || "Our trip";
+  const where = destination && destination !== title ? ` in ${destination}` : "";
+  const when = dateRange ? ` ${dateRange}` : "";
+  if (!where && !when) {
+    return `${headline} is on. Let me know if you're in.`;
+  }
+  return `${headline}${where}${when}. Let me know if you're in.`;
+}
+
+// ── Small inline toggle row ──────────────────────────────────────────────
+function ToggleRow({
+  label,
+  checked,
+  disabled,
+  onChange,
+  testid,
+}: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (value: boolean) => void;
+  testid: string;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-3">
+      <span
+        className="min-w-0 flex-1 text-[13px] font-medium"
+        style={{ color: "var(--color-bt-text)" }}
+      >
+        {label}
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        data-testid={testid}
+        onClick={() => onChange(!checked)}
+        className="relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50"
+        style={{
+          background: checked ? "var(--color-bt-accent)" : "var(--color-bt-border)",
+        }}
+      >
+        <span
+          className="inline-block h-4 w-4 transform rounded-full bg-white transition-transform"
+          style={{ transform: checked ? "translateX(18px)" : "translateX(2px)" }}
+        />
+      </button>
+    </label>
   );
 }

--- a/src/app/trips/[tripId]/tabs/types.ts
+++ b/src/app/trips/[tripId]/tabs/types.ts
@@ -10,6 +10,8 @@ export interface TripData {
   start_date?: string | null;
   end_date?: string | null;
   poll_mode?: boolean | null;
+  rsvp_enabled?: boolean | null;
+  travel_enabled?: boolean | null;
   accommodation?: string | null;
   notes?: string | null;
   activities?: string[] | null;

--- a/src/server/routers/trips.ts
+++ b/src/server/routers/trips.ts
@@ -835,6 +835,46 @@ export const tripsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
+  // updateActionCenterSettings — Owner/Planner toggles RSVP / Travel collection
+  // on the going-stage Action Center. Each toggle is an opt-in: false means
+  // the corresponding section doesn't render at all.
+  // -----------------------------------------------------------------------
+  updateActionCenterSettings: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        rsvpEnabled: z.boolean().optional(),
+        travelEnabled: z.boolean().optional(),
+      })
+    )
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }) => {
+      const update: Record<string, unknown> = {};
+      if (input.rsvpEnabled !== undefined) update.rsvp_enabled = input.rsvpEnabled;
+      if (input.travelEnabled !== undefined) update.travel_enabled = input.travelEnabled;
+
+      if (Object.keys(update).length === 0) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "No settings to update" });
+      }
+
+      const { data, error } = await ctx.supabase
+        .from("trips")
+        .update(update)
+        .eq("id", ctx.tripId)
+        .select("id, rsvp_enabled, travel_enabled")
+        .single();
+
+      if (error || !data) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to update Action Center settings",
+        });
+      }
+
+      return data;
+    }),
+
+  // -----------------------------------------------------------------------
   // updateAboutMessage — Owner/Planner can update about_message on a GOING+ trip
   // -----------------------------------------------------------------------
   updateAboutMessage: authedProcedure

--- a/supabase/migrations/20260420104129_052_action_center_toggles.sql
+++ b/supabase/migrations/20260420104129_052_action_center_toggles.sql
@@ -1,0 +1,37 @@
+-- Migration 052: Action Center opt-in toggles
+--
+-- Adds two boolean columns to trips that control whether the going-stage
+-- Action Center surfaces the RSVP and Travel sections at all. Defaulting
+-- both to false keeps the Action Center compact by default; owners opt
+-- in with simple inline toggles at the top of the card.
+--
+--   * trips.rsvp_enabled   — when true, members see the RSVP in/maybe/out
+--                            buttons and the owner sees the tallies.
+--   * trips.travel_enabled — when true, members see the Travel entry
+--                            form and the owner sees travel summaries.
+--
+-- Backfill: any trip that already has RSVP / travel data coming in from
+-- members gets the corresponding toggle flipped on so existing trips
+-- don't silently lose data visibility.
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS rsvp_enabled boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS travel_enabled boolean NOT NULL DEFAULT false;
+
+-- ───────────────────────── backfill ─────────────────────────
+
+UPDATE trips
+  SET rsvp_enabled = true
+  WHERE id IN (
+    SELECT DISTINCT trip_id FROM trip_members WHERE rsvp_status IS NOT NULL
+  );
+
+UPDATE trips
+  SET travel_enabled = true
+  WHERE id IN (
+    SELECT DISTINCT trip_id FROM trip_members WHERE travel_mode IS NOT NULL
+  );
+
+-- RLS on trips already covers these columns:
+--   * SELECT by members, UPDATE by owner/planner (003_rls.sql)
+-- No new policies needed.


### PR DESCRIPTION
## Summary
- Going-stage Action Center gets two inline toggles at the top — **Collect RSVPs** and **Share travel info**, both off by default so the card stays compact until the owner opts in. Persisted via new `trips.rsvp_enabled` / `trips.travel_enabled` columns (migration 052), with a backfill that flips them on for trips that already had RSVP or travel data.
- New always-visible **Invitation** section with a short canned default built from trip title + locked destination + date range. Owners get **Edit** (opens new `TripInvitationModal`), **Send invitation**, and a **Default invite** reset that clears the override so the canned draft returns. Member view is read-only.
- RSVP and Travel sections render only when their toggle is on. Travel form was lifted out of `HomeTab`'s standalone `TravelSection` so it lives exclusively inside the Action Center.
- `TripInvitationModal` is deliberately separate from `TripSummaryModal`, which stays as the planning→going recap/advance gate.

## Test plan
- [ ] Owner in going stage: toggles flip independently; card stays compact when both are off
- [ ] Invitation shows canned draft on a fresh trip; editing via the modal persists and survives reload
- [ ] "Default invite" button clears the custom message and returns the canned text
- [ ] Member view: no toggles, no invitation controls, sees RSVP buttons only when `rsvp_enabled`, sees Travel entry only when `travel_enabled` and their RSVP is in/maybe (or RSVP collection is off)
- [ ] Existing trips with RSVP/travel data keep their sections visible after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)