### PR TITLE
Crew tab redesign: panels, expand-to-edit, BT vs guest distinction

### DIFF
--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -49,7 +49,6 @@ function CrewMemberRow({
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const utils = trpc.useUtils();
-  const [editName, setEditName] = useState(m.displayName);
   const [editEmail, setEditEmail] = useState(m.user?.email ?? "");
   const [confirmRemove, setConfirmRemove] = useState(false);
 
@@ -74,20 +73,15 @@ function CrewMemberRow({
   const expandable = isOwnerView && !isMe && !isOwnerRow;
   const canActOnPlanner = isOwnerView && !isMe && isPlannerRow;
   const canPromoteToCoplanner = isOwnerView && !isMe && m.role === "Member" && !!m.user?.email;
-  const hasTextChanges = editName.trim() !== m.displayName || editEmail.trim() !== (m.user?.email ?? "");
+  const hasTextChanges = editEmail.trim() !== (m.user?.email ?? "");
 
   const handleSave = async () => {
-    if (m.isGuest && m.user_id) {
-      const nameChanged = editName.trim() !== m.displayName;
-      const emailChanged = editEmail.trim() !== (m.user?.email ?? "");
-      if (nameChanged || emailChanged) {
-        await updateGuest.mutateAsync({
-          tripId,
-          guestUserId: m.user_id,
-          ...(nameChanged && { name: editName.trim() }),
-          ...(emailChanged && { email: editEmail.trim() || null }),
-        });
-      }
+    if (m.isGuest && m.user_id && hasTextChanges) {
+      await updateGuest.mutateAsync({
+        tripId,
+        guestUserId: m.user_id,
+        email: editEmail.trim() || null,
+      });
     }
     onToggle();
     onUpdated();
@@ -236,31 +230,23 @@ function CrewMemberRow({
           className="space-y-2 rounded-lg px-3 py-2.5 mb-1"
           style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
         >
-          {/* Name + email — guest crew only (planners can't edit name/email here) */}
+          {/* Email — guest crew only. To change a guest's name, remove and
+              re-add them. */}
           {m.isGuest && !isPlannerSection && (
-            <div className="flex gap-2">
+            <div className="relative">
               <input
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                placeholder="Name"
-                className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+                value={editEmail}
+                onChange={(e) => setEditEmail(e.target.value)}
+                placeholder="Email"
+                type="email"
+                className="w-full rounded-lg border px-2.5 py-1.5 pr-7 text-sm outline-none"
                 style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
               />
-              <div className="relative min-w-0 flex-1">
-                <input
-                  value={editEmail}
-                  onChange={(e) => setEditEmail(e.target.value)}
-                  placeholder="Email"
-                  type="email"
-                  className="w-full rounded-lg border px-2.5 py-1.5 pr-7 text-sm outline-none"
-                  style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-                />
-                <Pencil
-                  size={11}
-                  className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                />
-              </div>
+              <Pencil
+                size={11}
+                className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              />
             </div>
           )}
 

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -113,9 +113,9 @@ function CrewMemberRow({
       <div
         className="flex items-center gap-3 py-2.5 px-1 -mx-1 rounded"
         style={{
-          cursor: editable && !isPlannerRow ? "pointer" : undefined,
+          cursor: editable ? "pointer" : undefined,
         }}
-        onClick={editable && !isPlannerRow ? onToggle : undefined}
+        onClick={editable ? onToggle : undefined}
       >
         {/* Avatar */}
         {m.isGuest ? (
@@ -151,16 +151,35 @@ function CrewMemberRow({
         {/* ── Right side: actions ──────────────────────────────────────────── */}
         <div className="flex flex-shrink-0 items-center">
           <div className="flex flex-shrink-0 items-center gap-1">
-            {/* Planner row: move to rest of crew */}
-            {isPlannerRow && canActOnPlanner && (
-              <button
-                onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Member" }); }}
-                disabled={updateRole.isPending}
-                className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
-                style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
-              >
-                Remove as planner
-              </button>
+            {/* Planner badge with remove × */}
+            {isPlannerRow && (
+              canActOnPlanner ? (
+                <button
+                  onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Member" }); }}
+                  disabled={updateRole.isPending}
+                  aria-label={`Remove ${display} as planner`}
+                  className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider disabled:opacity-40 hover:opacity-75 transition-opacity"
+                  style={{
+                    background: "var(--color-bt-accent-faint)",
+                    color: "var(--color-bt-accent)",
+                    border: "1px solid var(--color-bt-accent-border)",
+                  }}
+                >
+                  Planner
+                  <X size={10} strokeWidth={2.5} />
+                </button>
+              ) : (
+                <span
+                  className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+                  style={{
+                    background: "var(--color-bt-accent-faint)",
+                    color: "var(--color-bt-accent)",
+                    border: "1px solid var(--color-bt-accent-border)",
+                  }}
+                >
+                  Planner
+                </span>
+              )
             )}
             {/* Crew row: promote to co-planner */}
             {canPromoteToCoplanner && (
@@ -173,55 +192,18 @@ function CrewMemberRow({
                 Make planner
               </button>
             )}
-            {/* Remove (X) */}
-            {editable && (
-              <button
-                onClick={(e) => { e.stopPropagation(); setConfirmRemove(true); }}
-                className="flex h-7 w-7 items-center justify-center rounded-lg"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                <X size={14} />
-              </button>
-            )}
           </div>
         </div>
       </div>
 
-      {/* ── Remove confirmation ──────────────────────────────────────────── */}
-      {confirmRemove && (
-        <div
-          className="flex items-center gap-2 rounded-lg px-3 py-2 mb-1"
-          style={{ background: "color-mix(in srgb, var(--color-bt-danger) 6%, var(--color-bt-base))" }}
-        >
-          <p className="flex-1 text-xs" style={{ color: "var(--color-bt-danger)" }}>
-            Remove {display} from this trip?
-          </p>
-          <button
-            onClick={handleRemove}
-            disabled={removeMember.isPending || removeGuest.isPending}
-            className="rounded-lg px-3 py-1 text-xs font-semibold disabled:opacity-40"
-            style={{ background: "var(--color-bt-danger)", color: "white" }}
-          >
-            Remove
-          </button>
-          <button
-            onClick={() => setConfirmRemove(false)}
-            className="rounded-lg border px-3 py-1 text-xs"
-            style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-
-      {/* ── Expanded edit panel — crew only, not for planner rows ─────────── */}
-      {isExpanded && editable && !isPlannerRow && (
+      {/* ── Expanded panel ───────────────────────────────────────────────── */}
+      {isExpanded && editable && (
         <div
           className="space-y-2 rounded-lg px-3 py-2.5 mb-1"
           style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
         >
-          {/* Name + email — guest-only (validated users manage their own profile) */}
-          {m.isGuest && (
+          {/* Name + email — guest crew only */}
+          {m.isGuest && !isPlannerRow && (
             <div className="flex gap-2">
               <input
                 value={editName}
@@ -241,25 +223,59 @@ function CrewMemberRow({
             </div>
           )}
 
-          {/* Actions row — save/cancel (planner promotion lives in the inline row button) */}
-          <div className="flex items-center justify-end gap-2">
-            {m.isGuest && (
+          <div className="flex items-center gap-2">
+            {/* Remove from trip — left side */}
+            {confirmRemove ? (
+              <>
+                <span className="text-xs font-medium" style={{ color: "var(--color-bt-danger)" }}>
+                  Remove {display}?
+                </span>
+                <button
+                  onClick={handleRemove}
+                  disabled={removeMember.isPending || removeGuest.isPending}
+                  className="rounded-lg px-2.5 py-1 text-xs font-semibold disabled:opacity-40"
+                  style={{ background: "var(--color-bt-danger)", color: "white" }}
+                >
+                  Yes, remove
+                </button>
+                <button
+                  onClick={() => setConfirmRemove(false)}
+                  className="rounded-lg border px-2.5 py-1 text-xs"
+                  style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+                >
+                  Cancel
+                </button>
+              </>
+            ) : (
               <button
-                onClick={handleSave}
-                disabled={!hasTextChanges || updateGuest.isPending}
-                className="rounded-lg px-3 py-1 text-xs font-semibold disabled:opacity-40"
-                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                onClick={() => setConfirmRemove(true)}
+                className="rounded-lg px-2.5 py-1 text-xs font-medium"
+                style={{ color: "var(--color-bt-danger)", border: "1px solid var(--color-bt-danger)", opacity: 0.75 }}
               >
-                Save
+                Remove from trip
               </button>
             )}
-            <button
-              onClick={onToggle}
-              className="rounded-lg border px-3 py-1 text-xs"
-              style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-            >
-              {m.isGuest ? "Cancel" : "Close"}
-            </button>
+
+            {/* Save / Cancel — guest crew only */}
+            {m.isGuest && !isPlannerRow && (
+              <div className="ml-auto flex items-center gap-2">
+                <button
+                  onClick={handleSave}
+                  disabled={!hasTextChanges || updateGuest.isPending}
+                  className="rounded-lg px-3 py-1 text-xs font-semibold disabled:opacity-40"
+                  style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                >
+                  Save
+                </button>
+                <button
+                  onClick={onToggle}
+                  className="rounded-lg border px-3 py-1 text-xs"
+                  style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -335,7 +351,7 @@ export function CrewTab({ trip, canEdit }: TabProps) {
         {isOwner && (
           <>
             <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              Invite people who want to help plan. Planners can add destination ideas, vote, and weigh in before the trip is official — everyone else gets added when it&apos;s time to go.
+              Co-planners can help manage the trip alongside you.
             </p>
             <div className="mb-2">
               <CrewSearchInput
@@ -363,9 +379,9 @@ export function CrewTab({ trip, canEdit }: TabProps) {
               isOwner={isOwner}
               isMe={isMe}
               index={i}
-              isExpanded={false}
+              isExpanded={expandedId === m.user_id}
               isPlannerRow
-              onToggle={() => {}}
+              onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
               onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
             />
           );
@@ -385,7 +401,7 @@ export function CrewTab({ trip, canEdit }: TabProps) {
         {canEdit && (
           <div className="mb-2">
             <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              Start building your crew list. Add names and emails as you think of them — invites go out later when you&apos;re ready.
+              BuddyTrip members get access as soon as you add them. Guests without an account need an email invite — use the panel on the right.
             </p>
             <div className="flex gap-2">
               <input

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -103,7 +103,7 @@ function CrewMemberRow({
     >
       {/* ── Main row (tappable when expandable) ────────────────────────── */}
       <div
-        className="flex items-center gap-3 py-2.5 px-2 rounded"
+        className="flex items-center gap-3 py-2.5 px-3"
         style={{ cursor: expandable ? "pointer" : undefined }}
         onClick={expandable ? onToggle : undefined}
       >
@@ -228,7 +228,7 @@ function CrewMemberRow({
       {/* Indented under the name column: an empty cell mirrors the avatar +
           gap so the inputs align with the name above. */}
       {isExpanded && expandable && (
-        <div className="flex gap-3 px-2 pb-3">
+        <div className="flex gap-3 px-3 pb-3">
           <div className="w-8 flex-shrink-0" aria-hidden />
           <div className="min-w-0 flex-1 space-y-3">
           {/* Email — guest crew only. To change a guest's name, remove and
@@ -329,7 +329,7 @@ function AddSomeoneRow({ tripId, onAdded }: { tripId: string; onAdded: () => voi
     return (
       <button
         onClick={() => setIsExpanded(true)}
-        className="flex w-full items-center gap-3 py-2.5 px-2 rounded transition-colors hover:bg-[var(--color-bt-hover)]"
+        className="flex w-full items-center gap-3 py-2.5 px-3 transition-colors hover:bg-[var(--color-bt-hover)]"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         <div
@@ -428,7 +428,7 @@ export function CrewTab({ trip }: TabProps) {
               </p>
             )}
             <div
-              className="rounded-xl px-2 py-1"
+              className="overflow-hidden rounded-xl"
               style={{
                 background: "var(--color-bt-card)",
                 border: "1px solid var(--color-bt-border)",
@@ -468,7 +468,7 @@ export function CrewTab({ trip }: TabProps) {
               </p>
             )}
             <div
-              className="rounded-xl px-2 py-1"
+              className="overflow-hidden rounded-xl"
               style={{
                 background: "var(--color-bt-card)",
                 border: "1px solid var(--color-bt-border)",

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -292,7 +292,7 @@ function CrewMemberRow({
                 style={{ color: "var(--color-bt-danger)", border: "1px solid var(--color-bt-danger)", opacity: 0.75 }}
               >
                 <Trash2 size={12} />
-                Remove from trip
+                Remove {display} from trip
               </button>
             )}
           </div>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -95,7 +95,7 @@ function CrewMemberRow({
 
   return (
     <div
-      className="border-b"
+      className="border-b last:border-b-0"
       style={{
         borderColor: "var(--color-bt-border)",
         background: index % 2 === 1 ? (isDark ? "rgba(255,255,255,0.025)" : "rgba(0,0,0,0.025)") : undefined,

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Ghost, X, Check, Crown, ChevronDown, Plus, Trash2 } from "lucide-react";
+import { Ghost, X, Crown, ChevronDown, Plus, Trash2 } from "lucide-react";
 import { UserAvatar } from "@/components/UserAvatar";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -63,6 +63,10 @@ function CrewMemberRow({
   const display = m.displayName;
   const isOwnerRow = m.role === "Owner";
   const isPlannerRow = m.role === "Planner";
+  // BT members (real accounts in the "rest of crew" panel) get a faint
+  // teal tint instead of a "BT" badge so the eye separates them from
+  // guests at a glance.
+  const isBTMember = !m.isGuest && !isOwnerRow && !isPlannerRow;
   // Owner is the only role that can expand/edit rows. Owner can never
   // expand themselves or the Owner row of the trip.
   const expandable = isOwnerView && !isMe && !isOwnerRow;
@@ -93,7 +97,11 @@ function CrewMemberRow({
       className="border-b last:border-b-0"
       style={{
         borderColor: "var(--color-bt-border)",
-        background: isExpanded ? "var(--color-bt-card-raised)" : undefined,
+        background: isExpanded
+          ? "var(--color-bt-card-raised)"
+          : isBTMember
+            ? "color-mix(in srgb, var(--color-bt-accent) 5%, transparent)"
+            : undefined,
       }}
     >
       {/* ── Main row (tappable when expandable) ────────────────────────── */}
@@ -179,18 +187,6 @@ function CrewMemberRow({
                 Planner
               </span>
             )
-          )}
-
-          {/* BT member ✓ — non-guest, non-owner, non-planner */}
-          {!m.isGuest && !isOwnerRow && !isPlannerRow && (
-            <span
-              className="flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium"
-              style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
-              title="BuddyTrip account"
-            >
-              <Check size={10} strokeWidth={2.5} />
-              BT
-            </span>
           )}
 
           {/* Make-planner button — owner only, member rows with email */}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Ghost, X, Check, Crown, ChevronDown, Plus, Trash2 } from "lucide-react";
 import { UserAvatar } from "@/components/UserAvatar";
-import { useTheme } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { TabProps } from "./types";
@@ -31,7 +30,6 @@ function CrewMemberRow({
   isOwnerView,
   isMe,
   isExpanded,
-  index,
   isPlannerSection,
   onToggle,
   onUpdated,
@@ -41,13 +39,10 @@ function CrewMemberRow({
   isOwnerView: boolean;
   isMe: boolean;
   isExpanded: boolean;
-  index: number;
   isPlannerSection?: boolean;
   onToggle: () => void;
   onUpdated: () => void;
 }) {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
   const utils = trpc.useUtils();
   const [editEmail, setEditEmail] = useState(m.user?.email ?? "");
   const [confirmRemove, setConfirmRemove] = useState(false);
@@ -98,7 +93,7 @@ function CrewMemberRow({
       className="border-b last:border-b-0"
       style={{
         borderColor: "var(--color-bt-border)",
-        background: index % 2 === 1 ? (isDark ? "rgba(255,255,255,0.025)" : "rgba(0,0,0,0.025)") : undefined,
+        background: isExpanded ? "var(--color-bt-card-raised)" : undefined,
       }}
     >
       {/* ── Main row (tappable when expandable) ────────────────────────── */}
@@ -434,7 +429,7 @@ export function CrewTab({ trip }: TabProps) {
                 border: "1px solid var(--color-bt-border)",
               }}
             >
-              {plannersSorted.map((m, i) => {
+              {plannersSorted.map((m) => {
                 const isMe = m.user_id === currentUser?.id;
                 return (
                   <CrewMemberRow
@@ -443,7 +438,6 @@ export function CrewTab({ trip }: TabProps) {
                     tripId={tripId}
                     isOwnerView={isOwner}
                     isMe={isMe}
-                    index={i}
                     isExpanded={expandedId === m.user_id}
                     isPlannerSection
                     onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
@@ -474,7 +468,7 @@ export function CrewTab({ trip }: TabProps) {
                 border: "1px solid var(--color-bt-border)",
               }}
             >
-              {crewSorted.map((m, i) => {
+              {crewSorted.map((m) => {
                 const isMe = m.user_id === currentUser?.id;
                 return (
                   <CrewMemberRow
@@ -483,7 +477,6 @@ export function CrewTab({ trip }: TabProps) {
                     tripId={tripId}
                     isOwnerView={isOwner}
                     isMe={isMe}
-                    index={i}
                     isExpanded={expandedId === m.user_id}
                     onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
                     onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Ghost, X, Check, Crown, ChevronDown, Plus, Pencil } from "lucide-react";
+import { Ghost, X, Check, Crown, ChevronDown, Plus, Trash2 } from "lucide-react";
 import { UserAvatar } from "@/components/UserAvatar";
 import { useTheme } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
@@ -132,8 +132,8 @@ function CrewMemberRow({
               {m.user.email}
             </p>
           ) : m.isGuest ? (
-            <p className="truncate text-xs opacity-40" style={{ color: "var(--color-bt-text-dim)" }}>
-              no email on file
+            <p className="truncate text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
+              tap to add email
             </p>
           ) : null}
         </div>
@@ -226,32 +226,40 @@ function CrewMemberRow({
 
       {/* ── Expanded panel ───────────────────────────────────────────────── */}
       {isExpanded && expandable && (
-        <div
-          className="space-y-2 rounded-lg px-3 py-2.5 mb-1"
-          style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
-        >
+        <div className="space-y-3 px-2 pb-3">
           {/* Email — guest crew only. To change a guest's name, remove and
               re-add them. */}
           {m.isGuest && !isPlannerSection && (
-            <div className="relative">
-              <input
-                value={editEmail}
-                onChange={(e) => setEditEmail(e.target.value)}
-                placeholder="Email"
-                type="email"
-                className="w-full rounded-lg border px-2.5 py-1.5 pr-7 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-              />
-              <Pencil
-                size={11}
-                className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+            <div>
+              <label
+                className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
                 style={{ color: "var(--color-bt-text-dim)" }}
-              />
+              >
+                Email
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  value={editEmail}
+                  onChange={(e) => setEditEmail(e.target.value)}
+                  placeholder={`${m.displayName.toLowerCase()}@example.com`}
+                  type="email"
+                  className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+                  style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                />
+                <button
+                  onClick={handleSave}
+                  disabled={!hasTextChanges || updateGuest.isPending}
+                  className="rounded-lg px-4 py-1.5 text-sm font-semibold disabled:opacity-40"
+                  style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                >
+                  Save
+                </button>
+              </div>
             </div>
           )}
 
+          {/* Remove from trip */}
           <div className="flex items-center gap-2">
-            {/* Remove from trip */}
             {confirmRemove ? (
               <>
                 <span className="text-xs font-medium" style={{ color: "var(--color-bt-danger)" }}>
@@ -276,32 +284,12 @@ function CrewMemberRow({
             ) : (
               <button
                 onClick={() => setConfirmRemove(true)}
-                className="rounded-lg px-2.5 py-1 text-xs font-medium"
+                className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium"
                 style={{ color: "var(--color-bt-danger)", border: "1px solid var(--color-bt-danger)", opacity: 0.75 }}
               >
+                <Trash2 size={12} />
                 Remove from trip
               </button>
-            )}
-
-            {/* Save / Cancel — guest crew only */}
-            {m.isGuest && !isPlannerSection && (
-              <div className="ml-auto flex items-center gap-2">
-                <button
-                  onClick={handleSave}
-                  disabled={!hasTextChanges || updateGuest.isPending}
-                  className="rounded-lg px-3 py-1 text-xs font-semibold disabled:opacity-40"
-                  style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-                >
-                  Save
-                </button>
-                <button
-                  onClick={onToggle}
-                  className="rounded-lg border px-3 py-1 text-xs"
-                  style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-                >
-                  Cancel
-                </button>
-              </div>
             )}
           </div>
         </div>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -63,10 +63,9 @@ function CrewMemberRow({
   const display = m.displayName;
   const isOwnerRow = m.role === "Owner";
   const isPlannerRow = m.role === "Planner";
-  // BT members (real accounts in the "rest of crew" panel) get a faint
-  // teal tint instead of a "BT" badge so the eye separates them from
-  // guests at a glance.
-  const isBTMember = !m.isGuest && !isOwnerRow && !isPlannerRow;
+  // Any real BT account — Owner, Planner, or Member — gets a faint teal
+  // tint to separate them from guests at a glance.
+  const isBTMember = !m.isGuest;
   // Owner is the only role that can expand/edit rows. Owner can never
   // expand themselves or the Owner row of the trip.
   const expandable = isOwnerView && !isMe && !isOwnerRow;

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -467,6 +467,20 @@ export function CrewTab({ trip }: TabProps) {
                 BuddyTrip members get access as soon as you add them. Guests without an account need an email invite — use the panel on the right.
               </p>
             )}
+            {crewSorted.some((m) => m.isGuest) && (
+              <div
+                className="mb-2 flex items-center gap-2 text-[12px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                <span
+                  className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full"
+                  style={{ background: "var(--color-bt-border)" }}
+                >
+                  <Ghost size={11} />
+                </span>
+                <span>= hasn&apos;t joined BuddyTrip yet</span>
+              </div>
+            )}
             <div
               className="overflow-hidden rounded-xl"
               style={{

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -521,6 +521,15 @@ export function CrewTab({ trip }: TabProps) {
             stacks under the crew list. */}
         {isOwner && (
           <div className="mt-6 @[640px]:mt-0 @[640px]:absolute @[640px]:inset-y-0 @[640px]:right-0 @[640px]:w-[360px]">
+            <h2
+              className="mb-2 text-xs font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Notify crew
+            </h2>
+            <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+              Send your first invite, then keep everyone in the loop as the trip gets closer.
+            </p>
             <CrewEmailPanel trip={trip} isOwner={isOwner} />
           </div>
         )}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -240,6 +240,12 @@ function CrewMemberRow({
                 <input
                   value={editEmail}
                   onChange={(e) => setEditEmail(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && hasTextChanges && !updateGuest.isPending) {
+                      e.preventDefault();
+                      handleSave();
+                    }
+                  }}
                   placeholder={`${m.displayName.toLowerCase()}@example.com`}
                   type="email"
                   className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Ghost, X } from "lucide-react";
-import { CrewSearchInput } from "@/components/CrewSearchInput";
+import { Ghost, X, Check, Crown, ChevronDown, Plus, Pencil } from "lucide-react";
 import { UserAvatar } from "@/components/UserAvatar";
 import { useTheme } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
@@ -29,23 +28,21 @@ type Member = {
 function CrewMemberRow({
   member: m,
   tripId,
-  canEdit,
-  isOwner,
+  isOwnerView,
   isMe,
   isExpanded,
   index,
-  isPlannerRow,
+  isPlannerSection,
   onToggle,
   onUpdated,
 }: {
   member: Member;
   tripId: string;
-  canEdit: boolean;
-  isOwner: boolean;
+  isOwnerView: boolean;
   isMe: boolean;
   isExpanded: boolean;
   index: number;
-  isPlannerRow?: boolean;
+  isPlannerSection?: boolean;
   onToggle: () => void;
   onUpdated: () => void;
 }) {
@@ -70,9 +67,13 @@ function CrewMemberRow({
   });
 
   const display = m.displayName;
-  const editable = canEdit && !isMe && m.role !== "Owner";
-  const canActOnPlanner = isOwner && !isMe && m.role === "Planner";
-  const canPromoteToCoplanner = isOwner && !isMe && m.role === "Member" && !isPlannerRow && !!m.user?.email;
+  const isOwnerRow = m.role === "Owner";
+  const isPlannerRow = m.role === "Planner";
+  // Owner is the only role that can expand/edit rows. Owner can never
+  // expand themselves or the Owner row of the trip.
+  const expandable = isOwnerView && !isMe && !isOwnerRow;
+  const canActOnPlanner = isOwnerView && !isMe && isPlannerRow;
+  const canPromoteToCoplanner = isOwnerView && !isMe && m.role === "Member" && !!m.user?.email;
   const hasTextChanges = editName.trim() !== m.displayName || editEmail.trim() !== (m.user?.email ?? "");
 
   const handleSave = async () => {
@@ -94,11 +95,8 @@ function CrewMemberRow({
 
   const handleRemove = () => {
     if (!m.user_id) return;
-    if (m.isGuest) {
-      removeGuest.mutate({ tripId, guestUserId: m.user_id });
-    } else {
-      removeMember.mutate({ tripId, userId: m.user_id });
-    }
+    if (m.isGuest) removeGuest.mutate({ tripId, guestUserId: m.user_id });
+    else removeMember.mutate({ tripId, userId: m.user_id });
   };
 
   return (
@@ -109,13 +107,11 @@ function CrewMemberRow({
         background: index % 2 === 1 ? (isDark ? "rgba(255,255,255,0.025)" : "rgba(0,0,0,0.025)") : undefined,
       }}
     >
-      {/* ── Main row (tappable) ──────────────────────────────────────────── */}
+      {/* ── Main row (tappable when expandable) ────────────────────────── */}
       <div
         className="flex items-center gap-3 py-2.5 px-1 -mx-1 rounded"
-        style={{
-          cursor: editable ? "pointer" : undefined,
-        }}
-        onClick={editable ? onToggle : undefined}
+        style={{ cursor: expandable ? "pointer" : undefined }}
+        onClick={expandable ? onToggle : undefined}
       >
         {/* Avatar */}
         {m.isGuest ? (
@@ -148,62 +144,100 @@ function CrewMemberRow({
           ) : null}
         </div>
 
-        {/* ── Right side: actions ──────────────────────────────────────────── */}
-        <div className="flex flex-shrink-0 items-center">
-          <div className="flex flex-shrink-0 items-center gap-1">
-            {/* Planner badge with remove × */}
-            {isPlannerRow && (
-              canActOnPlanner ? (
-                <button
-                  onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Member" }); }}
-                  disabled={updateRole.isPending}
-                  aria-label={`Remove ${display} as planner`}
-                  className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider disabled:opacity-40 hover:opacity-75 transition-opacity"
-                  style={{
-                    background: "var(--color-bt-accent-faint)",
-                    color: "var(--color-bt-accent)",
-                    border: "1px solid var(--color-bt-accent-border)",
-                  }}
-                >
-                  Planner
-                  <X size={10} strokeWidth={2.5} />
-                </button>
-              ) : (
-                <span
-                  className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
-                  style={{
-                    background: "var(--color-bt-accent-faint)",
-                    color: "var(--color-bt-accent)",
-                    border: "1px solid var(--color-bt-accent-border)",
-                  }}
-                >
-                  Planner
-                </span>
-              )
-            )}
-            {/* Crew row: promote to co-planner */}
-            {canPromoteToCoplanner && (
+        {/* ── Right side: badges + chevron ─────────────────────────────── */}
+        <div className="flex flex-shrink-0 items-center gap-1.5">
+          {/* Owner badge */}
+          {isOwnerRow && (
+            <span
+              className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+              style={{
+                background: "color-mix(in srgb, var(--color-bt-warning) 15%, transparent)",
+                color: "var(--color-bt-warning)",
+                border: "1px solid color-mix(in srgb, var(--color-bt-warning) 30%, transparent)",
+              }}
+            >
+              <Crown size={10} />
+              Owner
+            </span>
+          )}
+
+          {/* Planner badge / Planner × button */}
+          {isPlannerRow && (
+            canActOnPlanner ? (
               <button
-                onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Planner" }); }}
+                onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Member" }); }}
                 disabled={updateRole.isPending}
-                className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
-                style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+                aria-label={`Remove ${display} as planner`}
+                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider disabled:opacity-40 hover:opacity-75 transition-opacity"
+                style={{
+                  background: "var(--color-bt-accent-faint)",
+                  color: "var(--color-bt-accent)",
+                  border: "1px solid var(--color-bt-accent-border)",
+                }}
               >
-                Make planner
+                Planner
+                <X size={10} strokeWidth={2.5} />
               </button>
-            )}
-          </div>
+            ) : (
+              <span
+                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+                style={{
+                  background: "var(--color-bt-accent-faint)",
+                  color: "var(--color-bt-accent)",
+                  border: "1px solid var(--color-bt-accent-border)",
+                }}
+              >
+                Planner
+              </span>
+            )
+          )}
+
+          {/* BT member ✓ — non-guest, non-owner, non-planner */}
+          {!m.isGuest && !isOwnerRow && !isPlannerRow && (
+            <span
+              className="flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+              style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+              title="BuddyTrip account"
+            >
+              <Check size={10} strokeWidth={2.5} />
+              BT
+            </span>
+          )}
+
+          {/* Make-planner button — owner only, member rows with email */}
+          {canPromoteToCoplanner && (
+            <button
+              onClick={(e) => { e.stopPropagation(); if (m.user_id) updateRole.mutate({ tripId, userId: m.user_id, role: "Planner" }); }}
+              disabled={updateRole.isPending}
+              className="rounded-lg px-2 py-1 text-xs disabled:opacity-40"
+              style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+            >
+              Make planner
+            </button>
+          )}
+
+          {/* Chevron — only on expandable rows */}
+          {expandable && (
+            <ChevronDown
+              size={16}
+              className="transition-transform duration-150"
+              style={{
+                color: "var(--color-bt-text-dim)",
+                transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
+              }}
+            />
+          )}
         </div>
       </div>
 
       {/* ── Expanded panel ───────────────────────────────────────────────── */}
-      {isExpanded && editable && (
+      {isExpanded && expandable && (
         <div
           className="space-y-2 rounded-lg px-3 py-2.5 mb-1"
           style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
         >
-          {/* Name + email — guest crew only */}
-          {m.isGuest && !isPlannerRow && (
+          {/* Name + email — guest crew only (planners can't edit name/email here) */}
+          {m.isGuest && !isPlannerSection && (
             <div className="flex gap-2">
               <input
                 value={editName}
@@ -212,19 +246,26 @@ function CrewMemberRow({
                 className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
                 style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
               />
-              <input
-                value={editEmail}
-                onChange={(e) => setEditEmail(e.target.value)}
-                placeholder="Email"
-                type="email"
-                className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-              />
+              <div className="relative min-w-0 flex-1">
+                <input
+                  value={editEmail}
+                  onChange={(e) => setEditEmail(e.target.value)}
+                  placeholder="Email"
+                  type="email"
+                  className="w-full rounded-lg border px-2.5 py-1.5 pr-7 text-sm outline-none"
+                  style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                />
+                <Pencil
+                  size={11}
+                  className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                />
+              </div>
             </div>
           )}
 
           <div className="flex items-center gap-2">
-            {/* Remove from trip — left side */}
+            {/* Remove from trip */}
             {confirmRemove ? (
               <>
                 <span className="text-xs font-medium" style={{ color: "var(--color-bt-danger)" }}>
@@ -257,7 +298,7 @@ function CrewMemberRow({
             )}
 
             {/* Save / Cancel — guest crew only */}
-            {m.isGuest && !isPlannerRow && (
+            {m.isGuest && !isPlannerSection && (
               <div className="ml-auto flex items-center gap-2">
                 <button
                   onClick={handleSave}
@@ -283,21 +324,99 @@ function CrewMemberRow({
   );
 }
 
+// ── AddSomeoneRow ─────────────────────────────────────────────────────────
+// Collapsed dashed-avatar row at the bottom of the crew list. Expands to a
+// name-only form. Email is added later via the row's edit panel — that's
+// where the existing-account auto-link runs.
+
+function AddSomeoneRow({ tripId, onAdded }: { tripId: string; onAdded: () => void }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [name, setName] = useState("");
+  const create = trpc.ghostCrew.create.useMutation({
+    onSuccess() {
+      setName("");
+      setIsExpanded(false);
+      onAdded();
+    },
+  });
+
+  const handleSubmit = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    create.mutate({ tripId, name: trimmed, role: "Member" });
+  };
+
+  if (!isExpanded) {
+    return (
+      <button
+        onClick={() => setIsExpanded(true)}
+        className="flex w-full items-center gap-3 py-2.5 px-1 -mx-1 rounded transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        <div
+          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
+          style={{ border: "1px dashed var(--color-bt-border)" }}
+        >
+          <Plus size={14} />
+        </div>
+        <span className="text-sm">Add someone</span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="space-y-2 rounded-lg px-3 py-2.5 my-1"
+      style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
+    >
+      <div className="flex gap-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+            if (e.key === "Escape") {
+              setIsExpanded(false);
+              setName("");
+            }
+          }}
+          className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+          style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={!name.trim() || create.isPending}
+          className="rounded-lg px-3 py-1.5 text-xs font-semibold disabled:opacity-40"
+          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+        >
+          {create.isPending ? "..." : "Add"}
+        </button>
+        <button
+          onClick={() => {
+            setIsExpanded(false);
+            setName("");
+          }}
+          className="rounded-lg border px-3 py-1.5 text-xs"
+          style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // ── CrewTab ───────────────────────────────────────────────────────────────
 
-export function CrewTab({ trip, canEdit }: TabProps) {
+export function CrewTab({ trip }: TabProps) {
   const currentUser = useCurrentUser();
   const utils = trpc.useUtils();
   const tripId = trip.id;
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
 
-  const [addName, setAddName] = useState("");
-  const [addEmail, setAddEmail] = useState("");
-  const [isAdding, setIsAdding] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
-
-  const createGhost = trpc.ghostCrew.create.useMutation();
-  const inviteByEmail = trpc.tripMembers.inviteByEmail.useMutation();
 
   const me = members.find((m) => m.user_id === currentUser?.id);
   const isOwner = me?.role === "Owner";
@@ -305,172 +424,105 @@ export function CrewTab({ trip, canEdit }: TabProps) {
     const aOrder = ROLE_ORDER[a.role] ?? 2;
     const bOrder = ROLE_ORDER[b.role] ?? 2;
     if (aOrder !== bOrder) return aOrder - bOrder;
-    // Real members before ghosts within the same role
     if (a.isGuest !== b.isGuest) return a.isGuest ? 1 : -1;
     return a.displayName.localeCompare(b.displayName);
   });
 
-  const handleAdd = async () => {
-    const name = addName.trim();
-    const email = addEmail.trim().toLowerCase() || null;
-    if (!name) return;
-
-    setIsAdding(true);
-    try {
-      if (email) {
-        // Email provided: use inviteByEmail which handles both
-        // existing accounts (adds directly) and new users (creates invite + sends email)
-        await inviteByEmail.mutateAsync({ tripId, email, role: "Member" });
-      } else {
-        await createGhost.mutateAsync({ tripId, name, role: "Member" });
-      }
-      setAddName("");
-      setAddEmail("");
-      utils.tripMembers.list.invalidate({ tripId });
-    } finally {
-      setIsAdding(false);
-    }
-  };
-
-  // Split members into planners and crew
   const plannersSorted = sorted.filter((m) => m.role === "Owner" || m.role === "Planner");
   const crewSorted = sorted.filter((m) => m.role !== "Owner" && m.role !== "Planner");
 
   return (
     <div className="@container px-4">
-      <div className="@[640px]:relative @[640px]:grid @[640px]:grid-cols-[minmax(0,1fr)_320px] @[640px]:gap-5">
-      <div className="min-w-0 space-y-4">
-      {/* ── PLANNERS section ── */}
-      <div>
-        <h2
-          className="mb-2 text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Planners
-        </h2>
+      <div className="@[640px]:relative @[640px]:grid @[640px]:grid-cols-[minmax(0,1fr)_360px] @[640px]:gap-5">
+        <div className="min-w-0 space-y-4">
+          {/* ── PLANNERS section ── */}
+          <div>
+            <h2
+              className="mb-2 text-xs font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Planners
+            </h2>
+            {isOwner && (
+              <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+                Co-planners can help manage the trip alongside you. Promote any crew member with a BuddyTrip account.
+              </p>
+            )}
+            {plannersSorted.map((m, i) => {
+              const isMe = m.user_id === currentUser?.id;
+              return (
+                <CrewMemberRow
+                  key={m.memberId}
+                  member={m}
+                  tripId={tripId}
+                  isOwnerView={isOwner}
+                  isMe={isMe}
+                  index={i}
+                  isExpanded={expandedId === m.user_id}
+                  isPlannerSection
+                  onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
+                  onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+                />
+              );
+            })}
+          </div>
+
+          {/* ── REST OF THE CREW section ── */}
+          <div className="pt-4">
+            <h2
+              className="mb-2 text-xs font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Rest of the crew
+            </h2>
+            {isOwner && (
+              <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+                BuddyTrip members get access as soon as you add them. Guests without an account need an email invite — use the panel on the right.
+              </p>
+            )}
+            <div>
+              {crewSorted.map((m, i) => {
+                const isMe = m.user_id === currentUser?.id;
+                return (
+                  <CrewMemberRow
+                    key={m.memberId}
+                    member={m}
+                    tripId={tripId}
+                    isOwnerView={isOwner}
+                    isMe={isMe}
+                    index={i}
+                    isExpanded={expandedId === m.user_id}
+                    onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
+                    onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+                  />
+                );
+              })}
+              {isOwner && (
+                <AddSomeoneRow
+                  tripId={tripId}
+                  onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
+                />
+              )}
+            </div>
+
+            {crewSorted.length === 0 && !isOwner && (
+              <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+                No crew members yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Email panel — owner-only.
+            At ≥640px container width it's absolutely positioned in the right
+            column so its content height doesn't stretch the grid row — the left
+            column dictates panel height. Below 640px the grid collapses and it
+            stacks under the crew list. */}
         {isOwner && (
-          <>
-            <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              Co-planners can help manage the trip alongside you.
-            </p>
-            <div className="mb-2">
-              <CrewSearchInput
-                tripId={tripId}
-                defaultRole="Planner"
-                defaultStatus="draft"
-                allowGhost={false}
-                allowInvite
-                showSearchIcon
-                placeholder="Search by email..."
-                frequentTripmates={[]}
-                onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-              />
-            </div>
-          </>
-        )}
-        {plannersSorted.map((m, i) => {
-          const isMe = m.user_id === currentUser?.id;
-          return (
-            <CrewMemberRow
-              key={m.memberId}
-              member={m}
-              tripId={tripId}
-              canEdit={canEdit}
-              isOwner={isOwner}
-              isMe={isMe}
-              index={i}
-              isExpanded={expandedId === m.user_id}
-              isPlannerRow
-              onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
-              onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
-            />
-          );
-        })}
-      </div>
-
-      {/* ── REST OF THE CREW section ── */}
-      <div className="pt-4">
-        <h2
-          className="mb-2 text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Rest of the crew
-        </h2>
-
-        {/* Name + email add for crew members */}
-        {canEdit && (
-          <div className="mb-2">
-            <p className="mb-2 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              BuddyTrip members get access as soon as you add them. Guests without an account need an email invite — use the panel on the right.
-            </p>
-            <div className="flex gap-2">
-              <input
-                value={addName}
-                onChange={(e) => setAddName(e.target.value)}
-                placeholder="Name"
-                className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-                onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
-              />
-              <input
-                value={addEmail}
-                onChange={(e) => setAddEmail(e.target.value)}
-                placeholder="Email (optional)"
-                type="email"
-                className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-                onKeyDown={(e) => { if (e.key === "Enter") handleAdd(); }}
-              />
-              <button
-                onClick={handleAdd}
-                disabled={!addName.trim() || isAdding}
-                className="flex-shrink-0 rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-40"
-                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-              >
-                {isAdding ? "..." : "Add"}
-              </button>
-            </div>
+          <div className="mt-6 @[640px]:mt-0 @[640px]:absolute @[640px]:inset-y-0 @[640px]:right-0 @[640px]:w-[360px]">
+            <CrewEmailPanel trip={trip} isOwner={isOwner} />
           </div>
         )}
-
-        <div>
-          {crewSorted.map((m, i) => {
-            const isMe = m.user_id === currentUser?.id;
-            return (
-              <CrewMemberRow
-                key={m.memberId}
-                member={m}
-                tripId={tripId}
-                canEdit={canEdit}
-                isOwner={isOwner}
-                isMe={isMe}
-                index={i}
-                isExpanded={expandedId === m.user_id}
-                onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
-                onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
-              />
-            );
-          })}
-        </div>
-
-        {crewSorted.length === 0 && !canEdit && (
-          <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-            No crew members yet.
-          </p>
-        )}
-      </div>
-      </div>
-
-      {/* Email panel — owner-only.
-          At ≥640px container width it's absolutely positioned in the right
-          column so its content height doesn't stretch the grid row — the left
-          column dictates panel height and content scrolls internally. Below
-          640px the grid collapses and it stacks under the crew list. */}
-      {isOwner && (
-        <div className="mt-6 @[640px]:mt-0 @[640px]:absolute @[640px]:inset-y-0 @[640px]:right-0 @[640px]:w-[320px]">
-          <CrewEmailPanel trip={trip} isOwner={isOwner} />
-        </div>
-      )}
       </div>
     </div>
   );

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -225,8 +225,12 @@ function CrewMemberRow({
       </div>
 
       {/* ── Expanded panel ───────────────────────────────────────────────── */}
+      {/* Indented under the name column: an empty cell mirrors the avatar +
+          gap so the inputs align with the name above. */}
       {isExpanded && expandable && (
-        <div className="space-y-3 px-2 pb-3">
+        <div className="flex gap-3 px-2 pb-3">
+          <div className="w-8 flex-shrink-0" aria-hidden />
+          <div className="min-w-0 flex-1 space-y-3">
           {/* Email — guest crew only. To change a guest's name, remove and
               re-add them. */}
           {m.isGuest && !isPlannerSection && (
@@ -291,6 +295,7 @@ function CrewMemberRow({
                 Remove from trip
               </button>
             )}
+          </div>
           </div>
         </div>
       )}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -109,7 +109,7 @@ function CrewMemberRow({
     >
       {/* ── Main row (tappable when expandable) ────────────────────────── */}
       <div
-        className="flex items-center gap-3 py-2.5 px-1 -mx-1 rounded"
+        className="flex items-center gap-3 py-2.5 px-2 rounded"
         style={{ cursor: expandable ? "pointer" : undefined }}
         onClick={expandable ? onToggle : undefined}
       >
@@ -350,7 +350,7 @@ function AddSomeoneRow({ tripId, onAdded }: { tripId: string; onAdded: () => voi
     return (
       <button
         onClick={() => setIsExpanded(true)}
-        className="flex w-full items-center gap-3 py-2.5 px-1 -mx-1 rounded transition-colors hover:bg-[var(--color-bt-hover)]"
+        className="flex w-full items-center gap-3 py-2.5 px-2 rounded transition-colors hover:bg-[var(--color-bt-hover)]"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         <div
@@ -448,23 +448,31 @@ export function CrewTab({ trip }: TabProps) {
                 Co-planners can help manage the trip alongside you. Promote any crew member with a BuddyTrip account.
               </p>
             )}
-            {plannersSorted.map((m, i) => {
-              const isMe = m.user_id === currentUser?.id;
-              return (
-                <CrewMemberRow
-                  key={m.memberId}
-                  member={m}
-                  tripId={tripId}
-                  isOwnerView={isOwner}
-                  isMe={isMe}
-                  index={i}
-                  isExpanded={expandedId === m.user_id}
-                  isPlannerSection
-                  onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
-                  onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
-                />
-              );
-            })}
+            <div
+              className="rounded-xl px-2 py-1"
+              style={{
+                background: "var(--color-bt-card)",
+                border: "1px solid var(--color-bt-border)",
+              }}
+            >
+              {plannersSorted.map((m, i) => {
+                const isMe = m.user_id === currentUser?.id;
+                return (
+                  <CrewMemberRow
+                    key={m.memberId}
+                    member={m}
+                    tripId={tripId}
+                    isOwnerView={isOwner}
+                    isMe={isMe}
+                    index={i}
+                    isExpanded={expandedId === m.user_id}
+                    isPlannerSection
+                    onToggle={() => setExpandedId(expandedId === m.user_id ? null : m.user_id)}
+                    onUpdated={() => utils.tripMembers.list.invalidate({ tripId })}
+                  />
+                );
+              })}
+            </div>
           </div>
 
           {/* ── REST OF THE CREW section ── */}
@@ -480,7 +488,13 @@ export function CrewTab({ trip }: TabProps) {
                 BuddyTrip members get access as soon as you add them. Guests without an account need an email invite — use the panel on the right.
               </p>
             )}
-            <div>
+            <div
+              className="rounded-xl px-2 py-1"
+              style={{
+                background: "var(--color-bt-card)",
+                border: "1px solid var(--color-bt-border)",
+              }}
+            >
               {crewSorted.map((m, i) => {
                 const isMe = m.user_id === currentUser?.id;
                 return (
@@ -503,13 +517,13 @@ export function CrewTab({ trip }: TabProps) {
                   onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
                 />
               )}
-            </div>
 
-            {crewSorted.length === 0 && !isOwner && (
-              <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-                No crew members yet.
-              </p>
-            )}
+              {crewSorted.length === 0 && !isOwner && (
+                <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+                  No crew members yet.
+                </p>
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -244,16 +244,17 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
             </button>
           </div>
 
-          <div className="mb-3 space-y-0.5">
+          <div className="mb-3">
             {withEmail.map((m) => {
               const checked = checkedIds.has(m.memberId);
               return (
                 <div
                   key={m.memberId}
                   onClick={() => toggleMember(m.memberId)}
-                  className={`flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors duration-150${!checked ? " hover:bg-[var(--color-bt-hover)]" : ""}`}
+                  className={`flex cursor-pointer items-center gap-2.5 border-b px-2 py-1.5 transition-colors duration-150 last:border-b-0${!checked ? " hover:bg-[var(--color-bt-hover)]" : ""}`}
                   style={{
                     background: checked ? "var(--color-bt-accent-faint)" : "transparent",
+                    borderColor: "var(--color-bt-border)",
                   }}
                 >
                   {checked ? (

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { CheckSquare, Mail, RotateCcw, Send, Square } from "lucide-react";
+import { CheckSquare, Ghost, Mail, RotateCcw, Send, Square } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { buildCannedInvitation } from "@/lib/invitationDefault";
@@ -79,7 +79,9 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
   const withEmail = others
     .filter((m) => !!m.user?.email)
     .sort(recipientSort) as RecipientMember[];
-  const noEmailCount = others.filter((m) => !m.user?.email).length;
+  const withoutEmail = others
+    .filter((m) => !m.user?.email)
+    .sort(recipientSort) as RecipientMember[];
 
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const [lastSentCount, setLastSentCount] = useState<number | null>(null);
@@ -302,17 +304,38 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
         </>
       )}
 
-      {/* No-email hint — counts guests still missing an email so the
-          owner knows they exist. Email entry happens in the crew list,
-          not here. */}
-      {noEmailCount > 0 && (
-        <p
-          className="mb-3 text-[12px] leading-relaxed"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          {noEmailCount === 1 ? "1 guest" : `${noEmailCount} guests`} still need an email — add one
-          from their crew row to invite them.
-        </p>
+      {/* No-email divider + static chips. Adding emails happens in the
+          crew list dropdown, so chips here are display-only. */}
+      {withEmail.length > 0 && withoutEmail.length > 0 && (
+        <div className="mb-3 flex items-center gap-2">
+          <div className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
+          <span
+            className="text-[9px] font-bold uppercase tracking-widest"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            No email yet
+          </span>
+          <div className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
+        </div>
+      )}
+
+      {withoutEmail.length > 0 && (
+        <div className="mb-3 flex flex-wrap items-center gap-1.5">
+          {withoutEmail.map((m) => (
+            <span
+              key={m.memberId}
+              className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px dashed var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+              }}
+            >
+              <Ghost size={11} style={{ color: "var(--color-bt-text-dim)" }} />
+              <span>{m.displayName}</span>
+            </span>
+          ))}
+        </div>
       )}
 
       {/* Send button */}

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -84,7 +84,6 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
     .sort(recipientSort) as RecipientMember[];
 
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
-  const [lastSentCount, setLastSentCount] = useState<number | null>(null);
   const [confirmingReset, setConfirmingReset] = useState(false);
 
   const toggleMember = (memberId: string) => {
@@ -99,8 +98,7 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
   const selectedMembers = withEmail.filter((m) => checkedIds.has(m.memberId));
 
   const blast = trpc.tripMembers.sendInvitationBlast.useMutation({
-    onSuccess(data) {
-      setLastSentCount(data.sent);
+    onSuccess() {
       setCheckedIds(new Set());
       utils.tripMembers.list.invalidate({ tripId });
       utils.trips.getById.invalidate({ tripId });
@@ -198,22 +196,6 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
         />
       </div>
 
-      {/* Success flash */}
-      {lastSentCount !== null && (
-        <div
-          className="mb-3 rounded-lg px-3 py-2 text-[13px] font-medium"
-          style={{
-            background: "var(--color-bt-accent-faint)",
-            color: "var(--color-bt-accent)",
-            border: "1px solid var(--color-bt-accent-border)",
-          }}
-        >
-          {lastSentCount === 0
-            ? "No emails sent — something went wrong"
-            : `Sent to ${lastSentCount} ${lastSentCount === 1 ? "person" : "people"}`}
-        </div>
-      )}
-
       {/* Recipient list */}
       {withEmail.length === 0 ? (
         <p className="mb-2 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -244,16 +226,26 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
             </button>
           </div>
 
-          <div className="mb-3">
+          <div className="mb-3 -mx-4">
             {withEmail.map((m) => {
               const checked = checkedIds.has(m.memberId);
+              const isBTMember = !m.isGuest;
               return (
                 <div
                   key={m.memberId}
                   onClick={() => toggleMember(m.memberId)}
-                  className={`flex cursor-pointer items-center gap-2.5 border-b px-2 py-1.5 transition-colors duration-150 last:border-b-0${!checked ? " hover:bg-[var(--color-bt-hover)]" : ""}`}
+                  title={
+                    isBTMember
+                      ? "Will be notified about the trip"
+                      : "Will be invited to sign up for BuddyTrip and join the trip"
+                  }
+                  className={`flex cursor-pointer items-center gap-2.5 border-b px-4 py-1.5 transition-colors duration-150${!checked ? " hover:bg-[var(--color-bt-hover)]" : ""}`}
                   style={{
-                    background: checked ? "var(--color-bt-accent-faint)" : "transparent",
+                    background: checked
+                      ? "var(--color-bt-accent-faint)"
+                      : isBTMember
+                        ? "color-mix(in srgb, var(--color-bt-accent) 5%, transparent)"
+                        : undefined,
                     borderColor: "var(--color-bt-border)",
                   }}
                 >
@@ -270,10 +262,17 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
                   )}
                   <div className="min-w-0 flex-1">
                     <div
-                      className="truncate text-[13px] font-medium"
+                      className="flex items-center gap-1.5 truncate text-[13px] font-medium"
                       style={{ color: "var(--color-bt-text)" }}
                     >
-                      {m.displayName}
+                      {m.isGuest && (
+                        <Ghost
+                          size={12}
+                          className="flex-shrink-0"
+                          style={{ color: "var(--color-bt-text-dim)" }}
+                        />
+                      )}
+                      <span className="truncate">{m.displayName}</span>
                     </div>
                     <div
                       className="truncate text-xs"

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { CheckSquare, Ghost, Mail, Plus, RotateCcw, Send, Square, X } from "lucide-react";
+import { CheckSquare, Mail, RotateCcw, Send, Square } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { buildCannedInvitation } from "@/lib/invitationDefault";
@@ -79,9 +79,7 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
   const withEmail = others
     .filter((m) => !!m.user?.email)
     .sort(recipientSort) as RecipientMember[];
-  const withoutEmail = others
-    .filter((m) => !m.user?.email && m.isGuest)
-    .sort(recipientSort) as RecipientMember[];
+  const noEmailCount = others.filter((m) => !m.user?.email).length;
 
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const [lastSentCount, setLastSentCount] = useState<number | null>(null);
@@ -97,24 +95,6 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
   };
 
   const selectedMembers = withEmail.filter((m) => checkedIds.has(m.memberId));
-
-  // Ghost chips — inline email capture
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [emailDraft, setEmailDraft] = useState("");
-
-  const updateGuest = trpc.ghostCrew.update.useMutation({
-    onSuccess() {
-      utils.tripMembers.list.invalidate({ tripId });
-      setEditingId(null);
-      setEmailDraft("");
-    },
-  });
-
-  const saveEmail = (guestUserId: string) => {
-    const email = emailDraft.trim();
-    if (!email) return;
-    updateGuest.mutate({ tripId, guestUserId, email });
-  };
 
   const blast = trpc.tripMembers.sendInvitationBlast.useMutation({
     onSuccess(data) {
@@ -322,118 +302,17 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
         </>
       )}
 
-      {/* No-email divider */}
-      {withEmail.length > 0 && withoutEmail.length > 0 && (
-        <div className="mb-3 flex items-center gap-2">
-          <div className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
-          <span
-            className="text-[9px] font-bold uppercase tracking-widest"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            No email yet
-          </span>
-          <div className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
-        </div>
-      )}
-
-      {/* Ghost chips */}
-      {withoutEmail.length > 0 && (
-        <div className="mb-3">
-          <div className="flex flex-wrap items-center gap-1.5">
-            {withoutEmail.map((m) => {
-              const guestUserId = m.user_id;
-              if (!guestUserId) return null;
-
-              if (editingId === m.memberId) {
-                return (
-                  <div
-                    key={m.memberId}
-                    className="flex items-center gap-1.5 rounded-full px-2 py-1"
-                    style={{
-                      background: "var(--color-bt-card-raised)",
-                      border: "1px solid var(--color-bt-accent)",
-                    }}
-                  >
-                    <span
-                      className="text-xs font-medium"
-                      style={{ color: "var(--color-bt-text)" }}
-                    >
-                      {m.displayName}
-                    </span>
-                    <input
-                      autoFocus
-                      type="email"
-                      value={emailDraft}
-                      onChange={(e) => setEmailDraft(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          saveEmail(guestUserId);
-                        } else if (e.key === "Escape") {
-                          setEditingId(null);
-                          setEmailDraft("");
-                        }
-                      }}
-                      placeholder="email@…"
-                      disabled={updateGuest.isPending}
-                      className="w-44 rounded border px-1.5 py-0.5 text-xs outline-none disabled:opacity-50"
-                      style={{
-                        background: "var(--color-bt-base)",
-                        borderColor: "var(--color-bt-border)",
-                        color: "var(--color-bt-text)",
-                      }}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => saveEmail(guestUserId)}
-                      disabled={!emailDraft.trim() || updateGuest.isPending}
-                      className="rounded-full px-2 py-0.5 text-xs font-semibold disabled:opacity-40"
-                      style={{
-                        background: "var(--color-bt-accent)",
-                        color: "var(--color-bt-base)",
-                      }}
-                    >
-                      Save
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditingId(null);
-                        setEmailDraft("");
-                      }}
-                      aria-label="Cancel"
-                      className="flex h-5 w-5 items-center justify-center rounded-full"
-                      style={{ color: "var(--color-bt-text-dim)" }}
-                    >
-                      <X size={12} />
-                    </button>
-                  </div>
-                );
-              }
-
-              return (
-                <button
-                  key={m.memberId}
-                  type="button"
-                  onClick={() => {
-                    setEditingId(m.memberId);
-                    setEmailDraft("");
-                  }}
-                  className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors hover:bg-[var(--color-bt-hover)]"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    border: "1px dashed var(--color-bt-border)",
-                    color: "var(--color-bt-text)",
-                  }}
-                >
-                  <Ghost size={11} style={{ color: "var(--color-bt-text-dim)" }} />
-                  <span>{m.displayName}</span>
-                  <Plus size={11} strokeWidth={2.5} style={{ color: "var(--color-bt-accent)" }} />
-                </button>
-              );
-            })}
-          </div>
-        </div>
+      {/* No-email hint — counts guests still missing an email so the
+          owner knows they exist. Email entry happens in the crew list,
+          not here. */}
+      {noEmailCount > 0 && (
+        <p
+          className="mb-3 text-[12px] leading-relaxed"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {noEmailCount === 1 ? "1 guest" : `${noEmailCount} guests`} still need an email — add one
+          from their crew row to invite them.
+        </p>
       )}
 
       {/* Send button */}

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { CheckSquare, Ghost, Mail, Plus, Send, Square, X } from "lucide-react";
+import { CheckSquare, Ghost, Mail, Plus, RotateCcw, Send, Square, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { buildCannedInvitation } from "@/lib/invitationDefault";
@@ -85,6 +85,7 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
 
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const [lastSentCount, setLastSentCount] = useState<number | null>(null);
+  const [confirmingReset, setConfirmingReset] = useState(false);
 
   const toggleMember = (memberId: string) => {
     setCheckedIds((prev) => {
@@ -124,14 +125,13 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
     },
   });
 
-  if (!isOwner) return null;
+  if (!isOwner || others.length === 0) return null;
 
-  const sendLabel = lastBlastSentAt ? "Send reminder" : "Send invite";
-  const subtitle = `${selectedMembers.length} ${selectedMembers.length === 1 ? "person" : "people"} will receive an email`;
+  const isDefaultMessage = messageDraft.trim() === cannedInvitation.trim();
 
   return (
     <div
-      className="rounded-xl p-4 @[640px]:h-full @[640px]:overflow-y-auto"
+      className="rounded-xl p-4"
       style={{
         background: "var(--color-bt-card)",
         border: "1px solid var(--color-bt-border)",
@@ -139,24 +139,61 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
       data-testid="crew-email-panel"
     >
       {/* Header */}
-      <div className="mb-3 flex items-start gap-2.5">
-        <span
-          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
-          style={{
-            background: "var(--color-bt-accent-faint)",
-            color: "var(--color-bt-accent)",
-          }}
-        >
-          <Mail size={14} />
-        </span>
-        <div className="min-w-0">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2.5">
+          <span
+            className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+            style={{
+              background: "var(--color-bt-accent-faint)",
+              color: "var(--color-bt-accent)",
+            }}
+          >
+            <Mail size={14} />
+          </span>
           <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
             Crew Email
           </p>
-          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-            {subtitle}
-          </p>
         </div>
+
+        {confirmingReset ? (
+          <div className="flex items-center gap-2">
+            <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+              Replace message?
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                setMessageDraft(cannedInvitation);
+                setConfirmingReset(false);
+                updateAbout.mutate({ tripId, aboutMessage: cannedInvitation });
+              }}
+              className="text-xs font-semibold"
+              style={{ color: "var(--color-bt-accent)" }}
+            >
+              Yes
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingReset(false)}
+              className="text-xs"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            disabled={isDefaultMessage}
+            onClick={() => setConfirmingReset(true)}
+            className="flex items-center gap-1 text-xs disabled:opacity-30"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            title="Reset to default invitation"
+          >
+            <RotateCcw size={11} />
+            Reset
+          </button>
+        )}
       </div>
 
       {/* Editable message */}
@@ -421,7 +458,7 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
         <Send size={13} />
         {blast.isPending
           ? "Sending…"
-          : `${sendLabel}${selectedMembers.length > 0 ? ` (${selectedMembers.length})` : ""}`}
+          : `Send message${selectedMembers.length > 0 ? ` (${selectedMembers.length})` : ""}`}
       </button>
     </div>
   );

--- a/src/server/routers/ghostCrew.test.ts
+++ b/src/server/routers/ghostCrew.test.ts
@@ -147,6 +147,65 @@ describe("ghostCrew router", () => {
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
+  it("update — auto-links to existing real BT account when email matches", async () => {
+    // Create a fresh ghost on this trip
+    const planner = ctx.callerAs("planner");
+    const ghost = await planner.ghostCrew.create({ tripId, name: "LinkMe" });
+    guestUserIds.push(ghost.id);
+
+    // 'outsider' has a real BT account but isn't a member of this trip
+    const outsider = ctx.getUser("outsider");
+
+    const result = await planner.ghostCrew.update({
+      tripId,
+      guestUserId: ghost.id,
+      email: outsider.email,
+    });
+
+    expect(result.linked).toBe(true);
+    expect(result.id).toBe(outsider.id);
+    expect(result.is_guest).toBe(false);
+
+    // trip_members should now point at the real user, not the ghost
+    const members = await planner.tripMembers.list({ tripId });
+    expect(members.find((m) => m.user_id === outsider.id)).toBeTruthy();
+    expect(members.find((m) => m.user_id === ghost.id)).toBeFalsy();
+  });
+
+  it("update — refuses link when real account is already a trip member", async () => {
+    // Create another ghost
+    const planner = ctx.callerAs("planner");
+    const ghost = await planner.ghostCrew.create({ tripId, name: "DupLink" });
+    guestUserIds.push(ghost.id);
+
+    // 'member' is already a real member of this trip
+    const member = ctx.getUser("member");
+    await expect(
+      planner.ghostCrew.update({
+        tripId,
+        guestUserId: ghost.id,
+        email: member.email,
+      })
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("update — non-matching email falls through to plain ghost update", async () => {
+    const planner = ctx.callerAs("planner");
+    const ghost = await planner.ghostCrew.create({ tripId, name: "Plain" });
+    guestUserIds.push(ghost.id);
+
+    const newEmail = `plain-${RUN_ID}@example.com`;
+    const result = await planner.ghostCrew.update({
+      tripId,
+      guestUserId: ghost.id,
+      email: newEmail,
+    });
+
+    expect(result.linked).toBe(false);
+    expect(result.email).toBe(newEmail);
+    expect(result.is_guest).toBe(true);
+  });
+
   // ── remove ────────────────────────────────────────────────────────────────
 
   it("remove — owner can remove a guest from the trip", async () => {

--- a/src/server/routers/ghostCrew.ts
+++ b/src/server/routers/ghostCrew.ts
@@ -184,7 +184,15 @@ export const ghostCrewRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // update — edit a guest user's name/nickname/email (Planner+)
+  // update — edit a guest user's name/nickname/email (Planner+).
+  //
+  // If `email` is provided and matches an existing real BuddyTrip account,
+  // this swaps trip_members.user_id from the ghost to the real user (the
+  // "auto-link" path) and returns the real user record with linked: true.
+  // The ghost users row is left intact in case it's referenced by other
+  // trips — only the trip_members pointer changes.
+  //
+  // Otherwise, falls through to a plain UPDATE on the ghost users row.
   // -----------------------------------------------------------------------
   update: authedProcedure
     .input(
@@ -201,7 +209,7 @@ export const ghostCrewRouter = router({
       // Verify this guest is a member of this trip
       const { data: membership } = await ctx.supabase
         .from("trip_members")
-        .select("id")
+        .select("id, role")
         .eq("trip_id", ctx.tripId)
         .eq("user_id", input.guestUserId)
         .maybeSingle();
@@ -213,6 +221,51 @@ export const ghostCrewRouter = router({
         });
       }
 
+      // ── Auto-link branch: email matches an existing real BT account ───
+      if (input.email) {
+        const { data: existingUser } = await ctx.supabase
+          .from("users")
+          .select("id, name, nickname, email, is_guest, created_at")
+          .eq("email", input.email)
+          .maybeSingle();
+
+        if (existingUser && !existingUser.is_guest) {
+          // Reject if the real user is already a member of this trip.
+          const { data: alreadyMember } = await ctx.supabase
+            .from("trip_members")
+            .select("id")
+            .eq("trip_id", ctx.tripId)
+            .eq("user_id", existingUser.id)
+            .maybeSingle();
+
+          if (alreadyMember) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A user with this email is already a member of this trip.",
+            });
+          }
+
+          // Swap the trip_members row to point at the real account. We
+          // preserve the ghost's role and flip status to 'in' since they
+          // now have a real account.
+          const { error: linkErr } = await ctx.supabase
+            .from("trip_members")
+            .update({ user_id: existingUser.id, status: "in" })
+            .eq("trip_id", ctx.tripId)
+            .eq("user_id", input.guestUserId);
+
+          if (linkErr) {
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: `Failed to link existing account: ${linkErr.message}`,
+            });
+          }
+
+          return { ...existingUser, linked: true as const };
+        }
+      }
+
+      // ── Plain ghost update ────────────────────────────────────────────
       const update: Record<string, unknown> = {};
       if (input.name !== undefined) update.name = input.name;
       if (input.nickname !== undefined) update.nickname = input.nickname;
@@ -237,7 +290,7 @@ export const ghostCrewRouter = router({
         });
       }
 
-      return data;
+      return { ...data, linked: false as const };
     }),
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wrap Planners + Rest-of-the-crew into card panels (matching prototype) and align row padding/dividers so backgrounds reach panel edges with the last row's border dropped.
- Replace the inline name-edit affordance with a row-expand pattern: chevron expands a panel under each guest with an email field (Enter to save), a personalized "Remove [name] from trip" action, and no nested background.
- Drop the BT ✓ pill in favor of a faint accent tint on every BT-member row (Owner, Planner, Member). Add a ghost-icon legend above the crew panel; mirror the BT-vs-guest distinction in the Crew Email recipient list with a tint + ghost icon + hover tooltip.
- Tidy the Crew Email panel: remove the post-send toast (the per-row Sent badge already covers it), pull recipient borders edge-to-edge, and add a NOTIFY CREW section header + blurb above the panel so the right column mirrors the left.
- ghostCrew router: when editing a guest's email matches an existing real BT account, auto-swap trip_members to that account; reject if they're already on the trip.

## Test plan
- [ ] Crew tab renders panels with rounded corners, no row bleed, and no bottom border on the last row of each panel.
- [ ] Expanding a guest row reveals the email input; Enter and Save both submit, and "Remove [name] from trip" reads correctly.
- [ ] BT-member rows (Owner, Planner, Member) carry the faint teal tint; guests do not.
- [ ] Crew Email panel: BT recipients are tinted with no ghost; guests-with-email show the ghost icon; hover tooltip differentiates them. SENT badge still appears after a blast; no toast.
- [ ] Editing a ghost's email to match a real BT account swaps the membership pointer (ghostCrew test passes).
- [ ] `npx tsc --noEmit` clean; no console errors in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)