### PR TITLE
Planning grid + itinerary home tab overhaul

### DIFF
--- a/src/app/trips/[tripId]/components/TripSummaryModal.tsx
+++ b/src/app/trips/[tripId]/components/TripSummaryModal.tsx
@@ -184,7 +184,7 @@ export function TripSummaryModal({ tripId, trip, onClose, onAdvanced }: TripSumm
             style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
           >
             <Send size={15} />
-            {advance.isPending ? "Sending..." : "Let's Go! 🎉"}
+            {advance.isPending ? "Sending..." : "View Itinerary →"}
           </button>
         )}
         <button

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -360,6 +360,7 @@ export default function TripDetailPage() {
                     onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
                     onOpenChat={() => setChatOpen(true)}
                     onWriteInvitation={() => setShowWriteInvitationModal(true)}
+                    onAdvanceToGoing={isOwner ? () => setShowInvitationModal(true) : undefined}
                     actionCenterTitleAction={summaryButton}
                   />
                 )}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -11,9 +11,9 @@ import { trpc } from "@/lib/trpc-client";
 import { getTripStatus } from "@/components/StatusBadge";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import IdeaZonePanel from "../components/IdeaZonePanel";
-import { ActionCenter } from "./components/ActionCenter";
 import { ItineraryPanel } from "../components/ItineraryPanel";
 import { PlanningGrid } from "./components/PlanningGrid";
+import { ItineraryView } from "./components/ItineraryView";
 import type { TripDisplayStatus } from "@/lib/tripStatus";
 import type { TabProps, TripData } from "./types";
 
@@ -332,15 +332,20 @@ export function HomeTab({
         />
       )}
 
