### PR TITLE
Sticky viewport-height crew chat + expand-to-drawer

### DIFF
--- a/src/app/trips/[tripId]/components/ChatDrawer.tsx
+++ b/src/app/trips/[tripId]/components/ChatDrawer.tsx
@@ -106,7 +106,7 @@ function ChatDrawerInner({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end lg:hidden"
+      className="fixed inset-0 z-50 flex items-end"
       style={{ background: "var(--color-bt-overlay)" }}
       onClick={onClose}
     >

--- a/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
+++ b/src/app/trips/[tripId]/components/PlanningChatPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Send } from "lucide-react";
+import { Send, Maximize2 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useRealtimeChat } from "@/hooks/useRealtimeChat";
@@ -20,10 +20,12 @@ interface ChatMessage {
 interface SidebarChatPanelProps {
   tripId: string;
   memberNames?: Record<string, string>;
+  /** When provided, an expand icon is shown in the header and fires this callback. */
+  onExpand?: () => void;
 }
 
 /** Shared desktop sidebar chat — used in both IDEA and PLANNING stages */
-export function SidebarChatPanel({ tripId, memberNames = {} }: SidebarChatPanelProps) {
+export function SidebarChatPanel({ tripId, memberNames = {}, onExpand }: SidebarChatPanelProps) {
   const currentUser = useCurrentUser();
   const utils = trpc.useUtils();
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -81,17 +83,16 @@ export function SidebarChatPanel({ tripId, memberNames = {} }: SidebarChatPanelP
 
   return (
     <div
-      className="hidden lg:flex flex-col rounded-xl border"
+      className="hidden lg:flex lg:min-h-0 lg:flex-1 flex-col rounded-xl border"
       style={{
         background: "var(--color-bt-card)",
         borderColor: "var(--color-bt-border)",
-        minHeight: "300px",
-        maxHeight: "500px",
+        minHeight: "320px",
       }}
     >
       {/* Header */}
       <div
-        className="flex-shrink-0 px-3 py-2"
+        className="flex flex-shrink-0 items-center justify-between px-3 py-2"
         style={{ borderBottom: "1px solid var(--color-bt-border)" }}
       >
         <p
@@ -100,6 +101,17 @@ export function SidebarChatPanel({ tripId, memberNames = {} }: SidebarChatPanelP
         >
           Crew Chat
         </p>
+        {onExpand && (
+          <button
+            onClick={onExpand}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            aria-label="Expand crew chat"
+            title="Expand"
+          >
+            <Maximize2 size={12} />
+          </button>
+        )}
       </div>
 
       {/* Messages — relative so the top-fade overlay can be positioned inside */}

--- a/src/app/trips/[tripId]/components/SidebarForStage.tsx
+++ b/src/app/trips/[tripId]/components/SidebarForStage.tsx
@@ -30,6 +30,8 @@ export interface SidebarForStageProps {
   /** Called when the user clicks "Add destination idea" (idea stage only). */
   onAddIdea?: () => void;
 
+  /** Opens the full-width ChatDrawer from the sidebar's expand icon. */
+  onExpandChat?: () => void;
 }
 
 /**
@@ -49,6 +51,7 @@ export function SidebarForStage({
   members,
   allVoterIds,
   onAddIdea,
+  onExpandChat,
 }: SidebarForStageProps) {
   return (
     <>
@@ -82,7 +85,7 @@ export function SidebarForStage({
       )}
 
       {/* Chat is universal across stages. */}
-      <SidebarChatPanel tripId={tripId} memberNames={memberNames} />
+      <SidebarChatPanel tripId={tripId} memberNames={memberNames} onExpand={onExpandChat} />
     </>
   );
 }

--- a/src/app/trips/[tripId]/components/TwoColumnLayout.tsx
+++ b/src/app/trips/[tripId]/components/TwoColumnLayout.tsx
@@ -31,7 +31,11 @@ export function TwoColumnLayout({
     <div className={`lg:grid lg:grid-cols-[1fr_320px] lg:gap-6 ${className}`}>
       <div className="min-w-0">{children}</div>
       <div
-        className={`hidden lg:flex lg:flex-col lg:gap-4 ${stickySidebar ? "lg:sticky lg:top-4 lg:self-start" : ""}`}
+        className={`hidden lg:flex lg:flex-col lg:gap-4 ${
+          stickySidebar
+            ? "lg:sticky lg:top-[4.5rem] lg:self-start lg:h-[calc(100vh-5rem)]"
+            : ""
+        }`}
       >
         {sidebar}
       </div>

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -224,67 +224,69 @@ export default function TripDetailPage() {
         onMarkAllRead={() => markAllRead.mutate({ tripId })}
       />
 
-      {/* ── Trip header card ──────────────────────────────────────────────── */}
-      <div className="mx-auto max-w-[1280px] px-4 pt-4">
-        {/* ── Owner toolbar: progress stepper + summary + settings ────── */}
-        {isOwner && (
-          <div className="mb-3 flex items-center gap-3">
-            <div className="min-w-0 flex-1">
-              <ProgressStepper
-                stage={stage}
-                displayStatus={status}
-                countdownText={countdownLabel(trip)}
-              />
-            </div>
-            {summaryButton}
-            {settingsButton}
-          </div>
-        )}
-
-        <TripHeader
-          tripName={trip.title}
-          status={status}
-          location={destLocation}
-          lockedTitle={trip.locked_destination_title}
-          dateRange={formatDateRange(trip.start_date, trip.end_date)}
-          isLocked={isLocked}
-          canEdit={canEdit}
-          myRole={role}
-          tripStartDate={trip.start_date}
-          onDestinationChange={(value) => {
-            lockDestination.mutate({
-              tripId: trip.id,
-              title: value,
-              location: value,
-            });
-          }}
-          onDatesTap={() => setActiveTab("schedule")}
-        />
-      </div>
-
-      {/* ── Tab bar + content ────────────────────────────────────────────── */}
+      {/* ── Trip content ────────────────────────────────────────────────── */}
       {stage === "idea" ? (
         /* Idea stage: no tab bar, no sidebar — IdeaZonePanel is the whole page. */
-        <main className="mx-auto max-w-[1280px] pt-4 pb-6">
-          {activeTab === "home" && (
-            <HomeTab
-              trip={trip}
-              role={role}
-              canEdit={effectiveCanEdit}
-              isOwner={isOwner}
-              displayStatus={status}
-              onTabChange={(tab) => setActiveTab(tab as TabId)}
-              onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
-              onOpenChat={() => setShowChatDrawer(true)}
+        <>
+          <div className="mx-auto max-w-[1280px] px-4 pt-4">
+            {/* ── Owner toolbar: progress stepper + summary + settings ────── */}
+            {isOwner && (
+              <div className="mb-3 flex items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <ProgressStepper
+                    stage={stage}
+                    displayStatus={status}
+                    countdownText={countdownLabel(trip)}
+                  />
+                </div>
+                {summaryButton}
+                {settingsButton}
+              </div>
+            )}
+
+            <TripHeader
+              tripName={trip.title}
+              status={status}
+              location={destLocation}
+              lockedTitle={trip.locked_destination_title}
+              dateRange={formatDateRange(trip.start_date, trip.end_date)}
+              isLocked={isLocked}
+              canEdit={canEdit}
+              myRole={role}
+              tripStartDate={trip.start_date}
+              onDestinationChange={(value) => {
+                lockDestination.mutate({
+                  tripId: trip.id,
+                  title: value,
+                  location: value,
+                });
+              }}
+              onDatesTap={() => setActiveTab("schedule")}
             />
-          )}
-        </main>
+          </div>
+          <main className="mx-auto max-w-[1280px] pt-4 pb-6">
+            {activeTab === "home" && (
+              <HomeTab
+                trip={trip}
+                role={role}
+                canEdit={effectiveCanEdit}
+                isOwner={isOwner}
+                displayStatus={status}
+                onTabChange={(tab) => setActiveTab(tab as TabId)}
+                onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
+                onOpenChat={() => setShowChatDrawer(true)}
+              />
+            )}
+          </main>
+        </>
       ) : (
         /* Planning / going / now / past / saved: persistent two-column layout —
-           tab bar, content, and sidebar share the same grid so the sidebar
-           aligns with the tab bar top and persists across all tab switches. */
-        <div className="mx-auto max-w-[1280px] px-4 mt-4">
+           owner toolbar, header, quick info, tab bar, and tab content live in
+           the main column so the sidebar column can sticky-fill the viewport
+           from the top of the content area. */
+        <div className="mx-auto max-w-[1280px] px-4 pt-4">
           <TwoColumnLayout
+            stickySidebar
             sidebar={
               <SidebarForStage
                 stage={stage as "planning" | "going" | "now" | "past" | "saved"}
@@ -294,11 +296,47 @@ export default function TripDetailPage() {
                 memberNames={Object.fromEntries(
                   members.map((m: { user_id: string | null; memberId: string; displayName: string }) => [m.user_id ?? m.memberId, m.displayName])
                 )}
+                onExpandChat={() => setShowChatDrawer(true)}
               />
             }
           >
-            {/* Left: quick info (post-planning only) + tab bar + all tab content */}
             <div>
+              {/* ── Owner toolbar: progress stepper + summary + settings ── */}
+              {isOwner && (
+                <div className="mb-3 flex items-center gap-3">
+                  <div className="min-w-0 flex-1">
+                    <ProgressStepper
+                      stage={stage}
+                      displayStatus={status}
+                      countdownText={countdownLabel(trip)}
+                    />
+                  </div>
+                  {summaryButton}
+                  {settingsButton}
+                </div>
+              )}
+
+              <TripHeader
+                tripName={trip.title}
+                status={status}
+                location={destLocation}
+                lockedTitle={trip.locked_destination_title}
+                dateRange={formatDateRange(trip.start_date, trip.end_date)}
+                isLocked={isLocked}
+                canEdit={canEdit}
+                myRole={role}
+                tripStartDate={trip.start_date}
+                onDestinationChange={(value) => {
+                  lockDestination.mutate({
+                    tripId: trip.id,
+                    title: value,
+                    location: value,
+                  });
+                }}
+                onDatesTap={() => setActiveTab("schedule")}
+              />
+
+              <div className="mt-4">
               {(stage === "going" || stage === "now" || stage === "past" || stage === "saved") && (
                 <div className="mb-4">
                   <QuickInfoSection tripId={tripId} isOwner={isOwner} />
@@ -351,6 +389,7 @@ export default function TripDetailPage() {
                 {activeTab === "comp" && (
                   <CompTab trip={trip} role={role} canEdit={effectiveCanEdit} isOwner={tripIsReadOnly ? false : isOwner} />
                 )}
+              </div>
               </div>
             </div>
           </TwoColumnLayout>


### PR DESCRIPTION
## Summary
- Sidebar column now sticks to the viewport (top-[4.5rem], h-[calc(100vh-5rem)]) with the chat input anchored to the bottom regardless of scroll position.
- Owner toolbar + trip header moved inside TwoColumnLayout's main column on non-idea stages so the sidebar starts from the top of the content area.
- New Maximize2 expand icon in the sidebar chat header opens the existing ChatDrawer as a full-width bottom sheet on desktop (drawer is no longer lg:hidden).

## Test plan
- [ ] Owner on planning/going desktop view: chat input sits near the bottom of the viewport without scrolling; scrolling the main column keeps the chat pinned.
- [ ] Resize height up/down — chat height recalculates, input stays ~17px from viewport bottom.
- [ ] Click the expand icon in the sidebar chat header — full-width drawer slides up from the bottom, close button dismisses.
- [ ] Mobile crew-chat FAB still opens the same drawer.
- [ ] Idea stage unaffected (IdeaZonePanel layout unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)