### PR TITLE
feat(invitation): remove RSVP, polish modal, add blast send

### DIFF
--- a/src/app/trips/[tripId]/components/DatesPanel.tsx
+++ b/src/app/trips/[tripId]/components/DatesPanel.tsx
@@ -220,18 +220,24 @@ export function DatesPanel({
   }
 
   // Owner, not-locked — segmented control state machine.
+  //
+  // No inner "Dates / TBD" header row here: placement inside the Action
+  // Center already says "this needs your attention" — a second heading
+  // before the segmented control is pure noise.
   const valid = !!directStart && !!directEnd && directStart < directEnd;
+  const outerBorder = pollMode
+    ? "var(--color-bt-accent-border)"
+    : "var(--color-bt-border)";
 
   return (
     <>
-      <PlanningRow
-        icon={<Calendar size={16} />}
-        label={headerLabel}
-        note={headerNote}
-        state={state}
-        isOpen={true}
-        onToggle={() => {}}
-        noExpand={true}
+      <div
+        className="rounded-xl p-4"
+        style={{
+          background: "var(--color-bt-card)",
+          border: `1px solid ${outerBorder}`,
+          boxShadow: "var(--shadow-raised)",
+        }}
       >
         <div className="space-y-3">
           {/* ── Segmented control: Pick your Dates | Poll the Crew ─────── */}
@@ -372,7 +378,7 @@ export function DatesPanel({
             />
           )}
         </div>
-      </PlanningRow>
+      </div>
 
       {/* Confirmation modal */}
       {showDatesModal && valid && (

--- a/src/app/trips/[tripId]/components/TripInvitationModal.tsx
+++ b/src/app/trips/[tripId]/components/TripInvitationModal.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { Send, Sparkles } from "lucide-react";
+import { RotateCcw, Send, Sparkles } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { buildCannedInvitation } from "@/lib/invitationDefault";
 
 export interface TripInvitationModalProps {
   tripId: string;
   trip: {
     title?: string | null;
     about_message?: string | null;
+    location?: string | null;
     locked_destination_title?: string | null;
     start_date?: string | null;
     end_date?: string | null;
@@ -18,16 +20,25 @@ export interface TripInvitationModalProps {
 }
 
 /**
- * TripInvitationModal — opened from the going-stage Action Center "Write
- * invitation" button. Lets the owner compose / edit the invitation message
- * the crew sees on their RSVP surface. Distinct from TripSummaryModal,
- * which is the planning→going recap/advance gate.
+ * TripInvitationModal — opened from the going-stage Action Center
+ * invitation pencil. Lets the owner compose / edit the invitation message
+ * the crew sees on their Home tab. Distinct from TripSummaryModal, which
+ * is the planning→going recap/advance gate.
  */
 export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationModalProps) {
   useModalBackButton(onClose);
   const utils = trpc.useUtils();
 
-  const [message, setMessage] = useState(trip.about_message ?? "");
+  // Preload with the message the crew currently sees: saved custom message
+  // if one exists, otherwise the canned default. That way the owner can edit
+  // from a real starting point instead of a blank page.
+  const cannedDefault = buildCannedInvitation(trip);
+  const initialMessage = trip.about_message?.trim() || cannedDefault;
+  const [message, setMessage] = useState(initialMessage);
+
+  // Reset only makes sense when the textarea is showing something other than
+  // the canned default — i.e. there's actually something to reset back from.
+  const canReset = message.trim() !== cannedDefault;
 
   const update = trpc.trips.updateAboutMessage.useMutation({
     onSuccess() {
@@ -37,7 +48,17 @@ export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationMod
   });
 
   const handleSave = () => {
-    update.mutate({ tripId, aboutMessage: message.trim() || null });
+    const trimmed = message.trim();
+    // If the owner saved back to the canned default (verbatim), persist
+    // `null` so we keep the "using default" state instead of pinning the
+    // literal string forever.
+    const aboutMessage =
+      !trimmed || trimmed === cannedDefault ? null : trimmed;
+    update.mutate({ tripId, aboutMessage });
+  };
+
+  const handleReset = () => {
+    update.mutate({ tripId, aboutMessage: null });
   };
 
   return (
@@ -58,8 +79,7 @@ export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationMod
           </h2>
         </div>
         <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          Tell the crew what this trip is about. This message shows up alongside
-          their RSVP so they know what they&apos;re saying yes to.
+          Tell the crew what this trip is about.
         </p>
 
         <textarea
@@ -76,7 +96,24 @@ export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationMod
           data-testid="trip-invitation-message-input"
         />
 
-        <div className="mt-4 flex gap-2">
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {canReset && (
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={update.isPending}
+              data-testid="trip-invitation-reset-btn"
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-3 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{
+                background: "transparent",
+                color: "var(--color-bt-text-dim)",
+                border: "1px solid var(--color-bt-border)",
+              }}
+            >
+              <RotateCcw size={13} />
+              Reset to Default
+            </button>
+          )}
           <button
             type="button"
             onClick={onClose}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -230,7 +230,7 @@ export default function TripDetailPage() {
         /* Idea stage: no tab bar, no sidebar — IdeaZonePanel is the whole page. */
         <>
           <div className="mx-auto max-w-[1280px] px-4 pt-4">
-            {/* ── Owner toolbar: progress stepper + summary + settings ────── */}
+            {/* ── Owner toolbar: progress stepper + settings ── */}
             {isOwner && (
               <div className="mb-3 flex items-center gap-3">
                 <div className="min-w-0 flex-1">
@@ -240,7 +240,6 @@ export default function TripDetailPage() {
                     countdownText={countdownLabel(trip)}
                   />
                 </div>
-                {summaryButton}
                 {settingsButton}
               </div>
             )}
@@ -305,7 +304,9 @@ export default function TripDetailPage() {
             }
           >
             <div>
-              {/* ── Owner toolbar: progress stepper + summary + settings ── */}
+              {/* ── Owner toolbar: progress stepper + settings ──
+                  The Trip Summary button lives inline with the Action
+                  Center title; see HomeTab below. */}
               {isOwner && (
                 <div className="mb-3 flex items-center gap-3">
                   <div className="min-w-0 flex-1">
@@ -315,7 +316,6 @@ export default function TripDetailPage() {
                       countdownText={countdownLabel(trip)}
                     />
                   </div>
-                  {summaryButton}
                   {settingsButton}
                 </div>
               )}
@@ -376,6 +376,7 @@ export default function TripDetailPage() {
                     onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
                     onOpenChat={() => setShowChatDrawer(true)}
                     onWriteInvitation={() => setShowWriteInvitationModal(true)}
+                    actionCenterTitleAction={summaryButton}
                   />
                 )}
                 {activeTab === "schedule" && (

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -324,7 +324,7 @@ export function CrewTab({ trip, canEdit }: TabProps) {
       {/* ── PLANNERS section ── */}
       <div>
         <h2
-          className="mb-1 text-xs font-semibold uppercase tracking-wider"
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
           Planners

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -294,7 +294,8 @@ export function HomeTab({
   onEnableComp,
   onOpenChat,
   onWriteInvitation,
-}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void }) {
+  actionCenterTitleAction,
+}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void; actionCenterTitleAction?: React.ReactNode }) {
   const { data: ideas = [] } = trpc.ideas.list.useQuery({ tripId: trip.id });
   const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId: trip.id });
 
@@ -322,7 +323,7 @@ export function HomeTab({
       {/*    the RSVP card. Rendered first so it stays visible        ── */}
       {/*    above the itinerary once the trip is going.              ── */}
       {(stage === "idea" || stage === "planning" || stage === "going") && (
-        <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} onWriteInvitation={onWriteInvitation} />
+        <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} onWriteInvitation={onWriteInvitation} titleAction={actionCenterTitleAction} />
       )}
 
       {/* ── Itinerary panel — read-only confirmed-only timeline ── */}

--- a/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ActionCenter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { Sparkles } from "lucide-react";
 import type { TripData } from "../types";
 import { DatePollCard } from "./DatePollCard";
@@ -12,6 +13,9 @@ export interface ActionCenterProps {
   canEdit: boolean;
   onTabChange?: (tab: string) => void;
   onWriteInvitation?: () => void;
+  /** Optional right-aligned node rendered inline with the "Action Center"
+   *  title — e.g. the Trip Summary button. */
+  titleAction?: ReactNode;
 }
 
 /**
@@ -28,7 +32,7 @@ export interface ActionCenterProps {
  * DatesPanel is removed from PlanningSection; it lives here exclusively.
  * Future cards (RsvpCard, TravelCard) slot in alongside the dates surface.
  */
-export function ActionCenter({ trip, isOwner, canEdit, onTabChange, onWriteInvitation }: ActionCenterProps) {
+export function ActionCenter({ trip, isOwner, canEdit, onTabChange, onWriteInvitation, titleAction }: ActionCenterProps) {
   const stage = trip.stage ?? "idea";
   if (stage !== "idea" && stage !== "planning" && stage !== "going") return null;
 
@@ -41,12 +45,7 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange, onWriteInvit
   if (stage === "going") {
     return (
       <section className="space-y-3">
-        <p
-          className="text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Action Center
-        </p>
+        <ActionCenterHeader titleAction={titleAction} />
         <InvitationCard trip={trip} isOwner={isOwner} onWriteInvitation={onWriteInvitation} />
       </section>
     );
@@ -54,12 +53,7 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange, onWriteInvit
 
   return (
     <section className="space-y-3">
-      <p
-        className="text-xs font-semibold uppercase tracking-wider"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        Action Center
-      </p>
+      <ActionCenterHeader titleAction={titleAction} />
 
       {datesLocked ? (
         // Dates locked — nothing to do
@@ -90,6 +84,25 @@ export function ActionCenter({ trip, isOwner, canEdit, onTabChange, onWriteInvit
 
       {/* TODO: RsvpCard + TravelCard slot in here in later phases */}
     </section>
+  );
+}
+
+/**
+ * Header row — "Action Center" label on the left, optional action slot
+ * (Trip Summary button) right-aligned. Slot stays out of the card panel
+ * so the title stays visually distinct from the card chrome.
+ */
+function ActionCenterHeader({ titleAction }: { titleAction?: ReactNode }) {
+  return (
+    <div className="flex min-h-[2rem] items-center justify-between gap-2">
+      <p
+        className="text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Action Center
+      </p>
+      {titleAction}
+    </div>
   );
 }
 

--- a/src/app/trips/[tripId]/tabs/components/InvitationCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/InvitationCard.tsx
@@ -5,8 +5,7 @@ import { CheckSquare, Ghost, Pencil, Plus, Send, Square, X } from "lucide-react"
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { buildCannedInvitation } from "@/lib/invitationDefault";
-import { RoleBadge } from "@/components/RoleBadge";
-import type { TripRole } from "@/server/middleware";
+import { parseLocalDate } from "@/lib/dates";
 import type { TripData } from "../types";
 import { TravelEntryForm } from "../../components/TravelEntryForm";
 import { ActionCard } from "./ActionCard";
@@ -326,68 +325,100 @@ function BlastSection({
           No one on your crew has an email yet — add one below to send the invite.
         </p>
       ) : (
-        <div className="mb-3 space-y-0.5">
-          {withEmail.map((m) => {
-            const checked = checkedIds.has(m.memberId);
-            const alreadySent =
-              !!m.last_invited_at &&
-              !!lastBlastSentAt &&
-              m.last_invited_at >= lastBlastSentAt;
-            return (
-              <div
-                key={m.memberId}
-                onClick={() => toggleMember(m.memberId)}
-                className="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-[var(--color-bt-hover)]"
-              >
-                {checked ? (
-                  <CheckSquare
-                    size={16}
-                    style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
-                  />
-                ) : (
-                  <Square
-                    size={16}
-                    style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
-                  />
-                )}
-                <RoleBadge role={m.role as TripRole} />
-                <div className="min-w-0 flex-1">
-                  <div
-                    className="truncate text-[13px] font-medium"
-                    style={{ color: "var(--color-bt-text)" }}
-                  >
-                    {m.displayName}
+        <>
+          {/* Toolbar: count + Select defaults */}
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+              {selectedMembers.length}{" "}
+              {selectedMembers.length === 1 ? "person" : "people"} will receive an email
+            </span>
+            <button
+              type="button"
+              onClick={() => setCheckedIds(computeDefaultChecked(withEmail, lastBlastSentAt))}
+              className="text-xs font-semibold"
+              style={{ color: "var(--color-bt-accent)", background: "transparent", border: "none" }}
+            >
+              Select defaults
+            </button>
+          </div>
+
+          <div className="mb-3 space-y-0.5">
+            {withEmail.map((m) => {
+              const checked = checkedIds.has(m.memberId);
+              return (
+                <div
+                  key={m.memberId}
+                  onClick={() => toggleMember(m.memberId)}
+                  className={`flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors duration-150${!checked ? " hover:bg-[var(--color-bt-hover)]" : ""}`}
+                  style={{
+                    background: checked ? "var(--color-bt-accent-faint)" : "transparent",
+                  }}
+                >
+                  {checked ? (
+                    <CheckSquare
+                      size={16}
+                      style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+                    />
+                  ) : (
+                    <Square
+                      size={16}
+                      style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+                    />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div
+                      className="truncate text-[13px] font-medium"
+                      style={{ color: "var(--color-bt-text)" }}
+                    >
+                      {m.displayName}
+                    </div>
+                    <div
+                      className="truncate text-xs"
+                      style={{ color: "var(--color-bt-text-dim)" }}
+                    >
+                      {m.user?.email}
+                    </div>
                   </div>
-                  <div
-                    className="truncate text-xs"
-                    style={{ color: "var(--color-bt-text-dim)" }}
-                  >
-                    {m.user?.email}
-                  </div>
+                  {m.last_invited_at && (
+                    <span
+                      className="flex-shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase"
+                      style={{
+                        background: "var(--color-bt-accent-faint)",
+                        color: "var(--color-bt-accent)",
+                        border: "1px solid var(--color-bt-accent-border)",
+                      }}
+                    >
+                      Sent{" "}
+                      {parseLocalDate(m.last_invited_at).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </span>
+                  )}
                 </div>
-                {alreadySent && (
-                  <span
-                    className="flex-shrink-0 text-[11px]"
-                    style={{ color: "var(--color-bt-text-dim)" }}
-                  >
-                    Sent
-                  </span>
-                )}
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Divider + "No email yet" label — only between two populated groups */}
+      {withEmail.length > 0 && withoutEmail.length > 0 && (
+        <div className="mb-3 flex items-center gap-2">
+          <div className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
+          <span
+            className="text-[10px] font-semibold uppercase tracking-widest"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            No email yet
+          </span>
+          <div className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
         </div>
       )}
 
       {/* Ghost chips — members missing an email */}
       {withoutEmail.length > 0 && (
         <div className="mb-3">
-          <p
-            className="mb-1.5 text-[11px]"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Missing an email — tap to add
-          </p>
           <div className="flex flex-wrap items-center gap-1.5">
             {withoutEmail.map((m) => {
               const guestUserId = m.user_id;
@@ -477,7 +508,7 @@ function BlastSection({
                 >
                   <Ghost size={11} style={{ color: "var(--color-bt-text-dim)" }} />
                   <span>{m.displayName}</span>
-                  <Plus size={11} style={{ color: "var(--color-bt-text-dim)" }} />
+                  <Plus size={11} strokeWidth={2.5} style={{ color: "var(--color-bt-accent)" }} />
                 </button>
               );
             })}

--- a/src/app/trips/[tripId]/tabs/components/InvitationCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/InvitationCard.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import { Ghost, Pencil, Plus, RotateCcw, Send, X } from "lucide-react";
+import { useState, useEffect } from "react";
+import { CheckSquare, Ghost, Pencil, Plus, Send, Square, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
-import { formatDateRange } from "@/lib/dates";
+import { buildCannedInvitation } from "@/lib/invitationDefault";
 import { RoleBadge } from "@/components/RoleBadge";
 import type { TripRole } from "@/server/middleware";
 import type { TripData } from "../types";
@@ -14,12 +14,41 @@ import { ActionCard } from "./ActionCard";
 // Same sort order as the Crew tab: Owner → Planner → Member, real before
 // guests within a role, then by display name.
 const ROLE_ORDER: Record<string, number> = { Owner: 0, Planner: 1, Member: 2 };
+
+type RecipientMember = {
+  memberId: string;
+  user_id: string | null;
+  role: string;
+  displayName: string;
+  isGuest: boolean;
+  last_invited_at?: string | null;
+  user: { email: string | null; is_guest?: boolean } | null;
+};
+
 function recipientSort(a: RecipientMember, b: RecipientMember) {
   const aOrder = ROLE_ORDER[a.role] ?? 2;
   const bOrder = ROLE_ORDER[b.role] ?? 2;
   if (aOrder !== bOrder) return aOrder - bOrder;
   if (a.isGuest !== b.isGuest) return a.isGuest ? 1 : -1;
   return a.displayName.localeCompare(b.displayName);
+}
+
+// Members sent in the last blast (last_invited_at >= last_blast_sent_at) are
+// unchecked by default so the owner sees "new" people pre-selected on re-blast.
+function computeDefaultChecked(
+  withEmail: RecipientMember[],
+  lastBlastSentAt: string | null
+): Set<string> {
+  return new Set(
+    withEmail
+      .filter((m) => {
+        if (!lastBlastSentAt) return true;
+        const inv = m.last_invited_at ?? null;
+        if (!inv) return true;
+        return inv < lastBlastSentAt;
+      })
+      .map((m) => m.memberId)
+  );
 }
 
 export interface InvitationCardProps {
@@ -29,18 +58,15 @@ export interface InvitationCardProps {
 }
 
 /**
- * InvitationCard — the going-stage Action Center body.
+ * InvitationCard — going-stage Action Center card.
  *
- * Structure (owner view, top → bottom):
- *   1. Owner travel toggle — gates the travel section for everyone.
- *   2. Invitation text + Edit / Default-invite buttons (message controls).
- *   3. Recipients — grid of crew who'll receive the email, plus inline
- *      chips for crew still missing an email (tap to fill in).
- *   4. Send Invitation — full-width primary, tied to the recipient list.
- *   5. Travel section — only when trip.travel_enabled.
+ * Owner view (top → bottom):
+ *   1. Travel toggle
+ *   2. Invitation text with pencil → TripInvitationModal
+ *   3. BlastSection: checkbox recipient list + Send button
+ *   4. Travel section (when travel_enabled)
  *
- * Member view is slimmer: just the invitation text and (if enabled)
- * the travel form.
+ * Member view: invitation text only + travel section.
  */
 export function InvitationCard({ trip, isOwner = false, onWriteInvitation }: InvitationCardProps) {
   const tripId = trip.id;
@@ -49,20 +75,13 @@ export function InvitationCard({ trip, isOwner = false, onWriteInvitation }: Inv
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
 
   const travelEnabled = !!trip.travel_enabled;
+  const lastBlastSentAt = trip.last_blast_sent_at ?? null;
 
-  // ── Canned invitation default ────────────────────────────────────────
-  const destination = trip.locked_destination_title?.trim() || trip.location?.trim() || "";
-  const dateRange = formatDateRange(trip.start_date, trip.end_date);
-  const cannedInvitation = buildCannedInvitation({
-    title: trip.title,
-    destination,
-    dateRange,
-  });
+  const cannedInvitation = buildCannedInvitation(trip);
   const savedMessage = trip.about_message?.trim() || "";
   const invitationText = savedMessage || cannedInvitation;
   const isUsingDefault = !savedMessage;
 
-  // ── Mutations ────────────────────────────────────────────────────────
   const updateSettings = trpc.trips.updateActionCenterSettings.useMutation({
     async onMutate(vars) {
       await utils.trips.getById.cancel({ tripId });
@@ -85,25 +104,16 @@ export function InvitationCard({ trip, isOwner = false, onWriteInvitation }: Inv
     },
   });
 
-  const resetInvitation = trpc.trips.updateAboutMessage.useMutation({
-    onSettled() {
-      utils.trips.getById.invalidate({ tripId });
-    },
-  });
-
   const myMember = members.find((m) => m.user_id === currentUser?.id);
 
-  // ── Recipient lists ──────────────────────────────────────────────────
-  // Split non-self crew into "has an email" (grid) vs "missing" (chips).
-  // Sort each list the same way the Crew tab does.
   type Member = typeof members[number];
   const others: Member[] = members.filter((m) => m.user_id !== currentUser?.id);
   const withEmail = others
     .filter((m) => !!m.user?.email)
-    .sort(recipientSort);
+    .sort(recipientSort) as RecipientMember[];
   const withoutEmail = others
     .filter((m) => !m.user?.email && m.isGuest)
-    .sort(recipientSort);
+    .sort(recipientSort) as RecipientMember[];
 
   return (
     <ActionCard isResolved={false}>
@@ -151,7 +161,7 @@ export function InvitationCard({ trip, isOwner = false, onWriteInvitation }: Inv
       )}
 
       <div
-        className="rounded-xl px-4 py-3 text-[13px] leading-relaxed whitespace-pre-wrap"
+        className="relative rounded-xl px-4 py-3 text-[13px] leading-relaxed whitespace-pre-wrap"
         style={{
           background: "var(--color-bt-card-raised)",
           border: "1px solid var(--color-bt-border)",
@@ -159,74 +169,36 @@ export function InvitationCard({ trip, isOwner = false, onWriteInvitation }: Inv
         }}
         data-testid="invitation-message"
       >
-        {invitationText}
-      </div>
-
-      {/* Message controls — Edit + Default invite (Send lives below, next
-          to the recipient list). */}
-      {isOwner && (
-        <div className="mt-3 flex flex-wrap gap-2">
+        {isOwner && onWriteInvitation && (
           <button
             type="button"
             onClick={onWriteInvitation}
-            disabled={!onWriteInvitation}
             data-testid="invitation-edit-btn"
-            className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
-            style={{
-              background: "transparent",
-              color: "var(--color-bt-accent)",
-              border: "1px solid var(--color-bt-accent)",
-            }}
+            aria-label="Edit invitation"
+            className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded"
           >
-            <Pencil size={13} />
-            Edit
+            <Pencil size={13} style={{ color: "var(--color-bt-text-dim)" }} />
           </button>
-          {!isUsingDefault && (
-            <button
-              type="button"
-              onClick={() => resetInvitation.mutate({ tripId, aboutMessage: null })}
-              disabled={resetInvitation.isPending}
-              data-testid="invitation-reset-btn"
-              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{
-                background: "transparent",
-                color: "var(--color-bt-text-dim)",
-                border: "1px solid var(--color-bt-border)",
-              }}
-            >
-              <RotateCcw size={13} />
-              Default invite
-            </button>
-          )}
+        )}
+        <div className={isOwner && onWriteInvitation ? "pr-8" : undefined}>
+          {invitationText}
         </div>
-      )}
+      </div>
 
-      {/* ── Recipients (owner only) ─────────────────────────────────── */}
+      {/* ── Blast section (owner only) ───────────────────────────────── */}
       {isOwner && (
-        <RecipientsSection
+        <BlastSection
+          key={lastBlastSentAt ?? "never"}
           tripId={tripId}
           withEmail={withEmail}
           withoutEmail={withoutEmail}
+          lastBlastSentAt={lastBlastSentAt}
+          onSuccess={() => {
+            utils.tripMembers.list.invalidate({ tripId });
+            utils.trips.getById.invalidate({ tripId });
+          }}
           onInvalidateMembers={() => utils.tripMembers.list.invalidate({ tripId })}
         />
-      )}
-
-      {/* ── Send invitation (owner only) ─────────────────────────────── */}
-      {isOwner && (
-        <button
-          type="button"
-          data-testid="invitation-send-btn"
-          disabled={withEmail.length === 0}
-          className="mt-4 inline-flex w-full items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
-          style={{
-            background: "var(--color-bt-accent)",
-            color: "var(--color-bt-base)",
-            border: "1px solid var(--color-bt-accent)",
-          }}
-        >
-          <Send size={13} />
-          Send invitation{withEmail.length > 0 ? ` (${withEmail.length})` : ""}
-        </button>
       )}
 
       {/* ── Travel section (opt-in) ─────────────────────────────────── */}
@@ -258,28 +230,38 @@ export function InvitationCard({ trip, isOwner = false, onWriteInvitation }: Inv
   );
 }
 
-// ── Recipient list ───────────────────────────────────────────────────────
+// ── Blast section ────────────────────────────────────────────────────────────
 
-type RecipientMember = {
-  memberId: string;
-  user_id: string | null;
-  role: string;
-  displayName: string;
-  isGuest: boolean;
-  user: { email: string | null; is_guest?: boolean } | null;
-};
-
-function RecipientsSection({
+function BlastSection({
   tripId,
   withEmail,
   withoutEmail,
+  lastBlastSentAt,
+  onSuccess,
   onInvalidateMembers,
 }: {
   tripId: string;
   withEmail: RecipientMember[];
   withoutEmail: RecipientMember[];
+  lastBlastSentAt: string | null;
+  onSuccess: () => void;
   onInvalidateMembers: () => void;
 }) {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(() =>
+    computeDefaultChecked(withEmail, lastBlastSentAt)
+  );
+  const [initialized, setInitialized] = useState(withEmail.length > 0);
+  const [lastSentCount, setLastSentCount] = useState<number | null>(null);
+
+  // Members load asynchronously — initialize once they arrive
+  useEffect(() => {
+    if (!initialized && withEmail.length > 0) {
+      setCheckedIds(computeDefaultChecked(withEmail, lastBlastSentAt));
+      setInitialized(true);
+    }
+  }, [withEmail.length, lastBlastSentAt, initialized]);
+
+  // Ghost email inline editing
   const [editingId, setEditingId] = useState<string | null>(null);
   const [emailDraft, setEmailDraft] = useState("");
 
@@ -291,15 +273,23 @@ function RecipientsSection({
     },
   });
 
-  const startEdit = (memberId: string) => {
-    setEditingId(memberId);
-    setEmailDraft("");
+  const blast = trpc.tripMembers.sendInvitationBlast.useMutation({
+    onSuccess(data) {
+      setLastSentCount(data.sent);
+      onSuccess();
+    },
+  });
+
+  const toggleMember = (memberId: string) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(memberId)) next.delete(memberId);
+      else next.add(memberId);
+      return next;
+    });
   };
 
-  const cancelEdit = () => {
-    setEditingId(null);
-    setEmailDraft("");
-  };
+  const selectedMembers = withEmail.filter((m) => checkedIds.has(m.memberId));
 
   const saveEmail = (guestUserId: string) => {
     const email = emailDraft.trim();
@@ -316,37 +306,82 @@ function RecipientsSection({
         Going out to
       </p>
 
-      {withEmail.length === 0 ? (
-        <p className="mb-2 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          No one on your crew has an email yet — add one below to send the
-          invite.
-        </p>
-      ) : (
-        <div className="mb-3 grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3 lg:grid-cols-4">
-          {withEmail.map((m) => (
-            <div key={m.memberId} className="flex min-w-0 flex-col">
-              <div className="flex min-w-0 items-center gap-1.5">
-                <RoleBadge role={m.role as TripRole} />
-                <span
-                  className="truncate text-[13px] font-medium"
-                  style={{ color: "var(--color-bt-text)" }}
-                >
-                  {m.displayName}
-                </span>
-              </div>
-              <span
-                className="truncate text-xs"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                {m.user?.email}
-              </span>
-            </div>
-          ))}
+      {/* Success flash */}
+      {lastSentCount !== null && (
+        <div
+          className="mb-3 rounded-lg px-3 py-2 text-[13px] font-medium"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+            border: "1px solid var(--color-bt-accent-border)",
+          }}
+        >
+          Invitation sent to {lastSentCount} {lastSentCount === 1 ? "person" : "people"}
         </div>
       )}
 
+      {/* Checkbox rows — members with email */}
+      {withEmail.length === 0 ? (
+        <p className="mb-2 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          No one on your crew has an email yet — add one below to send the invite.
+        </p>
+      ) : (
+        <div className="mb-3 space-y-0.5">
+          {withEmail.map((m) => {
+            const checked = checkedIds.has(m.memberId);
+            const alreadySent =
+              !!m.last_invited_at &&
+              !!lastBlastSentAt &&
+              m.last_invited_at >= lastBlastSentAt;
+            return (
+              <div
+                key={m.memberId}
+                onClick={() => toggleMember(m.memberId)}
+                className="flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-[var(--color-bt-hover)]"
+              >
+                {checked ? (
+                  <CheckSquare
+                    size={16}
+                    style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+                  />
+                ) : (
+                  <Square
+                    size={16}
+                    style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+                  />
+                )}
+                <RoleBadge role={m.role as TripRole} />
+                <div className="min-w-0 flex-1">
+                  <div
+                    className="truncate text-[13px] font-medium"
+                    style={{ color: "var(--color-bt-text)" }}
+                  >
+                    {m.displayName}
+                  </div>
+                  <div
+                    className="truncate text-xs"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    {m.user?.email}
+                  </div>
+                </div>
+                {alreadySent && (
+                  <span
+                    className="flex-shrink-0 text-[11px]"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    Sent
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Ghost chips — members missing an email */}
       {withoutEmail.length > 0 && (
-        <div className="mt-2">
+        <div className="mb-3">
           <p
             className="mb-1.5 text-[11px]"
             style={{ color: "var(--color-bt-text-dim)" }}
@@ -384,7 +419,8 @@ function RecipientsSection({
                           e.preventDefault();
                           saveEmail(guestUserId);
                         } else if (e.key === "Escape") {
-                          cancelEdit();
+                          setEditingId(null);
+                          setEmailDraft("");
                         }
                       }}
                       placeholder="email@…"
@@ -410,7 +446,10 @@ function RecipientsSection({
                     </button>
                     <button
                       type="button"
-                      onClick={cancelEdit}
+                      onClick={() => {
+                        setEditingId(null);
+                        setEmailDraft("");
+                      }}
                       aria-label="Cancel"
                       className="flex h-5 w-5 items-center justify-center rounded-full"
                       style={{ color: "var(--color-bt-text-dim)" }}
@@ -425,7 +464,10 @@ function RecipientsSection({
                 <button
                   key={m.memberId}
                   type="button"
-                  onClick={() => startEdit(m.memberId)}
+                  onClick={() => {
+                    setEditingId(m.memberId);
+                    setEmailDraft("");
+                  }}
                   className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors hover:bg-[var(--color-bt-hover)]"
                   style={{
                     background: "var(--color-bt-card-raised)",
@@ -442,32 +484,37 @@ function RecipientsSection({
           </div>
         </div>
       )}
+
+      {/* Send button */}
+      <button
+        type="button"
+        data-testid="invitation-send-btn"
+        disabled={selectedMembers.length === 0 || blast.isPending}
+        onClick={() => {
+          if (selectedMembers.length === 0) return;
+          blast.mutate({
+            tripId,
+            memberUserIds: selectedMembers.map((m) => m.memberId),
+          });
+        }}
+        className="inline-flex w-full items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
+        style={{
+          background: "var(--color-bt-accent)",
+          color: "var(--color-bt-base)",
+          border: "1px solid var(--color-bt-accent)",
+        }}
+      >
+        <Send size={13} />
+        {blast.isPending
+          ? "Sending…"
+          : `Send invitation${selectedMembers.length > 0 ? ` (${selectedMembers.length})` : ""}`}
+      </button>
     </div>
   );
 }
 
-// ── Canned invitation builder ────────────────────────────────────────────
-// Short-and-sweet single-paragraph message built from the bits we already
-// know. Falls back gracefully when a field is missing.
-function buildCannedInvitation({
-  title,
-  destination,
-  dateRange,
-}: {
-  title: string;
-  destination: string;
-  dateRange: string;
-}): string {
-  const headline = title || destination || "Our trip";
-  const where = destination && destination !== title ? ` in ${destination}` : "";
-  const when = dateRange ? ` ${dateRange}` : "";
-  if (!where && !when) {
-    return `${headline} is on. Let me know if you're in.`;
-  }
-  return `${headline}${where}${when}. Let me know if you're in.`;
-}
+// ── Small inline toggle row ──────────────────────────────────────────────────
 
-// ── Small inline toggle row ──────────────────────────────────────────────
 function ToggleRow({
   label,
   checked,

--- a/src/app/trips/[tripId]/tabs/types.ts
+++ b/src/app/trips/[tripId]/tabs/types.ts
@@ -30,6 +30,7 @@ export interface TripData {
   event_id?: string | null;
   series_id?: string | null;
   created_at?: string | null;
+  last_blast_sent_at?: string | null;
 }
 
 export interface TabProps {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -61,6 +61,48 @@ export async function sendInviteExistingUser({
   });
 }
 
+// ── Invitation blast — owner sends trip invitation to selected crew ─────
+
+export async function sendInvitationBlast({
+  toEmail,
+  toName,
+  ownerName,
+  tripTitle,
+  invitationMessage,
+  tripId,
+}: {
+  toEmail: string;
+  toName: string;
+  ownerName: string;
+  tripTitle: string;
+  invitationMessage: string;
+  tripId: string;
+}) {
+  const tripUrl = `${BASE_URL}/trips/${tripId}`;
+
+  return resend.emails.send({
+    from: FROM,
+    to: resolveRecipient(toEmail),
+    subject: `${ownerName} invited you to ${tripTitle}`,
+    html: `
+      <div style="font-family:sans-serif;max-width:480px;margin:0 auto;padding:24px">
+        <p style="margin:0 0 16px">Hey ${toName},</p>
+        <p style="margin:0 0 16px;white-space:pre-wrap">${invitationMessage}</p>
+        <p style="margin:0 0 24px">
+          Tap below to check it out &mdash; see what&apos;s planned so far.
+        </p>
+        <a href="${tripUrl}"
+           style="display:inline-block;background:#2dd4bf;color:#0d1f1a;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600">
+          View Trip
+        </a>
+        <p style="margin:24px 0 0;color:#94a3b8;font-size:14px">
+          See you there,<br/>${ownerName}
+        </p>
+      </div>
+    `,
+  });
+}
+
 // ── Email for new users (no BuddyTrip account yet) ─────────────────────
 
 export async function sendInviteNewUser({

--- a/src/lib/invitationDefault.ts
+++ b/src/lib/invitationDefault.ts
@@ -1,0 +1,27 @@
+import { formatDateRange } from "@/lib/dates";
+
+/**
+ * Short-and-sweet single-paragraph invitation built from trip fields —
+ * shown on the going-stage Home tab when the owner hasn't saved a custom
+ * message. Falls back gracefully when a field is missing.
+ */
+export function buildCannedInvitation(trip: {
+  title?: string | null;
+  location?: string | null;
+  locked_destination_title?: string | null;
+  start_date?: string | null;
+  end_date?: string | null;
+}): string {
+  const title = trip.title ?? "";
+  const destination =
+    trip.locked_destination_title?.trim() || trip.location?.trim() || "";
+  const dateRange = formatDateRange(trip.start_date, trip.end_date);
+
+  const headline = title || destination || "Our trip";
+  const where = destination && destination !== title ? ` in ${destination}` : "";
+  const when = dateRange ? ` ${dateRange}` : "";
+  if (!where && !when) {
+    return `${headline} is on. Let me know if you're in.`;
+  }
+  return `${headline}${where}${when}. Let me know if you're in.`;
+}

--- a/src/server/routers/tripMembers.test.ts
+++ b/src/server/routers/tripMembers.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { vi, describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext, genId } from "../../__tests__/helpers/test-setup";
+import { sendInvitationBlast } from "@/lib/email";
+
+vi.mock("@/lib/email", () => ({
+  sendInvitationBlast: vi.fn().mockResolvedValue({ id: "mock-email-id" }),
+  sendInviteExistingUser: vi.fn().mockResolvedValue({}),
+  sendInviteNewUser: vi.fn().mockResolvedValue({}),
+}));
 
 let ctx: TestContext;
 let tripId: string;
@@ -203,5 +210,67 @@ describe("tripMembers router — travel", () => {
       travelShared: false,
     });
     expect(result.travel_mode).toBeNull();
+  });
+});
+
+// ── sendInvitationBlast tests ────────────────────────────────────────────────
+
+describe("tripMembers router — sendInvitationBlast", () => {
+  let ctx: TestContext;
+  let tripId: string;
+
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    tripId = await ctx.createTrip("Blast Test Trip");
+    await ctx.addTripMember(tripId, "planner", "Planner");
+    await ctx.addTripMember(tripId, "member", "Member");
+  }, 30_000);
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  }, 30_000);
+
+  it("sendInvitationBlast — owner can blast to members with email", async () => {
+    vi.mocked(sendInvitationBlast).mockClear();
+    const caller = ctx.caller();
+    const planner = ctx.getUser("planner");
+    const member = ctx.getUser("member");
+
+    const result = await caller.tripMembers.sendInvitationBlast({
+      tripId,
+      memberUserIds: [planner.id, member.id],
+    });
+
+    expect(result.sent).toBeGreaterThan(0);
+    expect(vi.mocked(sendInvitationBlast)).toHaveBeenCalled();
+  });
+
+  it("sendInvitationBlast — updates last_blast_sent_at on the trip", async () => {
+    const admin = ctx.admin;
+    const caller = ctx.caller();
+    const planner = ctx.getUser("planner");
+
+    await caller.tripMembers.sendInvitationBlast({
+      tripId,
+      memberUserIds: [planner.id],
+    });
+
+    const { data: trip } = await admin
+      .from("trips")
+      .select("last_blast_sent_at")
+      .eq("id", tripId)
+      .single();
+
+    expect(trip?.last_blast_sent_at).toBeTruthy();
+  });
+
+  it("sendInvitationBlast — member cannot blast", async () => {
+    const caller = ctx.callerAs("member");
+    await expect(
+      caller.tripMembers.sendInvitationBlast({
+        tripId,
+        memberUserIds: [ctx.getUser("planner").id],
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -16,7 +16,7 @@ export const tripMembersRouter = router({
     .query(async ({ ctx }) => {
       const { data, error } = await ctx.supabase
         .from("trip_members")
-        .select("id, trip_id, user_id, role, status, joined_at, travel_mode, travel_detail, flight_airline, flight_number, flight_arrival_time, flight_airport, travel_shared")
+        .select("id, trip_id, user_id, role, status, joined_at, travel_mode, travel_detail, flight_airline, flight_number, flight_arrival_time, flight_airport, travel_shared, last_invited_at")
         .eq("trip_id", ctx.tripId)
         .order("joined_at", { ascending: true });
 
@@ -462,6 +462,96 @@ export const tripMembersRouter = router({
       }
 
       return data;
+    }),
+
+  // -----------------------------------------------------------------------
+  // sendInvitationBlast — Owner sends the trip invitation email to a
+  // selected subset of crew members. Updates last_invited_at per recipient
+  // and last_blast_sent_at on the trip.
+  // -----------------------------------------------------------------------
+  sendInvitationBlast: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        memberUserIds: z.array(z.string()).min(1),
+      })
+    )
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      // Fetch trip for email content
+      const { data: trip } = await ctx.supabase
+        .from("trips")
+        .select("title, about_message, location, locked_destination_title, start_date, end_date")
+        .eq("id", ctx.tripId)
+        .single();
+
+      if (!trip) throw new TRPCError({ code: "NOT_FOUND", message: "Trip not found" });
+
+      // Fetch owner display name
+      const { data: owner } = await ctx.supabase
+        .from("users")
+        .select("name, nickname")
+        .eq("id", ctx.user!.id)
+        .single();
+      const ownerName = owner?.nickname ?? owner?.name ?? "Your host";
+
+      // Verify recipients are actual trip members (prevents spoofed IDs)
+      const { data: memberRows } = await ctx.supabase
+        .from("trip_members")
+        .select("user_id")
+        .eq("trip_id", ctx.tripId)
+        .in("user_id", input.memberUserIds);
+
+      const verifiedIds = (memberRows ?? []).map((m) => m.user_id).filter(Boolean) as string[];
+      if (verifiedIds.length === 0) return { sent: 0 };
+
+      // Fetch user records with emails
+      const { data: users } = await ctx.supabase
+        .from("users")
+        .select("id, name, nickname, email")
+        .in("id", verifiedIds);
+
+      // Build invitation message (custom or canned default)
+      const { buildCannedInvitation } = await import("@/lib/invitationDefault");
+      const invitationMessage = trip.about_message?.trim() || buildCannedInvitation(trip);
+
+      const { sendInvitationBlast: sendBlast } = await import("@/lib/email");
+      const now = new Date().toISOString();
+      const sentIds: string[] = [];
+
+      for (const user of users ?? []) {
+        if (!user.email) continue;
+        try {
+          await sendBlast({
+            toEmail: user.email,
+            toName: user.nickname ?? user.name ?? user.email.split("@")[0],
+            ownerName,
+            tripTitle: trip.title,
+            invitationMessage,
+            tripId: ctx.tripId,
+          });
+          sentIds.push(user.id);
+        } catch {
+          // Email failure for one recipient shouldn't stop others
+        }
+      }
+
+      // Update last_invited_at for each successfully sent recipient
+      if (sentIds.length > 0) {
+        await ctx.supabase
+          .from("trip_members")
+          .update({ last_invited_at: now })
+          .eq("trip_id", ctx.tripId)
+          .in("user_id", sentIds);
+      }
+
+      // Update trip.last_blast_sent_at
+      await ctx.supabase
+        .from("trips")
+        .update({ last_blast_sent_at: now })
+        .eq("id", ctx.tripId);
+
+      return { sent: sentIds.length };
     }),
 
   // -----------------------------------------------------------------------

--- a/supabase/migrations/20260422000000_054_invitation_blast_tracking.sql
+++ b/supabase/migrations/20260422000000_054_invitation_blast_tracking.sql
@@ -1,0 +1,6 @@
+-- Track per-member and per-trip invitation blast timestamps
+ALTER TABLE trip_members
+  ADD COLUMN IF NOT EXISTS last_invited_at timestamptz;
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS last_blast_sent_at timestamptz;


### PR DESCRIPTION
## Summary

- **RSVP removed**: InvitationCard (the going-stage Action Center card) no longer has any RSVP mechanism — crew tab is consistent across all stages
- **Invitation modal polished**: pre-loads current message (saved or canned default); "Reset to Default" button appears only when textarea differs from canned text; saves `null` when reverting so the canned default isn't pinned as a literal string
- **Blast send**: owner can select recipients via checkbox rows and send the trip invitation email to the crew. Members sent in the last blast are unchecked by default on re-blast. Ghost chips remain for members missing an email (inline email editor to add one)
- **Tracking columns**: `trip_members.last_invited_at` and `trips.last_blast_sent_at` (migration 054)
- **`buildCannedInvitation`** extracted to `src/lib/invitationDefault.ts` — shared between `InvitationCard` and `TripInvitationModal`
- **DatesPanel**: removed redundant header row from the unlocked owner branch
- **ActionCenter**: Summary button rendered inline with "Action Center" label

## Test plan

- [ ] Vitest: `sendInvitationBlast` tests pass (requires Docker/local Supabase)
- [ ] Going-stage trip: checkbox rows show all crew with email checked, ghost chips for those without
- [ ] Send button shows `(N)` count and fires mutation; success banner appears
- [ ] Re-blast: members from last blast show "Sent" label and are unchecked by default
- [ ] Ghost chip → tap → type email → Save moves member to checkbox list
- [ ] Invitation modal: opens with current text, Reset to Default visible only after editing
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)