-      {/* ── Action Center — GOING only (idea is handled above; planning
-              now uses PlanningGrid). Still renders for the going-stage
-              travel + invitation cards.                                   */}
-      {stage === "going" && (
-        <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} onWriteInvitation={onWriteInvitation} titleAction={actionCenterTitleAction} />
+      {/* ── GOING / NOW stage: consolidated ItineraryView (owner nudge +
+              Getting There + filter pills + day-by-day timeline).          */}
+      {stage === "going" && (status === "going" || status === "now") && (
+        <ItineraryView
+          trip={trip}
+          isOwner={!!isOwner}
+          onTabChange={onTabChange}
+        />
       )}
 
-      {/* ── Itinerary panel — read-only confirmed-only timeline ── */}
-      {stage !== "idea" && stage !== "planning" && (
+      {/* ── PAST / SAVED: keep the existing ItineraryPanel; it's read-only
+              and its bucketed layout is still useful after the trip. The
+              ActionCenter stays off — there's no action to take.           */}
+      {stage !== "idea" && stage !== "planning" && status !== "going" && status !== "now" && (
         <ItineraryPanel
           tripId={trip.id}
           tripStartDate={trip.start_date}
@@ -349,6 +354,7 @@ export function HomeTab({
           onTabChange={onTabChange}
         />
       )}
+
 
       {/* ── Lodging moved to its own Lodging tab (between Crew and   ── */}
       {/*    Schedule). Home deliberately doesn't render it anymore so ── */}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -319,7 +319,7 @@ export function HomeTab({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 px-4">
       {/* ── PLANNING stage: 2×2 tile grid + dates accordion + View Itinerary.
               Replaces the old ActionCenter / PlanningSection treatment.      */}
       {stage === "planning" && (

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -13,6 +13,7 @@ import { useModalBackButton } from "@/hooks/useModalBackButton";
 import IdeaZonePanel from "../components/IdeaZonePanel";
 import { ActionCenter } from "./components/ActionCenter";
 import { ItineraryPanel } from "../components/ItineraryPanel";
+import { PlanningGrid } from "./components/PlanningGrid";
 import type { TripDisplayStatus } from "@/lib/tripStatus";
 import type { TabProps, TripData } from "./types";
 
@@ -294,8 +295,9 @@ export function HomeTab({
   onEnableComp,
   onOpenChat,
   onWriteInvitation,
+  onAdvanceToGoing,
   actionCenterTitleAction,
-}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void; actionCenterTitleAction?: React.ReactNode }) {
+}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void; onAdvanceToGoing?: () => void; actionCenterTitleAction?: React.ReactNode }) {
   const { data: ideas = [] } = trpc.ideas.list.useQuery({ tripId: trip.id });
   const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId: trip.id });
 
@@ -318,11 +320,22 @@ export function HomeTab({
 
   return (
     <div className="space-y-4">
-      {/* ── Action Center — unified "what needs your attention"   ── */}
-      {/*    surface: idea/planning show Dates cards, going shows    ── */}
-      {/*    the RSVP card. Rendered first so it stays visible        ── */}
-      {/*    above the itinerary once the trip is going.              ── */}
-      {(stage === "idea" || stage === "planning" || stage === "going") && (
+      {/* ── PLANNING stage: 2×2 tile grid + dates accordion + View Itinerary.
+              Replaces the old ActionCenter / PlanningSection treatment.      */}
+      {stage === "planning" && (
+        <PlanningGrid
+          trip={trip}
+          canEdit={canEditProp}
+          isOwner={!!isOwner}
+          onTabChange={onTabChange}
+          onAdvanceToGoing={onAdvanceToGoing}
+        />
+      )}
+
+      {/* ── Action Center — GOING only (idea is handled above; planning
+              now uses PlanningGrid). Still renders for the going-stage
+              travel + invitation cards.                                   */}
+      {stage === "going" && (
         <ActionCenter trip={trip} isOwner={!!isOwner} canEdit={canEditProp} onTabChange={onTabChange} onWriteInvitation={onWriteInvitation} titleAction={actionCenterTitleAction} />
       )}
 

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Car,
+  ChevronDown,
+  HelpCircle,
+  Plane,
+  Plus,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { UserAvatar } from "@/components/UserAvatar";
+
+type TravelMode = "driving" | "flying" | "other";
+
+interface TripMemberLite {
+  memberId: string;
+  user_id: string | null;
+  displayName: string;
+  isGuest?: boolean;
+  travel_mode?: string | null;
+  travel_detail?: string | null;
+  flight_airline?: string | null;
+  flight_number?: string | null;
+  flight_airport?: string | null;
+  flight_arrival_time?: string | null;
+}
+
+export interface GettingThereSectionProps {
+  tripId: string;
+  isOwner: boolean;
+}
+
+/**
+ * GettingThereSection — the Home tab "Getting There" block shown during
+ * the GOING/NOW stages.
+ *
+ * Everything renders in a single card:
+ *   1. Section heading + helper line
+ *   2. Your own travel row (expandable; opens automatically when empty)
+ *   3. Owner-only pending tally: "N haven't shared travel plans" with a
+ *      3-avatar stack
+ *
+ * Travel info is always shared — no opt-in toggle. The wider TravelEntryForm
+ * in the Action Center still exists for older callers; this component
+ * writes to the same `tripMembers.updateTravel` mutation.
+ */
+export function GettingThereSection({ tripId, isOwner }: GettingThereSectionProps) {
+  const utils = trpc.useUtils();
+  const currentUser = useCurrentUser();
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+
+  const myMember = (members as TripMemberLite[]).find(
+    (m) => m.user_id === currentUser?.id,
+  );
+  const otherMembers = (members as TripMemberLite[]).filter(
+    (m) => m.user_id !== currentUser?.id,
+  );
+  const hasMyTravel = !!myMember?.travel_mode;
+
+  const [expanded, setExpanded] = useState(!hasMyTravel);
+
+  // Re-sync expanded state when the underlying travel data changes — e.g.
+  // user saves, member row refetches, expanded can close automatically.
+  useEffect(() => {
+    if (hasMyTravel) setExpanded(false);
+  }, [hasMyTravel]);
+
+  // ── Render ──────────────────────────────────────────────────────────────
+  return (
+    <section className="space-y-2">
+      <h2
+        className="text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Getting there
+      </h2>
+      <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        Share your travel plans so the crew can coordinate arrivals.
+      </p>
+
+      <div
+        className="overflow-hidden rounded-xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+        data-testid="getting-there-section"
+      >
+        {/* Your row */}
+        {myMember ? (
+          <YourTravelRow
+            tripId={tripId}
+            member={myMember}
+            expanded={expanded}
+            onToggleExpanded={() => setExpanded((v) => !v)}
+            onSaved={() => {
+              utils.tripMembers.list.invalidate({ tripId });
+              setExpanded(false);
+            }}
+          />
+        ) : null}
+
+        {/* Owner-only pending tally */}
+        {isOwner && <PendingTravelRow members={otherMembers} />}
+      </div>
+    </section>
+  );
+}
+
+// ── YourTravelRow ─────────────────────────────────────────────────────────
+
+function YourTravelRow({
+  tripId,
+  member,
+  expanded,
+  onToggleExpanded,
+  onSaved,
+}: {
+  tripId: string;
+  member: TripMemberLite;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onSaved: () => void;
+}) {
+  const hasTravel = !!member.travel_mode;
+
+  return (
+    <div>
+      {/* Row header */}
+      <button
+        type="button"
+        onClick={onToggleExpanded}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+      >
+        {hasTravel ? (
+          <UserAvatar name={member.displayName} avatarUrl={null} size="md" />
+        ) : (
+          <span
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px dashed var(--color-bt-border)",
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            <Plus size={14} />
+          </span>
+        )}
+
+        <div className="min-w-0 flex-1">
+          {hasTravel ? (
+            <>
+              <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                {member.displayName}{" "}
+                <span className="text-xs font-normal" style={{ color: "var(--color-bt-text-dim)" }}>
+                  (you)
+                </span>
+              </p>
+              <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                {summarizeTravel(member)}
+              </p>
+            </>
+          ) : (
+            <p className="text-[13px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
+              Add your travel info
+            </p>
+          )}
+        </div>
+
+        {hasTravel && <TravelModeBadge mode={member.travel_mode as TravelMode | null} />}
+
+        <ChevronDown
+          size={16}
+          className="flex-shrink-0 transition-transform"
+          style={{
+            color: "var(--color-bt-text-dim)",
+            transform: expanded ? "rotate(180deg)" : undefined,
+          }}
+        />
+      </button>
+
+      {/* Expand panel */}
+      {expanded && (
+        <div
+          className="border-t px-4 pb-4 pt-3"
+          style={{ borderColor: "var(--color-bt-border)" }}
+        >
+          <TravelExpandForm tripId={tripId} member={member} onSaved={onSaved} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── TravelExpandForm ──────────────────────────────────────────────────────
+
+function TravelExpandForm({
+  tripId,
+  member,
+  onSaved,
+}: {
+  tripId: string;
+  member: TripMemberLite;
+  onSaved: () => void;
+}) {
+  const [mode, setMode] = useState<TravelMode>(
+    (member.travel_mode as TravelMode) ?? "driving",
+  );
+  // Details is the single free-text field for driving/other OR flight airline/number for flying.
+  const [details, setDetails] = useState(() =>
+    member.travel_mode === "flying"
+      ? [member.flight_airline, member.flight_number].filter(Boolean).join(" ")
+      : member.travel_detail ?? "",
+  );
+  // Arrival is free text for both — "Sep 10 · 3:00 PM" per the spec.
+  const [arrival, setArrival] = useState(() =>
+    member.travel_mode === "flying"
+      ? member.flight_arrival_time ?? ""
+      : member.travel_detail ?? "",
+  );
+
+  const updateTravel = trpc.tripMembers.updateTravel.useMutation({
+    onSuccess: onSaved,
+  });
+
+  const handleSave = () => {
+    if (mode === "flying") {
+      updateTravel.mutate({
+        tripId,
+        travelMode: mode,
+        travelDetail: null,
+        flightAirline: details.trim() || null,
+        flightNumber: null,
+        flightArrivalTime: arrival.trim() || null,
+        flightAirport: null,
+        travelShared: true,
+      });
+    } else {
+      // Driving / other — stash details and arrival in travel_detail as a
+      // combined blob. This stays compatible with TravelPanel's existing
+      // "{travel_detail}" summary rendering.
+      const combined = [details.trim(), arrival.trim()].filter(Boolean).join(" · ");
+      updateTravel.mutate({
+        tripId,
+        travelMode: mode,
+        travelDetail: combined || null,
+        flightAirline: null,
+        flightNumber: null,
+        flightArrivalTime: null,
+        flightAirport: null,
+        travelShared: true,
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Mode segmented control */}
+      <div
+        className="flex rounded-xl p-1"
+        style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+      >
+        {(
+          [
+            { value: "driving", label: "Driving", Icon: Car },
+            { value: "flying", label: "Flying", Icon: Plane },
+            { value: "other", label: "Other", Icon: HelpCircle },
+          ] as const
+        ).map(({ value, label, Icon }) => {
+          const active = mode === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setMode(value)}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-semibold"
+              style={
+                active
+                  ? {
+                      background: "var(--color-bt-card)",
+                      color: "var(--color-bt-text)",
+                      boxShadow: "var(--shadow-card)",
+                    }
+                  : { background: "transparent", color: "var(--color-bt-text-dim)" }
+              }
+            >
+              <Icon size={12} />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Fields row */}
+      <div className="flex flex-wrap items-end gap-2">
+        <div style={{ flex: "1.2 1 180px" }}>
+          <label
+            className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {mode === "flying" ? "Flight" : "Details"}
+          </label>
+          <input
+            type="text"
+            value={details}
+            onChange={(e) => setDetails(e.target.value)}
+            placeholder={mode === "flying" ? "e.g. Delta 1733" : "e.g. driving from Charlotte"}
+            className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+        </div>
+        <div style={{ flex: "1 1 140px" }}>
+          <label
+            className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Arriving
+          </label>
+          <input
+            type="text"
+            value={arrival}
+            onChange={(e) => setArrival(e.target.value)}
+            placeholder="Sep 10 · 3:00 PM"
+            className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={updateTravel.isPending}
+          className="flex-shrink-0 rounded-lg px-4 py-2 text-xs font-bold disabled:opacity-40"
+          style={{
+            background: "var(--color-bt-accent)",
+            color: "var(--color-bt-base)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {updateTravel.isPending ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── TravelModeBadge ───────────────────────────────────────────────────────
+
+function TravelModeBadge({ mode }: { mode: TravelMode | null }) {
+  if (!mode) return null;
+  const style: React.CSSProperties = {};
+  let label: string;
+  let Icon: LucideIcon;
+  if (mode === "flying") {
+    style.background = "var(--color-bt-accent-faint)";
+    style.color = "var(--color-bt-accent)";
+    style.border = "1px solid var(--color-bt-accent-border)";
+    label = "Flying";
+    Icon = Plane;
+  } else if (mode === "driving") {
+    style.background = "var(--color-bt-warning-faint)";
+    style.color = "var(--color-bt-warning)";
+    style.border = "1px solid var(--color-bt-warning-border)";
+    label = "Driving";
+    Icon = Car;
+  } else {
+    style.background = "var(--color-bt-card-raised)";
+    style.color = "var(--color-bt-text-dim)";
+    style.border = "1px solid var(--color-bt-border)";
+    label = "Other";
+    Icon = HelpCircle;
+  }
+  return (
+    <span
+      className="flex flex-shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+      style={style}
+    >
+      <Icon size={10} />
+      {label}
+    </span>
+  );
+}
+
+// ── PendingTravelRow ──────────────────────────────────────────────────────
+
+function PendingTravelRow({ members }: { members: TripMemberLite[] }) {
+  const pending = members.filter((m) => !m.travel_mode);
+  if (pending.length === 0) return null;
+
+  const visible = pending.slice(0, 3);
+  const extra = pending.length - visible.length;
+
+  return (
+    <div
+      className="flex items-center justify-between gap-3 border-t px-4 py-2.5"
+      style={{
+        background: "color-mix(in srgb, var(--color-bt-text-dim) 4%, transparent)",
+        borderColor: "var(--color-bt-border)",
+      }}
+    >
+      <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+        <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
+          {pending.length}
+        </span>{" "}
+        haven&apos;t shared travel plans
+      </p>
+      <div className="flex items-center">
+        {visible.map((m, i) => (
+          <span
+            key={m.memberId}
+            className="flex h-[18px] w-[18px] items-center justify-center overflow-hidden rounded-full"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-card)",
+              color: "var(--color-bt-text-dim)",
+              marginLeft: i === 0 ? 0 : -4,
+              fontSize: 9,
+              fontWeight: 600,
+            }}
+            aria-hidden
+          >
+            {initials(m.displayName)}
+          </span>
+        ))}
+        {extra > 0 && (
+          <span
+            className="flex h-[18px] items-center justify-center rounded-full px-1.5 text-[9px] font-bold"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-card)",
+              color: "var(--color-bt-text-dim)",
+              marginLeft: -4,
+            }}
+          >
+            +{extra}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function summarizeTravel(m: TripMemberLite): string {
+  if (m.travel_mode === "flying") {
+    const parts = [
+      m.flight_airline,
+      m.flight_number,
+      m.flight_arrival_time && `arriving ${m.flight_arrival_time}`,
+    ].filter(Boolean);
+    return parts.length ? parts.join(" · ") : "Flying";
+  }
+  if (m.travel_detail) return m.travel_detail;
+  return m.travel_mode === "driving" ? "Driving" : "Other";
+}
+
+function initials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0][0]!.toUpperCase();
+  return (words[0][0]! + words[1][0]!).toUpperCase();
+}
+

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Clock,
+  Home,
+  Mail,
+  Plane,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { UserAvatar } from "@/components/UserAvatar";
+import { parseLocalDate, fmtTime12 } from "@/lib/dates";
+import { addDays, differenceInDays } from "@/lib/tripStatus";
+import {
+  buildItinerary,
+  groupByDay,
+  todayLocalISO,
+  type ItineraryEvent,
+  type ItineraryLogisticsItem,
+  type ItineraryScheduleItem,
+  type ItineraryTripMember,
+} from "../../components/itinerary";
+import type { TripData } from "../types";
+import { GettingThereSection } from "./GettingThereSection";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+type FilterKey = "all" | "lodging" | "travel" | "events";
+
+type EventCategory = "lodging" | "travel" | "event";
+
+function categoryOf(event: ItineraryEvent): EventCategory {
+  switch (event.kind) {
+    case "lodging-checkin":
+    case "lodging-checkout":
+      return "lodging";
+    case "arrival":
+      return "travel";
+    case "schedule":
+      return "event";
+  }
+}
+
+export interface ItineraryViewProps {
+  trip: TripData;
+  isOwner: boolean;
+  onTabChange?: (tab: string) => void;
+}
+
+/**
+ * ItineraryView — the Home tab surface during the GOING / NOW stages.
+ *
+ * Replaces the old ActionCenter + ItineraryPanel pair with:
+ *   1. Owner-only nudge strip when there are crew members who haven't
+ *      joined BuddyTrip yet.
+ *   2. Getting There section (per-user travel row + owner pending tally).
+ *   3. Filter pills: All / Lodging / Travel / Events (multi-select).
+ *   4. Day-by-day timeline from trip start through trip end, pulling from
+ *      confirmed schedule items, lodging check-in/out, and shared travel
+ *      arrivals — the same data ItineraryPanel was built on, but laid out
+ *      as a continuous day-by-day reel.
+ */
+export function ItineraryView({ trip, isOwner, onTabChange }: ItineraryViewProps) {
+  const tripId = trip.id;
+
+  // ── Data ────────────────────────────────────────────────────────────────
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+  const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId });
+  const { data: logisticsItems = [] } = trpc.logistics.list.useQuery({ tripId });
+
+  const unlinkedCrewCount = useMemo(
+    () =>
+      (members as Array<{ isGuest?: boolean; user?: { is_guest?: boolean } | null }>).filter(
+        (m) => m.isGuest || m.user?.is_guest,
+      ).length,
+    [members],
+  );
+
+  // ── Itinerary events ───────────────────────────────────────────────────
+  const events = useMemo(
+    () =>
+      buildItinerary({
+        scheduleItems: scheduleItems as unknown as ItineraryScheduleItem[],
+        logisticsItems: logisticsItems as unknown as ItineraryLogisticsItem[],
+        members: members as unknown as ItineraryTripMember[],
+      }),
+    [scheduleItems, logisticsItems, members],
+  );
+
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, ItineraryEvent[]>();
+    for (const day of groupByDay(events)) {
+      map.set(day.date, day.events);
+    }
+    return map;
+  }, [events]);
+
+  // ── Day range: trip.start_date → trip.end_date inclusive ───────────────
+  const days = useMemo(() => {
+    if (!trip.start_date || !trip.end_date) return [];
+    const start = parseLocalDate(trip.start_date);
+    const end = parseLocalDate(trip.end_date);
+    const span = Math.max(0, differenceInDays(end, start));
+    const out: string[] = [];
+    for (let i = 0; i <= span; i++) {
+      const d = addDays(start, i);
+      out.push(d.toLocaleDateString("en-CA"));
+    }
+    return out;
+  }, [trip.start_date, trip.end_date]);
+
+  const today = todayLocalISO();
+
+  // ── Filter pills ───────────────────────────────────────────────────────
+  const [activeFilters, setActiveFilters] = useState<Set<FilterKey>>(new Set(["all"]));
+
+  const toggleFilter = (key: FilterKey) => {
+    setActiveFilters((prev) => {
+      const next = new Set(prev);
+      if (key === "all") {
+        return new Set<FilterKey>(["all"]);
+      }
+      next.delete("all");
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      if (next.size === 0) return new Set<FilterKey>(["all"]);
+      return next;
+    });
+  };
+
+  const showEvent = (event: ItineraryEvent): boolean => {
+    if (activeFilters.has("all")) return true;
+    const cat = categoryOf(event);
+    if (cat === "lodging" && activeFilters.has("lodging")) return true;
+    if (cat === "travel" && activeFilters.has("travel")) return true;
+    if (cat === "event" && activeFilters.has("events")) return true;
+    return false;
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-4">
+      {isOwner && unlinkedCrewCount > 0 && (
+        <UnlinkedCrewNudge count={unlinkedCrewCount} onGoToCrew={() => onTabChange?.("crew")} />
+      )}
+
+      <GettingThereSection tripId={tripId} isOwner={isOwner} />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <FilterPill label="All" active={activeFilters.has("all")} onClick={() => toggleFilter("all")} />
+        <FilterPill label="Lodging" active={activeFilters.has("lodging")} onClick={() => toggleFilter("lodging")} />
+        <FilterPill label="Travel" active={activeFilters.has("travel")} onClick={() => toggleFilter("travel")} />
+        <FilterPill label="Events" active={activeFilters.has("events")} onClick={() => toggleFilter("events")} />
+      </div>
+
+      {days.length === 0 ? (
+        <p className="rounded-xl p-4 text-center text-sm italic"
+          style={{
+            background: "var(--color-bt-card)",
+            border: "1px dashed var(--color-bt-border)",
+            color: "var(--color-bt-text-dim)",
+          }}
+        >
+          Lock your dates to see a day-by-day itinerary.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {days.map((date, i) => (
+            <DaySection
+              key={date}
+              date={date}
+              dayNumber={i + 1}
+              isToday={date === today}
+              events={(eventsByDate.get(date) ?? []).filter(showEvent)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── UnlinkedCrewNudge ─────────────────────────────────────────────────────
+
+function UnlinkedCrewNudge({ count, onGoToCrew }: { count: number; onGoToCrew: () => void }) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3 rounded-xl px-4 py-3"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      data-testid="unlinked-crew-nudge"
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+          style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }}
+        >
+          <Mail size={14} />
+        </span>
+        <div>
+          <p className="text-[13px] font-semibold leading-tight" style={{ color: "var(--color-bt-text)" }}>
+            {count} {count === 1 ? "person hasn't" : "people haven't"} joined yet
+          </p>
+          <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
+            Send them an email so they can see the plan
+          </p>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onGoToCrew}
+        className="flex-shrink-0 text-xs font-semibold"
+        style={{
+          color: "var(--color-bt-accent)",
+          background: "transparent",
+          border: "none",
+          whiteSpace: "nowrap",
+        }}
+      >
+        Go to Crew →
+      </button>
+    </div>
+  );
+}
+
+// ── FilterPill ────────────────────────────────────────────────────────────
+
+function FilterPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-active={active}
+      className="rounded-full px-3 py-1.5 text-xs font-semibold"
+      style={
+        active
+          ? {
+              background: "var(--color-bt-accent-faint)",
+              color: "var(--color-bt-accent)",
+              border: "1px solid var(--color-bt-accent-border)",
+            }
+          : {
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+              border: "1px solid var(--color-bt-border)",
+            }
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+// ── DaySection ────────────────────────────────────────────────────────────
+
+function DaySection({
+  date,
+  dayNumber,
+  isToday,
+  events,
+}: {
+  date: string;
+  dayNumber: number;
+  isToday: boolean;
+  events: ItineraryEvent[];
+}) {
+  const dateLabel = parseLocalDate(date).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <section data-testid={`day-section-${date}`} data-today={isToday ? "true" : undefined}>
+      <div className="mb-2 flex items-center gap-2">
+        {isToday && (
+          <span
+            className="inline-block h-1.5 w-1.5 rounded-full"
+            style={{ background: "var(--color-bt-accent)" }}
+            aria-hidden
+          />
+        )}
+        <p
+          className="text-[10px] font-bold uppercase tracking-widest"
+          style={{
+            color: isToday ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+          }}
+        >
+          Day {dayNumber} — {dateLabel}
+        </p>
+      </div>
+      {events.length === 0 ? (
+        <p className="pl-3 text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
+          Nothing scheduled
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {events.map((event) => (
+            <EventCard key={event.id} event={event} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ── EventCard ─────────────────────────────────────────────────────────────
+
+function EventCard({ event }: { event: ItineraryEvent }) {
+  const category = categoryOf(event);
+
+  const timeLabel = event.time ? fmtTime12(event.time) : "All day";
+
+  let borderColor: string;
+  let iconBg: string;
+  let iconColor: string;
+  let Icon: LucideIcon | null;
+
+  if (category === "lodging") {
+    borderColor = "rgba(96,165,250,0.2)";
+    iconBg = "rgba(96,165,250,0.12)";
+    iconColor = "#60a5fa";
+    Icon = Home;
+  } else if (category === "travel") {
+    borderColor = "var(--color-bt-accent-border)";
+    iconBg = "var(--color-bt-accent-faint)";
+    iconColor = "var(--color-bt-accent)";
+    Icon = Plane;
+  } else {
+    borderColor = "var(--color-bt-border)";
+    iconBg = "var(--color-bt-card-raised)";
+    iconColor = "var(--color-bt-text-dim)";
+    Icon = Clock;
+  }
+
+  return (
+    <div
+      className="flex items-start gap-3 rounded-xl px-3 py-2.5"
+      style={{
+        background: "var(--color-bt-card)",
+        border: `1px solid ${borderColor}`,
+      }}
+    >
+      {event.kind === "arrival" ? (
+        <UserAvatar name={event.displayName} avatarUrl={null} size="md" />
+      ) : (
+        <span
+          className="flex h-[26px] w-[26px] flex-shrink-0 items-center justify-center rounded-full"
+          style={{ background: iconBg, color: iconColor }}
+        >
+          {Icon && <Icon size={13} />}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          {timeLabel}
+        </p>
+        <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          {event.title}
+        </p>
+        {event.subtitle && (
+          <p className="truncate text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {event.subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ArrowRight,
   Calendar,
@@ -87,24 +87,24 @@ interface TileProps {
   icon: LucideIcon;
   label: string;
   state: TileState;
-  /** Visual-only override — true when the dates tile has its accordion
-   *  expanded, so it picks up the active styling. */
+  /** Visual-only override — true when the dates tile has its accordion expanded. */
   isActive?: boolean;
-  /** Empty-state body. */
   emptyDescription: string;
   emptyCTA: string;
-  /** Complete-state body. */
   completeValue?: string;
   completeSub?: React.ReactNode;
   /** canEdit gates the Skip affordance. */
   canEdit: boolean;
-  /** Called when the tile body (not the skip button) is clicked. */
   onClick?: () => void;
   onSkip: () => void;
   onUnskip: () => void;
   skipping: boolean;
-  /** Optional warning shown below "Not needed for this trip" when skipped. */
+  /** Warning shown below "Not needed for this trip" when skipped + crew complete. */
   skippedNudge?: React.ReactNode;
+  /** Short action label for Edit/Manage link, e.g. "Edit dates", "Manage crew" */
+  editLabel: string;
+  /** Rich preview content — rendered on sm+ breakpoint, hidden on mobile. */
+  preview?: React.ReactNode;
   testId?: string;
 }
 
@@ -123,11 +123,12 @@ function Tile({
   onUnskip,
   skipping,
   skippedNudge,
+  editLabel,
+  preview,
   testId,
 }: TileProps) {
   const styling = stylingForState(state, !!isActive);
-  // All tiles are navigable regardless of state — checkmark means "addressed",
-  // not "locked". onClick prop being set is the only gate.
+  // All tiles always navigable — checkmark means "addressed", not locked.
   const clickable = !!onClick;
 
   return (
@@ -136,7 +137,7 @@ function Tile({
       data-state={state}
       data-active={isActive ? "true" : undefined}
       onClick={clickable ? onClick : undefined}
-      className="relative flex flex-col rounded-xl p-3 transition-colors"
+      className="group relative flex flex-col rounded-xl p-3 transition-all duration-150 hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
       style={{
         background: styling.background,
         border: styling.border,
@@ -145,7 +146,7 @@ function Tile({
         cursor: clickable ? "pointer" : "default",
       }}
     >
-      {/* Top row: icon + status indicator */}
+      {/* Top row: icon + badge column (badge + edit/manage link) */}
       <div className="mb-2 flex items-start justify-between">
         <span
           className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl"
@@ -154,28 +155,38 @@ function Tile({
           <Icon size={22} strokeWidth={1.75} />
         </span>
 
-        {state === "complete" && (
+        {/* Right column: status badge + edit link */}
+        <div className="flex flex-col items-end gap-0.5">
+          {state === "complete" && (
+            <span
+              className="flex h-5 w-5 items-center justify-center rounded-full"
+              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+              aria-label="Complete"
+            >
+              <Check size={11} strokeWidth={3} />
+            </span>
+          )}
+          {state === "skipped" && (
+            <span
+              className="flex h-5 w-5 items-center justify-center rounded-full"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+              aria-label="Skipped"
+            >
+              <X size={11} strokeWidth={2.5} />
+            </span>
+          )}
+          {/* Edit/Manage link — always visible on mobile, fades in on desktop hover */}
           <span
-            className="flex h-5 w-5 items-center justify-center rounded-full"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-            aria-label="Complete"
+            className="text-[11px] transition-opacity duration-150 lg:opacity-0 lg:group-hover:opacity-100"
+            style={{ color: "var(--color-bt-text-dim)" }}
           >
-            <Check size={11} strokeWidth={3} />
+            {editLabel} →
           </span>
-        )}
-        {state === "skipped" && (
-          <span
-            className="flex h-5 w-5 items-center justify-center rounded-full"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              border: "1px solid var(--color-bt-border)",
-              color: "var(--color-bt-text-dim)",
-            }}
-            aria-label="Skipped"
-          >
-            <X size={11} strokeWidth={2.5} />
-          </span>
-        )}
+        </div>
       </div>
 
       {/* Label */}
@@ -213,7 +224,14 @@ function Tile({
         </p>
       )}
 
-      {/* Footer: CTA + Skip (empty), or Undo (skipped) */}
+      {/* Rich preview — hidden on mobile, shown on sm+ */}
+      {preview && (
+        <div className="mt-2 hidden flex-col gap-1.5 sm:flex">
+          {preview}
+        </div>
+      )}
+
+      {/* Footer */}
       <div className="mt-auto flex items-end justify-between gap-2 pt-2">
         {state === "empty" && (
           <>
@@ -250,6 +268,11 @@ function Tile({
             )}
           </>
         )}
+        {state === "complete" && (
+          <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {editLabel} →
+          </span>
+        )}
         {state === "skipped" && canEdit && (
           <button
             type="button"
@@ -273,6 +296,39 @@ function Tile({
       </div>
     </div>
   );
+}
+
+// ── Local helpers ─────────────────────────────────────────────────────────
+
+function initials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0][0]!.toUpperCase();
+  return (words[0][0]! + words[1][0]!).toUpperCase();
+}
+
+// ── Typed member / item shapes ────────────────────────────────────────────
+
+interface GridMember {
+  memberId: string;
+  user_id: string | null;
+  displayName: string;
+  role: string;
+  isGuest: boolean;
+}
+
+interface GridLogisticsItem {
+  id?: string;
+  type: string;
+  property_name?: string | null;
+  is_confirmed?: boolean | null;
+}
+
+interface GridScheduleItem {
+  id: string;
+  title: string;
+  scheduled_time?: string | null;
+  is_confirmed: boolean;
 }
 
 // ── Main grid ─────────────────────────────────────────────────────────────
@@ -301,20 +357,23 @@ export function PlanningGrid({
   const { data: logisticsItems = [] } = trpc.logistics.list.useQuery({ tripId });
   const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId });
 
-  // ── Derived counts + locked date ───────────────────────────────────────
-  const crewCount = members.length;
-  const hasCrew = crewCount > 1; // more than just the owner
+  // ── Typed data ─────────────────────────────────────────────────────────
+  const typedMembers = members as unknown as GridMember[];
+  const typedLogistics = logisticsItems as unknown as GridLogisticsItem[];
+  const typedSchedule = scheduleItems as unknown as GridScheduleItem[];
 
-  // Lodging lives on the logistics_items table under type='lodging';
-  // reservations is for tee-times/restaurants/transport.
-  const lodgingItems = (logisticsItems as Array<{ type: string; is_confirmed?: boolean | null }>).filter(
-    (r) => r.type === "lodging",
-  );
+  // ── Derived counts ─────────────────────────────────────────────────────
+  const crewCount = typedMembers.length;
+  const hasCrew = crewCount > 1;
+  const plannerCount = typedMembers.filter((m) => m.role === "Planner").length;
+  const noEmailCount = typedMembers.filter((m) => m.isGuest).length;
+
+  const lodgingItems = typedLogistics.filter((r) => r.type === "lodging");
   const lodgingCount = lodgingItems.length;
   const lodgingConfirmed = lodgingItems.filter((r) => r.is_confirmed).length;
   const lodgingPending = lodgingCount - lodgingConfirmed;
 
-  const scheduleCount = (scheduleItems as Array<unknown>).length;
+  const scheduleCount = typedSchedule.length;
 
   const datesLocked = !!(trip.start_date && trip.end_date);
   const pollMode = !!trip.poll_mode;
@@ -324,7 +383,9 @@ export function PlanningGrid({
   );
 
   // ── Tile states ────────────────────────────────────────────────────────
-  const planningSkipped: string[] = Array.isArray((trip as unknown as { planning_skipped?: unknown }).planning_skipped)
+  const planningSkipped: string[] = Array.isArray(
+    (trip as unknown as { planning_skipped?: unknown }).planning_skipped,
+  )
     ? ((trip as unknown as { planning_skipped: string[] }).planning_skipped ?? [])
     : [];
 
@@ -343,16 +404,43 @@ export function PlanningGrid({
     (s) => s === "complete" || s === "skipped",
   );
 
-  // ── Dates accordion ────────────────────────────────────────────────────
-  const [datesPanelOpen, setDatesPanelOpen] = useState(false);
+  // ── Date poll (for dates tile preview when poll is active) ─────────────
+  const { data: datePoll } = trpc.datePoll.get.useQuery(
+    { tripId },
+    { enabled: pollMode && datesState !== "complete" },
+  );
+
+  // ── Dates accordion — persisted to localStorage so it survives tab switches ──
+  const storageKey = `bt-dates-panel-open-${tripId}`;
+  const [datesPanelOpen, setDatesPanelOpen] = useState(() => {
+    try {
+      return localStorage.getItem(storageKey) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  const toggleDatesPanel = useCallback(() => {
+    setDatesPanelOpen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(storageKey, String(next));
+      } catch {}
+      return next;
+    });
+  }, [storageKey]);
+
   const [dateMode, setDateMode] = useState<"set" | "poll">(pollMode ? "poll" : "set");
 
-  // Close the panel when the user skips dates.
+  // Auto-close + clear localStorage when dates are resolved.
   useEffect(() => {
-    if (datesState === "skipped") {
+    if (datesState === "complete" || datesState === "skipped") {
       setDatesPanelOpen(false);
+      try {
+        localStorage.removeItem(storageKey);
+      } catch {}
     }
-  }, [datesState]);
+  }, [datesState, storageKey]);
 
   // Pick-your-dates form state
   const [directStart, setDirectStart] = useState("");
@@ -386,9 +474,6 @@ export function PlanningGrid({
   };
 
   // ── Skip / unskip ──────────────────────────────────────────────────────
-  // Track which tile is currently mutating so only that tile's button
-  // dims — otherwise all four buttons would flash together while a single
-  // mutation is in flight.
   const [pendingTile, setPendingTile] = useState<TileKey | null>(null);
   const skipTile = trpc.trips.skipPlanningTile.useMutation({
     onSettled() {
@@ -412,14 +497,216 @@ export function PlanningGrid({
     unskipTile.mutate({ tripId, tile });
   };
 
+  // ── Rich tile previews ─────────────────────────────────────────────────
+
+  // Dates: show poll vote pips when poll is active and windows exist.
+  const datesPreview = useMemo(() => {
+    if (!pollMode || !datePoll || datePoll.windows.length === 0) return null;
+    return (
+      <div className="space-y-1">
+        {datePoll.windows.slice(0, 3).map((w) => {
+          const yes = w.votes.filter((v: { answer: string }) => v.answer === "yes").length;
+          const maybe = w.votes.filter((v: { answer: string }) => v.answer === "maybe").length;
+          const no = w.votes.filter((v: { answer: string }) => v.answer === "no").length;
+          return (
+            <div key={w.id} className="flex items-center gap-1.5">
+              <span
+                className="flex-1 truncate text-[11px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {formatDateRangeCompact(w.start_date, w.end_date)}
+              </span>
+              <div className="flex items-center gap-1 text-[10px] font-semibold">
+                <span style={{ color: "var(--color-bt-accent)" }}>✓{yes}</span>
+                <span style={{ color: "var(--color-bt-warning)" }}>~{maybe}</span>
+                <span style={{ color: "var(--color-bt-danger)" }}>✕{no}</span>
+              </div>
+            </div>
+          );
+        })}
+        {datePoll.windows.length > 3 && (
+          <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            +{datePoll.windows.length - 3} more options
+          </p>
+        )}
+      </div>
+    );
+  }, [pollMode, datePoll]);
+
+  // Crew: avatar chips + planner count + missing email tally.
+  const crewPreview = useMemo(() => {
+    if (crewCount === 0) return null;
+    const visible = typedMembers.slice(0, 6);
+    const extra = crewCount - visible.length;
+    return (
+      <div className="space-y-1.5">
+        <div className="flex flex-wrap items-center gap-1">
+          {visible.map((m) => (
+            <span
+              key={m.memberId}
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-[9px] font-bold"
+              style={{
+                background: "var(--color-bt-accent-faint)",
+                border: "1px solid var(--color-bt-accent-border)",
+                color: "var(--color-bt-accent)",
+              }}
+              title={m.displayName}
+            >
+              {initials(m.displayName)}
+            </span>
+          ))}
+          {extra > 0 && (
+            <span
+              className="flex h-6 items-center justify-center rounded-full px-1.5 text-[9px] font-bold"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              +{extra}
+            </span>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2 text-[10px]">
+          {plannerCount > 0 && (
+            <span style={{ color: "var(--color-bt-text-dim)" }}>
+              {plannerCount} {plannerCount === 1 ? "planner" : "planners"}
+            </span>
+          )}
+          {noEmailCount > 0 && (
+            <span style={{ color: "var(--color-bt-warning)" }}>
+              {noEmailCount} missing email
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }, [typedMembers, crewCount, plannerCount, noEmailCount]);
+
+  // Lodging: first 2 properties with confirmed/pending distinction.
+  const lodgingPreview = useMemo(() => {
+    if (lodgingItems.length === 0) return null;
+    const visible = lodgingItems.slice(0, 2);
+    const extra = lodgingItems.length - visible.length;
+    return (
+      <div className="space-y-1">
+        {visible.map((item, i) => (
+          <div
+            key={item.id ?? i}
+            className="flex items-center gap-1.5 rounded-lg px-2 py-1"
+            style={{
+              background: item.is_confirmed
+                ? "var(--color-bt-accent-faint)"
+                : "var(--color-bt-warning-faint)",
+              border: `1px solid ${
+                item.is_confirmed
+                  ? "var(--color-bt-accent-border)"
+                  : "var(--color-bt-warning-border)"
+              }`,
+            }}
+          >
+            <span
+              className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+              style={{
+                background: item.is_confirmed
+                  ? "var(--color-bt-accent)"
+                  : "var(--color-bt-warning)",
+              }}
+            />
+            <span
+              className="flex-1 truncate text-[11px]"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {item.property_name ?? "Lodging option"}
+            </span>
+            <span
+              className="flex-shrink-0 text-[10px]"
+              style={{
+                color: item.is_confirmed
+                  ? "var(--color-bt-accent)"
+                  : "var(--color-bt-warning)",
+              }}
+            >
+              {item.is_confirmed ? "confirmed" : "pending"}
+            </span>
+          </div>
+        ))}
+        {extra > 0 && (
+          <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            +{extra} more
+          </p>
+        )}
+      </div>
+    );
+  }, [lodgingItems]);
+
+  // Schedule: first 3 items with confirmed/unconfirmed dots.
+  const schedulePreview = useMemo(() => {
+    if (typedSchedule.length === 0) return null;
+    const visible = typedSchedule.slice(0, 3);
+    const extra = typedSchedule.length - visible.length;
+    return (
+      <div className="space-y-1">
+        {visible.map((item) => (
+          <div key={item.id} className="flex items-center gap-1.5">
+            <span
+              className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+              style={{
+                background: item.is_confirmed
+                  ? "var(--color-bt-accent)"
+                  : "var(--color-bt-border)",
+              }}
+            />
+            <span
+              className="flex-1 truncate text-[11px]"
+              style={{
+                color: item.is_confirmed
+                  ? "var(--color-bt-text)"
+                  : "var(--color-bt-text-dim)",
+              }}
+            >
+              {item.title}
+            </span>
+            {item.scheduled_time && (
+              <span
+                className="flex-shrink-0 text-[10px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {item.scheduled_time}
+              </span>
+            )}
+          </div>
+        ))}
+        {extra > 0 && (
+          <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            +{extra} more
+          </p>
+        )}
+      </div>
+    );
+  }, [typedSchedule]);
+
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <div className="space-y-4">
-      {/* Orientation copy — always visible */}
-      <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-        Destination locked in — now let&apos;s get the details sorted.
-      </p>
+      {/* ── Section header — matches Crew / Lodging / Schedule tab style ── */}
+      <div>
+        <h2
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Planning
+        </h2>
+        <p
+          className="text-[13px] leading-relaxed"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Destination locked in — now let&apos;s get the details sorted.
+        </p>
+      </div>
 
+      {/* ── 2×2 tile grid ─────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 gap-2.5 sm:gap-3">
         <Tile
           testId="planning-tile-dates"
@@ -430,8 +717,10 @@ export function PlanningGrid({
           emptyDescription="Not set yet"
           emptyCTA="Set dates"
           completeValue={lockedDateLabel ?? undefined}
+          editLabel="Edit dates"
+          preview={datesPreview}
           canEdit={canEdit}
-          onClick={canEdit ? () => setDatesPanelOpen((v) => !v) : undefined}
+          onClick={canEdit ? toggleDatesPanel : undefined}
           onSkip={() => handleSkip("dates")}
           onUnskip={() => handleUnskip("dates")}
           skipping={pendingTile === "dates"}
@@ -444,6 +733,8 @@ export function PlanningGrid({
           emptyDescription="No one added yet"
           emptyCTA="Add crew"
           completeValue={`${crewCount} ${crewCount === 1 ? "person" : "people"}`}
+          editLabel="Manage crew"
+          preview={crewPreview}
           canEdit={canEdit}
           onClick={() => onTabChange?.("crew")}
           onSkip={() => handleSkip("crew")}
@@ -461,12 +752,18 @@ export function PlanningGrid({
           completeSub={
             lodgingCount > 0 ? (
               <>
-                <span style={{ color: "var(--color-bt-accent)" }}>{lodgingConfirmed} confirmed</span>
+                <span style={{ color: "var(--color-bt-accent)" }}>
+                  {lodgingConfirmed} confirmed
+                </span>
                 {" · "}
-                <span style={{ color: "var(--color-bt-warning)" }}>{lodgingPending} pending</span>
+                <span style={{ color: "var(--color-bt-warning)" }}>
+                  {lodgingPending} pending
+                </span>
               </>
             ) : null
           }
+          editLabel="Manage lodging"
+          preview={lodgingPreview}
           canEdit={canEdit}
           onClick={() => onTabChange?.("lodging")}
           onSkip={() => handleSkip("lodging")}
@@ -488,6 +785,8 @@ export function PlanningGrid({
           emptyDescription="Nothing planned yet"
           emptyCTA="Add items"
           completeValue={`${scheduleCount} ${scheduleCount === 1 ? "item" : "items"}`}
+          editLabel="Manage schedule"
+          preview={schedulePreview}
           canEdit={canEdit}
           onClick={() => onTabChange?.("schedule")}
           onSkip={() => handleSkip("schedule")}
@@ -518,7 +817,10 @@ export function PlanningGrid({
           <div className="p-3">
             <div
               className="flex rounded-xl p-1"
-              style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+              style={{
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+              }}
             >
               <button
                 type="button"
@@ -527,7 +829,11 @@ export function PlanningGrid({
                 className="flex flex-1 items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-semibold"
                 style={
                   dateMode === "set"
-                    ? { background: "var(--color-bt-card)", color: "var(--color-bt-text)", boxShadow: "var(--shadow-card)" }
+                    ? {
+                        background: "var(--color-bt-card)",
+                        color: "var(--color-bt-text)",
+                        boxShadow: "var(--shadow-card)",
+                      }
                     : { background: "transparent", color: "var(--color-bt-text-dim)" }
                 }
               >
@@ -542,7 +848,11 @@ export function PlanningGrid({
                 className="flex flex-1 items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-40"
                 style={
                   dateMode === "poll" && hasCrew
-                    ? { background: "var(--color-bt-card)", color: "var(--color-bt-text)", boxShadow: "var(--shadow-card)" }
+                    ? {
+                        background: "var(--color-bt-card)",
+                        color: "var(--color-bt-text)",
+                        boxShadow: "var(--shadow-card)",
+                      }
                     : { background: "transparent", color: "var(--color-bt-text-dim)" }
                 }
               >
@@ -558,7 +868,11 @@ export function PlanningGrid({
                   type="button"
                   onClick={() => onTabChange?.("crew")}
                   className="font-semibold underline"
-                  style={{ color: "var(--color-bt-accent)", background: "transparent", border: "none" }}
+                  style={{
+                    color: "var(--color-bt-accent)",
+                    background: "transparent",
+                    border: "none",
+                  }}
                 >
                   go to Crew tab →
                 </button>
@@ -568,13 +882,19 @@ export function PlanningGrid({
 
           {/* Body */}
           {dateMode === "set" ? (
-            <div className="border-t px-3 pb-3 pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
+            <div
+              className="border-t px-3 pb-3 pt-3"
+              style={{ borderColor: "var(--color-bt-border)" }}
+            >
               <p className="mb-2 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
                 Already know the dates? Lock them in directly.
               </p>
               <div className="flex flex-wrap items-end gap-2">
                 <div className="min-w-[140px] flex-1">
-                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                  <label
+                    className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
                     Start date
                   </label>
                   <input
@@ -590,7 +910,10 @@ export function PlanningGrid({
                   />
                 </div>
                 <div className="min-w-[140px] flex-1">
-                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                  <label
+                    className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
                     End date
                   </label>
                   <input
@@ -624,8 +947,12 @@ export function PlanningGrid({
               </div>
 
               {confirmClearPoll && (
-                <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2 text-[13px]"
-                  style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}
+                <div
+                  className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2 text-[13px]"
+                  style={{
+                    background: "var(--color-bt-warning-faint)",
+                    borderColor: "var(--color-bt-warning-border)",
+                  }}
                 >
                   <span style={{ color: "var(--color-bt-text)" }}>
                     This will clear the poll. Are you sure?
@@ -634,7 +961,10 @@ export function PlanningGrid({
                     type="button"
                     onClick={() => setConfirmClearPoll(false)}
                     className="ml-auto rounded-lg px-3 py-1 text-xs font-semibold"
-                    style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+                    style={{
+                      color: "var(--color-bt-text-dim)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
                   >
                     Cancel
                   </button>
@@ -651,7 +981,10 @@ export function PlanningGrid({
               )}
             </div>
           ) : hasCrew ? (
-            <div className="border-t px-3 pb-3 pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
+            <div
+              className="border-t px-3 pb-3 pt-3"
+              style={{ borderColor: "var(--color-bt-border)" }}
+            >
               <DatePollCard
                 trip={trip}
                 isOwner={isOwner}
@@ -662,14 +995,16 @@ export function PlanningGrid({
         </div>
       )}
 
-      {/* ── View Itinerary ─────────────────────────────────────────────── */}
+      {/* ── View Itinerary — right-aligned, normal size ──────────────── */}
       {isOwner && (
         <div className="flex items-center justify-between gap-3">
-          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+          <p className="flex-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
             {allResolved ? (
               <>
                 Everything&apos;s set —{" "}
-                <span style={{ color: "var(--color-bt-accent)" }}>let&apos;s make it official</span>
+                <span style={{ color: "var(--color-bt-accent)" }}>
+                  let&apos;s make it official
+                </span>
               </>
             ) : (
               "Complete or skip all four areas to continue"

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -1,0 +1,668 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  ArrowRight,
+  Calendar,
+  CalendarDays,
+  Check,
+  ChevronRight,
+  Home,
+  Users,
+  X,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { formatDateRangeCompact } from "@/lib/dates";
+import type { TripData } from "../types";
+import { DatePollCard } from "./DatePollCard";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export type TileKey = "dates" | "crew" | "lodging" | "schedule";
+export type TileState = "empty" | "complete" | "skipped";
+
+export interface PlanningGridProps {
+  trip: TripData;
+  canEdit: boolean;
+  isOwner: boolean;
+  onTabChange?: (tab: string) => void;
+  /** Opens the TripSummaryModal, which fires advanceToGoing. */
+  onAdvanceToGoing?: () => void;
+}
+
+// ── Tile primitives ───────────────────────────────────────────────────────
+
+interface TileStyling {
+  background: string;
+  border: string;
+  opacity: number;
+  iconBg: string;
+  iconColor: string;
+  labelColor: string;
+}
+
+function stylingForState(state: TileState, isActive: boolean): TileStyling {
+  if (isActive) {
+    return {
+      background: "var(--color-bt-accent-faint)",
+      border: "1px solid var(--color-bt-accent-border)",
+      opacity: 1,
+      iconBg: "var(--color-bt-accent-faint)",
+      iconColor: "var(--color-bt-accent)",
+      labelColor: "var(--color-bt-accent)",
+    };
+  }
+  if (state === "complete") {
+    return {
+      background: "var(--color-bt-accent-faint)",
+      border: "1px solid var(--color-bt-accent-border)",
+      opacity: 1,
+      iconBg: "var(--color-bt-accent-faint)",
+      iconColor: "var(--color-bt-accent)",
+      labelColor: "var(--color-bt-accent)",
+    };
+  }
+  if (state === "skipped") {
+    return {
+      background: "var(--color-bt-card)",
+      border: "1px solid var(--color-bt-border)",
+      opacity: 0.6,
+      iconBg: "var(--color-bt-card-raised)",
+      iconColor: "var(--color-bt-text-dim)",
+      labelColor: "var(--color-bt-text-dim)",
+    };
+  }
+  return {
+    background: "var(--color-bt-card)",
+    border: "1px solid var(--color-bt-border)",
+    opacity: 1,
+    iconBg: "var(--color-bt-card-raised)",
+    iconColor: "var(--color-bt-text-dim)",
+    labelColor: "var(--color-bt-text-dim)",
+  };
+}
+
+interface TileProps {
+  icon: LucideIcon;
+  label: string;
+  state: TileState;
+  /** Visual-only override — true when the dates tile has its accordion
+   *  expanded, so it picks up the complete-styling without being complete. */
+  isActive?: boolean;
+  /** Empty-state body. */
+  emptyDescription: string;
+  emptyCTA: string;
+  /** Complete-state body. */
+  completeValue?: string;
+  completeSub?: React.ReactNode;
+  /** canEdit gates the Skip affordance. */
+  canEdit: boolean;
+  /** Called when the tile body (not the skip button) is clicked. */
+  onClick?: () => void;
+  onSkip: () => void;
+  onUnskip: () => void;
+  skipping: boolean;
+  testId?: string;
+}
+
+function Tile({
+  icon: Icon,
+  label,
+  state,
+  isActive,
+  emptyDescription,
+  emptyCTA,
+  completeValue,
+  completeSub,
+  canEdit,
+  onClick,
+  onSkip,
+  onUnskip,
+  skipping,
+  testId,
+}: TileProps) {
+  const styling = stylingForState(state, !!isActive);
+  const clickable = state === "empty" && !!onClick;
+
+  return (
+    <div
+      data-testid={testId}
+      data-state={state}
+      data-active={isActive ? "true" : undefined}
+      onClick={clickable ? onClick : undefined}
+      className="relative flex flex-col rounded-xl p-3 transition-colors"
+      style={{
+        background: styling.background,
+        border: styling.border,
+        opacity: styling.opacity,
+        minHeight: 130,
+        cursor: clickable ? "pointer" : "default",
+      }}
+    >
+      {/* Top row: icon + status indicator */}
+      <div className="mb-2 flex items-start justify-between">
+        <span
+          className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl"
+          style={{ background: styling.iconBg, color: styling.iconColor }}
+        >
+          <Icon size={22} strokeWidth={1.75} />
+        </span>
+
+        {state === "complete" && (
+          <span
+            className="flex h-5 w-5 items-center justify-center rounded-full"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            aria-label="Complete"
+          >
+            <Check size={11} strokeWidth={3} />
+          </span>
+        )}
+        {state === "skipped" && (
+          <span
+            className="flex h-5 w-5 items-center justify-center rounded-full"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-text-dim)",
+            }}
+            aria-label="Skipped"
+          >
+            <X size={11} strokeWidth={2.5} />
+          </span>
+        )}
+      </div>
+
+      {/* Label */}
+      <p
+        className="mb-1 text-[10px] font-bold uppercase tracking-wider"
+        style={{ color: styling.labelColor }}
+      >
+        {label}
+      </p>
+
+      {/* Body */}
+      {state === "complete" ? (
+        <>
+          {completeValue && (
+            <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {completeValue}
+            </p>
+          )}
+          {completeSub && (
+            <p className="mt-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              {completeSub}
+            </p>
+          )}
+        </>
+      ) : state === "skipped" ? (
+        <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          Skipped
+        </p>
+      ) : (
+        <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          {emptyDescription}
+        </p>
+      )}
+
+      {/* Footer: CTA + Skip (empty), or Undo (skipped) */}
+      <div className="mt-auto flex items-end justify-between gap-2 pt-2">
+        {state === "empty" && (
+          <>
+            {clickable ? (
+              <span
+                className="flex items-center gap-1 text-[11px] font-semibold"
+                style={{ color: "var(--color-bt-accent)" }}
+              >
+                {emptyCTA}
+                <ChevronRight size={10} />
+              </span>
+            ) : (
+              <span />
+            )}
+            {canEdit && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSkip();
+                }}
+                disabled={skipping}
+                className="text-[11px] disabled:opacity-40"
+                style={{
+                  color: "var(--color-bt-text-dim)",
+                  background: "transparent",
+                  border: "none",
+                  textDecoration: "underline dotted",
+                  textUnderlineOffset: 2,
+                }}
+              >
+                Skip
+              </button>
+            )}
+          </>
+        )}
+        {state === "skipped" && canEdit && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUnskip();
+            }}
+            disabled={skipping}
+            className="ml-auto text-[11px] disabled:opacity-40"
+            style={{
+              color: "var(--color-bt-text-dim)",
+              background: "transparent",
+              border: "none",
+              textDecoration: "underline dotted",
+              textUnderlineOffset: 2,
+            }}
+          >
+            Undo skip
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main grid ─────────────────────────────────────────────────────────────
+
+/**
+ * PlanningGrid — the Home tab surface during the PLANNING stage.
+ *
+ * Four tiles (Dates / Crew / Lodging / Schedule) in a 2×2 grid.
+ * Each tile has three states: empty, complete, skipped. The Dates tile
+ * opens an inline accordion below the grid with "Pick Dates" / "Poll the
+ * Crew" segments. Below everything, a "View Itinerary" button advances
+ * the trip to going once every tile is either complete or skipped.
+ */
+export function PlanningGrid({
+  trip,
+  canEdit,
+  isOwner,
+  onTabChange,
+  onAdvanceToGoing,
+}: PlanningGridProps) {
+  const tripId = trip.id;
+  const utils = trpc.useUtils();
+
+  // ── Data fetching ──────────────────────────────────────────────────────
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+  const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId });
+  const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId });
+
+  // ── Derived counts + locked date ───────────────────────────────────────
+  const crewCount = members.length;
+  const hasCrew = crewCount > 1; // more than just the owner
+
+  const lodgingItems = (reservations as Array<{ type: string; is_confirmed?: boolean | null }>).filter(
+    (r) => r.type === "lodging",
+  );
+  const lodgingCount = lodgingItems.length;
+  const lodgingConfirmed = lodgingItems.filter((r) => r.is_confirmed).length;
+  const lodgingPending = lodgingCount - lodgingConfirmed;
+
+  const scheduleCount = (scheduleItems as Array<unknown>).length;
+
+  const datesLocked = !!(trip.start_date && trip.end_date);
+  const pollMode = !!trip.poll_mode;
+  const lockedDateLabel = useMemo(
+    () => (datesLocked ? formatDateRangeCompact(trip.start_date, trip.end_date) : null),
+    [datesLocked, trip.start_date, trip.end_date],
+  );
+
+  // ── Tile states ────────────────────────────────────────────────────────
+  const planningSkipped: string[] = Array.isArray((trip as unknown as { planning_skipped?: unknown }).planning_skipped)
+    ? ((trip as unknown as { planning_skipped: string[] }).planning_skipped ?? [])
+    : [];
+
+  const stateFor = (tile: TileKey, complete: boolean): TileState => {
+    if (complete) return "complete";
+    if (planningSkipped.includes(tile)) return "skipped";
+    return "empty";
+  };
+
+  const datesState = stateFor("dates", datesLocked);
+  const crewState = stateFor("crew", hasCrew);
+  const lodgingState = stateFor("lodging", lodgingCount > 0);
+  const scheduleState = stateFor("schedule", scheduleCount > 0);
+
+  const allResolved = [datesState, crewState, lodgingState, scheduleState].every(
+    (s) => s === "complete" || s === "skipped",
+  );
+
+  // ── Dates accordion ────────────────────────────────────────────────────
+  const [datesPanelOpen, setDatesPanelOpen] = useState(false);
+  const [dateMode, setDateMode] = useState<"set" | "poll">(pollMode ? "poll" : "set");
+
+  // Close the panel when the user resolves dates (locked or skipped).
+  useEffect(() => {
+    if (datesState === "complete" || datesState === "skipped") {
+      setDatesPanelOpen(false);
+    }
+  }, [datesState]);
+
+  // Pick-your-dates form state
+  const [directStart, setDirectStart] = useState("");
+  const [directEnd, setDirectEnd] = useState("");
+  const [confirmClearPoll, setConfirmClearPoll] = useState(false);
+
+  const lockDates = trpc.trips.lockDates.useMutation({
+    onSuccess() {
+      setDirectStart("");
+      setDirectEnd("");
+      setConfirmClearPoll(false);
+      utils.trips.getById.invalidate({ tripId });
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+  const setPollActive = trpc.datePoll.setPollMode.useMutation({
+    onSuccess() {
+      utils.trips.getById.invalidate({ tripId });
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  const handleSet = () => {
+    if (!directStart || !directEnd || directStart >= directEnd) return;
+    if (pollMode && !confirmClearPoll) {
+      setConfirmClearPoll(true);
+      return;
+    }
+    if (pollMode) setPollActive.mutate({ tripId, pollMode: false });
+    lockDates.mutate({ tripId, startDate: directStart, endDate: directEnd });
+  };
+
+  // ── Skip / unskip ──────────────────────────────────────────────────────
+  const skipTile = trpc.trips.skipPlanningTile.useMutation({
+    onSuccess() { utils.trips.getById.invalidate({ tripId }); },
+  });
+  const unskipTile = trpc.trips.unskipPlanningTile.useMutation({
+    onSuccess() { utils.trips.getById.invalidate({ tripId }); },
+  });
+  const skipping = skipTile.isPending || unskipTile.isPending;
+
+  const handleSkip = (tile: TileKey) => {
+    skipTile.mutate({ tripId, tile });
+  };
+  const handleUnskip = (tile: TileKey) => {
+    unskipTile.mutate({ tripId, tile });
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-2.5 sm:gap-3">
+        <Tile
+          testId="planning-tile-dates"
+          icon={Calendar}
+          label="Dates"
+          state={datesState}
+          isActive={datesPanelOpen && datesState === "empty"}
+          emptyDescription="Not set yet"
+          emptyCTA="Set dates"
+          completeValue={lockedDateLabel ?? undefined}
+          canEdit={canEdit}
+          onClick={canEdit && datesState === "empty" ? () => setDatesPanelOpen((v) => !v) : undefined}
+          onSkip={() => handleSkip("dates")}
+          onUnskip={() => handleUnskip("dates")}
+          skipping={skipping}
+        />
+        <Tile
+          testId="planning-tile-crew"
+          icon={Users}
+          label="Crew"
+          state={crewState}
+          emptyDescription="No one added yet"
+          emptyCTA="Add crew"
+          completeValue={`${crewCount} ${crewCount === 1 ? "person" : "people"}`}
+          canEdit={canEdit}
+          onClick={() => onTabChange?.("crew")}
+          onSkip={() => handleSkip("crew")}
+          onUnskip={() => handleUnskip("crew")}
+          skipping={skipping}
+        />
+        <Tile
+          testId="planning-tile-lodging"
+          icon={Home}
+          label="Lodging"
+          state={lodgingState}
+          emptyDescription="Nothing added yet"
+          emptyCTA="Add property"
+          completeValue={`${lodgingCount} ${lodgingCount === 1 ? "option" : "options"}`}
+          completeSub={
+            lodgingCount > 0 ? (
+              <>
+                <span style={{ color: "var(--color-bt-accent)" }}>{lodgingConfirmed} confirmed</span>
+                {" · "}
+                <span style={{ color: "var(--color-bt-warning)" }}>{lodgingPending} pending</span>
+              </>
+            ) : null
+          }
+          canEdit={canEdit}
+          onClick={() => onTabChange?.("lodging")}
+          onSkip={() => handleSkip("lodging")}
+          onUnskip={() => handleUnskip("lodging")}
+          skipping={skipping}
+        />
+        <Tile
+          testId="planning-tile-schedule"
+          icon={CalendarDays}
+          label="Schedule"
+          state={scheduleState}
+          emptyDescription="Nothing planned yet"
+          emptyCTA="Add items"
+          completeValue={`${scheduleCount} ${scheduleCount === 1 ? "item" : "items"}`}
+          canEdit={canEdit}
+          onClick={() => onTabChange?.("schedule")}
+          onSkip={() => handleSkip("schedule")}
+          onUnskip={() => handleUnskip("schedule")}
+          skipping={skipping}
+        />
+      </div>
+
+      {/* ── Dates accordion ─────────────────────────────────────────────── */}
+      {datesPanelOpen && canEdit && datesState === "empty" && (
+        <div
+          className="overflow-hidden rounded-xl"
+          style={{
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+            boxShadow: "var(--shadow-raised)",
+          }}
+          data-testid="planning-dates-panel"
+        >
+          {/* Segmented control */}
+          <div className="p-3">
+            <div
+              className="flex rounded-xl p-1"
+              style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+            >
+              <button
+                type="button"
+                onClick={() => setDateMode("set")}
+                data-active={dateMode === "set"}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-semibold"
+                style={
+                  dateMode === "set"
+                    ? { background: "var(--color-bt-card)", color: "var(--color-bt-text)", boxShadow: "var(--shadow-card)" }
+                    : { background: "transparent", color: "var(--color-bt-text-dim)" }
+                }
+              >
+                <Calendar size={12} />
+                Pick your Dates
+              </button>
+              <button
+                type="button"
+                onClick={() => hasCrew && setDateMode("poll")}
+                disabled={!hasCrew}
+                data-active={dateMode === "poll"}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+                style={
+                  dateMode === "poll" && hasCrew
+                    ? { background: "var(--color-bt-card)", color: "var(--color-bt-text)", boxShadow: "var(--shadow-card)" }
+                    : { background: "transparent", color: "var(--color-bt-text-dim)" }
+                }
+              >
+                <Users size={12} />
+                Poll the Crew
+              </button>
+            </div>
+
+            {!hasCrew && (
+              <p className="mt-2 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Add crew members first —{" "}
+                <button
+                  type="button"
+                  onClick={() => onTabChange?.("crew")}
+                  className="font-semibold underline"
+                  style={{ color: "var(--color-bt-accent)", background: "transparent", border: "none" }}
+                >
+                  go to Crew tab →
+                </button>
+              </p>
+            )}
+          </div>
+
+          {/* Body */}
+          {dateMode === "set" ? (
+            <div className="border-t px-3 pb-3 pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
+              <p className="mb-2 text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Already know the dates? Lock them in directly.
+              </p>
+              <div className="flex flex-wrap items-end gap-2">
+                <div className="min-w-[140px] flex-1">
+                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                    Start date
+                  </label>
+                  <input
+                    type="date"
+                    value={directStart}
+                    onChange={(e) => setDirectStart(e.target.value)}
+                    className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+                    style={{
+                      background: "var(--color-bt-base)",
+                      borderColor: "var(--color-bt-border)",
+                      color: "var(--color-bt-text)",
+                    }}
+                  />
+                </div>
+                <div className="min-w-[140px] flex-1">
+                  <label className="mb-1 block text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                    End date
+                  </label>
+                  <input
+                    type="date"
+                    value={directEnd}
+                    onChange={(e) => setDirectEnd(e.target.value)}
+                    className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+                    style={{
+                      background: "var(--color-bt-base)",
+                      borderColor: "var(--color-bt-border)",
+                      color: "var(--color-bt-text)",
+                    }}
+                  />
+                </div>
+                {!confirmClearPoll && (
+                  <button
+                    type="button"
+                    onClick={handleSet}
+                    disabled={
+                      !directStart ||
+                      !directEnd ||
+                      directStart >= directEnd ||
+                      lockDates.isPending
+                    }
+                    className="flex-shrink-0 rounded-lg px-4 py-1.5 text-sm font-semibold disabled:opacity-40"
+                    style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                  >
+                    Set
+                  </button>
+                )}
+              </div>
+
+              {confirmClearPoll && (
+                <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2 text-[13px]"
+                  style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}
+                >
+                  <span style={{ color: "var(--color-bt-text)" }}>
+                    This will clear the poll. Are you sure?
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmClearPoll(false)}
+                    className="ml-auto rounded-lg px-3 py-1 text-xs font-semibold"
+                    style={{ color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSet}
+                    disabled={lockDates.isPending || setPollActive.isPending}
+                    className="rounded-lg px-3 py-1 text-xs font-semibold disabled:opacity-40"
+                    style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                  >
+                    Confirm
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : hasCrew ? (
+            <div className="border-t px-3 pb-3 pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
+              <DatePollCard
+                trip={trip}
+                isOwner={isOwner}
+                onManageCrew={canEdit && onTabChange ? () => onTabChange("crew") : undefined}
+              />
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      {/* ── View Itinerary ─────────────────────────────────────────────── */}
+      {isOwner && (
+        <div>
+          <button
+            type="button"
+            data-testid="view-itinerary-btn"
+            disabled={!allResolved}
+            onClick={allResolved ? onAdvanceToGoing : undefined}
+            className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-4 text-base font-bold"
+            style={
+              allResolved
+                ? {
+                    background: "var(--color-bt-accent)",
+                    color: "var(--color-bt-base)",
+                    border: "1px solid var(--color-bt-accent)",
+                    cursor: "pointer",
+                  }
+                : {
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-border)",
+                    cursor: "not-allowed",
+                  }
+            }
+          >
+            View Itinerary
+            <ArrowRight size={16} />
+          </button>
+          <p className="mt-2 text-center text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+            {allResolved ? (
+              <>
+                Everything&apos;s set —{" "}
+                <span style={{ color: "var(--color-bt-accent)" }}>let&apos;s make it official</span>
+              </>
+            ) : (
+              "Complete or skip all four areas to continue"
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -290,14 +290,16 @@ export function PlanningGrid({
 
   // ── Data fetching ──────────────────────────────────────────────────────
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
-  const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId });
+  const { data: logisticsItems = [] } = trpc.logistics.list.useQuery({ tripId });
   const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId });
 
   // ── Derived counts + locked date ───────────────────────────────────────
   const crewCount = members.length;
   const hasCrew = crewCount > 1; // more than just the owner
 
-  const lodgingItems = (reservations as Array<{ type: string; is_confirmed?: boolean | null }>).filter(
+  // Lodging lives on the logistics_items table under type='lodging';
+  // reservations is for tee-times/restaurants/transport.
+  const lodgingItems = (logisticsItems as Array<{ type: string; is_confirmed?: boolean | null }>).filter(
     (r) => r.type === "lodging",
   );
   const lodgingCount = lodgingItems.length;

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -4,10 +4,10 @@ import { useEffect, useMemo, useState } from "react";
 import {
   ArrowRight,
   Calendar,
-  CalendarDays,
+  CalendarRange,
   Check,
   ChevronRight,
-  Home,
+  Hotel,
   Users,
   X,
 } from "lucide-react";
@@ -88,7 +88,7 @@ interface TileProps {
   label: string;
   state: TileState;
   /** Visual-only override — true when the dates tile has its accordion
-   *  expanded, so it picks up the complete-styling without being complete. */
+   *  expanded, so it picks up the active styling. */
   isActive?: boolean;
   /** Empty-state body. */
   emptyDescription: string;
@@ -103,6 +103,8 @@ interface TileProps {
   onSkip: () => void;
   onUnskip: () => void;
   skipping: boolean;
+  /** Optional warning shown below "Not needed for this trip" when skipped. */
+  skippedNudge?: React.ReactNode;
   testId?: string;
 }
 
@@ -120,10 +122,13 @@ function Tile({
   onSkip,
   onUnskip,
   skipping,
+  skippedNudge,
   testId,
 }: TileProps) {
   const styling = stylingForState(state, !!isActive);
-  const clickable = state === "empty" && !!onClick;
+  // All tiles are navigable regardless of state — checkmark means "addressed",
+  // not "locked". onClick prop being set is the only gate.
+  const clickable = !!onClick;
 
   return (
     <div
@@ -196,11 +201,14 @@ function Tile({
           )}
         </>
       ) : state === "skipped" ? (
-        <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          Skipped
-        </p>
+        <div className="space-y-1">
+          <p className="text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
+            Not needed for this trip
+          </p>
+          {skippedNudge}
+        </div>
       ) : (
-        <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        <p className="text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
           {emptyDescription}
         </p>
       )}
@@ -339,9 +347,9 @@ export function PlanningGrid({
   const [datesPanelOpen, setDatesPanelOpen] = useState(false);
   const [dateMode, setDateMode] = useState<"set" | "poll">(pollMode ? "poll" : "set");
 
-  // Close the panel when the user resolves dates (locked or skipped).
+  // Close the panel when the user skips dates.
   useEffect(() => {
-    if (datesState === "complete" || datesState === "skipped") {
+    if (datesState === "skipped") {
       setDatesPanelOpen(false);
     }
   }, [datesState]);
@@ -407,18 +415,23 @@ export function PlanningGrid({
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <div className="space-y-4">
+      {/* Orientation copy — always visible */}
+      <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        Destination locked in — now let&apos;s get the details sorted.
+      </p>
+
       <div className="grid grid-cols-2 gap-2.5 sm:gap-3">
         <Tile
           testId="planning-tile-dates"
-          icon={Calendar}
+          icon={CalendarRange}
           label="Dates"
           state={datesState}
-          isActive={datesPanelOpen && datesState === "empty"}
+          isActive={datesPanelOpen}
           emptyDescription="Not set yet"
           emptyCTA="Set dates"
           completeValue={lockedDateLabel ?? undefined}
           canEdit={canEdit}
-          onClick={canEdit && datesState === "empty" ? () => setDatesPanelOpen((v) => !v) : undefined}
+          onClick={canEdit ? () => setDatesPanelOpen((v) => !v) : undefined}
           onSkip={() => handleSkip("dates")}
           onUnskip={() => handleUnskip("dates")}
           skipping={pendingTile === "dates"}
@@ -439,7 +452,7 @@ export function PlanningGrid({
         />
         <Tile
           testId="planning-tile-lodging"
-          icon={Home}
+          icon={Hotel}
           label="Lodging"
           state={lodgingState}
           emptyDescription="Nothing added yet"
@@ -459,10 +472,17 @@ export function PlanningGrid({
           onSkip={() => handleSkip("lodging")}
           onUnskip={() => handleUnskip("lodging")}
           skipping={pendingTile === "lodging"}
+          skippedNudge={
+            lodgingState === "skipped" && crewState === "complete" ? (
+              <p className="text-[11px]" style={{ color: "var(--color-bt-warning)" }}>
+                Your crew won&apos;t know where you&apos;re staying
+              </p>
+            ) : undefined
+          }
         />
         <Tile
           testId="planning-tile-schedule"
-          icon={CalendarDays}
+          icon={Calendar}
           label="Schedule"
           state={scheduleState}
           emptyDescription="Nothing planned yet"
@@ -473,11 +493,18 @@ export function PlanningGrid({
           onSkip={() => handleSkip("schedule")}
           onUnskip={() => handleUnskip("schedule")}
           skipping={pendingTile === "schedule"}
+          skippedNudge={
+            scheduleState === "skipped" && crewState === "complete" ? (
+              <p className="text-[11px]" style={{ color: "var(--color-bt-warning)" }}>
+                Your crew won&apos;t know what&apos;s planned
+              </p>
+            ) : undefined
+          }
         />
       </div>
 
       {/* ── Dates accordion ─────────────────────────────────────────────── */}
-      {datesPanelOpen && canEdit && datesState === "empty" && (
+      {datesPanelOpen && canEdit && (
         <div
           className="overflow-hidden rounded-xl"
           style={{
@@ -504,7 +531,7 @@ export function PlanningGrid({
                     : { background: "transparent", color: "var(--color-bt-text-dim)" }
                 }
               >
-                <Calendar size={12} />
+                <CalendarRange size={12} />
                 Pick your Dates
               </button>
               <button
@@ -637,19 +664,28 @@ export function PlanningGrid({
 
       {/* ── View Itinerary ─────────────────────────────────────────────── */}
       {isOwner && (
-        <div>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+            {allResolved ? (
+              <>
+                Everything&apos;s set —{" "}
+                <span style={{ color: "var(--color-bt-accent)" }}>let&apos;s make it official</span>
+              </>
+            ) : (
+              "Complete or skip all four areas to continue"
+            )}
+          </p>
           <button
             type="button"
             data-testid="view-itinerary-btn"
             disabled={!allResolved}
             onClick={allResolved ? onAdvanceToGoing : undefined}
-            className="flex w-full items-center justify-center gap-2 rounded-xl px-6 py-4 text-base font-bold"
+            className="flex flex-shrink-0 items-center gap-1.5 rounded-xl px-4 py-2 text-sm font-semibold"
             style={
               allResolved
                 ? {
                     background: "var(--color-bt-accent)",
                     color: "var(--color-bt-base)",
-                    border: "1px solid var(--color-bt-accent)",
                     cursor: "pointer",
                   }
                 : {
@@ -661,21 +697,10 @@ export function PlanningGrid({
             }
           >
             View Itinerary
-            <ArrowRight size={16} />
+            <ArrowRight size={14} />
           </button>
-          <p className="mt-2 text-center text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-            {allResolved ? (
-              <>
-                Everything&apos;s set —{" "}
-                <span style={{ color: "var(--color-bt-accent)" }}>let&apos;s make it official</span>
-              </>
-            ) : (
-              "Complete or skip all four areas to continue"
-            )}
-          </p>
         </div>
       )}
     </div>
   );
 }
-

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { formatDateRangeCompact } from "@/lib/dates";
+import { formatDateRangeCompact, fmtTime12 } from "@/lib/dates";
 import type { TripData } from "../types";
 import { DatePollCard } from "./DatePollCard";
 
@@ -31,57 +31,55 @@ export interface PlanningGridProps {
   onAdvanceToGoing?: () => void;
 }
 
-// ── Tile primitives ───────────────────────────────────────────────────────
+// ── Tile styling helpers ──────────────────────────────────────────────────
 
-interface TileStyling {
-  background: string;
-  border: string;
-  opacity: number;
-  iconBg: string;
-  iconColor: string;
-  labelColor: string;
-}
+/** CSS class string for the tile wrapper — handles hover states via className
+ *  so Tailwind hover variants can override them (style prop can't be hovered). */
+function tileWrapperClass(
+  state: TileState,
+  isActive: boolean,
+  clickable: boolean,
+): string {
+  const shared =
+    "group relative flex flex-col rounded-xl border p-3 transition-all duration-150";
+  const cursor = clickable ? "cursor-pointer" : "cursor-default";
 
-function stylingForState(state: TileState, isActive: boolean): TileStyling {
   if (isActive) {
-    return {
-      background: "var(--color-bt-accent-faint)",
-      border: "1px solid var(--color-bt-accent-border)",
-      opacity: 1,
-      iconBg: "var(--color-bt-accent-faint)",
-      iconColor: "var(--color-bt-accent)",
-      labelColor: "var(--color-bt-accent)",
-    };
+    // Dates panel open — accent styling, no hover needed
+    return `${shared} ${cursor} bg-[var(--color-bt-accent-faint)] border-[var(--color-bt-accent-border)]`;
   }
   if (state === "complete") {
+    // Teal tint base; subtle ring on hover to signal interactivity
+    return `${shared} ${cursor} bg-[var(--color-bt-accent-faint)] border-[var(--color-bt-accent-border)] hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]`;
+  }
+  if (state === "skipped") {
+    // Dimmed — no hover affordance
+    return `${shared} ${cursor} bg-[var(--color-bt-card)] border-[var(--color-bt-border)] opacity-60`;
+  }
+  // empty — raised background + accent border on hover
+  return `${shared} ${cursor} bg-[var(--color-bt-card)] border-[var(--color-bt-border)] hover:bg-[var(--color-bt-card-raised)] hover:border-[var(--color-bt-accent-border)]`;
+}
+
+/** Icon and label colors only (background/border handled via className above). */
+function iconLabelColors(
+  state: TileState,
+  isActive: boolean,
+): { iconBg: string; iconColor: string; labelColor: string } {
+  if (isActive || state === "complete") {
     return {
-      background: "var(--color-bt-accent-faint)",
-      border: "1px solid var(--color-bt-accent-border)",
-      opacity: 1,
       iconBg: "var(--color-bt-accent-faint)",
       iconColor: "var(--color-bt-accent)",
       labelColor: "var(--color-bt-accent)",
-    };
-  }
-  if (state === "skipped") {
-    return {
-      background: "var(--color-bt-card)",
-      border: "1px solid var(--color-bt-border)",
-      opacity: 0.6,
-      iconBg: "var(--color-bt-card-raised)",
-      iconColor: "var(--color-bt-text-dim)",
-      labelColor: "var(--color-bt-text-dim)",
     };
   }
   return {
-    background: "var(--color-bt-card)",
-    border: "1px solid var(--color-bt-border)",
-    opacity: 1,
     iconBg: "var(--color-bt-card-raised)",
     iconColor: "var(--color-bt-text-dim)",
     labelColor: "var(--color-bt-text-dim)",
   };
 }
+
+// ── Tile component ────────────────────────────────────────────────────────
 
 interface TileProps {
   icon: LucideIcon;
@@ -101,7 +99,10 @@ interface TileProps {
   skipping: boolean;
   /** Warning shown below "Not needed for this trip" when skipped + crew complete. */
   skippedNudge?: React.ReactNode;
-  /** Short action label for Edit/Manage link, e.g. "Edit dates", "Manage crew" */
+  /**
+   * Short action label used in the label row for complete tiles, e.g.
+   * "Edit dates", "Manage crew". The " →" arrow is appended automatically.
+   */
   editLabel: string;
   /** Rich preview content — rendered on sm+ breakpoint, hidden on mobile. */
   preview?: React.ReactNode;
@@ -127,7 +128,7 @@ function Tile({
   preview,
   testId,
 }: TileProps) {
-  const styling = stylingForState(state, !!isActive);
+  const colors = iconLabelColors(state, !!isActive);
   // All tiles always navigable — checkmark means "addressed", not locked.
   const clickable = !!onClick;
 
@@ -137,71 +138,69 @@ function Tile({
       data-state={state}
       data-active={isActive ? "true" : undefined}
       onClick={clickable ? onClick : undefined}
-      className="group relative flex flex-col rounded-xl p-3 transition-all duration-150 hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
-      style={{
-        background: styling.background,
-        border: styling.border,
-        opacity: styling.opacity,
-        minHeight: 130,
-        cursor: clickable ? "pointer" : "default",
-      }}
+      className={tileWrapperClass(state, !!isActive, clickable)}
+      style={{ minHeight: 130 }}
     >
-      {/* Top row: icon + badge column (badge + edit/manage link) */}
-      <div className="mb-2 flex items-start justify-between">
+      {/* ── Top row: icon + status badge (ml-auto) ───────────────────── */}
+      <div className="mb-2 flex items-center">
         <span
           className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl"
-          style={{ background: styling.iconBg, color: styling.iconColor }}
+          style={{ background: colors.iconBg, color: colors.iconColor }}
         >
           <Icon size={22} strokeWidth={1.75} />
         </span>
 
-        {/* Right column: status badge + edit link */}
-        <div className="flex flex-col items-end gap-0.5">
-          {state === "complete" && (
-            <span
-              className="flex h-5 w-5 items-center justify-center rounded-full"
-              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-              aria-label="Complete"
-            >
-              <Check size={11} strokeWidth={3} />
-            </span>
-          )}
-          {state === "skipped" && (
-            <span
-              className="flex h-5 w-5 items-center justify-center rounded-full"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text-dim)",
-              }}
-              aria-label="Skipped"
-            >
-              <X size={11} strokeWidth={2.5} />
-            </span>
-          )}
-          {/* Edit/Manage link — always visible on mobile, fades in on desktop hover */}
+        {state === "complete" && (
           <span
-            className="text-[11px] transition-opacity duration-150 lg:opacity-0 lg:group-hover:opacity-100"
+            className="ml-auto flex h-5 w-5 items-center justify-center rounded-full"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            aria-label="Complete"
+          >
+            <Check size={11} strokeWidth={3} />
+          </span>
+        )}
+        {state === "skipped" && (
+          <span
+            className="ml-auto flex h-5 w-5 items-center justify-center rounded-full"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-text-dim)",
+            }}
+            aria-label="Skipped"
+          >
+            <X size={11} strokeWidth={2.5} />
+          </span>
+        )}
+      </div>
+
+      {/* ── Label row: LABEL (left) + Edit link (right, complete-only) ── */}
+      <div className="mb-1 flex items-center justify-between gap-1">
+        <p
+          className="text-[10px] font-bold uppercase tracking-wider"
+          style={{ color: colors.labelColor }}
+        >
+          {label}
+        </p>
+        {/* Edit link — visible on mobile, fades in on desktop hover */}
+        {state === "complete" && (
+          <span
+            className="flex-shrink-0 text-[11px] opacity-100 transition-opacity duration-150 sm:opacity-0 sm:group-hover:opacity-100"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             {editLabel} →
           </span>
-        </div>
+        )}
       </div>
 
-      {/* Label */}
-      <p
-        className="mb-1 text-[10px] font-bold uppercase tracking-wider"
-        style={{ color: styling.labelColor }}
-      >
-        {label}
-      </p>
-
-      {/* Body */}
+      {/* ── Body ─────────────────────────────────────────────────────── */}
       {state === "complete" ? (
         <>
           {completeValue && (
-            <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            <p
+              className="truncate text-sm font-semibold"
+              style={{ color: "var(--color-bt-text)" }}
+            >
               {completeValue}
             </p>
           )}
@@ -224,14 +223,14 @@ function Tile({
         </p>
       )}
 
-      {/* Rich preview — hidden on mobile, shown on sm+ */}
+      {/* ── Rich preview — hidden mobile, shown sm+ ───────────────────── */}
       {preview && (
-        <div className="mt-2 hidden flex-col gap-1.5 sm:flex">
+        <div className="mt-2 hidden min-h-0 flex-1 flex-col gap-1.5 sm:flex">
           {preview}
         </div>
       )}
 
-      {/* Footer */}
+      {/* ── Footer: CTA + Skip (empty) | Undo skip (skipped) ─────────── */}
       <div className="mt-auto flex items-end justify-between gap-2 pt-2">
         {state === "empty" && (
           <>
@@ -268,11 +267,6 @@ function Tile({
             )}
           </>
         )}
-        {state === "complete" && (
-          <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            {editLabel} →
-          </span>
-        )}
         {state === "skipped" && canEdit && (
           <button
             type="button"
@@ -307,7 +301,7 @@ function initials(name: string): string {
   return (words[0][0]! + words[1][0]!).toUpperCase();
 }
 
-// ── Typed member / item shapes ────────────────────────────────────────────
+// ── Typed shapes for local casts ──────────────────────────────────────────
 
 interface GridMember {
   memberId: string;
@@ -331,16 +325,28 @@ interface GridScheduleItem {
   is_confirmed: boolean;
 }
 
+interface GridPollVote {
+  window_id: string;
+  user_id: string;
+  answer: string;
+}
+
+interface GridPollWindow {
+  id: string;
+  start_date: string;
+  end_date: string;
+  votes: GridPollVote[];
+}
+
 // ── Main grid ─────────────────────────────────────────────────────────────
 
 /**
  * PlanningGrid — the Home tab surface during the PLANNING stage.
  *
- * Four tiles (Dates / Crew / Lodging / Schedule) in a 2×2 grid.
- * Each tile has three states: empty, complete, skipped. The Dates tile
- * opens an inline accordion below the grid with "Pick Dates" / "Poll the
- * Crew" segments. Below everything, a "View Itinerary" button advances
- * the trip to going once every tile is either complete or skipped.
+ * Four tiles (Dates / Crew / Lodging / Schedule) in a responsive grid:
+ * 1-col on mobile, 2×2 on tablet, 4×1 on desktop.
+ * Each tile has three states: empty, complete, skipped.
+ * The Dates tile opens an inline accordion below the grid.
  */
 export function PlanningGrid({
   trip,
@@ -357,7 +363,7 @@ export function PlanningGrid({
   const { data: logisticsItems = [] } = trpc.logistics.list.useQuery({ tripId });
   const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId });
 
-  // ── Typed data ─────────────────────────────────────────────────────────
+  // ── Typed casts ────────────────────────────────────────────────────────
   const typedMembers = members as unknown as GridMember[];
   const typedLogistics = logisticsItems as unknown as GridLogisticsItem[];
   const typedSchedule = scheduleItems as unknown as GridScheduleItem[];
@@ -410,9 +416,9 @@ export function PlanningGrid({
     { enabled: pollMode && datesState !== "complete" },
   );
 
-  // ── Dates accordion — persisted to localStorage so it survives tab switches ──
+  // ── Dates accordion — persisted to localStorage ────────────────────────
   const storageKey = `bt-dates-panel-open-${tripId}`;
-  const [datesPanelOpen, setDatesPanelOpen] = useState(() => {
+  const [datesPanelOpen, setDatesPanelOpen] = useState<boolean>(() => {
     try {
       return localStorage.getItem(storageKey) === "true";
     } catch {
@@ -499,39 +505,82 @@ export function PlanningGrid({
 
   // ── Rich tile previews ─────────────────────────────────────────────────
 
-  // Dates: show poll vote pips when poll is active and windows exist.
+  // Dates: per-member vote pips when poll is active.
   const datesPreview = useMemo(() => {
-    if (!pollMode || !datePoll || datePoll.windows.length === 0) return null;
+    if (!pollMode || !datePoll) return null;
+    const pollWindows = datePoll.windows as unknown as GridPollWindow[];
+    if (pollWindows.length === 0) return null;
+    // Only members with an account can vote.
+    const votableMembers = typedMembers.filter((m) => m.user_id !== null);
     return (
       <div className="space-y-1">
-        {datePoll.windows.slice(0, 3).map((w) => {
-          const yes = w.votes.filter((v: { answer: string }) => v.answer === "yes").length;
-          const maybe = w.votes.filter((v: { answer: string }) => v.answer === "maybe").length;
-          const no = w.votes.filter((v: { answer: string }) => v.answer === "no").length;
-          return (
-            <div key={w.id} className="flex items-center gap-1.5">
-              <span
-                className="flex-1 truncate text-[11px]"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                {formatDateRangeCompact(w.start_date, w.end_date)}
-              </span>
-              <div className="flex items-center gap-1 text-[10px] font-semibold">
-                <span style={{ color: "var(--color-bt-accent)" }}>✓{yes}</span>
-                <span style={{ color: "var(--color-bt-warning)" }}>~{maybe}</span>
-                <span style={{ color: "var(--color-bt-danger)" }}>✕{no}</span>
-              </div>
+        {pollWindows.slice(0, 3).map((w) => (
+          <div
+            key={w.id}
+            className="flex items-center gap-2 rounded-lg px-2 py-1"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            <span
+              className="flex-1 truncate text-[11px] font-medium"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              {formatDateRangeCompact(w.start_date, w.end_date)}
+            </span>
+            <div className="flex gap-0.5">
+              {votableMembers.slice(0, 6).map((m) => {
+                const vote = w.votes.find((v) => v.user_id === m.user_id);
+                const answer = vote?.answer ?? null;
+                const pipBg =
+                  answer === "yes"
+                    ? "var(--color-bt-accent-faint)"
+                    : answer === "maybe"
+                      ? "var(--color-bt-warning-faint)"
+                      : answer === "no"
+                        ? "var(--color-bt-danger-faint)"
+                        : "var(--color-bt-card-raised)";
+                const pipColor =
+                  answer === "yes"
+                    ? "var(--color-bt-accent)"
+                    : answer === "maybe"
+                      ? "var(--color-bt-warning)"
+                      : answer === "no"
+                        ? "var(--color-bt-danger)"
+                        : "var(--color-bt-text-dim)";
+                const pipLabel =
+                  answer === "yes" ? "✓" : answer === "maybe" ? "~" : answer === "no" ? "✗" : "?";
+                return (
+                  <div
+                    key={m.memberId}
+                    className="flex h-4 w-4 items-center justify-center rounded text-[9px] font-bold"
+                    style={{ background: pipBg, color: pipColor }}
+                    title={m.displayName}
+                  >
+                    {pipLabel}
+                  </div>
+                );
+              })}
+              {votableMembers.length > 6 && (
+                <span
+                  className="text-[10px]"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  +{votableMembers.length - 6}
+                </span>
+              )}
             </div>
-          );
-        })}
-        {datePoll.windows.length > 3 && (
+          </div>
+        ))}
+        {pollWindows.length > 3 && (
           <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            +{datePoll.windows.length - 3} more options
+            +{pollWindows.length - 3} more options
           </p>
         )}
       </div>
     );
-  }, [pollMode, datePoll]);
+  }, [pollMode, datePoll, typedMembers]);
 
   // Crew: avatar chips + planner count + missing email tally.
   const crewPreview = useMemo(() => {
@@ -544,10 +593,9 @@ export function PlanningGrid({
           {visible.map((m) => (
             <span
               key={m.memberId}
-              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-[9px] font-bold"
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-[9px] font-semibold"
               style={{
-                background: "var(--color-bt-accent-faint)",
-                border: "1px solid var(--color-bt-accent-border)",
+                background: "var(--color-bt-card-raised)",
                 color: "var(--color-bt-accent)",
               }}
               title={m.displayName}
@@ -560,7 +608,7 @@ export function PlanningGrid({
               className="flex h-6 items-center justify-center rounded-full px-1.5 text-[9px] font-bold"
               style={{
                 background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
+                border: "1px dashed var(--color-bt-border)",
                 color: "var(--color-bt-text-dim)",
               }}
             >
@@ -594,7 +642,7 @@ export function PlanningGrid({
         {visible.map((item, i) => (
           <div
             key={item.id ?? i}
-            className="flex items-center gap-1.5 rounded-lg px-2 py-1"
+            className="flex items-center gap-2 rounded-lg px-2 py-1"
             style={{
               background: item.is_confirmed
                 ? "var(--color-bt-accent-faint)"
@@ -606,7 +654,7 @@ export function PlanningGrid({
               }`,
             }}
           >
-            <span
+            <div
               className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
               style={{
                 background: item.is_confirmed
@@ -615,17 +663,25 @@ export function PlanningGrid({
               }}
             />
             <span
-              className="flex-1 truncate text-[11px]"
+              className="flex-1 truncate text-xs font-medium"
               style={{ color: "var(--color-bt-text)" }}
             >
               {item.property_name ?? "Lodging option"}
             </span>
             <span
-              className="flex-shrink-0 text-[10px]"
+              className="flex-shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
               style={{
+                background: item.is_confirmed
+                  ? "var(--color-bt-accent-faint)"
+                  : "var(--color-bt-warning-faint)",
                 color: item.is_confirmed
                   ? "var(--color-bt-accent)"
                   : "var(--color-bt-warning)",
+                border: `1px solid ${
+                  item.is_confirmed
+                    ? "var(--color-bt-accent-border)"
+                    : "var(--color-bt-warning-border)"
+                }`,
               }}
             >
               {item.is_confirmed ? "confirmed" : "pending"}
@@ -633,9 +689,9 @@ export function PlanningGrid({
           </div>
         ))}
         {extra > 0 && (
-          <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          <span className="pl-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
             +{extra} more
-          </p>
+          </span>
         )}
       </div>
     );
@@ -649,8 +705,8 @@ export function PlanningGrid({
     return (
       <div className="space-y-1">
         {visible.map((item) => (
-          <div key={item.id} className="flex items-center gap-1.5">
-            <span
+          <div key={item.id} className="flex items-center gap-2">
+            <div
               className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
               style={{
                 background: item.is_confirmed
@@ -659,7 +715,7 @@ export function PlanningGrid({
               }}
             />
             <span
-              className="flex-1 truncate text-[11px]"
+              className="flex-1 truncate text-xs"
               style={{
                 color: item.is_confirmed
                   ? "var(--color-bt-text)"
@@ -670,18 +726,18 @@ export function PlanningGrid({
             </span>
             {item.scheduled_time && (
               <span
-                className="flex-shrink-0 text-[10px]"
+                className="flex-shrink-0 text-[11px]"
                 style={{ color: "var(--color-bt-text-dim)" }}
               >
-                {item.scheduled_time}
+                {fmtTime12(item.scheduled_time)}
               </span>
             )}
           </div>
         ))}
         {extra > 0 && (
-          <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          <span className="pl-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
             +{extra} more
-          </p>
+          </span>
         )}
       </div>
     );
@@ -698,16 +754,13 @@ export function PlanningGrid({
         >
           Planning
         </h2>
-        <p
-          className="text-[13px] leading-relaxed"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
+        <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
           Destination locked in — now let&apos;s get the details sorted.
         </p>
       </div>
 
-      {/* ── 2×2 tile grid ─────────────────────────────────────────────── */}
-      <div className="grid grid-cols-2 gap-2.5 sm:gap-3">
+      {/* ── Responsive grid: 1-col → 2×2 → 4×1 ──────────────────────── */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <Tile
           testId="planning-tile-dates"
           icon={CalendarRange}
@@ -771,9 +824,12 @@ export function PlanningGrid({
           skipping={pendingTile === "lodging"}
           skippedNudge={
             lodgingState === "skipped" && crewState === "complete" ? (
-              <p className="text-[11px]" style={{ color: "var(--color-bt-warning)" }}>
+              <span
+                className="mt-1 block text-[11px]"
+                style={{ color: "var(--color-bt-warning)" }}
+              >
                 Your crew won&apos;t know where you&apos;re staying
-              </p>
+              </span>
             ) : undefined
           }
         />
@@ -794,9 +850,12 @@ export function PlanningGrid({
           skipping={pendingTile === "schedule"}
           skippedNudge={
             scheduleState === "skipped" && crewState === "complete" ? (
-              <p className="text-[11px]" style={{ color: "var(--color-bt-warning)" }}>
+              <span
+                className="mt-1 block text-[11px]"
+                style={{ color: "var(--color-bt-warning)" }}
+              >
                 Your crew won&apos;t know what&apos;s planned
-              </p>
+              </span>
             ) : undefined
           }
         />
@@ -1015,7 +1074,7 @@ export function PlanningGrid({
             data-testid="view-itinerary-btn"
             disabled={!allResolved}
             onClick={allResolved ? onAdvanceToGoing : undefined}
-            className="flex flex-shrink-0 items-center gap-1.5 rounded-xl px-4 py-2 text-sm font-semibold"
+            className="flex flex-shrink-0 items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold"
             style={
               allResolved
                 ? {
@@ -1026,7 +1085,7 @@ export function PlanningGrid({
                 : {
                     background: "var(--color-bt-card-raised)",
                     color: "var(--color-bt-text-dim)",
-                    border: "1px solid var(--color-bt-border)",
+                    border: "0.5px solid var(--color-bt-border)",
                     cursor: "not-allowed",
                   }
             }

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -378,18 +378,29 @@ export function PlanningGrid({
   };
 
   // ── Skip / unskip ──────────────────────────────────────────────────────
+  // Track which tile is currently mutating so only that tile's button
+  // dims — otherwise all four buttons would flash together while a single
+  // mutation is in flight.
+  const [pendingTile, setPendingTile] = useState<TileKey | null>(null);
   const skipTile = trpc.trips.skipPlanningTile.useMutation({
-    onSuccess() { utils.trips.getById.invalidate({ tripId }); },
+    onSettled() {
+      setPendingTile(null);
+      utils.trips.getById.invalidate({ tripId });
+    },
   });
   const unskipTile = trpc.trips.unskipPlanningTile.useMutation({
-    onSuccess() { utils.trips.getById.invalidate({ tripId }); },
+    onSettled() {
+      setPendingTile(null);
+      utils.trips.getById.invalidate({ tripId });
+    },
   });
-  const skipping = skipTile.isPending || unskipTile.isPending;
 
   const handleSkip = (tile: TileKey) => {
+    setPendingTile(tile);
     skipTile.mutate({ tripId, tile });
   };
   const handleUnskip = (tile: TileKey) => {
+    setPendingTile(tile);
     unskipTile.mutate({ tripId, tile });
   };
 
@@ -410,7 +421,7 @@ export function PlanningGrid({
           onClick={canEdit && datesState === "empty" ? () => setDatesPanelOpen((v) => !v) : undefined}
           onSkip={() => handleSkip("dates")}
           onUnskip={() => handleUnskip("dates")}
-          skipping={skipping}
+          skipping={pendingTile === "dates"}
         />
         <Tile
           testId="planning-tile-crew"
@@ -424,7 +435,7 @@ export function PlanningGrid({
           onClick={() => onTabChange?.("crew")}
           onSkip={() => handleSkip("crew")}
           onUnskip={() => handleUnskip("crew")}
-          skipping={skipping}
+          skipping={pendingTile === "crew"}
         />
         <Tile
           testId="planning-tile-lodging"
@@ -447,7 +458,7 @@ export function PlanningGrid({
           onClick={() => onTabChange?.("lodging")}
           onSkip={() => handleSkip("lodging")}
           onUnskip={() => handleUnskip("lodging")}
-          skipping={skipping}
+          skipping={pendingTile === "lodging"}
         />
         <Tile
           testId="planning-tile-schedule"
@@ -461,7 +472,7 @@ export function PlanningGrid({
           onClick={() => onTabChange?.("schedule")}
           onSkip={() => handleSkip("schedule")}
           onUnskip={() => handleUnskip("schedule")}
-          skipping={skipping}
+          skipping={pendingTile === "schedule"}
         />
       </div>
 

--- a/src/server/routers/trips.test.ts
+++ b/src/server/routers/trips.test.ts
@@ -545,3 +545,81 @@ describe("trips router — setOwnerAlert", () => {
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });
+
+// ── skipPlanningTile / unskipPlanningTile ────────────────────────────────
+
+describe("trips router — planning tile skip", () => {
+  let ctx: TestContext;
+  let skipTripId: string;
+
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    skipTripId = await ctx.createTrip("Skip Tile Test");
+    await ctx.addTripMember(skipTripId, "planner", "Planner");
+    await ctx.addTripMember(skipTripId, "member", "Member");
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it("skipPlanningTile — planner can skip a tile", async () => {
+    const caller = ctx.callerAs("planner");
+    const res = await caller.trips.skipPlanningTile({
+      tripId: skipTripId,
+      tile: "lodging",
+    });
+    expect(res.planning_skipped).toEqual(["lodging"]);
+  });
+
+  it("skipPlanningTile — idempotent (same tile twice does not duplicate)", async () => {
+    const caller = ctx.callerAs("planner");
+    const res = await caller.trips.skipPlanningTile({
+      tripId: skipTripId,
+      tile: "lodging",
+    });
+    expect(res.planning_skipped).toEqual(["lodging"]);
+  });
+
+  it("skipPlanningTile — stacks multiple tiles", async () => {
+    const caller = ctx.callerAs("planner");
+    const res = await caller.trips.skipPlanningTile({
+      tripId: skipTripId,
+      tile: "schedule",
+    });
+    expect(res.planning_skipped).toEqual(expect.arrayContaining(["lodging", "schedule"]));
+    expect(res.planning_skipped).toHaveLength(2);
+  });
+
+  it("skipPlanningTile — member is FORBIDDEN", async () => {
+    const caller = ctx.callerAs("member");
+    await expect(
+      caller.trips.skipPlanningTile({ tripId: skipTripId, tile: "crew" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("unskipPlanningTile — planner can unskip", async () => {
+    const caller = ctx.callerAs("planner");
+    const res = await caller.trips.unskipPlanningTile({
+      tripId: skipTripId,
+      tile: "lodging",
+    });
+    expect(res.planning_skipped).toEqual(["schedule"]);
+  });
+
+  it("unskipPlanningTile — idempotent on missing tile", async () => {
+    const caller = ctx.callerAs("planner");
+    const res = await caller.trips.unskipPlanningTile({
+      tripId: skipTripId,
+      tile: "dates",
+    });
+    expect(res.planning_skipped).toEqual(["schedule"]);
+  });
+
+  it("unskipPlanningTile — member is FORBIDDEN", async () => {
+    const caller = ctx.callerAs("member");
+    await expect(
+      caller.trips.unskipPlanningTile({ tripId: skipTripId, tile: "schedule" })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/src/server/routers/trips.ts
+++ b/src/server/routers/trips.ts
@@ -1007,4 +1007,102 @@ export const tripsRouter = router({
 
       return data;
     }),
+
+  // -----------------------------------------------------------------------
+  // skipPlanningTile — mark a planning tile as explicitly skipped.
+  //
+  // The planning Home tab renders a 2×2 tile grid (dates/crew/lodging/
+  // schedule). Each can be "empty", "complete" (data present), or
+  // "skipped". Skipped tiles count as resolved for the View Itinerary
+  // gate, letting the owner advance even when an area doesn't apply.
+  //
+  // Storage: trips.planning_skipped is a JSONB array of tile keys.
+  // We do a read-modify-write rather than an array concat so callers can
+  // invoke this idempotently without creating duplicates.
+  // -----------------------------------------------------------------------
+  skipPlanningTile: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        tile: z.enum(["dates", "crew", "lodging", "schedule"]),
+      })
+    )
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: trip, error: fetchErr } = await ctx.supabase
+        .from("trips")
+        .select("planning_skipped")
+        .eq("id", ctx.tripId)
+        .single();
+
+      if (fetchErr || !trip) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Trip not found" });
+      }
+
+      const current: string[] = Array.isArray(trip.planning_skipped)
+        ? (trip.planning_skipped as string[])
+        : [];
+      const next = current.includes(input.tile) ? current : [...current, input.tile];
+
+      const { data, error } = await ctx.supabase
+        .from("trips")
+        .update({ planning_skipped: next })
+        .eq("id", ctx.tripId)
+        .select("id, planning_skipped")
+        .single();
+
+      if (error || !data) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to skip planning tile",
+        });
+      }
+
+      return data;
+    }),
+
+  // -----------------------------------------------------------------------
+  // unskipPlanningTile — remove a tile from the skipped list.
+  // Mirror of skipPlanningTile; idempotent on missing entries.
+  // -----------------------------------------------------------------------
+  unskipPlanningTile: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        tile: z.enum(["dates", "crew", "lodging", "schedule"]),
+      })
+    )
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: trip, error: fetchErr } = await ctx.supabase
+        .from("trips")
+        .select("planning_skipped")
+        .eq("id", ctx.tripId)
+        .single();
+
+      if (fetchErr || !trip) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Trip not found" });
+      }
+
+      const current: string[] = Array.isArray(trip.planning_skipped)
+        ? (trip.planning_skipped as string[])
+        : [];
+      const next = current.filter((t) => t !== input.tile);
+
+      const { data, error } = await ctx.supabase
+        .from("trips")
+        .update({ planning_skipped: next })
+        .eq("id", ctx.tripId)
+        .select("id, planning_skipped")
+        .single();
+
+      if (error || !data) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to unskip planning tile",
+        });
+      }
+
+      return data;
+    }),
 });

--- a/supabase/migrations/20260425015723_055_planning_skipped.sql
+++ b/supabase/migrations/20260425015723_055_planning_skipped.sql
@@ -1,0 +1,21 @@
+-- Migration 055: Planning tile skip state
+--
+-- The planning stage Home tab shows a 2×2 grid (Dates / Crew / Lodging /
+-- Schedule). Each tile can be "complete" (data present), "empty", or
+-- "skipped" — the owner explicitly dismissing that area (flexible dates,
+-- solo trip, camping, unplanned).
+--
+-- Skipped tiles count as "resolved" for the purposes of gating the
+-- "View Itinerary" advance button, so the owner isn't blocked on e.g.
+-- schedule items for a spontaneous weekend.
+--
+-- Travel columns on trip_members already exist (migration 038); no
+-- schema work is needed there.
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS planning_skipped jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- Sanity-check: only four tile keys are ever stored. We don't enforce
+-- this in the database (values are small and server-side-validated), but
+-- the application code should only ever write:
+--   'dates' | 'crew' | 'lodging' | 'schedule'


### PR DESCRIPTION
## Summary
- **Planning stage**: replace the ActionCenter/DatesPanel treatment with a 2×2 tile grid (Dates / Crew / Lodging / Schedule). Each tile has three states — empty, complete, skipped — so a trip can advance even when a whole area doesn't apply (flexible dates, solo trip, camping, unplanned). Tapping the Dates tile opens an inline accordion with "Pick your Dates" / "Poll the Crew" segments; the existing DatePollCard is embedded for the poll path. A gated "View Itinerary" button sits below the grid and unlocks once every tile is complete or skipped.
- **Going/now stage**: replace the ActionCenter + ItineraryPanel pair with a consolidated ItineraryView — owner nudge strip when crew hasn't joined, GettingThereSection for per-user travel, multi-select filter pills (All / Lodging / Travel / Events), and a day-by-day reel from trip.start_date to trip.end_date pulling from the existing buildItinerary aggregator.
- **Schema**: new jsonb column `trips.planning_skipped` stores which tiles the owner has dismissed. Travel columns already exist on `trip_members` (migration 038) so no duplicate work there — the new GettingThereSection writes through `tripMembers.updateTravel`.
- **tRPC**: two new mutations, `skipPlanningTile` and `unskipPlanningTile`, both gated on `requireTripRole("Planner")` and idempotent. 7 new Vitest cases covering happy path, role gating, and dedup.
- **Rename**: TripSummaryModal's advance CTA flipped from "Let's Go! 🎉" → "View Itinerary →". `advanceToGoing` was already `about_message` optional so no gate change was needed.

## Files touched
- `supabase/migrations/20260425015723_055_planning_skipped.sql`
- `src/server/routers/trips.ts` + `trips.test.ts`
- `src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx` (new)
- `src/app/trips/[tripId]/tabs/components/ItineraryView.tsx` (new)
- `src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx` (new)
- `src/app/trips/[tripId]/tabs/HomeTab.tsx` (stage routing)
- `src/app/trips/[tripId]/page.tsx` (onAdvanceToGoing wiring)
- `src/app/trips/[tripId]/components/TripSummaryModal.tsx` (rename)

## Test plan
- [ ] Planning stage Home tab shows 2×2 tile grid; empty tiles show CTA + Skip, complete tiles show teal check + value, skipped tiles dim with Undo skip.
- [ ] Dates tile tap toggles the accordion; accordion shows "Pick your Dates" + "Poll the Crew" segments; poll segment disabled + hint when no crew.
- [ ] Pick-dates inputs + inline Set button lock the trip dates; when a poll is active, a confirm-clear step appears before Set fires.
- [ ] Skip + Undo skip persist via `skipPlanningTile` / `unskipPlanningTile`.
- [ ] View Itinerary button disabled until all four tiles resolve; enabled click opens TripSummaryModal → advance to going.
- [ ] `canEdit=false` members see the grid but no Skip, no dates panel, no View Itinerary.
- [ ] Going/now stage Home tab shows owner nudge (when unlinked crew > 0), GettingThereSection, filter pills, day-by-day reel with today indicator.
- [ ] Filter pills are multi-select; All clears others; deselecting last specific filter re-elects All.
- [ ] `npx tsc --noEmit` clean.
- [ ] `trips.test.ts` skip-tile suite passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)