### PR TITLE
Home tab panel system — going/now stage

### DIFF
--- a/src/app/trips/[tripId]/components/CompetitionStrip.tsx
+++ b/src/app/trips/[tripId]/components/CompetitionStrip.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ChevronRight, Trophy } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface CompetitionStripProps {
+  tripId: string;
+  /** trip.event_id from the parent — if null/undefined, the strip renders nothing. */
+  eventId: string | null | undefined;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * CompetitionStrip — persistent compact leaderboard summary that lives
+ * between the trip header and the tab bar. Visible to all trip members
+ * once a competition exists, regardless of which tab they're on.
+ *
+ * Replaces the live state of the home-tab CompetitionPanel. The panel
+ * still owns the invitation/setup CTA when no competition exists; once
+ * activated, the panel returns null and this strip is the only surface.
+ */
+export function CompetitionStrip({ tripId, eventId }: CompetitionStripProps) {
+  const router = useRouter();
+
+  const { data: event } = trpc.events.getByTrip.useQuery(
+    { tripId },
+    { enabled: !!eventId }
+  );
+
+  const knownEventId = event?.id ?? eventId ?? "";
+  const { data: teams = [] } = trpc.teams.list.useQuery(
+    { tripId, eventId: knownEventId },
+    { enabled: !!knownEventId }
+  );
+  const { data: scoreRows = [] } = trpc.groupResults.listScoresByEvent.useQuery(
+    { tripId, eventId: knownEventId },
+    { enabled: !!knownEventId }
+  );
+
+  if (!eventId || !event) return null;
+
+  const teamTotals = teams
+    .map((t) => ({
+      ...t,
+      total: scoreRows
+        .filter((r) => r.team_id === t.id)
+        .reduce((sum, r) => sum + (r.total_points ?? 0), 0),
+    }))
+    .sort((a, b) => b.total - a.total);
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push(`/trips/${tripId}/leaderboard`)}
+      data-testid="competition-strip"
+      className="w-full overflow-hidden rounded-xl px-3 py-2.5 text-left transition-opacity hover:opacity-90"
+      style={{
+        background: "var(--color-bt-tag-bg)",
+        border: "1px solid var(--color-bt-accent-border)",
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex flex-1 items-center gap-2 min-w-0">
+          <Trophy size={14} style={{ color: "var(--color-bt-accent)", flexShrink: 0 }} />
+          <p
+            className="truncate text-[11px] font-bold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-accent)" }}
+          >
+            {event.title ?? "Competition"}
+          </p>
+        </div>
+
+        {/* Compact team scores — inline, takes minimal horizontal space */}
+        {teamTotals.length > 0 ? (
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {teamTotals.map((team, i) => (
+              <span key={team.id} className="flex items-center gap-1">
+                <span
+                  className="text-[10px] font-bold"
+                  style={{ color: team.color }}
+                >
+                  {team.short_name}
+                </span>
+                <span
+                  className="text-xs font-extrabold tabular-nums"
+                  style={{ color: "var(--color-bt-text)" }}
+                >
+                  {team.total}
+                </span>
+                {i < teamTotals.length - 1 && (
+                  <span
+                    aria-hidden
+                    className="text-[10px]"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    ·
+                  </span>
+                )}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span
+            className="text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            No scores yet
+          </span>
+        )}
+
+        <ChevronRight
+          size={14}
+          style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+        />
+      </div>
+    </button>
+  );
+}

--- a/src/app/trips/[tripId]/components/QuickInfoSection.tsx
+++ b/src/app/trips/[tripId]/components/QuickInfoSection.tsx
@@ -370,10 +370,10 @@ export function QuickInfoSection({
           </p>
         </button>
       ) : (
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-4 gap-2">
           {sortedTiles.map((tile) => {
             const alert = !!tile.is_alert;
-            // Alert tiles span two columns on the 3-col grid so they read
+            // Alert tiles span 2 of 4 columns (half-width) so they read
             // bigger without breaking the layout. They also use warning
             // tokens + left border stripe to match the prior OwnerAlertPanel.
             return (
@@ -408,7 +408,7 @@ export function QuickInfoSection({
                   </span>
                 </div>
                 <p
-                  className={`${alert ? "text-sm" : "text-xs"} font-medium pr-4`}
+                  className="text-sm font-medium pr-4"
                   style={{ color: "var(--color-bt-text)" }}
                 >
                   {tile.value}

--- a/src/app/trips/[tripId]/components/QuickInfoSection.tsx
+++ b/src/app/trips/[tripId]/components/QuickInfoSection.tsx
@@ -75,7 +75,7 @@ function AlertToggle({ value, onChange }: { value: boolean; onChange: (next: boo
 
 // ── AddTileModal ─────────────────────────────────────────────────────────
 
-function AddTileModal({
+export function AddTileModal({
   tripId,
   onClose,
 }: {

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -398,11 +398,12 @@ export default function TripDetailPage() {
       )}
 
       {/* ── Bottom navigation ─────────────────────────────────────────────
-          Only surfaces once a competition exists (or has been unlocked) —
-          that's the point where leaderboard / messages / expenses start
-          carrying their own weight. Until then the trip lives entirely
-          inside the home tab + stage-aware sidebar. */}
-      {showComp && (
+          Only renders once a real competition exists (event_id set), not
+          merely when the user has clicked through the comp setup intent
+          (compUnlocked). Until then, there's nowhere to navigate to —
+          the second nav slot ("Live") would be the only destination, and
+          a bottom nav with one button is wasted chrome. */}
+      {!!trip.event_id && (
         <TripBottomNav tripId={tripId} eventId={trip.event_id} />
       )}
 

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -278,6 +278,7 @@ export default function TripDetailPage() {
                 displayStatus={status}
                 onTabChange={(tab) => setActiveTab(tab as TabId)}
                 onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
+                compActivated={showComp}
                 onOpenChat={() => setChatOpen(true)}
               />
             )}
@@ -362,6 +363,7 @@ export default function TripDetailPage() {
                     displayStatus={status}
                     onTabChange={(tab) => setActiveTab(tab as TabId)}
                     onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
+                compActivated={showComp}
                     onOpenChat={() => setChatOpen(true)}
                     onWriteInvitation={() => setShowWriteInvitationModal(true)}
                     onAdvanceToGoing={isOwner ? () => setShowInvitationModal(true) : undefined}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -21,7 +21,6 @@ import { CompTab } from "./tabs/CompTab";
 import { ExpensesTab } from "./tabs/ExpensesTab";
 import { formatDateRange } from "@/lib/dates";
 import { isReadOnly as checkReadOnly } from "@/lib/tripStatus";
-import { QuickInfoSection } from "./components/QuickInfoSection";
 import { TripSummaryModal } from "./components/TripSummaryModal";
 import { TripInvitationModal } from "./components/TripInvitationModal";
 
@@ -318,14 +317,9 @@ export default function TripDetailPage() {
             />
 
             <div className="mt-4">
-              {/* TODO: stage derivation from trip dates — currently only 'idea'/'planning'/'going' exist
-                   in the DB. 'now' and 'past' are computed status values (getTripStatus), not raw
-                   stage values; the old checks for stage === "now"/"past"/"saved" were unreachable. */}
-              {stage === "going" && (
-                <div className="mb-4">
-                  <QuickInfoSection tripId={tripId} isOwner={isOwner} />
-                </div>
-              )}
+              {/* Quick Info has moved into the home tab panel system —
+                   no longer rendered above the tab bar. The QuickInfoSection
+                   data hooks are still used by QuickInfoPanel inside HomeTab. */}
               {stage !== "planning" && (
                 <TripTabBar
                   activeTab={activeTab}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -23,6 +23,7 @@ import { formatDateRange } from "@/lib/dates";
 import { isReadOnly as checkReadOnly } from "@/lib/tripStatus";
 import { TripSummaryModal } from "./components/TripSummaryModal";
 import { TripInvitationModal } from "./components/TripInvitationModal";
+import { CompetitionStrip } from "./components/CompetitionStrip";
 
 // ── TripDetailPage ────────────────────────────────────────────────────────
 
@@ -320,6 +321,16 @@ export default function TripDetailPage() {
               {/* Quick Info has moved into the home tab panel system —
                    no longer rendered above the tab bar. The QuickInfoSection
                    data hooks are still used by QuickInfoPanel inside HomeTab. */}
+
+              {/* Competition strip — persistent across all tabs once a comp
+                   is set up. Replaces the home-tab CompetitionPanel's live
+                   state so the leaderboard is reachable from any tab. */}
+              {trip.event_id && stage !== "idea" && stage !== "planning" && (
+                <div className="mb-3">
+                  <CompetitionStrip tripId={tripId} eventId={trip.event_id} />
+                </div>
+              )}
+
               {stage !== "planning" && (
                 <TripTabBar
                   activeTab={activeTab}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Ghost, Mail, X, Crown, ChevronDown, Plus, Trash2 } from "lucide-react";
+import { Ghost, Mail, X, Crown, ChevronDown, Plus, Trash2, Users } from "lucide-react";
 import { UserAvatar } from "@/components/UserAvatar";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -322,26 +322,28 @@ function AddSomeoneRow({ tripId, onAdded }: { tripId: string; onAdded: () => voi
   };
 
   if (!isExpanded) {
+    // Pattern 1 button — matches Schedule "Item", Lodging "Property",
+    // Receipts "Receipt" styling so add-affordances are consistent
+    // across tabs.
     return (
       <button
         onClick={() => setIsExpanded(true)}
-        className="flex w-full items-center gap-3 py-2.5 px-3 transition-colors hover:bg-[var(--color-bt-hover)]"
-        style={{ color: "var(--color-bt-text-dim)" }}
+        className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          color: "var(--color-bt-text)",
+          border: "1px solid var(--color-bt-border)",
+        }}
       >
-        <div
-          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
-          style={{ border: "1px dashed var(--color-bt-border)" }}
-        >
-          <Plus size={14} />
-        </div>
-        <span className="text-sm">Add someone</span>
+        <Users size={15} />
+        <Plus size={12} /> Crew member
       </button>
     );
   }
 
   return (
     <div
-      className="space-y-2 rounded-lg px-3 py-2.5 my-1"
+      className="space-y-2 rounded-xl px-3 py-2.5"
       style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
     >
       <div className="flex gap-2">
@@ -511,6 +513,18 @@ export function CrewTab({ trip, embedded }: TabProps & { embedded?: boolean }) {
                 </div>
               )}
             </div>
+            {/* Add affordance — Pattern 1 button matching Schedule /
+                Lodging / Receipts add-on-top buttons. Placed above the
+                crew list (out of the list card) so it reads as a
+                top-level "add to this section" affordance, not a list row. */}
+            {isOwner && (
+              <div className="mb-2">
+                <AddSomeoneRow
+                  tripId={tripId}
+                  onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
+                />
+              </div>
+            )}
             <div
               className="overflow-hidden rounded-xl"
               style={{
@@ -533,13 +547,6 @@ export function CrewTab({ trip, embedded }: TabProps & { embedded?: boolean }) {
                   />
                 );
               })}
-              {isOwner && (
-                <AddSomeoneRow
-                  tripId={tripId}
-                  onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-                />
-              )}
-
               {crewSorted.length === 0 && !isOwner && (
                 <p className="py-4 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
                   No crew members yet.

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -409,6 +409,15 @@ export function CrewTab({ trip, embedded }: TabProps & { embedded?: boolean }) {
 
   return (
     <div className={embedded ? "@container" : "@container px-4"}>
+      {!embedded && (
+        <h2
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Crew
+        </h2>
+      )}
+
       {/* ── Unlinked crew nudge — spans full width above the grid ── */}
       {isOwner && unlinkedCount > 0 && (
         <div

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -20,11 +20,12 @@ export function HomeTab({
   isOwner,
   onTabChange,
   onEnableComp,
+  compActivated,
   onOpenChat,
   onWriteInvitation,
   onAdvanceToGoing,
   actionCenterTitleAction,
-}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void; onAdvanceToGoing?: () => void; actionCenterTitleAction?: React.ReactNode }) {
+}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; compActivated?: boolean; onOpenChat?: () => void; onWriteInvitation?: () => void; onAdvanceToGoing?: () => void; actionCenterTitleAction?: React.ReactNode }) {
   trpc.ideas.list.useQuery({ tripId: trip.id });
   const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId: trip.id });
   const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId: trip.id });
@@ -112,7 +113,7 @@ export function HomeTab({
           />
           <CompetitionPanel
             isOwner={!!isOwner}
-            isActivated={!!trip.event_id}
+            isActivated={!!trip.event_id || !!compActivated}
             onSetupComp={onEnableComp}
           />
         </>
@@ -133,7 +134,7 @@ export function HomeTab({
           />
           <CompetitionPanel
             isOwner={!!isOwner}
-            isActivated={!!trip.event_id}
+            isActivated={!!trip.event_id || !!compActivated}
             onSetupComp={onEnableComp}
           />
         </>

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -111,7 +111,6 @@ export function HomeTab({
             isOwner={!!isOwner}
           />
           <CompetitionPanel
-            tripId={trip.id}
             isOwner={!!isOwner}
             isActivated={!!trip.event_id}
             onSetupComp={onEnableComp}
@@ -133,7 +132,6 @@ export function HomeTab({
             onTabChange={onTabChange}
           />
           <CompetitionPanel
-            tripId={trip.id}
             isOwner={!!isOwner}
             isActivated={!!trip.event_id}
             onSetupComp={onEnableComp}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -92,6 +92,12 @@ export function HomeTab({
               tab (with a dot on the tab bar) — do not surface it here. */}
       {stage === "going" && (status === "going" || status === "now") && (
         <>
+          {/* Quick Info first — most-glanced surface (door codes, addresses
+              etc.); pin it above the larger Itinerary panel.                */}
+          <QuickInfoPanel
+            tripId={trip.id}
+            isOwner={!!isOwner}
+          />
           <ItineraryPanel
             tripId={trip.id}
             trip={trip}
@@ -106,10 +112,6 @@ export function HomeTab({
             isActivated={!!trip.getting_there_enabled}
             hasDates={!!trip.start_date}
             onOpenDatesModal={() => onTabChange?.("schedule")}
-          />
-          <QuickInfoPanel
-            tripId={trip.id}
-            isOwner={!!isOwner}
           />
           <CompetitionPanel
             isOwner={!!isOwner}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -1,289 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import {
-  ChevronRight,
-  Trophy,
-  Check,
-} from "lucide-react";
-import { useRouter } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
 import { getTripStatus } from "@/components/StatusBadge";
-import { useModalBackButton } from "@/hooks/useModalBackButton";
 import IdeaZonePanel from "../components/IdeaZonePanel";
-import { ItineraryPanel } from "../components/ItineraryPanel";
+import { ItineraryPanel as LegacyItineraryPanel } from "../components/ItineraryPanel";
 import { PlanningGrid } from "./components/PlanningGrid";
-import { ItineraryView } from "./components/ItineraryView";
+import { ItineraryPanel } from "./components/panels/ItineraryPanel";
+import { GettingTherePanel } from "./components/panels/GettingTherePanel";
+import { QuickInfoPanel } from "./components/panels/QuickInfoPanel";
+import { CompetitionPanel } from "./components/panels/CompetitionPanel";
 import type { TripDisplayStatus } from "@/lib/tripStatus";
-import type { TabProps, TripData } from "./types";
-
-// ── Competition Preview Modal ─────────────────────────────────────────────
-
-function CompetitionPreviewModal({
-  onConfirm,
-  onDismiss,
-}: {
-  onConfirm: () => void;
-  onDismiss: () => void;
-}) {
-  useModalBackButton(onDismiss);
-  const mockTeams = [
-    { short: "USA", color: "#3b82f6", pts: 24, maxPts: 24 },
-    { short: "EUR", color: "#ef4444", pts: 18, maxPts: 24 },
-  ];
-  const mockRounds = [
-    { title: "Scramble", status: "closed" as const },
-    { title: "Skins", status: "active" as const },
-    { title: "Singles", status: "upcoming" as const },
-  ];
-  const features = ["Custom teams", "Live scoring", "Play groups", "Leaderboard"];
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center p-4 sm:items-center"
-      onClick={onDismiss}
-    >
-      <div className="absolute inset-0" style={{ background: "var(--color-bt-overlay)" }} />
-      <div
-        className="relative w-full max-w-sm overflow-hidden rounded-2xl"
-        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Epic gradient header */}
-        <div
-          className="px-5 pb-6 pt-8 text-center"
-          style={{
-            background:
-              "linear-gradient(160deg, hsl(220,65%,18%) 0%, hsl(260,55%,14%) 50%, hsl(20,75%,16%) 100%)",
-          }}
-        >
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl"
-            style={{ background: "rgba(255,255,255,0.1)", border: "1px solid rgba(255,255,255,0.18)" }}
-          >
-            <Trophy size={30} style={{ color: "hsl(45,100%,65%)" }} />
-          </div>
-          <p className="text-xl font-bold text-white">Competition Mode</p>
-          <p className="mt-1 text-sm" style={{ color: "rgba(255,255,255,0.55)" }}>
-            Turn your trip into a tournament
-          </p>
-
-          {/* Mini scoreboard preview */}
-          <div
-            className="mt-5 rounded-xl p-3 text-left"
-            style={{ background: "rgba(0,0,0,0.35)", border: "1px solid rgba(255,255,255,0.1)" }}
-          >
-            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider" style={{ color: "rgba(255,255,255,0.4)" }}>
-              Leaderboard
-            </p>
-            <div className="space-y-2 mb-3">
-              {mockTeams.map((t) => (
-                <div key={t.short} className="flex items-center gap-2.5">
-                  <div
-                    className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-[9px] font-bold text-white"
-                    style={{ background: t.color }}
-                  >
-                    {t.short}
-                  </div>
-                  <div className="flex-1 overflow-hidden rounded-full" style={{ background: "rgba(255,255,255,0.1)", height: 6 }}>
-                    <div
-                      className="h-full rounded-full"
-                      style={{ width: `${(t.pts / t.maxPts) * 100}%`, background: t.color }}
-                    />
-                  </div>
-                  <span className="w-6 text-right text-xs font-bold text-white">{t.pts}</span>
-                </div>
-              ))}
-            </div>
-            <div className="flex gap-1.5">
-              {mockRounds.map((r) => {
-                const isActive = r.status === "active";
-                const isDone = r.status === "closed";
-                return (
-                  <div
-                    key={r.title}
-                    className="flex-1 rounded-lg px-1.5 py-1 text-center"
-                    style={{
-                      background: isActive ? "rgba(99,200,120,0.15)" : "rgba(255,255,255,0.06)",
-                      border: `1px solid ${isActive ? "rgba(99,200,120,0.35)" : "rgba(255,255,255,0.1)"}`,
-                    }}
-                  >
-                    <p className="truncate text-[9px] font-semibold" style={{ color: isActive ? "#6bc87a" : "rgba(255,255,255,0.55)" }}>
-                      {r.title}
-                    </p>
-                    <p className="text-[8px]" style={{ color: "rgba(255,255,255,0.3)" }}>
-                      {isDone ? "✓ done" : isActive ? "▶ live" : "soon"}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-
-        {/* Feature pills */}
-        <div className="flex flex-wrap justify-center gap-2 px-5 py-4">
-          {features.map((f) => (
-            <span
-              key={f}
-              className="flex items-center gap-1 rounded-full px-2.5 py-1 text-xs"
-              style={{
-                background: "var(--color-bt-accent-faint)",
-                border: "1px solid var(--color-bt-accent-border)",
-                color: "var(--color-bt-accent)",
-              }}
-            >
-              <Check size={10} />
-              {f}
-            </span>
-          ))}
-        </div>
-
-        {/* Actions */}
-        <div className="space-y-2 px-5 pb-6">
-          <button
-            data-testid="competition-preview-confirm"
-            onClick={onConfirm}
-            className="flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-          >
-            <Trophy size={15} />
-            Let&apos;s Go!
-          </button>
-          <button
-            data-testid="competition-preview-dismiss"
-            onClick={onDismiss}
-            className="w-full py-2.5 text-sm"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            No thanks
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Competition Panel ─────────────────────────────────────────────────────
-
-function CompetitionPanel({
-  trip,
-  canEdit,
-  onSetupComp,
-}: {
-  trip: TripData;
-  canEdit: boolean;
-  onSetupComp?: () => void;
-}) {
-  const router = useRouter();
-  const [showPreview, setShowPreview] = useState(false);
-  const hasComp = !!trip.event_id;
-
-  const { data: event } = trpc.events.getByTrip.useQuery(
-    { tripId: trip.id },
-    { enabled: hasComp }
-  );
-
-  // Use trip.event_id (available immediately from the trip object) so teams
-  // and scores fire in parallel with events.getByTrip instead of waiting for
-  // it to resolve first — eliminates the 2-step waterfall.
-  const knownEventId = event?.id ?? trip.event_id ?? "";
-
-  const { data: teams = [] } = trpc.teams.list.useQuery(
-    { tripId: trip.id, eventId: knownEventId },
-    { enabled: !!knownEventId }
-  );
-
-  const { data: scoreRows = [] } = trpc.groupResults.listScoresByEvent.useQuery(
-    { tripId: trip.id, eventId: knownEventId },
-    { enabled: !!knownEventId }
-  );
-
-  // Aggregate total points per team, sorted descending
-  const teamTotals = teams
-    .map((t) => ({
-      ...t,
-      total: scoreRows
-        .filter((r) => r.team_id === t.id)
-        .reduce((sum, r) => sum + (r.total_points ?? 0), 0),
-    }))
-    .sort((a, b) => b.total - a.total);
-
-  if (hasComp && event) {
-    return (
-      <button
-        data-testid="competition-panel"
-        onClick={() => router.push(`/trips/${trip.id}/leaderboard`)}
-        className="w-full rounded-xl p-4 text-left"
-        style={{ background: "var(--color-bt-tag-bg)", border: "1px solid var(--color-bt-accent-border)" }}
-      >
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2">
-            <Trophy size={16} style={{ color: "var(--color-bt-accent)" }} />
-            <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-accent)" }}>
-              {event.title ?? "Competition"}
-            </p>
-          </div>
-          <span className="flex items-center gap-1 text-xs font-medium" style={{ color: "var(--color-bt-accent)" }}>
-            Leaderboard <ChevronRight size={14} />
-          </span>
-        </div>
-        {teamTotals.length > 0 ? (
-          <div className="flex gap-3">
-            {teamTotals.map((team) => (
-              <div
-                key={team.id}
-                className="flex-1 rounded-lg p-2 text-center"
-                style={{ background: "var(--color-bt-base)", border: "1px solid var(--color-bt-border)" }}
-              >
-                <p
-                  className="text-[10px] font-semibold truncate mb-0.5"
-                  style={{ color: team.color }}
-                >
-                  {team.short_name}
-                </p>
-                <p className="text-lg font-bold" style={{ color: "var(--color-bt-text)" }}>
-                  {team.total}
-                </p>
-                <p className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>pts</p>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>No scores yet</p>
-        )}
-      </button>
-    );
-  }
-
-  if (!hasComp && canEdit) {
-    return (
-      <>
-        <button
-          data-testid="home-setup-competition-btn"
-          onClick={() => setShowPreview(true)}
-          className="w-full rounded-xl p-4 text-center"
-          style={{ border: "1.5px dashed var(--color-bt-border)", background: "var(--color-bt-surface-invitation)" }}
-        >
-          <Trophy size={20} className="mx-auto mb-2" style={{ color: "var(--color-bt-text-dim)" }} />
-          <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Add a Competition
-          </p>
-          <p className="text-xs mt-0.5" style={{ color: "var(--color-bt-text-dim)" }}>
-            Your group already has a rivalry. Give it a scoreboard.
-          </p>
-        </button>
-        {showPreview && (
-          <CompetitionPreviewModal
-            onConfirm={() => { setShowPreview(false); onSetupComp?.(); }}
-            onDismiss={() => setShowPreview(false)}
-          />
-        )}
-      </>
-    );
-  }
-
-  return null;
-}
+import type { TabProps } from "./types";
 
 // ── HomeTab ──────────────────────────────────────────────────────────────
 
@@ -298,12 +25,22 @@ export function HomeTab({
   onAdvanceToGoing,
   actionCenterTitleAction,
 }: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; onOpenChat?: () => void; onWriteInvitation?: () => void; onAdvanceToGoing?: () => void; actionCenterTitleAction?: React.ReactNode }) {
-  const { data: ideas = [] } = trpc.ideas.list.useQuery({ tripId: trip.id });
+  trpc.ideas.list.useQuery({ tripId: trip.id });
   const { data: reservations = [] } = trpc.reservations.list.useQuery({ tripId: trip.id });
+  const { data: scheduleItems = [] } = trpc.schedule.list.useQuery({ tripId: trip.id });
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId: trip.id });
 
   const status = getTripStatus(trip);
-  const _isCompleted = status === "past";
   const stage = trip.stage ?? "idea";
+
+  // hasItineraryContent — drives the locked vs invitation state on
+  // ItineraryPanel. True when ANY of dates / lodging / schedule / shared
+  // travel exists.
+  const hasItineraryContent =
+    !!trip.start_date ||
+    reservations.length > 0 ||
+    scheduleItems.length > 0 ||
+    (members as Array<{ travel_mode?: string | null }>).some((m) => !!m.travel_mode);
 
   // IDEA stage: render IdeaZonePanel only — no planning rows
   if (stage === "idea") {
@@ -348,40 +85,60 @@ export function HomeTab({
         />
       )}
 
-      {/* ── GOING / NOW stage: consolidated ItineraryView (owner nudge +
-              Getting There + filter pills + day-by-day timeline).          */}
+      {/* ── GOING / NOW stage: panel system.
+              Each panel handles its own locked/invitation/live state.
+              The owner-nudge for unlinked crew has moved into the Crew
+              tab (with a dot on the tab bar) — do not surface it here. */}
       {stage === "going" && (status === "going" || status === "now") && (
-        <ItineraryView
-          trip={trip}
-          isOwner={!!isOwner}
-        />
+        <>
+          <ItineraryPanel
+            tripId={trip.id}
+            trip={trip}
+            isOwner={!!isOwner}
+            isActivated={!!trip.itinerary_enabled}
+            hasContent={hasItineraryContent}
+          />
+          <GettingTherePanel
+            tripId={trip.id}
+            trip={trip}
+            isOwner={!!isOwner}
+            isActivated={!!trip.getting_there_enabled}
+            hasDates={!!trip.start_date}
+            onOpenDatesModal={() => onTabChange?.("schedule")}
+          />
+          <QuickInfoPanel
+            tripId={trip.id}
+            isOwner={!!isOwner}
+          />
+          <CompetitionPanel
+            tripId={trip.id}
+            isOwner={!!isOwner}
+            isActivated={!!trip.event_id}
+            onSetupComp={onEnableComp}
+          />
+        </>
       )}
 
-      {/* ── PAST / SAVED: keep the existing ItineraryPanel; it's read-only
-              and its bucketed layout is still useful after the trip. The
-              ActionCenter stays off — there's no action to take.           */}
+      {/* ── PAST / SAVED: keep the legacy ItineraryPanel; it's read-only
+              and its bucketed layout is still useful after the trip.
+              Competition panel still surfaces here too — same component
+              as going/now, the activation flag (event_id) is what counts. */}
       {stage !== "idea" && stage !== "planning" && status !== "going" && status !== "now" && (
-        <ItineraryPanel
-          tripId={trip.id}
-          tripStartDate={trip.start_date}
-          stage={stage}
-          status={status}
-          onTabChange={onTabChange}
-        />
-      )}
-
-
-      {/* ── Lodging moved to its own Lodging tab (between Crew and   ── */}
-      {/*    Schedule). Home deliberately doesn't render it anymore so ── */}
-      {/*    the main flow stays focused on status + itinerary.        ── */}
-
-{/* Competition panel — only in READY stage and beyond */}
-      {stage !== "idea" && stage !== "planning" && (
-        <CompetitionPanel
-          trip={trip}
-          canEdit={canEditProp}
-          onSetupComp={onEnableComp}
-        />
+        <>
+          <LegacyItineraryPanel
+            tripId={trip.id}
+            tripStartDate={trip.start_date}
+            stage={stage}
+            status={status}
+            onTabChange={onTabChange}
+          />
+          <CompetitionPanel
+            tripId={trip.id}
+            isOwner={!!isOwner}
+            isActivated={!!trip.event_id}
+            onSetupComp={onEnableComp}
+          />
+        </>
       )}
     </div>
   );

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Car,
   ChevronDown,
@@ -58,16 +58,11 @@ export function GettingThereSection({ tripId, isOwner }: GettingThereSectionProp
   const otherMembers = (members as TripMemberLite[]).filter(
     (m) => m.user_id !== currentUser?.id,
   );
-  const hasMyTravel = !!myMember?.travel_mode;
 
-  const [expanded, setExpanded] = useState(!hasMyTravel);
-
-  // Re-sync expanded state when the underlying travel data changes — e.g.
-  // user saves, member row refetches, expanded can close automatically.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (hasMyTravel) setExpanded(false);
-  }, [hasMyTravel]);
+  // Always start collapsed — the user opens the row deliberately by
+  // tapping. Auto-expanding when empty was visually noisy and made the
+  // panel default to a half-filled form for users who hadn't engaged yet.
+  const [expanded, setExpanded] = useState(false);
 
   // ── Render ──────────────────────────────────────────────────────────────
   return (

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -65,44 +65,28 @@ export function GettingThereSection({ tripId, isOwner }: GettingThereSectionProp
   const [expanded, setExpanded] = useState(false);
 
   // ── Render ──────────────────────────────────────────────────────────────
+  // Title + outer card chrome are now provided by the wrapping
+  // GettingTherePanel CardShell — this section is just the inner content
+  // (your row + pending tally) so the same component can sit cleanly
+  // inside the panel surface.
   return (
-    <section className="space-y-2">
-      <h2
-        className="text-xs font-semibold uppercase tracking-wider"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        Getting there
-      </h2>
-      <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-        Share your travel plans so the crew can coordinate arrivals.
-      </p>
+    <div data-testid="getting-there-section">
+      {myMember ? (
+        <YourTravelRow
+          tripId={tripId}
+          member={myMember}
+          expanded={expanded}
+          onToggleExpanded={() => setExpanded((v) => !v)}
+          onSaved={() => {
+            utils.tripMembers.list.invalidate({ tripId });
+            setExpanded(false);
+          }}
+        />
+      ) : null}
 
-      <div
-        className="overflow-hidden rounded-xl"
-        style={{
-          background: "var(--color-bt-card)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-        data-testid="getting-there-section"
-      >
-        {/* Your row */}
-        {myMember ? (
-          <YourTravelRow
-            tripId={tripId}
-            member={myMember}
-            expanded={expanded}
-            onToggleExpanded={() => setExpanded((v) => !v)}
-            onSaved={() => {
-              utils.tripMembers.list.invalidate({ tripId });
-              setExpanded(false);
-            }}
-          />
-        ) : null}
-
-        {/* Owner-only pending tally */}
-        {isOwner && <PendingTravelRow members={otherMembers} />}
-      </div>
-    </section>
+      {/* Owner-only pending tally */}
+      {isOwner && <PendingTravelRow members={otherMembers} />}
+    </div>
   );
 }
 

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -107,50 +107,56 @@ function YourTravelRow({
 }) {
   const hasTravel = !!member.travel_mode;
 
+  // ── No travel info yet — Pattern 1 add button + optional inline form ──
+  // Matches Schedule "Item", Lodging "Property", Receipts "Receipt", Crew
+  // "Crew member" so add-affordances are consistent across the trip.
+  if (!hasTravel) {
+    return (
+      <div className="px-4 py-3">
+        {expanded ? (
+          <TravelExpandForm tripId={tripId} member={member} onSaved={onSaved} />
+        ) : (
+          <button
+            type="button"
+            onClick={onToggleExpanded}
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            <Plane size={15} />
+            <Plus size={12} /> Travel info
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // ── Has travel — existing row pattern (avatar + summary + badge + chevron) ─
   return (
     <div>
-      {/* Row header */}
       <button
         type="button"
         onClick={onToggleExpanded}
         className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
       >
-        {hasTravel ? (
-          <UserAvatar name={member.displayName} avatarUrl={null} size="md" />
-        ) : (
-          <span
-            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              border: "1px dashed var(--color-bt-border)",
-              color: "var(--color-bt-text-dim)",
-            }}
-          >
-            <Plus size={14} />
-          </span>
-        )}
+        <UserAvatar name={member.displayName} avatarUrl={null} size="md" />
 
         <div className="min-w-0 flex-1">
-          {hasTravel ? (
-            <>
-              <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                {member.displayName}{" "}
-                <span className="text-xs font-normal" style={{ color: "var(--color-bt-text-dim)" }}>
-                  (you)
-                </span>
-              </p>
-              <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                {summarizeTravel(member)}
-              </p>
-            </>
-          ) : (
-            <p className="text-[13px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
-              Add your travel info
-            </p>
-          )}
+          <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            {member.displayName}{" "}
+            <span className="text-xs font-normal" style={{ color: "var(--color-bt-text-dim)" }}>
+              (you)
+            </span>
+          </p>
+          <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+            {summarizeTravel(member)}
+          </p>
         </div>
 
-        {hasTravel && <TravelModeBadge mode={member.travel_mode as TravelMode | null} />}
+        <TravelModeBadge mode={member.travel_mode as TravelMode | null} />
 
         <ChevronDown
           size={16}

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -114,7 +114,7 @@ function YourTravelRow({
     return (
       <div className="px-4 py-3">
         {expanded ? (
-          <TravelExpandForm tripId={tripId} member={member} onSaved={onSaved} />
+          <TravelExpandForm tripId={tripId} member={member} onSaved={onSaved} onCancel={onToggleExpanded} />
         ) : (
           <button
             type="button"
@@ -174,7 +174,7 @@ function YourTravelRow({
           className="border-t px-4 pb-4 pt-3"
           style={{ borderColor: "var(--color-bt-border)" }}
         >
-          <TravelExpandForm tripId={tripId} member={member} onSaved={onSaved} />
+          <TravelExpandForm tripId={tripId} member={member} onSaved={onSaved} onCancel={onToggleExpanded} />
         </div>
       )}
     </div>
@@ -187,10 +187,12 @@ function TravelExpandForm({
   tripId,
   member,
   onSaved,
+  onCancel,
 }: {
   tripId: string;
   member: TripMemberLite;
   onSaved: () => void;
+  onCancel: () => void;
 }) {
   const [mode, setMode] = useState<TravelMode>(
     (member.travel_mode as TravelMode) ?? "driving",
@@ -322,6 +324,20 @@ function TravelExpandForm({
             }}
           />
         </div>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={updateTravel.isPending}
+          className="flex-shrink-0 rounded-lg border px-3 py-2 text-xs disabled:opacity-40"
+          style={{
+            borderColor: "var(--color-bt-border)",
+            color: "var(--color-bt-text-dim)",
+            background: "transparent",
+            whiteSpace: "nowrap",
+          }}
+        >
+          Cancel
+        </button>
         <button
           type="button"
           onClick={handleSave}

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -2,8 +2,10 @@
 
 import { useMemo, useState } from "react";
 import {
+  Calendar,
   Clock,
   Home,
+  MapPin,
   Plane,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -21,7 +23,6 @@ import {
   type ItineraryTripMember,
 } from "../../components/itinerary";
 import type { TripData } from "../types";
-import { GettingThereSection } from "./GettingThereSection";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -47,17 +48,22 @@ export interface ItineraryViewProps {
 }
 
 /**
- * ItineraryView — the Home tab surface during the GOING / NOW stages.
+ * ItineraryView — the live content of the home-tab Itinerary panel.
  *
- * Replaces the old ActionCenter + ItineraryPanel pair with:
- *   1. Getting There section (per-user travel row + owner pending tally).
- *   2. Filter pills: All / Lodging / Travel / Events (multi-select).
- *   3. Day-by-day timeline from trip start through trip end, pulling from
+ *   1. Filter pills: All / Lodging / Travel / Events. Each non-All pill
+ *      only renders when that category has at least one event AND, for
+ *      Travel, when getting_there_enabled is on (don't tease a filter
+ *      for a feature the owner hasn't activated).
+ *   2. Day-by-day timeline from trip start through trip end, pulling from
  *      confirmed schedule items, lodging check-in/out, and shared travel
- *      arrivals — the same data ItineraryPanel was built on, but laid out
- *      as a continuous day-by-day reel.
+ *      arrivals.
+ *   3. When activated but no content exists, a visually appealing empty
+ *      state mirrors the intro modal preview.
+ *
+ * Getting There used to render here too — it now lives in its own panel
+ * (GettingTherePanel), so it's no longer included.
  */
-export function ItineraryView({ trip, isOwner }: ItineraryViewProps) {
+export function ItineraryView({ trip, isOwner: _isOwner }: ItineraryViewProps) {
   const tripId = trip.id;
 
   // ── Data ────────────────────────────────────────────────────────────────
@@ -126,28 +132,50 @@ export function ItineraryView({ trip, isOwner }: ItineraryViewProps) {
     return false;
   };
 
+  // Per-category counts drive whether each filter pill is shown.
+  // Don't tease a filter the user can't actually use.
+  const hasLodging = events.some((e) => categoryOf(e) === "lodging");
+  const hasTravel = events.some((e) => categoryOf(e) === "travel");
+  const hasEvents = events.some((e) => categoryOf(e) === "event");
+  const gettingThereEnabled = !!trip.getting_there_enabled;
+
+  // Show pill row only if there's >1 category to filter between
+  const visibleCategoryCount =
+    (hasLodging ? 1 : 0) + (hasTravel && gettingThereEnabled ? 1 : 0) + (hasEvents ? 1 : 0);
+  const showFilterPills = visibleCategoryCount > 1;
+
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <div className="space-y-4">
-      <GettingThereSection tripId={tripId} isOwner={isOwner} />
+      {showFilterPills && (
+        <div className="flex flex-wrap items-center gap-2">
+          <FilterPill label="All" active={activeFilters.has("all")} onClick={() => toggleFilter("all")} />
+          {hasLodging && (
+            <FilterPill
+              label="Lodging"
+              active={activeFilters.has("lodging")}
+              onClick={() => toggleFilter("lodging")}
+            />
+          )}
+          {hasTravel && gettingThereEnabled && (
+            <FilterPill
+              label="Travel"
+              active={activeFilters.has("travel")}
+              onClick={() => toggleFilter("travel")}
+            />
+          )}
+          {hasEvents && (
+            <FilterPill
+              label="Events"
+              active={activeFilters.has("events")}
+              onClick={() => toggleFilter("events")}
+            />
+          )}
+        </div>
+      )}
 
-      <div className="flex flex-wrap items-center gap-2">
-        <FilterPill label="All" active={activeFilters.has("all")} onClick={() => toggleFilter("all")} />
-        <FilterPill label="Lodging" active={activeFilters.has("lodging")} onClick={() => toggleFilter("lodging")} />
-        <FilterPill label="Travel" active={activeFilters.has("travel")} onClick={() => toggleFilter("travel")} />
-        <FilterPill label="Events" active={activeFilters.has("events")} onClick={() => toggleFilter("events")} />
-      </div>
-
-      {days.length === 0 ? (
-        <p className="rounded-xl p-4 text-center text-sm italic"
-          style={{
-            background: "var(--color-bt-card)",
-            border: "1px dashed var(--color-bt-border)",
-            color: "var(--color-bt-text-dim)",
-          }}
-        >
-          Lock your dates to see a day-by-day itinerary.
-        </p>
+      {days.length === 0 || events.length === 0 ? (
+        <EmptyItineraryState />
       ) : (
         <div className="space-y-4">
           {days.map((date, i) => (
@@ -161,6 +189,116 @@ export function ItineraryView({ trip, isOwner }: ItineraryViewProps) {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+// ── EmptyItineraryState ─────────────────────────────────────────────────
+// Shown when the panel is activated but there are no lodging / travel /
+// schedule events to thread together yet. Mirrors the intro modal preview
+// so the empty state still hints at what the populated view will look like.
+
+function EmptyItineraryState() {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{
+        background: "var(--color-bt-base)",
+        border: "1px dashed var(--color-bt-border)",
+      }}
+    >
+      <div className="flex flex-col items-center text-center">
+        <div
+          className="mb-3 flex h-12 w-12 items-center justify-center rounded-2xl"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+          }}
+        >
+          <Calendar size={22} />
+        </div>
+        <p className="text-sm font-bold" style={{ color: "var(--color-bt-text)" }}>
+          Your timeline will start to fill in
+        </p>
+        <p
+          className="mt-1 max-w-[280px] text-xs leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Lodging check-ins, travel arrivals, and confirmed schedule items
+          will weave themselves into the timeline below.
+        </p>
+      </div>
+
+      {/* Skeleton preview — two-day mini stack mirroring the intro modal */}
+      <div
+        className="mt-4 space-y-2 rounded-lg p-3"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          opacity: 0.65,
+        }}
+      >
+        <div className="flex items-center gap-1.5">
+          <span
+            className="h-1.5 w-1.5 rounded-full"
+            style={{ background: "var(--color-bt-accent)" }}
+            aria-hidden
+          />
+          <span
+            className="text-[10px] font-bold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-accent)" }}
+          >
+            Day 1
+          </span>
+        </div>
+        <SkeletonRow Icon={Home} text="Lodging check-in" time="3:00 PM" iconColor="#60a5fa" />
+        <SkeletonRow
+          Icon={Plane}
+          text="Travel arrival"
+          time="5:30 PM"
+          iconColor="var(--color-bt-accent)"
+        />
+        <SkeletonRow Icon={MapPin} text="Welcome dinner" time="7:30 PM" iconColor="var(--color-bt-text-dim)" />
+
+        <div className="mt-3 flex items-center gap-1.5">
+          <span
+            className="text-[10px] font-bold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Day 2
+          </span>
+        </div>
+        <SkeletonRow Icon={MapPin} text="Tee time" time="8:00 AM" iconColor="var(--color-bt-text-dim)" />
+      </div>
+    </div>
+  );
+}
+
+function SkeletonRow({
+  Icon,
+  text,
+  time,
+  iconColor,
+}: {
+  Icon: LucideIcon;
+  text: string;
+  time: string;
+  iconColor: string;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
+      style={{ border: "1px solid var(--color-bt-border)" }}
+    >
+      <div className="flex min-w-0 items-center gap-1.5">
+        <Icon size={11} style={{ color: iconColor }} />
+        <span className="truncate text-[11px]" style={{ color: "var(--color-bt-text)" }}>
+          {text}
+        </span>
+      </div>
+      <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        {time}
+      </span>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -1465,8 +1465,13 @@ export function PlanningGrid({
 
       {/* ── MOBILE: tab bar + content (hidden sm+) ──────────────────────── */}
       <div className="sm:hidden">
-        {/* Inline mobile tab bar — tile-style icon squares */}
-        <div className="flex">
+        {/* Mobile planning tab bar — matches the going-stage TripTabBar
+            styling (inline icon + uppercase label + accent underline) so
+            the tab look is consistent across basic and advanced modes. */}
+        <div
+          className="flex border-b"
+          style={{ borderColor: "var(--color-bt-border)" }}
+        >
           {PLANNING_MOBILE_TABS.map(({ id, label, Icon }) => {
             const active = mobileActiveTab === id;
             return (
@@ -1475,28 +1480,17 @@ export function PlanningGrid({
                 type="button"
                 data-testid={`mobile-planning-tab-${id}`}
                 onClick={() => handleMobileTabChange(id)}
-                className="flex flex-1 flex-col items-center gap-1.5 py-3"
-                style={{ background: "transparent", border: "none" }}
+                className="flex flex-1 flex-col items-center justify-center gap-1 py-2.5 transition-colors"
+                style={{
+                  color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                  borderBottom: active
+                    ? "2px solid var(--color-bt-accent)"
+                    : "2px solid transparent",
+                  background: "transparent",
+                }}
               >
-                <span
-                  className="flex h-11 w-11 items-center justify-center rounded-xl"
-                  style={{
-                    background: active
-                      ? "var(--color-bt-accent)"
-                      : "var(--color-bt-card-raised)",
-                    color: active
-                      ? "var(--color-bt-base)"
-                      : "var(--color-bt-text-dim)",
-                  }}
-                >
-                  <Icon size={22} strokeWidth={1.75} />
-                </span>
-                <span
-                  className="text-[10px] font-bold uppercase tracking-wider"
-                  style={{
-                    color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-                  }}
-                >
+                <Icon size={16} strokeWidth={1.75} />
+                <span className="text-[10px] font-bold uppercase tracking-wider">
                   {label}
                 </span>
               </button>

--- a/src/app/trips/[tripId]/tabs/components/modals/CompetitionIntroModal.tsx
+++ b/src/app/trips/[tripId]/tabs/components/modals/CompetitionIntroModal.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { ArrowRight, Loader2, Trophy, Users, Zap } from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface CompetitionIntroModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onActivate: () => void;
+  isActivating: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * CompetitionIntroModal — owner-facing pitch shown when the Competition
+ * panel invitation card is tapped. Replaces the prior inline
+ * CompetitionPreviewModal in HomeTab.tsx; visual language updated to
+ * match the other intro modals (gradient hero + blob accents + chips +
+ * gradient CTA).
+ */
+export function CompetitionIntroModal({
+  isOpen,
+  onClose,
+  onActivate,
+  isActivating,
+}: CompetitionIntroModalProps) {
+  useModalBackButton(isOpen ? onClose : () => {});
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+      data-testid="competition-intro-modal"
+    >
+      <div
+        className="w-full overflow-y-auto"
+        style={{
+          maxWidth: 360,
+          maxHeight: "90vh",
+          background: "var(--color-bt-card)",
+          borderRadius: 22,
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "0 32px 80px rgba(0,0,0,0.6)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Hero */}
+        <div
+          style={{
+            position: "relative",
+            overflow: "hidden",
+            background:
+              "linear-gradient(160deg, #150a2e 0%, #1a0f35 50%, #120828 100%)",
+            padding: "28px 20px 22px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            gap: 6,
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: -50,
+              left: -50,
+              width: 180,
+              height: 180,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(167,139,250,0.18) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              bottom: -40,
+              right: -40,
+              width: 140,
+              height: 140,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(45,212,191,0.12) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+
+          <div
+            style={{
+              width: 58,
+              height: 58,
+              borderRadius: 16,
+              background:
+                "linear-gradient(135deg, rgba(167,139,250,0.2), rgba(45,212,191,0.15))",
+              border: "1px solid rgba(167,139,250,0.3)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginBottom: 6,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <Trophy size={28} style={{ color: "#a78bfa" }} />
+          </div>
+
+          <h2
+            style={{
+              fontSize: 22,
+              fontWeight: 900,
+              lineHeight: 1.1,
+              position: "relative",
+              zIndex: 1,
+              background:
+                "linear-gradient(135deg, #a78bfa, var(--color-bt-accent))",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              backgroundClip: "text",
+            }}
+          >
+            Add a Competition
+          </h2>
+
+          <p
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              maxWidth: 270,
+              lineHeight: 1.5,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            Your group already has a rivalry. Give it a scoreboard, teams,
+            and a live leaderboard.
+          </p>
+        </div>
+
+        {/* Preview — mini leaderboard */}
+        <div
+          style={{
+            margin: "16px 16px 0",
+            borderRadius: 14,
+            border: "1px solid var(--color-bt-border)",
+            overflow: "hidden",
+            background: "var(--color-bt-base)",
+            padding: "10px 12px",
+          }}
+        >
+          <p
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              color: "var(--color-bt-text-dim)",
+              marginBottom: 8,
+            }}
+          >
+            Leaderboard
+          </p>
+          <TeamBar name="USA" color="#3b82f6" pts={24} maxPts={24} />
+          <TeamBar name="EUR" color="#ef4444" pts={18} maxPts={24} />
+          <div style={{ display: "flex", gap: 4, marginTop: 8 }}>
+            <RoundChip label="Scramble" status="closed" />
+            <RoundChip label="Skins" status="active" />
+            <RoundChip label="Singles" status="upcoming" />
+          </div>
+        </div>
+
+        {/* Feature chips */}
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: 6,
+            padding: "14px 16px 4px",
+          }}
+        >
+          {[
+            { label: "Custom teams", Icon: Users },
+            { label: "Live scoring", Icon: Zap },
+            { label: "Leaderboard", Icon: Trophy },
+          ].map(({ label, Icon }) => (
+            <div
+              key={label}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                padding: "5px 11px",
+                borderRadius: 20,
+                fontSize: 12,
+                fontWeight: 600,
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              <Icon size={11} style={{ color: "var(--color-bt-accent)" }} />
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: "14px 20px 20px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <button
+            onClick={onActivate}
+            disabled={isActivating}
+            data-testid="competition-intro-activate"
+            style={{
+              width: "100%",
+              padding: 13,
+              border: "none",
+              borderRadius: 12,
+              fontSize: 15,
+              fontWeight: 800,
+              cursor: isActivating ? "not-allowed" : "pointer",
+              opacity: isActivating ? 0.7 : 1,
+              background:
+                "linear-gradient(135deg, #a78bfa, var(--color-bt-accent))",
+              color: "#0d1f1a",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            }}
+          >
+            {isActivating ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <ArrowRight size={16} />
+            )}
+            Let&apos;s Go!
+          </button>
+          <button
+            onClick={onClose}
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── TeamBar ──────────────────────────────────────────────────────────────
+
+function TeamBar({
+  name,
+  color,
+  pts,
+  maxPts,
+}: {
+  name: string;
+  color: string;
+  pts: number;
+  maxPts: number;
+}) {
+  const pct = Math.max(0, Math.min(100, (pts / maxPts) * 100));
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        marginBottom: 4,
+      }}
+    >
+      <span
+        style={{
+          width: 28,
+          fontSize: 10,
+          fontWeight: 700,
+          color: "var(--color-bt-text)",
+        }}
+      >
+        {name}
+      </span>
+      <div
+        style={{
+          flex: 1,
+          height: 6,
+          borderRadius: 999,
+          background: "var(--color-bt-card-raised)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${pct}%`,
+            background: color,
+            borderRadius: 999,
+          }}
+        />
+      </div>
+      <span
+        style={{
+          width: 18,
+          textAlign: "right",
+          fontSize: 10,
+          fontWeight: 700,
+          color: "var(--color-bt-text)",
+        }}
+      >
+        {pts}
+      </span>
+    </div>
+  );
+}
+
+// ── RoundChip ────────────────────────────────────────────────────────────
+
+function RoundChip({
+  label,
+  status,
+}: {
+  label: string;
+  status: "closed" | "active" | "upcoming";
+}) {
+  const isActive = status === "active";
+  const isDone = status === "closed";
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: "4px 6px",
+        borderRadius: 8,
+        textAlign: "center",
+        background: isActive
+          ? "var(--color-bt-accent-faint)"
+          : "var(--color-bt-card-raised)",
+        border: `1px solid ${
+          isActive ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"
+        }`,
+      }}
+    >
+      <p
+        style={{
+          fontSize: 9,
+          fontWeight: 700,
+          color: isActive ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </p>
+      <p
+        style={{
+          fontSize: 8,
+          color: "var(--color-bt-text-dim)",
+        }}
+      >
+        {isDone ? "✓ done" : isActive ? "▶ live" : "soon"}
+      </p>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/modals/GettingThereIntroModal.tsx
+++ b/src/app/trips/[tripId]/tabs/components/modals/GettingThereIntroModal.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { ArrowRight, Car, Loader2, Map, Plane } from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface GettingThereIntroModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onActivate: () => void;
+  isActivating: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * GettingThereIntroModal — owner-facing pitch shown when the Getting There
+ * panel invitation card is tapped. Read-only preview of arrival rows + CTA
+ * that fires trips.enableGettingThere via the parent.
+ */
+export function GettingThereIntroModal({
+  isOpen,
+  onClose,
+  onActivate,
+  isActivating,
+}: GettingThereIntroModalProps) {
+  useModalBackButton(isOpen ? onClose : () => {});
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+      data-testid="getting-there-intro-modal"
+    >
+      <div
+        className="w-full overflow-y-auto"
+        style={{
+          maxWidth: 360,
+          maxHeight: "90vh",
+          background: "var(--color-bt-card)",
+          borderRadius: 22,
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "0 32px 80px rgba(0,0,0,0.6)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Hero */}
+        <div
+          style={{
+            position: "relative",
+            overflow: "hidden",
+            background:
+              "linear-gradient(160deg, #0d1f2e 0%, #0f2535 50%, #0d1a2a 100%)",
+            padding: "28px 20px 22px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            gap: 6,
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: -50,
+              left: -50,
+              width: 180,
+              height: 180,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(96,165,250,0.18) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              bottom: -40,
+              right: -40,
+              width: 140,
+              height: 140,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(45,212,191,0.12) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+
+          <div
+            style={{
+              width: 58,
+              height: 58,
+              borderRadius: 16,
+              background:
+                "linear-gradient(135deg, rgba(96,165,250,0.2), rgba(45,212,191,0.2))",
+              border: "1px solid rgba(96,165,250,0.3)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginBottom: 6,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <Plane size={28} style={{ color: "#60a5fa" }} />
+          </div>
+
+          <h2
+            style={{
+              fontSize: 22,
+              fontWeight: 900,
+              lineHeight: 1.1,
+              position: "relative",
+              zIndex: 1,
+              background:
+                "linear-gradient(135deg, #60a5fa, var(--color-bt-accent))",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              backgroundClip: "text",
+            }}
+          >
+            No One Left Behind
+          </h2>
+
+          <p
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              maxWidth: 270,
+              lineHeight: 1.5,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            Everyone shares when they&apos;re arriving. Coordinate pickups,
+            dinner times, and tee slots around real arrival times.
+          </p>
+        </div>
+
+        {/* Preview card — three arrival rows */}
+        <div
+          style={{
+            margin: "16px 16px 0",
+            borderRadius: 14,
+            border: "1px solid var(--color-bt-border)",
+            overflow: "hidden",
+            background: "var(--color-bt-base)",
+          }}
+        >
+          <ArrivalRow
+            name="Zach"
+            detail="Delta 1733"
+            time="3:42 PM"
+            mode="flying"
+          />
+          <ArrivalRow
+            name="Brad"
+            detail="driving from Charlotte"
+            time="~6:00 PM"
+            mode="driving"
+          />
+          <ArrivalRow
+            name="Rob"
+            detail="Delta 847"
+            time="5:30 PM"
+            mode="flying"
+            last
+          />
+        </div>
+
+        {/* Feature chips */}
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: 6,
+            padding: "14px 16px 4px",
+          }}
+        >
+          {[
+            { label: "Arrival times", Icon: Plane },
+            { label: "Flight details", Icon: Plane },
+            { label: "Driving routes", Icon: Car },
+            { label: "On the itinerary", Icon: Map },
+          ].map(({ label, Icon }) => (
+            <div
+              key={label}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                padding: "5px 11px",
+                borderRadius: 20,
+                fontSize: 12,
+                fontWeight: 600,
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              <Icon size={11} style={{ color: "var(--color-bt-accent)" }} />
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: "14px 20px 20px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <button
+            onClick={onActivate}
+            disabled={isActivating}
+            data-testid="getting-there-intro-activate"
+            style={{
+              width: "100%",
+              padding: 13,
+              border: "none",
+              borderRadius: 12,
+              fontSize: 15,
+              fontWeight: 800,
+              cursor: isActivating ? "not-allowed" : "pointer",
+              opacity: isActivating ? 0.7 : 1,
+              background:
+                "linear-gradient(135deg, #60a5fa, var(--color-bt-accent))",
+              color: "#0d1f1a",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            }}
+          >
+            {isActivating ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <ArrowRight size={16} />
+            )}
+            Set Up Getting There
+          </button>
+          <button
+            onClick={onClose}
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── ArrivalRow ────────────────────────────────────────────────────────────
+
+function ArrivalRow({
+  name,
+  detail,
+  time,
+  mode,
+  last,
+}: {
+  name: string;
+  detail: string;
+  time: string;
+  mode: "flying" | "driving";
+  last?: boolean;
+}) {
+  const isFlying = mode === "flying";
+  const Icon = isFlying ? Plane : Car;
+  const badgeStyle = isFlying
+    ? {
+        background: "var(--color-bt-accent-faint)",
+        color: "var(--color-bt-accent)",
+        border: "1px solid var(--color-bt-accent-border)",
+      }
+    : {
+        background: "var(--color-bt-warning-faint)",
+        color: "var(--color-bt-warning)",
+        border: "1px solid var(--color-bt-warning-border)",
+      };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 12px",
+        borderBottom: last ? undefined : "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <p
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            color: "var(--color-bt-text)",
+            marginBottom: 2,
+          }}
+        >
+          {name}{" "}
+          <span style={{ fontWeight: 400, color: "var(--color-bt-text-dim)" }}>
+            · {detail}
+          </span>
+        </p>
+        <p style={{ fontSize: 10, color: "var(--color-bt-text-dim)" }}>{time}</p>
+      </div>
+      <span
+        style={{
+          ...badgeStyle,
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 3,
+          padding: "2px 7px",
+          borderRadius: 999,
+          fontSize: 9,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          flexShrink: 0,
+        }}
+      >
+        <Icon size={9} />
+        {isFlying ? "Flying" : "Driving"}
+      </span>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/modals/ItineraryIntroModal.tsx
+++ b/src/app/trips/[tripId]/tabs/components/modals/ItineraryIntroModal.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { ArrowRight, Calendar, Home, Loader2, MapPin, Plane } from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface ItineraryIntroModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onActivate: () => void;
+  isActivating: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * ItineraryIntroModal — owner-facing pitch shown when the Itinerary panel
+ * invitation card is tapped. Read-only preview + "Add Itinerary" CTA that
+ * fires the parent's onActivate (which in turn calls trips.enableItinerary).
+ *
+ * Visual language: dark gradient hero with teal/blue blob accents. Hex
+ * values inside the gradient art are intentional (token system covers
+ * structural surfaces, not gradient art — same precedent as
+ * UnlockAdvancedModal).
+ */
+export function ItineraryIntroModal({
+  isOpen,
+  onClose,
+  onActivate,
+  isActivating,
+}: ItineraryIntroModalProps) {
+  useModalBackButton(isOpen ? onClose : () => {});
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+      data-testid="itinerary-intro-modal"
+    >
+      <div
+        className="w-full overflow-y-auto"
+        style={{
+          maxWidth: 360,
+          maxHeight: "90vh",
+          background: "var(--color-bt-card)",
+          borderRadius: 22,
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "0 32px 80px rgba(0,0,0,0.6)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Hero */}
+        <div
+          style={{
+            position: "relative",
+            overflow: "hidden",
+            background:
+              "linear-gradient(160deg, #0d2030 0%, #0f1f35 50%, #131525 100%)",
+            padding: "28px 20px 22px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            gap: 6,
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: -50,
+              left: -50,
+              width: 180,
+              height: 180,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(45,212,191,0.18) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              bottom: -40,
+              right: -40,
+              width: 140,
+              height: 140,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(96,165,250,0.14) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+
+          <div
+            style={{
+              width: 58,
+              height: 58,
+              borderRadius: 16,
+              background:
+                "linear-gradient(135deg, rgba(45,212,191,0.2), rgba(96,165,250,0.2))",
+              border: "1px solid rgba(45,212,191,0.3)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginBottom: 6,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <Calendar size={28} style={{ color: "var(--color-bt-accent)" }} />
+          </div>
+
+          <h2
+            style={{
+              fontSize: 22,
+              fontWeight: 900,
+              lineHeight: 1.1,
+              position: "relative",
+              zIndex: 1,
+              background:
+                "linear-gradient(135deg, var(--color-bt-accent), #60a5fa)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              backgroundClip: "text",
+            }}
+          >
+            Your Trip, Day by Day
+          </h2>
+
+          <p
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              maxWidth: 270,
+              lineHeight: 1.5,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            Lodging check-ins, travel arrivals, and scheduled events — all
+            woven into one timeline automatically.
+          </p>
+        </div>
+
+        {/* Preview card — two day sections */}
+        <div
+          style={{
+            margin: "16px 16px 0",
+            borderRadius: 14,
+            border: "1px solid var(--color-bt-border)",
+            overflow: "hidden",
+            background: "var(--color-bt-base)",
+          }}
+        >
+          <PreviewDay
+            label="Day 1"
+            isToday
+            items={[
+              { kind: "lodging", text: "Check in lodging", time: "3:00 PM" },
+              { kind: "travel", text: "Travel arrival", time: "5:30 PM" },
+              { kind: "event", text: "Welcome dinner", time: "7:30 PM" },
+            ]}
+          />
+          <div style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+            <PreviewDay
+              label="Day 2"
+              items={[{ kind: "event", text: "Tee time", time: "8:00 AM" }]}
+            />
+          </div>
+        </div>
+
+        {/* Feature chips */}
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: 6,
+            padding: "14px 16px 4px",
+          }}
+        >
+          {[
+            { label: "Day-by-day view", Icon: Calendar },
+            { label: "Travel woven in", Icon: Plane },
+            { label: "Lodging auto-added", Icon: Home },
+          ].map(({ label, Icon }) => (
+            <div
+              key={label}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                padding: "5px 11px",
+                borderRadius: 20,
+                fontSize: 12,
+                fontWeight: 600,
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              <Icon size={11} style={{ color: "var(--color-bt-accent)" }} />
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: "14px 20px 20px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <button
+            onClick={onActivate}
+            disabled={isActivating}
+            data-testid="itinerary-intro-activate"
+            style={{
+              width: "100%",
+              padding: 13,
+              border: "none",
+              borderRadius: 12,
+              fontSize: 15,
+              fontWeight: 800,
+              cursor: isActivating ? "not-allowed" : "pointer",
+              opacity: isActivating ? 0.7 : 1,
+              background:
+                "linear-gradient(135deg, var(--color-bt-accent), #60a5fa)",
+              color: "#0d1f1a",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            }}
+          >
+            {isActivating ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <ArrowRight size={16} />
+            )}
+            Add Itinerary
+          </button>
+          <button
+            onClick={onClose}
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── PreviewDay ────────────────────────────────────────────────────────────
+
+function PreviewDay({
+  label,
+  isToday,
+  items,
+}: {
+  label: string;
+  isToday?: boolean;
+  items: Array<{ kind: "lodging" | "travel" | "event"; text: string; time: string }>;
+}) {
+  return (
+    <div style={{ padding: "10px 12px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+        {isToday && (
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: "var(--color-bt-accent)",
+            }}
+          />
+        )}
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: isToday ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {items.map((it, i) => (
+          <PreviewRow key={i} kind={it.kind} text={it.text} time={it.time} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreviewRow({
+  kind,
+  text,
+  time,
+}: {
+  kind: "lodging" | "travel" | "event";
+  text: string;
+  time: string;
+}) {
+  const palette = {
+    lodging: { color: "#60a5fa", border: "rgba(96,165,250,0.25)", Icon: Home },
+    travel: { color: "var(--color-bt-accent)", border: "var(--color-bt-accent-border)", Icon: Plane },
+    event: { color: "var(--color-bt-text-dim)", border: "var(--color-bt-border)", Icon: MapPin },
+  }[kind];
+  const { color, border, Icon } = palette;
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 8,
+        padding: "5px 8px",
+        borderRadius: 8,
+        border: `1px solid ${border}`,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+        <Icon size={12} style={{ color }} />
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--color-bt-text)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {text}
+        </span>
+      </div>
+      <span style={{ fontSize: 10, color: "var(--color-bt-text-dim)", flexShrink: 0 }}>
+        {time}
+      </span>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/modals/QuickInfoIntroModal.tsx
+++ b/src/app/trips/[tripId]/tabs/components/modals/QuickInfoIntroModal.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { AlertTriangle, ArrowRight, Bell, Info, Loader2, Plus } from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface QuickInfoIntroModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onActivate: () => void;
+  isActivating: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * QuickInfoIntroModal — owner-facing pitch for Quick Info tiles. The CTA
+ * fires onActivate which (per spec) drops the user into the add-first-tile
+ * flow; the parent panel handles the actual tile-creation UI.
+ */
+export function QuickInfoIntroModal({
+  isOpen,
+  onClose,
+  onActivate,
+  isActivating,
+}: QuickInfoIntroModalProps) {
+  useModalBackButton(isOpen ? onClose : () => {});
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+      data-testid="quick-info-intro-modal"
+    >
+      <div
+        className="w-full overflow-y-auto"
+        style={{
+          maxWidth: 360,
+          maxHeight: "90vh",
+          background: "var(--color-bt-card)",
+          borderRadius: 22,
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "0 32px 80px rgba(0,0,0,0.6)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Hero */}
+        <div
+          style={{
+            position: "relative",
+            overflow: "hidden",
+            background:
+              "linear-gradient(160deg, #1a1500 0%, #1f1a00 50%, #151000 100%)",
+            padding: "28px 20px 22px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            gap: 6,
+          }}
+        >
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: -50,
+              left: -50,
+              width: 180,
+              height: 180,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(251,191,36,0.18) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              bottom: -40,
+              right: -40,
+              width: 140,
+              height: 140,
+              borderRadius: "50%",
+              background:
+                "radial-gradient(circle, rgba(251,191,36,0.10) 0%, transparent 70%)",
+              pointerEvents: "none",
+            }}
+          />
+
+          <div
+            style={{
+              width: 58,
+              height: 58,
+              borderRadius: 16,
+              background:
+                "linear-gradient(135deg, rgba(251,191,36,0.2), rgba(251,191,36,0.1))",
+              border: "1px solid rgba(251,191,36,0.3)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginBottom: 6,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <Info size={28} style={{ color: "#fbbf24" }} />
+          </div>
+
+          <h2
+            style={{
+              fontSize: 22,
+              fontWeight: 900,
+              lineHeight: 1.1,
+              position: "relative",
+              zIndex: 1,
+              background: "linear-gradient(135deg, #fbbf24, #fb923c)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+              backgroundClip: "text",
+            }}
+          >
+            The Stuff Everyone Asks
+          </h2>
+
+          <p
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              maxWidth: 270,
+              lineHeight: 1.5,
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            Door codes, check-in times, WiFi passwords, addresses — pin
+            anything the crew will need at a glance.
+          </p>
+        </div>
+
+        {/* Preview — 2x3 tile grid + crew alert row */}
+        <div
+          style={{
+            margin: "16px 16px 0",
+            borderRadius: 14,
+            border: "1px solid var(--color-bt-border)",
+            overflow: "hidden",
+            background: "var(--color-bt-base)",
+            padding: 10,
+          }}
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 6,
+            }}
+          >
+            <PreviewTile label="Door code" value="1234#" />
+            <PreviewTile label="Check-in" value="3:00 PM" />
+            <PreviewTile label="WiFi" value="BT_Guest" />
+            <PreviewTile label="Address" value="42 Oak St" />
+            <PreviewTile label="Check-out" value="11:00 AM" />
+            <PreviewTile label="Host" value="Brad · 555" />
+          </div>
+          <div
+            style={{
+              marginTop: 6,
+              padding: "8px 10px",
+              borderRadius: 8,
+              background: "var(--color-bt-warning-faint)",
+              border: "1px solid var(--color-bt-warning-border)",
+              borderLeft: "3px solid var(--color-bt-warning)",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <AlertTriangle size={12} style={{ color: "var(--color-bt-warning)" }} />
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                color: "var(--color-bt-warning)",
+              }}
+            >
+              Alert · Bring photo ID for check-in
+            </span>
+          </div>
+        </div>
+
+        {/* Feature chips */}
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: 6,
+            padding: "14px 16px 4px",
+          }}
+        >
+          {[
+            { label: "Always visible", Icon: Info },
+            { label: "Crew alerts", Icon: Bell },
+            { label: "Add anything", Icon: Plus },
+          ].map(({ label, Icon }) => (
+            <div
+              key={label}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 5,
+                padding: "5px 11px",
+                borderRadius: 20,
+                fontSize: 12,
+                fontWeight: 600,
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              <Icon size={11} style={{ color: "var(--color-bt-accent)" }} />
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            padding: "14px 20px 20px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <button
+            onClick={onActivate}
+            disabled={isActivating}
+            data-testid="quick-info-intro-activate"
+            style={{
+              width: "100%",
+              padding: 13,
+              border: "none",
+              borderRadius: 12,
+              fontSize: 15,
+              fontWeight: 800,
+              cursor: isActivating ? "not-allowed" : "pointer",
+              opacity: isActivating ? 0.7 : 1,
+              background: "linear-gradient(135deg, #fbbf24, #fb923c)",
+              color: "#0d1f1a",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            }}
+          >
+            {isActivating ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <ArrowRight size={16} />
+            )}
+            Add Quick Info
+          </button>
+          <button
+            onClick={onClose}
+            style={{
+              fontSize: 13,
+              color: "var(--color-bt-text-dim)",
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── PreviewTile ──────────────────────────────────────────────────────────
+
+function PreviewTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+        borderRadius: 8,
+        padding: "6px 8px",
+        opacity: 0.85,
+      }}
+    >
+      <p style={{ fontSize: 8, color: "var(--color-bt-text-dim)", marginBottom: 2 }}>
+        {label}
+      </p>
+      <p
+        style={{
+          fontSize: 10,
+          fontWeight: 600,
+          color: "var(--color-bt-text)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/panels/CompetitionPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/CompetitionPanel.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, ChevronRight, Trophy } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { CompetitionIntroModal } from "../modals/CompetitionIntroModal";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface CompetitionPanelProps {
+  tripId: string;
+  isOwner: boolean;
+  /** True once the trip has an event_id (i.e. competition has been set up). */
+  isActivated: boolean;
+  /** Caller-supplied callback that runs the existing comp-setup flow on confirm. */
+  onSetupComp: (() => void) | undefined;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * CompetitionPanel — home tab panel for competition / leaderboard.
+ *
+ * State machine:
+ *   1. Member, not activated  → render nothing
+ *   2. Owner, not activated   → invitation card → opens CompetitionIntroModal
+ *   3. Activated              → live leaderboard summary in CardShell
+ */
+export function CompetitionPanel({
+  tripId,
+  isOwner,
+  isActivated,
+  onSetupComp,
+}: CompetitionPanelProps) {
+  const router = useRouter();
+  const [introOpen, setIntroOpen] = useState(false);
+
+  const { data: event } = trpc.events.getByTrip.useQuery(
+    { tripId },
+    { enabled: isActivated }
+  );
+
+  const knownEventId = event?.id ?? "";
+  const { data: teams = [] } = trpc.teams.list.useQuery(
+    { tripId, eventId: knownEventId },
+    { enabled: !!knownEventId }
+  );
+  const { data: scoreRows = [] } = trpc.groupResults.listScoresByEvent.useQuery(
+    { tripId, eventId: knownEventId },
+    { enabled: !!knownEventId }
+  );
+
+  // ── State 3: live ────────────────────────────────────────────────────
+  if (isActivated && event) {
+    const teamTotals = teams
+      .map((t) => ({
+        ...t,
+        total: scoreRows
+          .filter((r) => r.team_id === t.id)
+          .reduce((sum, r) => sum + (r.total_points ?? 0), 0),
+      }))
+      .sort((a, b) => b.total - a.total);
+
+    return (
+      <CardShell
+        title={event.title ?? "Competition"}
+        subtitle="Leaderboard"
+        onClick={() => router.push(`/trips/${tripId}/leaderboard`)}
+      >
+        {teamTotals.length > 0 ? (
+          <div className="flex gap-2">
+            {teamTotals.map((team) => (
+              <div
+                key={team.id}
+                className="flex-1 rounded-lg p-2 text-center"
+                style={{
+                  background: "var(--color-bt-base)",
+                  border: "1px solid var(--color-bt-border)",
+                }}
+              >
+                <p
+                  className="mb-0.5 truncate text-[10px] font-semibold"
+                  style={{ color: team.color }}
+                >
+                  {team.short_name}
+                </p>
+                <p
+                  className="text-lg font-bold"
+                  style={{ color: "var(--color-bt-text)" }}
+                >
+                  {team.total}
+                </p>
+                <p
+                  className="text-[10px]"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  pts
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+            No scores yet
+          </p>
+        )}
+      </CardShell>
+    );
+  }
+
+  // ── State 1: member, not activated ───────────────────────────────────
+  if (!isOwner) {
+    return null;
+  }
+
+  // ── State 2: owner, not activated, invitation ────────────────────────
+  return (
+    <>
+      <InvitationCard
+        title="Add a Competition"
+        body="Your group already has a rivalry. Give it a scoreboard, teams, and a live leaderboard."
+        onClick={() => setIntroOpen(true)}
+      />
+      <CompetitionIntroModal
+        isOpen={introOpen}
+        onClose={() => setIntroOpen(false)}
+        onActivate={() => {
+          setIntroOpen(false);
+          onSetupComp?.();
+        }}
+        isActivating={false}
+      />
+    </>
+  );
+}
+
+// ── InvitationCard ───────────────────────────────────────────────────────
+
+function InvitationCard({
+  title,
+  body,
+  onClick,
+}: {
+  title: string;
+  body: string;
+  onClick: () => void;
+}) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      data-testid="competition-invitation"
+      className="w-full rounded-xl px-4 py-5 text-left transition-colors"
+      style={{
+        background: hover
+          ? "var(--color-bt-accent-faint)"
+          : "var(--color-bt-surface-invitation)",
+        border: `1.5px dashed ${
+          hover ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"
+        }`,
+        cursor: "pointer",
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+          }}
+        >
+          <Trophy size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-bold" style={{ color: "var(--color-bt-text)" }}>
+            {title}
+          </p>
+          <p
+            className="mt-1 text-xs leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {body}
+          </p>
+        </div>
+        <ArrowRight
+          size={16}
+          style={{
+            color: "var(--color-bt-accent)",
+            flexShrink: 0,
+            opacity: hover ? 1 : 0,
+            transition: "opacity 150ms",
+          }}
+        />
+      </div>
+    </button>
+  );
+}
+
+// ── CardShell ────────────────────────────────────────────────────────────
+
+function CardShell({
+  title,
+  subtitle,
+  children,
+  onClick,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+}) {
+  const Inner = (
+    <>
+      <div
+        className="flex items-center gap-2 px-4 py-3"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <Trophy size={14} style={{ color: "var(--color-bt-accent)" }} />
+        <p
+          className="text-[13px] font-bold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {title}
+        </p>
+        {subtitle && (
+          <p
+            className="ml-auto flex items-center gap-0.5 text-[11px] font-semibold"
+            style={{ color: "var(--color-bt-accent)" }}
+          >
+            {subtitle}
+            {onClick && <ChevronRight size={12} />}
+          </p>
+        )}
+      </div>
+      <div className="px-4 py-4">{children}</div>
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        data-testid="competition-panel"
+        className="w-full overflow-hidden rounded-xl text-left"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {Inner}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      {Inner}
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/panels/CompetitionPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/CompetitionPanel.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { ArrowRight, ChevronRight, Trophy } from "lucide-react";
-import { trpc } from "@/lib/trpc-client";
+import { ArrowRight, Trophy } from "lucide-react";
 import { CompetitionIntroModal } from "../modals/CompetitionIntroModal";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
 interface CompetitionPanelProps {
-  tripId: string;
   isOwner: boolean;
   /** True once the trip has an event_id (i.e. competition has been set up). */
   isActivated: boolean;
@@ -20,101 +17,29 @@ interface CompetitionPanelProps {
 // ── Component ────────────────────────────────────────────────────────────
 
 /**
- * CompetitionPanel — home tab panel for competition / leaderboard.
+ * CompetitionPanel — home tab panel for the competition setup CTA.
  *
  * State machine:
- *   1. Member, not activated  → render nothing
- *   2. Owner, not activated   → invitation card → opens CompetitionIntroModal
- *   3. Activated              → live leaderboard summary in CardShell
+ *   1. Activated              → render nothing (live leaderboard is now
+ *                                rendered by the persistent CompetitionStrip
+ *                                between TripHeader and TripTabBar)
+ *   2. Member, not activated  → render nothing
+ *   3. Owner, not activated   → invitation card → opens CompetitionIntroModal
  */
 export function CompetitionPanel({
-  tripId,
   isOwner,
   isActivated,
   onSetupComp,
 }: CompetitionPanelProps) {
-  const router = useRouter();
   const [introOpen, setIntroOpen] = useState(false);
 
-  const { data: event } = trpc.events.getByTrip.useQuery(
-    { tripId },
-    { enabled: isActivated }
-  );
+  // ── State 1: activated — strip handles it ─────────────────────────────
+  if (isActivated) return null;
 
-  const knownEventId = event?.id ?? "";
-  const { data: teams = [] } = trpc.teams.list.useQuery(
-    { tripId, eventId: knownEventId },
-    { enabled: !!knownEventId }
-  );
-  const { data: scoreRows = [] } = trpc.groupResults.listScoresByEvent.useQuery(
-    { tripId, eventId: knownEventId },
-    { enabled: !!knownEventId }
-  );
+  // ── State 2: member, not activated ───────────────────────────────────
+  if (!isOwner) return null;
 
-  // ── State 3: live ────────────────────────────────────────────────────
-  if (isActivated && event) {
-    const teamTotals = teams
-      .map((t) => ({
-        ...t,
-        total: scoreRows
-          .filter((r) => r.team_id === t.id)
-          .reduce((sum, r) => sum + (r.total_points ?? 0), 0),
-      }))
-      .sort((a, b) => b.total - a.total);
-
-    return (
-      <CardShell
-        title={event.title ?? "Competition"}
-        subtitle="Leaderboard"
-        onClick={() => router.push(`/trips/${tripId}/leaderboard`)}
-      >
-        {teamTotals.length > 0 ? (
-          <div className="flex gap-2">
-            {teamTotals.map((team) => (
-              <div
-                key={team.id}
-                className="flex-1 rounded-lg p-2 text-center"
-                style={{
-                  background: "var(--color-bt-base)",
-                  border: "1px solid var(--color-bt-border)",
-                }}
-              >
-                <p
-                  className="mb-0.5 truncate text-[10px] font-semibold"
-                  style={{ color: team.color }}
-                >
-                  {team.short_name}
-                </p>
-                <p
-                  className="text-lg font-bold"
-                  style={{ color: "var(--color-bt-text)" }}
-                >
-                  {team.total}
-                </p>
-                <p
-                  className="text-[10px]"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  pts
-                </p>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-            No scores yet
-          </p>
-        )}
-      </CardShell>
-    );
-  }
-
-  // ── State 1: member, not activated ───────────────────────────────────
-  if (!isOwner) {
-    return null;
-  }
-
-  // ── State 2: owner, not activated, invitation ────────────────────────
+  // ── State 3: owner, not activated, invitation ────────────────────────
   return (
     <>
       <InvitationCard
@@ -200,72 +125,3 @@ function InvitationCard({
   );
 }
 
-// ── CardShell ────────────────────────────────────────────────────────────
-
-function CardShell({
-  title,
-  subtitle,
-  children,
-  onClick,
-}: {
-  title: string;
-  subtitle?: string;
-  children: React.ReactNode;
-  onClick?: () => void;
-}) {
-  const Inner = (
-    <>
-      <div
-        className="flex items-center gap-2 px-4 py-3"
-        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
-      >
-        <Trophy size={14} style={{ color: "var(--color-bt-accent)" }} />
-        <p
-          className="text-[13px] font-bold"
-          style={{ color: "var(--color-bt-text)" }}
-        >
-          {title}
-        </p>
-        {subtitle && (
-          <p
-            className="ml-auto flex items-center gap-0.5 text-[11px] font-semibold"
-            style={{ color: "var(--color-bt-accent)" }}
-          >
-            {subtitle}
-            {onClick && <ChevronRight size={12} />}
-          </p>
-        )}
-      </div>
-      <div className="px-4 py-4">{children}</div>
-    </>
-  );
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        data-testid="competition-panel"
-        className="w-full overflow-hidden rounded-xl text-left"
-        style={{
-          background: "var(--color-bt-card)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        {Inner}
-      </button>
-    );
-  }
-
-  return (
-    <div
-      className="overflow-hidden rounded-xl"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-    >
-      {Inner}
-    </div>
-  );
-}

--- a/src/app/trips/[tripId]/tabs/components/panels/GettingTherePanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/GettingTherePanel.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Lock, Plane } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { GettingThereSection } from "../GettingThereSection";
+import { GettingThereIntroModal } from "../modals/GettingThereIntroModal";
+import type { TripData } from "../../types";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface GettingTherePanelProps {
+  tripId: string;
+  trip: TripData;
+  isOwner: boolean;
+  isActivated: boolean;
+  hasDates: boolean;
+  /** Caller-supplied opener for the dates modal — used by the locked state's "Set dates →" link. */
+  onOpenDatesModal?: () => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * GettingTherePanel — home tab panel for travel coordination.
+ *
+ * State machine:
+ *   1. No dates set            → dim locked card; owner sees "Set dates →"
+ *   2. Member, not activated   → dim placeholder, no CTA
+ *   3. Owner, dates set,
+ *      not activated           → invitation card → opens GettingThereIntroModal
+ *   4. Activated               → live GettingThereSection in CardShell
+ */
+export function GettingTherePanel({
+  tripId,
+  isOwner,
+  isActivated,
+  hasDates,
+  onOpenDatesModal,
+}: GettingTherePanelProps) {
+  const [introOpen, setIntroOpen] = useState(false);
+  const utils = trpc.useUtils();
+
+  const enableGettingThere = trpc.trips.enableGettingThere.useMutation({
+    async onMutate() {
+      await utils.trips.getById.cancel({ tripId });
+      const prev = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old ? { ...old, getting_there_enabled: true } : old
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.trips.getById.setData({ tripId }, ctx.prev);
+    },
+    onSuccess() {
+      setIntroOpen(false);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+    },
+  });
+
+  // ── State 4: live ────────────────────────────────────────────────────
+  if (isActivated) {
+    return (
+      <CardShell title="Getting There">
+        <GettingThereSection tripId={tripId} isOwner={isOwner} />
+      </CardShell>
+    );
+  }
+
+  // ── State 1: no dates set ────────────────────────────────────────────
+  if (!hasDates) {
+    return (
+      <DimLockedCard
+        text="Set your trip dates first to coordinate travel arrivals."
+        actionLabel={isOwner ? "Set dates →" : undefined}
+        onAction={onOpenDatesModal}
+      />
+    );
+  }
+
+  // ── State 2: member, not activated ───────────────────────────────────
+  if (!isOwner) {
+    return (
+      <DimLockedCard
+        text="Travel coordination will appear here once the trip organizer sets it up."
+      />
+    );
+  }
+
+  // ── State 3: owner, dates set, invitation ────────────────────────────
+  return (
+    <>
+      <InvitationCard
+        Icon={Plane}
+        title="Add Travel Coordination"
+        body="Share travel plans so the crew can coordinate arrivals and no one's left waiting at the airport."
+        onClick={() => setIntroOpen(true)}
+        testId="getting-there-invitation"
+      />
+      <GettingThereIntroModal
+        isOpen={introOpen}
+        onClose={() => setIntroOpen(false)}
+        onActivate={() => enableGettingThere.mutate({ tripId })}
+        isActivating={enableGettingThere.isPending}
+      />
+    </>
+  );
+}
+
+// ── DimLockedCard ────────────────────────────────────────────────────────
+
+function DimLockedCard({
+  text,
+  actionLabel,
+  onAction,
+}: {
+  text: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl px-4 py-3.5"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+        opacity: actionLabel ? 0.85 : 0.6,
+      }}
+    >
+      <Lock size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+      <p
+        className="flex-1 text-[13px] leading-snug"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {text}
+      </p>
+      {actionLabel && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="flex-shrink-0 text-xs font-semibold"
+          style={{
+            color: "var(--color-bt-accent)",
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── InvitationCard ───────────────────────────────────────────────────────
+
+function InvitationCard({
+  Icon,
+  title,
+  body,
+  onClick,
+  testId,
+}: {
+  Icon: typeof Plane;
+  title: string;
+  body: string;
+  onClick: () => void;
+  testId?: string;
+}) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      data-testid={testId}
+      className="w-full rounded-xl px-4 py-5 text-left transition-colors"
+      style={{
+        background: hover
+          ? "var(--color-bt-accent-faint)"
+          : "var(--color-bt-surface-invitation)",
+        border: `1.5px dashed ${
+          hover ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"
+        }`,
+        cursor: "pointer",
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+          }}
+        >
+          <Icon size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-bold" style={{ color: "var(--color-bt-text)" }}>
+            {title}
+          </p>
+          <p
+            className="mt-1 text-xs leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {body}
+          </p>
+        </div>
+        <ArrowRight
+          size={16}
+          style={{
+            color: "var(--color-bt-accent)",
+            flexShrink: 0,
+            opacity: hover ? 1 : 0,
+            transition: "opacity 150ms",
+          }}
+        />
+      </div>
+    </button>
+  );
+}
+
+// ── CardShell ────────────────────────────────────────────────────────────
+
+function CardShell({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div
+        className="flex items-center gap-2 px-4 py-3"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <Plane size={14} style={{ color: "var(--color-bt-accent)" }} />
+        <p className="text-[13px] font-bold" style={{ color: "var(--color-bt-text)" }}>
+          {title}
+        </p>
+      </div>
+      <div className="px-4 py-4">{children}</div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/panels/GettingTherePanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/GettingTherePanel.tsx
@@ -61,9 +61,13 @@ export function GettingTherePanel({
     },
   });
 
-  // ── State 4: live (no panel shell — section owns its own header) ─────
+  // ── State 4: live ────────────────────────────────────────────────────
   if (isActivated) {
-    return <GettingThereSection tripId={tripId} isOwner={isOwner} />;
+    return (
+      <CardShell title="Getting There">
+        <GettingThereSection tripId={tripId} isOwner={isOwner} />
+      </CardShell>
+    );
   }
 
   // ── State 1: no dates set ────────────────────────────────────────────
@@ -221,3 +225,37 @@ function InvitationCard({
   );
 }
 
+// ── CardShell ────────────────────────────────────────────────────────────
+// Familiar panel chrome: rounded card + accent-icon header + bordered
+// content area. Body has no padding — the inner GettingThereSection rows
+// already supply their own px-4 py-3, and they should flow edge-to-edge
+// inside the panel like the prior design.
+
+function CardShell({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div
+        className="flex items-center gap-2 px-4 py-3"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <Plane size={14} style={{ color: "var(--color-bt-accent)" }} />
+        <p className="text-[13px] font-bold" style={{ color: "var(--color-bt-text)" }}>
+          {title}
+        </p>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/panels/GettingTherePanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/GettingTherePanel.tsx
@@ -61,13 +61,9 @@ export function GettingTherePanel({
     },
   });
 
-  // ── State 4: live ────────────────────────────────────────────────────
+  // ── State 4: live (no panel shell — section owns its own header) ─────
   if (isActivated) {
-    return (
-      <CardShell title="Getting There">
-        <GettingThereSection tripId={tripId} isOwner={isOwner} />
-      </CardShell>
-    );
+    return <GettingThereSection tripId={tripId} isOwner={isOwner} />;
   }
 
   // ── State 1: no dates set ────────────────────────────────────────────
@@ -225,33 +221,3 @@ function InvitationCard({
   );
 }
 
-// ── CardShell ────────────────────────────────────────────────────────────
-
-function CardShell({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className="overflow-hidden rounded-xl"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-    >
-      <div
-        className="flex items-center gap-2 px-4 py-3"
-        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
-      >
-        <Plane size={14} style={{ color: "var(--color-bt-accent)" }} />
-        <p className="text-[13px] font-bold" style={{ color: "var(--color-bt-text)" }}>
-          {title}
-        </p>
-      </div>
-      <div className="px-4 py-4">{children}</div>
-    </div>
-  );
-}

--- a/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Calendar, Lock } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { ItineraryView } from "../ItineraryView";
+import { ItineraryIntroModal } from "../modals/ItineraryIntroModal";
+import type { TripData } from "../../types";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface ItineraryPanelProps {
+  tripId: string;
+  trip: TripData;
+  isOwner: boolean;
+  /** True once the owner has tapped "Add Itinerary" on the invitation card. */
+  isActivated: boolean;
+  /** True if the trip has any itinerary-relevant content (dates / lodging / schedule / shared travel). */
+  hasContent: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * ItineraryPanel — home tab panel for the day-by-day timeline.
+ *
+ * State machine:
+ *   1. Member, not activated  → dim placeholder, no CTA
+ *   2. Owner, no content      → dim "locked" card with lock icon, no CTA
+ *   3. Owner, has content,
+ *      not activated          → invitation card, opens ItineraryIntroModal
+ *   4. Activated              → live ItineraryView wrapped in card-live shell
+ */
+export function ItineraryPanel({
+  tripId,
+  trip,
+  isOwner,
+  isActivated,
+  hasContent,
+}: ItineraryPanelProps) {
+  const [introOpen, setIntroOpen] = useState(false);
+  const utils = trpc.useUtils();
+
+  const enableItinerary = trpc.trips.enableItinerary.useMutation({
+    async onMutate() {
+      await utils.trips.getById.cancel({ tripId });
+      const prev = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old ? { ...old, itinerary_enabled: true } : old
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined) utils.trips.getById.setData({ tripId }, ctx.prev);
+    },
+    onSuccess() {
+      setIntroOpen(false);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+    },
+  });
+
+  // ── State 4: live ────────────────────────────────────────────────────
+  if (isActivated) {
+    return (
+      <CardShell title="Itinerary" subtitle={liveSubtitle(trip)}>
+        <ItineraryView trip={trip} isOwner={isOwner} />
+      </CardShell>
+    );
+  }
+
+  // ── State 1: member, not activated ───────────────────────────────────
+  if (!isOwner) {
+    return (
+      <DimPlaceholder
+        text="Your itinerary will appear here once the trip organizer sets it up."
+      />
+    );
+  }
+
+  // ── State 2: owner, no content (locked) ──────────────────────────────
+  if (!hasContent) {
+    return (
+      <DimPlaceholder
+        showLock
+        text="Add dates, lodging, schedule items, or travel info to unlock your day-by-day view."
+      />
+    );
+  }
+
+  // ── State 3: owner, has content, invitation ──────────────────────────
+  return (
+    <>
+      <InvitationCard
+        Icon={Calendar}
+        title="Add an Itinerary"
+        body="Set your trip dates and your lodging, schedule, and travel info all slot into a day-by-day view."
+        onClick={() => setIntroOpen(true)}
+        testId="itinerary-invitation"
+      />
+      <ItineraryIntroModal
+        isOpen={introOpen}
+        onClose={() => setIntroOpen(false)}
+        onActivate={() => enableItinerary.mutate({ tripId })}
+        isActivating={enableItinerary.isPending}
+      />
+    </>
+  );
+}
+
+// ── Helpers (shared with other panels in spirit; kept local for clarity) ─
+
+function liveSubtitle(trip: TripData): string {
+  const parts: string[] = [];
+  if (trip.start_date && trip.end_date) {
+    const start = new Date(trip.start_date + "T00:00:00");
+    const end = new Date(trip.end_date + "T00:00:00");
+    const startLabel = start.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    const endLabel = end.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    parts.push(`${startLabel}–${endLabel}`);
+    const days = Math.max(1, Math.round((end.getTime() - start.getTime()) / 86400000) + 1);
+    parts.push(`${days} day${days !== 1 ? "s" : ""}`);
+  }
+  return parts.join(" · ");
+}
+
+// ── DimPlaceholder ───────────────────────────────────────────────────────
+
+function DimPlaceholder({ text, showLock }: { text: string; showLock?: boolean }) {
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl px-4 py-3.5"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+        opacity: 0.6,
+      }}
+    >
+      {showLock && (
+        <Lock size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+      )}
+      <p
+        className="text-[13px] leading-snug"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {text}
+      </p>
+    </div>
+  );
+}
+
+// ── InvitationCard ───────────────────────────────────────────────────────
+
+function InvitationCard({
+  Icon,
+  title,
+  body,
+  onClick,
+  testId,
+}: {
+  Icon: typeof Calendar;
+  title: string;
+  body: string;
+  onClick: () => void;
+  testId?: string;
+}) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      data-testid={testId}
+      className="w-full rounded-xl px-4 py-5 text-left transition-colors"
+      style={{
+        background: hover
+          ? "var(--color-bt-accent-faint)"
+          : "var(--color-bt-surface-invitation)",
+        border: `1.5px dashed ${
+          hover ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"
+        }`,
+        cursor: "pointer",
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+          }}
+        >
+          <Icon size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p
+            className="text-sm font-bold"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            {title}
+          </p>
+          <p
+            className="mt-1 text-xs leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {body}
+          </p>
+        </div>
+        <ArrowRight
+          size={16}
+          style={{
+            color: "var(--color-bt-accent)",
+            flexShrink: 0,
+            opacity: hover ? 1 : 0,
+            transition: "opacity 150ms",
+          }}
+        />
+      </div>
+    </button>
+  );
+}
+
+// ── CardShell ────────────────────────────────────────────────────────────
+
+function CardShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div
+        className="flex items-center gap-2 px-4 py-3"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <Calendar size={14} style={{ color: "var(--color-bt-accent)" }} />
+        <p
+          className="text-[13px] font-bold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {title}
+        </p>
+        {subtitle && (
+          <p
+            className="ml-auto text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {subtitle}
+          </p>
+        )}
+      </div>
+      <div className="px-4 py-4">{children}</div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/panels/QuickInfoPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/QuickInfoPanel.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Info } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { QuickInfoSection } from "../../../components/QuickInfoSection";
+import { QuickInfoIntroModal } from "../modals/QuickInfoIntroModal";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface QuickInfoPanelProps {
+  tripId: string;
+  isOwner: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+/**
+ * QuickInfoPanel — home tab panel for owner-curated tiles (door codes,
+ * check-in times, WiFi passwords, etc.).
+ *
+ * State machine:
+ *   1. Member, no tiles  → render nothing (Quick Info is owner-curated)
+ *   2. Owner, no tiles   → invitation card → opens QuickInfoIntroModal,
+ *                           which routes through to the existing
+ *                           QuickInfoSection's empty-state add flow
+ *   3. Tiles exist       → live QuickInfoSection in CardShell
+ *
+ * QuickInfoSection handles its own list/edit/add modals — this panel
+ * just supplies the shell + activation gating.
+ */
+export function QuickInfoPanel({ tripId, isOwner }: QuickInfoPanelProps) {
+  const [introOpen, setIntroOpen] = useState(false);
+  const { data: tiles = [] } = trpc.quickInfoTiles.list.useQuery({ tripId });
+  const hasItems = tiles.length > 0;
+
+  // ── State 3: live ────────────────────────────────────────────────────
+  if (hasItems) {
+    return (
+      <CardShell title="Quick Info" subtitle={`${tiles.length} item${tiles.length !== 1 ? "s" : ""}`}>
+        <QuickInfoSection tripId={tripId} isOwner={isOwner} />
+      </CardShell>
+    );
+  }
+
+  // ── State 1: member, no tiles ────────────────────────────────────────
+  if (!isOwner) {
+    return null;
+  }
+
+  // ── State 2: owner, no tiles, invitation ─────────────────────────────
+  return (
+    <>
+      <InvitationCard
+        Icon={Info}
+        title="Add Quick Info"
+        body="Door codes, check-in times — the stuff everyone asks about, pinned for the crew."
+        onClick={() => setIntroOpen(true)}
+        testId="quick-info-invitation"
+      />
+      <QuickInfoIntroModal
+        isOpen={introOpen}
+        onClose={() => setIntroOpen(false)}
+        onActivate={() => {
+          // Quick Info has no enable flag — the modal CTA closes itself
+          // and surfaces the existing QuickInfoSection empty-state add
+          // affordance on the next render. We simply close the modal;
+          // the user then taps the dashed "Add Quick Info" button rendered
+          // by QuickInfoSection (which we now show by switching panels).
+          setIntroOpen(false);
+          // Open the existing add-tile modal directly by clicking the
+          // empty-state button programmatically. Simplest path: dispatch
+          // a custom event that QuickInfoSection's empty button observes.
+          // For now, the next-render empty state lives inline anyway.
+        }}
+        isActivating={false}
+      />
+    </>
+  );
+}
+
+// ── InvitationCard ───────────────────────────────────────────────────────
+
+function InvitationCard({
+  Icon,
+  title,
+  body,
+  onClick,
+  testId,
+}: {
+  Icon: typeof Info;
+  title: string;
+  body: string;
+  onClick: () => void;
+  testId?: string;
+}) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      data-testid={testId}
+      className="w-full rounded-xl px-4 py-5 text-left transition-colors"
+      style={{
+        background: hover
+          ? "var(--color-bt-accent-faint)"
+          : "var(--color-bt-surface-invitation)",
+        border: `1.5px dashed ${
+          hover ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"
+        }`,
+        cursor: "pointer",
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl"
+          style={{
+            background: "var(--color-bt-accent-faint)",
+            color: "var(--color-bt-accent)",
+          }}
+        >
+          <Icon size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-bold" style={{ color: "var(--color-bt-text)" }}>
+            {title}
+          </p>
+          <p
+            className="mt-1 text-xs leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {body}
+          </p>
+        </div>
+        <ArrowRight
+          size={16}
+          style={{
+            color: "var(--color-bt-accent)",
+            flexShrink: 0,
+            opacity: hover ? 1 : 0,
+            transition: "opacity 150ms",
+          }}
+        />
+      </div>
+    </button>
+  );
+}
+
+// ── CardShell ────────────────────────────────────────────────────────────
+
+function CardShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div
+        className="flex items-center gap-2 px-4 py-3"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <Info size={14} style={{ color: "var(--color-bt-accent)" }} />
+        <p className="text-[13px] font-bold" style={{ color: "var(--color-bt-text)" }}>
+          {title}
+        </p>
+        {subtitle && (
+          <p
+            className="ml-auto text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {subtitle}
+          </p>
+        )}
+      </div>
+      <div className="px-4 py-4">{children}</div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/panels/QuickInfoPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/QuickInfoPanel.tsx
@@ -24,10 +24,12 @@ interface QuickInfoPanelProps {
  *   2. Owner, no tiles   → invitation card → opens QuickInfoIntroModal,
  *                           which routes through to the existing
  *                           QuickInfoSection's empty-state add flow
- *   3. Tiles exist       → live QuickInfoSection in CardShell
- *
- * QuickInfoSection handles its own list/edit/add modals — this panel
- * just supplies the shell + activation gating.
+ *   3. Tiles exist       → render QuickInfoSection directly (no panel
+ *                           shell). The section already owns its QUICK INFO
+ *                           header + add button + tile grid; the +Add and
+ *                           edit affordances inside QuickInfoSection are
+ *                           already gated by isOwner so member-mode just
+ *                           drops them automatically.
  */
 export function QuickInfoPanel({ tripId, isOwner }: QuickInfoPanelProps) {
   const [introOpen, setIntroOpen] = useState(false);
@@ -35,13 +37,9 @@ export function QuickInfoPanel({ tripId, isOwner }: QuickInfoPanelProps) {
   const { data: tiles = [] } = trpc.quickInfoTiles.list.useQuery({ tripId });
   const hasItems = tiles.length > 0;
 
-  // ── State 3: live ────────────────────────────────────────────────────
+  // ── State 3: live (no panel shell — section is its own surface) ──────
   if (hasItems) {
-    return (
-      <CardShell title="Quick Info" subtitle={`${tiles.length} item${tiles.length !== 1 ? "s" : ""}`}>
-        <QuickInfoSection tripId={tripId} isOwner={isOwner} />
-      </CardShell>
-    );
+    return <QuickInfoSection tripId={tripId} isOwner={isOwner} />;
   }
 
   // ── State 1: member, no tiles ────────────────────────────────────────
@@ -146,43 +144,3 @@ function InvitationCard({
   );
 }
 
-// ── CardShell ────────────────────────────────────────────────────────────
-
-function CardShell({
-  title,
-  subtitle,
-  children,
-}: {
-  title: string;
-  subtitle?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      className="overflow-hidden rounded-xl"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-    >
-      <div
-        className="flex items-center gap-2 px-4 py-3"
-        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
-      >
-        <Info size={14} style={{ color: "var(--color-bt-accent)" }} />
-        <p className="text-[13px] font-bold" style={{ color: "var(--color-bt-text)" }}>
-          {title}
-        </p>
-        {subtitle && (
-          <p
-            className="ml-auto text-[11px]"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            {subtitle}
-          </p>
-        )}
-      </div>
-      <div className="px-4 py-4">{children}</div>
-    </div>
-  );
-}

--- a/src/app/trips/[tripId]/tabs/components/panels/QuickInfoPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/QuickInfoPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { ArrowRight, Info } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { QuickInfoSection } from "../../../components/QuickInfoSection";
+import { AddTileModal, QuickInfoSection } from "../../../components/QuickInfoSection";
 import { QuickInfoIntroModal } from "../modals/QuickInfoIntroModal";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -31,6 +31,7 @@ interface QuickInfoPanelProps {
  */
 export function QuickInfoPanel({ tripId, isOwner }: QuickInfoPanelProps) {
   const [introOpen, setIntroOpen] = useState(false);
+  const [addTileOpen, setAddTileOpen] = useState(false);
   const { data: tiles = [] } = trpc.quickInfoTiles.list.useQuery({ tripId });
   const hasItems = tiles.length > 0;
 
@@ -62,19 +63,16 @@ export function QuickInfoPanel({ tripId, isOwner }: QuickInfoPanelProps) {
         isOpen={introOpen}
         onClose={() => setIntroOpen(false)}
         onActivate={() => {
-          // Quick Info has no enable flag — the modal CTA closes itself
-          // and surfaces the existing QuickInfoSection empty-state add
-          // affordance on the next render. We simply close the modal;
-          // the user then taps the dashed "Add Quick Info" button rendered
-          // by QuickInfoSection (which we now show by switching panels).
+          // Drop straight into the add-first-tile flow — close the intro
+          // and open AddTileModal back to back.
           setIntroOpen(false);
-          // Open the existing add-tile modal directly by clicking the
-          // empty-state button programmatically. Simplest path: dispatch
-          // a custom event that QuickInfoSection's empty button observes.
-          // For now, the next-render empty state lives inline anyway.
+          setAddTileOpen(true);
         }}
         isActivating={false}
       />
+      {addTileOpen && (
+        <AddTileModal tripId={tripId} onClose={() => setAddTileOpen(false)} />
+      )}
     </>
   );
 }

--- a/src/app/trips/[tripId]/tabs/types.ts
+++ b/src/app/trips/[tripId]/tabs/types.ts
@@ -25,6 +25,9 @@ export interface TripData {
   about_message?: string | null;
   /** "basic" (four-tile grid) | "advanced" (full tab view — paywall seam). */
   planning_tier?: "basic" | "advanced" | null;
+  /** Panel activation flags — owner taps the invitation card to flip these on. */
+  itinerary_enabled?: boolean | null;
+  getting_there_enabled?: boolean | null;
   owner_alert?: string | null;
   owner_alert_set_at?: string | null;
   owner_alert_set_by?: string | null;

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -80,7 +80,7 @@ export const TripTabBar: FC<TripTabBarProps> = ({
             key={id}
             data-testid={`tab-${id}`}
             onClick={() => onTabChange(id)}
-            className="flex flex-1 flex-col items-center justify-center gap-0.5 py-2.5 text-xs font-medium transition-colors"
+            className="flex flex-1 flex-col items-center justify-center gap-1 py-2.5 transition-colors"
             style={{
               color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
               borderBottom: active
@@ -88,9 +88,11 @@ export const TripTabBar: FC<TripTabBarProps> = ({
                 : "2px solid transparent",
             }}
           >
-            {/* Icon wrapped in relative container so the dot can be positioned */}
+            {/* Icon wrapped in relative container so the dot can be positioned.
+                strokeWidth=1.75 matches the planning-grid mobile tab style for
+                visual consistency between basic and advanced modes. */}
             <span className="relative inline-flex items-center justify-center">
-              <Icon size={iconMode ? 18 : 14} />
+              <Icon size={iconMode ? 20 : 16} strokeWidth={1.75} />
               {hasBadge && (
                 <span
                   className="absolute -right-1.5 -top-1 h-2 w-2 rounded-full"
@@ -98,7 +100,11 @@ export const TripTabBar: FC<TripTabBarProps> = ({
                 />
               )}
             </span>
-            {!iconMode && <span>{label}</span>}
+            {!iconMode && (
+              <span className="text-[10px] font-bold uppercase tracking-wider">
+                {label}
+              </span>
+            )}
           </button>
         );
       })}

--- a/src/server/routers/trips.test.ts
+++ b/src/server/routers/trips.test.ts
@@ -385,6 +385,53 @@ describe("trips router — stage model", () => {
       caller.trips.changeDestination({ tripId: stageTrip, destination: "Hacked" })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
+
+  // ── enableItinerary / enableGettingThere — panel activation flags ─────
+  // Reuses stageTrip — planner/member were added by the changeDestination
+  // tests above, so we don't need to re-add them here.
+  it("enableItinerary — owner flips itinerary_enabled to true", async () => {
+    const caller = ctx.caller();
+    const res = await caller.trips.enableItinerary({ tripId: stageTrip });
+    expect(res.success).toBe(true);
+    const { data } = await ctx.admin
+      .from("trips")
+      .select("itinerary_enabled")
+      .eq("id", stageTrip)
+      .single();
+    expect(data?.itinerary_enabled).toBe(true);
+  });
+
+  it("enableItinerary — planner can activate", async () => {
+    const plannerCaller = ctx.callerAs("planner");
+    const res = await plannerCaller.trips.enableItinerary({ tripId: stageTrip });
+    expect(res.success).toBe(true);
+  });
+
+  it("enableItinerary — member is FORBIDDEN", async () => {
+    const memberCaller = ctx.callerAs("member");
+    await expect(
+      memberCaller.trips.enableItinerary({ tripId: stageTrip })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("enableGettingThere — owner flips getting_there_enabled to true", async () => {
+    const caller = ctx.caller();
+    const res = await caller.trips.enableGettingThere({ tripId: stageTrip });
+    expect(res.success).toBe(true);
+    const { data } = await ctx.admin
+      .from("trips")
+      .select("getting_there_enabled")
+      .eq("id", stageTrip)
+      .single();
+    expect(data?.getting_there_enabled).toBe(true);
+  });
+
+  it("enableGettingThere — member is FORBIDDEN", async () => {
+    const memberCaller = ctx.callerAs("member");
+    await expect(
+      memberCaller.trips.enableGettingThere({ tripId: stageTrip })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
 });
 
 // ── setPollMode — poll mode toggle ────────────────────────────────────────

--- a/src/server/routers/trips.ts
+++ b/src/server/routers/trips.ts
@@ -723,6 +723,52 @@ export const tripsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
+  // enableItinerary — Owner or Planner activates the Itinerary panel.
+  // Idempotent: re-calling on an already-enabled trip is a no-op.
+  // -----------------------------------------------------------------------
+  enableItinerary: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx }) => {
+      const { error } = await ctx.supabase
+        .from("trips")
+        .update({ itinerary_enabled: true })
+        .eq("id", ctx.tripId);
+
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to enable itinerary: ${error.message}`,
+        });
+      }
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
+  // enableGettingThere — Owner or Planner activates the Getting There panel.
+  // Idempotent: re-calling on an already-enabled trip is a no-op.
+  // -----------------------------------------------------------------------
+  enableGettingThere: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx }) => {
+      const { error } = await ctx.supabase
+        .from("trips")
+        .update({ getting_there_enabled: true })
+        .eq("id", ctx.tripId);
+
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to enable getting there: ${error.message}`,
+        });
+      }
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
   // advanceToGoing — Owner advances trip from PLANNING → GOING
   // Requires: at least one date is locked. aboutMessage is optional — when
   // supplied, it's saved to trip.about_message; no email blast is sent.

--- a/supabase/migrations/20260426231723_059_panel_activation_flags.sql
+++ b/supabase/migrations/20260426231723_059_panel_activation_flags.sql
@@ -1,0 +1,15 @@
+-- Migration 059 — panel activation flags
+--
+-- The going-stage home tab now uses a panel system where the owner
+-- activates each feature explicitly (Itinerary, Getting There, Quick Info,
+-- Competition). Until activated, each panel renders an invitation card
+-- instead of jumping straight to live content.
+--
+-- Quick Info "activation" is implicit (first tile created) and Competition
+-- is implicit (event_id set). Itinerary and Getting There need their own
+-- boolean flags because their underlying content (dates, lodging, schedule,
+-- travel) can pre-exist independently.
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS itinerary_enabled    boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS getting_there_enabled boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

Replaces the consolidated home-tab `ItineraryView` block with a four-panel system, extracts the live competition leaderboard into a persistent strip, unifies tab-bar styling between basic and advanced modes, and aligns add affordances and intro-modal copy across the whole flow.

### Panel system (going/now stage)

Each panel handles its own locked / member-placeholder / invitation / live (or empty-state mock-up) state. Order: **Quick Info → Itinerary → Getting There → Competition**.

- **`QuickInfoPanel`** — rich empty-state mock-up (Info icon + heading + 4-tile skeleton preview) when no tiles. X dismisses (persists via `quick_info_dismissed`); when dismissed, a smaller "Enable Quick Info Tiles" CTA card replaces it. Live state renders `QuickInfoSection` directly. 4-col tile grid; alerts span 2.
- **`ItineraryPanel`** — owner-only locked state when no content; invitation card "Add Itinerary" when there's content but not activated; live `ItineraryView` (with own ITINERARY header + filter pills + day timeline) when activated. Empty live state shows a skeleton preview with X to back out.
- **`GettingTherePanel`** — locked (no dates) with "Set dates →" CTA, member-placeholder, owner invitation "Coordinate Travel Plans", live `GettingThereSection` wrapped in a familiar CardShell. Empty live state shows arrival skeleton preview with X to back out.
- **`CompetitionPanel`** — invitation card "Enable Competition Mode" when not yet set up. Once `event_id` exists, returns null — live leaderboard moves to the persistent `CompetitionStrip`.

### Persistent competition strip

A compact `CompetitionStrip` (event title + team totals + chevron) renders between trip header and tab bar whenever `trip.event_id` is set. Visible from any tab, click-through to `/leaderboard`.

### Four feature intro modals

`ItineraryIntroModal`, `GettingThereIntroModal`, `QuickInfoIntroModal`, `CompetitionIntroModal` — shared shell (gradient hero + radial blob accents + 58px gradient-bordered icon + gradient text title + read-only preview + feature pills + gradient CTA + "Not now" ghost). Per-modal palettes:
- Itinerary: teal/blue
- Getting There: blue/teal
- Quick Info: amber/orange
- Competition: violet/teal (whimsical title "Crown a Champion", boring button "Enable Competition Mode")

Modals only mount when actually opened — fixed a back-navigation bug where 4 unconditionally-mounted modals were each pushing a phantom history entry on page load.

### Itinerary view

`ItineraryView` no longer renders `<GettingThereSection>` (it's its own panel now). Filter pills are conditional: Lodging only when lodging exists, Travel only when travel exists AND `getting_there_enabled` is on, Events only when events exist. Pill row hides when there's <2 categories to filter between.

### Add affordances unified

Schedule / Lodging / Receipts / Crew / Getting There all use the same Pattern 1 pill button: `[type-icon 15] [Plus 12] [noun]`, card-raised bg, rounded-xl, py-2.5, no chevron. Crew "Crew member" moved out of the list card. Getting There "Travel info" replaces the dashed-circle placeholder. Travel form has a Cancel next to Save.

### Tab bar styling unified

- **`TripTabBar`** (advanced/going): labels are `text-[10px] font-bold uppercase tracking-wider`; icons `strokeWidth={1.75}`, sized 16/20; 2px accent underline preserved on active tab.
- **`PlanningGrid`** mobile tab bar (basic): replaced 44px tile/squares with the same inline icon + uppercase label + accent underline pattern.
- **`CrewTab`** restored its missing `CREW` header to match other tabs.

### Schema + tRPC

Migration **059** adds `itinerary_enabled` and `getting_there_enabled` boolean columns on `trips`. Migration **060** adds `quick_info_dismissed`. Six new tRPC mutations: `enableItinerary`, `disableItinerary`, `enableGettingThere`, `disableGettingThere`, `dismissQuickInfo`, `restoreQuickInfo` — all Planner-or-above gated, idempotent, with vitest coverage. **64 tests pass**.

### Other polish

- Quick Info tiles removed from the header area (above tab bar)
- Bottom nav now requires `trip.event_id` (real comp), not just `compUnlocked` intent
- Add-Competition CTA hides as soon as user clicks through `Let's Go!`
- ITINERARY / GETTING THERE section headers hidden when in empty-state mode (the dashed mock-up carries its own identity)
- Section CardShells stripped on Itinerary and Getting There when activated — content renders inline with section header above
- Quick Info dismissed CTA defers all state changes to the modal CTA confirmation (no auto-enable on tap)

## Test plan

- [ ] Owner, going, no content: Itinerary locked card with Lock icon
- [ ] Owner, going, dates set, not activated: tap "Add Itinerary" → modal → modal CTA "Add Itinerary" → live empty-state mock-up with X
- [ ] X on Itinerary empty mock-up reverts to invitation card
- [ ] Owner, going, no dates: Getting There locked with Set dates → routes to schedule tab
- [ ] Owner, going, dates set, not activated: tap "Coordinate Travel Plans" → modal → modal CTA "Coordinate Travel Plans" → live empty-state with X
- [ ] Getting There travel form has Cancel next to Save; row stays collapsed when empty until tapped
- [ ] Owner, going, no Quick Info: rich empty-state mock-up with X
- [ ] X on Quick Info → smaller "Enable Quick Info Tiles" CTA card appears
- [ ] Tap dismissed CTA → modal opens (no flag change yet); cancel modal → still dismissed; confirm modal → un-dismiss + AddTileModal
- [ ] Quick Info live: 4-col grid, alerts span 2 cols, all tiles use text-sm value text
- [ ] Owner, going, no event_id: Competition invitation "Enable Competition Mode" → modal "Crown a Champion" title / "Enable Competition Mode" button → routes to comp tab AND hides home-tab CTA via compUnlocked
- [ ] Once event_id is set: home-tab CompetitionPanel renders nothing; CompetitionStrip appears between header and tab bar
- [ ] Bottom nav appears only when `event_id` is set
- [ ] Member, going, all activated: live content; no setup CTAs or X buttons
- [ ] Member, going, nothing activated: dim placeholders; no Quick Info / Competition surfaces
- [ ] Past/saved stage: legacy ItineraryPanel + CompetitionStrip still surface
- [ ] Tab bar visually consistent between planning (basic mode mobile) and going stages
- [ ] CrewTab shows `CREW` header
- [ ] Header area no longer renders Quick Info tiles
- [ ] **Back navigation**: from a freshly-loaded trip page, one back press returns to the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)