### PR TITLE
Idea stage redesign, Crew tab polish, planning panel fixes

### DIFF
--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1965,6 +1965,7 @@ export default function IdeaZonePanel({
       role: m.role.toLowerCase() as "owner" | "planner",
       hasVoted: allVoterIds.has(m.user_id),
       isMe: m.user_id === currentUser?.id,
+      isGuest: !!(m as { isGuest?: boolean }).isGuest,
     }));
 
   if (ideasTyped.length === 0) {

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -217,7 +217,7 @@ function IdeaCard({
   return (
     <div
       data-testid={`idea-card-${idea.id}`}
-      className="overflow-hidden rounded-2xl transition-shadow"
+      className="overflow-hidden rounded-2xl transition-shadow flex flex-col"
       style={{
         background: "var(--color-bt-card)",
         border: "1px solid var(--color-bt-border)",
@@ -392,8 +392,8 @@ function IdeaCard({
       </div>
 
       {/* ── Body — single column ────────────────────────────────────── */}
-      <div style={{ borderTop: "1px solid var(--color-bt-border)" }}>
-        <div className="space-y-4 p-4">
+      <div className="flex flex-col flex-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+        <div className="flex flex-col flex-1 gap-4 p-4">
           {/* Description */}
           {editingField === "description" ? (
             <div>
@@ -763,7 +763,7 @@ function IdeaCard({
           {/* Footer actions — owner only (set destination + remove) */}
           {isOwner && (
             <div
-              className="flex items-center justify-between pt-3"
+              className="flex items-center justify-between pt-3 mt-auto"
               style={{ borderTop: "1px solid var(--color-bt-border)" }}
             >
               <button

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -302,92 +302,6 @@ function CrewMemberRow({
   );
 }
 
-// ── AddSomeoneRow ─────────────────────────────────────────────────────────
-// Collapsed dashed-avatar row at the bottom of the crew list. Expands to a
-// name-only form. Email is added later via the row's edit panel — that's
-// where the existing-account auto-link runs.
-
-function AddSomeoneRow({ tripId, onAdded }: { tripId: string; onAdded: () => void }) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [name, setName] = useState("");
-  const create = trpc.ghostCrew.create.useMutation({
-    onSuccess() {
-      setName("");
-      setIsExpanded(false);
-      onAdded();
-    },
-  });
-
-  const handleSubmit = () => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    create.mutate({ tripId, name: trimmed, role: "Member" });
-  };
-
-  if (!isExpanded) {
-    // Pattern 1 button — matches Schedule "Item", Lodging "Property",
-    // Receipts "Receipt" styling so add-affordances are consistent
-    // across tabs.
-    return (
-      <button
-        onClick={() => setIsExpanded(true)}
-        className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          color: "var(--color-bt-text)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        <Users size={15} />
-        <Plus size={12} /> Crew member
-      </button>
-    );
-  }
-
-  return (
-    <div
-      className="space-y-2 rounded-xl px-3 py-2.5"
-      style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
-    >
-      <div className="flex gap-2">
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Name"
-          autoFocus
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleSubmit();
-            if (e.key === "Escape") {
-              setIsExpanded(false);
-              setName("");
-            }
-          }}
-          className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
-          style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
-        />
-        <button
-          onClick={handleSubmit}
-          disabled={!name.trim() || create.isPending}
-          className="rounded-lg px-3 py-1.5 text-xs font-semibold disabled:opacity-40"
-          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-        >
-          {create.isPending ? "..." : "Add"}
-        </button>
-        <button
-          onClick={() => {
-            setIsExpanded(false);
-            setName("");
-          }}
-          className="rounded-lg border px-3 py-1.5 text-xs"
-          style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  );
-}
-
 // ── CrewTab ───────────────────────────────────────────────────────────────
 
 export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boolean }) {
@@ -398,6 +312,16 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showEmailModal, setShowEmailModal] = useState(false);
+  const [showAddMember, setShowAddMember] = useState(false);
+  const [addMemberName, setAddMemberName] = useState("");
+
+  const createGuest = trpc.ghostCrew.create.useMutation({
+    onSuccess() {
+      setAddMemberName("");
+      setShowAddMember(false);
+      utils.tripMembers.list.invalidate({ tripId });
+    },
+  });
 
   const me = members.find((m) => m.user_id === currentUser?.id);
   const isOwner = me?.role === "Owner";
@@ -444,14 +368,12 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         </div>
       )}
 
-      {!embedded && (
-        <h2
-          className="mb-2 text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Crew
-        </h2>
-      )}
+      <h2
+        className="mb-2 text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Crew
+      </h2>
 
       {/* Member view — single cohesive list, no Planners/Rest split,
           no Planner badges. Owner badge + ghost-guest legend stay. */}
@@ -500,24 +422,79 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
 
       {canEdit && (
       <div className="space-y-4">
-          {/* ── Cohesive blurb + Crew Email button ── */}
+          {/* ── Owner blurb + action buttons ── */}
           {isOwner && (
-            <div className="flex items-start gap-3">
-              <p className="flex-1 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+            <div className="space-y-2.5">
+              <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
                 Planners can help manage the trip alongside you — promote any crew member with a BuddyTrip account and they get access right away.
               </p>
-              {members.length > 1 && (
+
+              {/* Half+half action row */}
+              <div className="flex gap-2">
+                <button
+                  onClick={() => { setShowAddMember((v) => !v); setAddMemberName(""); }}
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text)",
+                    border: "1px solid var(--color-bt-border)",
+                  }}
+                >
+                  <Users size={13} />
+                  <Plus size={10} />
+                  Add crew member
+                </button>
                 <button
                   onClick={() => setShowEmailModal(true)}
-                  className="flex flex-shrink-0 items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-semibold transition-opacity hover:opacity-85"
+                  className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-semibold transition-opacity hover:opacity-85"
                   style={{
                     background: "var(--color-bt-accent)",
                     color: "var(--color-bt-base)",
                   }}
                 >
                   <Mail size={13} />
-                  Crew Email
+                  Email the Crew
                 </button>
+              </div>
+
+              {/* Inline add-member form */}
+              {showAddMember && (
+                <div
+                  className="flex gap-2 rounded-xl px-3 py-2.5"
+                  style={{ background: "color-mix(in srgb, var(--color-bt-accent) 6%, var(--color-bt-base))" }}
+                >
+                  <input
+                    value={addMemberName}
+                    onChange={(e) => setAddMemberName(e.target.value)}
+                    placeholder="Name"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && addMemberName.trim()) {
+                        createGuest.mutate({ tripId, name: addMemberName.trim(), role: "Member" });
+                      }
+                      if (e.key === "Escape") { setShowAddMember(false); setAddMemberName(""); }
+                    }}
+                    className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+                    style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                  />
+                  <button
+                    onClick={() => {
+                      if (addMemberName.trim()) createGuest.mutate({ tripId, name: addMemberName.trim(), role: "Member" });
+                    }}
+                    disabled={!addMemberName.trim() || createGuest.isPending}
+                    className="rounded-lg px-3 py-1.5 text-xs font-semibold disabled:opacity-40"
+                    style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                  >
+                    {createGuest.isPending ? "..." : "Add"}
+                  </button>
+                  <button
+                    onClick={() => { setShowAddMember(false); setAddMemberName(""); }}
+                    className="rounded-lg border px-3 py-1.5 text-xs"
+                    style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+                  >
+                    Cancel
+                  </button>
+                </div>
               )}
             </div>
           )}
@@ -580,18 +557,6 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
                 </div>
               )}
             </div>
-            {/* Add affordance — Pattern 1 button matching Schedule /
-                Lodging / Receipts add-on-top buttons. Placed above the
-                crew list (out of the list card) so it reads as a
-                top-level "add to this section" affordance, not a list row. */}
-            {isOwner && (
-              <div className="mb-2">
-                <AddSomeoneRow
-                  tripId={tripId}
-                  onAdded={() => utils.tripMembers.list.invalidate({ tripId })}
-                />
-              </div>
-            )}
             <div
               className="overflow-hidden rounded-xl"
               style={{
@@ -652,7 +617,7 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
                 <Mail size={15} />
               </span>
               <span className="flex-1 text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                Crew Email
+                Email the Crew
               </span>
               <button
                 onClick={() => setShowEmailModal(false)}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -502,20 +502,20 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
       <div className="space-y-4">
           {/* ── Cohesive blurb + Crew Email button ── */}
           {isOwner && (
-            <div className="space-y-3">
-              <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+            <div className="flex items-start gap-3">
+              <p className="flex-1 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
                 Planners can help manage the trip alongside you — promote any crew member with a BuddyTrip account and they get access right away.
               </p>
               {members.length > 1 && (
                 <button
                   onClick={() => setShowEmailModal(true)}
-                  className="flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-85"
+                  className="flex flex-shrink-0 items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-semibold transition-opacity hover:opacity-85"
                   style={{
                     background: "var(--color-bt-accent)",
                     color: "var(--color-bt-base)",
                   }}
                 >
-                  <Mail size={15} />
+                  <Mail size={13} />
                   Crew Email
                 </button>
               )}
@@ -667,6 +667,20 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
             {/* Modal body — scrollable */}
             <div className="overflow-y-auto p-4">
               <CrewEmailPanel trip={trip} isOwner={isOwner} />
+            </div>
+
+            {/* Modal footer */}
+            <div
+              className="flex flex-shrink-0 justify-end px-4 py-3"
+              style={{ borderTop: "1px solid var(--color-bt-border)" }}
+            >
+              <button
+                onClick={() => setShowEmailModal(false)}
+                className="rounded-xl px-4 py-2 text-sm font-medium transition-opacity hover:opacity-70"
+                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
+              >
+                Cancel
+              </button>
             </div>
           </div>
         </div>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -397,6 +397,7 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showEmailModal, setShowEmailModal] = useState(false);
 
   const me = members.find((m) => m.user_id === currentUser?.id);
   const isOwner = me?.role === "Owner";
@@ -498,13 +499,27 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
       )}
 
       {canEdit && (
-      <div className={isOwner && members.length > 1 ? "@[640px]:grid @[640px]:grid-cols-[minmax(0,1fr)_360px] @[640px]:gap-5" : ""}>
-        <div className="min-w-0 space-y-4">
-          {/* ── Cohesive blurb — sits between the outer CREW panel title and PLANNERS ── */}
+      <div className="space-y-4">
+          {/* ── Cohesive blurb + Crew Email button ── */}
           {isOwner && (
-            <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              Planners can help manage the trip alongside you — promote any crew member with a BuddyTrip account and they get access right away. Guests without an account can be reached via the email panel.
-            </p>
+            <div className="space-y-3">
+              <p className="text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+                Planners can help manage the trip alongside you — promote any crew member with a BuddyTrip account and they get access right away.
+              </p>
+              {members.length > 1 && (
+                <button
+                  onClick={() => setShowEmailModal(true)}
+                  className="flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-85"
+                  style={{
+                    background: "var(--color-bt-accent)",
+                    color: "var(--color-bt-base)",
+                  }}
+                >
+                  <Mail size={15} />
+                  Crew Email
+                </button>
+              )}
+            </div>
           )}
 
           {/* ── PLANNERS section ── */}
@@ -607,15 +622,54 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
             </div>
           </div>
         </div>
+      )}
 
-        {/* Email panel — owner-only. Stacks below crew list on small containers,
-            sits in the right grid column at ≥640px. */}
-        {isOwner && members.length > 1 && (
-          <div className="mt-6 @[640px]:mt-0">
-            <CrewEmailPanel trip={trip} isOwner={isOwner} />
+      {/* ── Crew Email modal ─────────────────────────────────────────────── */}
+      {showEmailModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+          style={{ background: "rgba(0,0,0,0.5)" }}
+          onClick={(e) => { if (e.target === e.currentTarget) setShowEmailModal(false); }}
+        >
+          <div
+            className="relative w-full max-w-lg overflow-hidden rounded-t-2xl sm:rounded-2xl"
+            style={{
+              background: "var(--color-bt-base)",
+              maxHeight: "90dvh",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            {/* Modal header */}
+            <div
+              className="flex flex-shrink-0 items-center gap-3 px-4 py-3"
+              style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+            >
+              <span
+                className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
+                style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }}
+              >
+                <Mail size={15} />
+              </span>
+              <span className="flex-1 text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                Crew Email
+              </span>
+              <button
+                onClick={() => setShowEmailModal(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-lg transition-opacity hover:opacity-70"
+                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+                aria-label="Close"
+              >
+                <X size={15} />
+              </button>
+            </div>
+
+            {/* Modal body — scrollable */}
+            <div className="overflow-y-auto p-4">
+              <CrewEmailPanel trip={trip} isOwner={isOwner} />
+            </div>
           </div>
-        )}
-      </div>
+        </div>
       )}
     </div>
   );

--- a/src/app/trips/[tripId]/tabs/LodgingTab.tsx
+++ b/src/app/trips/[tripId]/tabs/LodgingTab.tsx
@@ -26,7 +26,6 @@ export function LodgingTab({ trip, canEdit, embedded }: TabProps & { embedded?: 
         isOpen={true}
         onToggle={() => {}}
         inline
-        hideHeader={embedded}
       />
     </div>
   );

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -690,14 +690,12 @@ export function ScheduleTab({
         )}
 
       <section>
-        {!embedded && (
-          <h2
-            className="mb-2 text-xs font-semibold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Schedule
-          </h2>
-        )}
+        <h2
+          className="mb-2 text-xs font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Schedule
+        </h2>
 
         {/* Guidance text — stage-aware */}
         <p

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -111,8 +111,13 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
 
   return (
     <div data-testid="crew-email-panel">
-      {/* Reset button row */}
-      <div className="mb-3 flex items-center justify-end gap-2">
+      {/* Blurb — top of panel */}
+      <p className="mb-3 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        Send your first invite, then keep everyone in the loop as the trip gets closer.
+      </p>
+
+      {/* Reset button — pinned below blurb, right-aligned */}
+      <div className="mb-2 flex items-center justify-end gap-2">
         {confirmingReset ? (
           <div className="flex items-center gap-2">
             <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -153,11 +158,6 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
           </button>
         )}
       </div>
-
-      {/* Blurb */}
-      <p className="mb-3 text-[13px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-        Send your first invite, then keep everyone in the loop as the trip gets closer.
-      </p>
 
       {/* Editable message */}
       <div

--- a/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/CrewEmailPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { CheckSquare, Ghost, Mail, RotateCcw, Send, Square } from "lucide-react";
+import { CheckSquare, Ghost, RotateCcw, Send, Square } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { buildCannedInvitation } from "@/lib/invitationDefault";
@@ -110,31 +110,9 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
   const isDefaultMessage = messageDraft.trim() === cannedInvitation.trim();
 
   return (
-    <div
-      className="rounded-xl p-4"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-      data-testid="crew-email-panel"
-    >
-      {/* Header */}
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2.5">
-          <span
-            className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
-            style={{
-              background: "var(--color-bt-accent-faint)",
-              color: "var(--color-bt-accent)",
-            }}
-          >
-            <Mail size={14} />
-          </span>
-          <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Crew Email
-          </p>
-        </div>
-
+    <div data-testid="crew-email-panel">
+      {/* Reset button row */}
+      <div className="mb-3 flex items-center justify-end gap-2">
         {confirmingReset ? (
           <div className="flex items-center gap-2">
             <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -158,7 +136,7 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
               className="text-xs"
               style={{ color: "var(--color-bt-text-dim)" }}
             >
-              Cancel
+              No
             </button>
           </div>
         ) : (
@@ -366,3 +344,4 @@ export function CrewEmailPanel({ trip, isOwner }: CrewEmailPanelProps) {
     </div>
   );
 }
+

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -155,29 +155,29 @@ export function DatePollGrid({
   // Empty-state short-circuit: no date windows yet.
   if (!hasWindows) {
     return (
-      <EmptyState
-        icon={<CalendarDays className="h-10 w-10" />}
-        headline="No date options yet"
-        subtext={
-          showAddColumn
-            ? "Add date windows below so the crew can vote on what works."
-            : "The organizer hasn't added any date options yet."
-        }
-        action={
-          showAddColumn ? (
-            <button
-              type="button"
-              onClick={onAddDateWindow}
-              className="flex items-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-medium transition-all"
-              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-            >
-              <CalendarPlus size={15} />
-              <Plus size={12} />
-              Add date option
-            </button>
-          ) : undefined
-        }
-      />
+      <div>
+        {showAddColumn && (
+          <button
+            type="button"
+            onClick={onAddDateWindow}
+            className="mb-4 flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+          >
+            <CalendarPlus size={15} />
+            <Plus size={12} />
+            Add date option
+          </button>
+        )}
+        <EmptyState
+          icon={<CalendarDays className="h-10 w-10" />}
+          headline="No date options yet"
+          subtext={
+            showAddColumn
+              ? "Add date windows above so the crew can vote on what works."
+              : "The organizer hasn't added any date options yet."
+          }
+        />
+      </div>
     );
   }
 

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { CalendarDays, CalendarPlus, Check, CheckCircle2, Trash2 } from "lucide-react";
+import { CalendarDays, CalendarPlus, Check, CheckCircle2, Plus, Trash2 } from "lucide-react";
 import { parseLocalDate } from "@/lib/dates";
 import { UserAvatar } from "@/components/UserAvatar";
 import { EmptyState } from "@/components/EmptyState";
@@ -171,7 +171,8 @@ export function DatePollGrid({
               className="flex items-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-medium transition-all"
               style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
             >
-              <CalendarPlus size={14} />
+              <CalendarPlus size={15} />
+              <Plus size={12} />
               Add date option
             </button>
           ) : undefined

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -168,8 +168,8 @@ export function DatePollGrid({
             <button
               type="button"
               onClick={onAddDateWindow}
-              className="flex items-center gap-1.5 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-80"
-              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+              className="flex items-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-medium transition-all"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
             >
               <CalendarPlus size={14} />
               Add date option

--- a/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollGrid.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { CalendarPlus, Check, CheckCircle2, Trash2 } from "lucide-react";
+import { CalendarDays, CalendarPlus, Check, CheckCircle2, Trash2 } from "lucide-react";
 import { parseLocalDate } from "@/lib/dates";
 import { UserAvatar } from "@/components/UserAvatar";
+import { EmptyState } from "@/components/EmptyState";
 
 export type VoteAnswer = "yes" | "maybe" | "no" | null;
 
@@ -151,34 +152,31 @@ export function DatePollGrid({
     dateWindows.length * COLUMN_WIDTH +
     (showAddColumn ? ADD_COL_WIDTH : 0);
 
-  // Empty-state short-circuit: no date windows yet. Keep a single-row
-  // banner layout so member rows don't flow across undefined columns.
+  // Empty-state short-circuit: no date windows yet.
   if (!hasWindows) {
     return (
-      <div
-        className="overflow-hidden rounded-xl"
-        style={{ background: "var(--color-bt-card-raised)" }}
-      >
-        {showAddColumn ? (
-          <button
-            type="button"
-            onClick={onAddDateWindow}
-            className="flex w-full items-center justify-center gap-2 py-5 text-[13px] font-medium transition-colors hover:opacity-80"
-            style={{ color: "var(--color-bt-accent)" }}
-            aria-label="Add date option"
-          >
-            <CalendarPlus size={16} />
-            Add your first date option
-          </button>
-        ) : (
-          <p
-            className="px-4 py-5 text-center text-[13px] italic"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            No date options added yet.
-          </p>
-        )}
-      </div>
+      <EmptyState
+        icon={<CalendarDays className="h-10 w-10" />}
+        headline="No date options yet"
+        subtext={
+          showAddColumn
+            ? "Add date windows below so the crew can vote on what works."
+            : "The organizer hasn't added any date options yet."
+        }
+        action={
+          showAddColumn ? (
+            <button
+              type="button"
+              onClick={onAddDateWindow}
+              className="flex items-center gap-1.5 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-80"
+              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            >
+              <CalendarPlus size={14} />
+              Add date option
+            </button>
+          ) : undefined
+        }
+      />
     );
   }
 

--- a/src/app/trips/[tripId]/tabs/components/PlannersPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlannersPanel.tsx
@@ -89,6 +89,20 @@ function PlannerRow({
         </div>
 
         <div className="flex flex-shrink-0 items-center gap-1.5">
+          {/* Pending badge — guest planners without a BT account */}
+          {planner.isGuest && (
+            <span
+              className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+              style={{
+                background: "color-mix(in srgb, var(--color-bt-warning) 12%, transparent)",
+                color: "var(--color-bt-warning)",
+                border: "1px solid color-mix(in srgb, var(--color-bt-warning) 25%, transparent)",
+              }}
+            >
+              Pending
+            </span>
+          )}
+
           {/* Owner badge */}
           {isOwnerRow && (
             <span
@@ -115,20 +129,6 @@ function PlannerRow({
               }}
             >
               Planner
-            </span>
-          )}
-
-          {/* Pending badge — guest planners without a BT account */}
-          {planner.isGuest && (
-            <span
-              className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
-              style={{
-                background: "color-mix(in srgb, var(--color-bt-warning) 12%, transparent)",
-                color: "var(--color-bt-warning)",
-                border: "1px solid color-mix(in srgb, var(--color-bt-warning) 25%, transparent)",
-              }}
-            >
-              Pending
             </span>
           )}
 

--- a/src/app/trips/[tripId]/tabs/components/PlannersPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlannersPanel.tsx
@@ -15,6 +15,8 @@ export interface PlannerWithVoteStatus {
   role: "owner" | "planner";
   hasVoted: boolean;
   isMe: boolean;
+  /** True when added by email but no BuddyTrip account exists yet */
+  isGuest: boolean;
 }
 
 interface PlannersPanelProps {
@@ -113,6 +115,20 @@ function PlannerRow({
               }}
             >
               Planner
+            </span>
+          )}
+
+          {/* Pending badge — guest planners without a BT account */}
+          {planner.isGuest && (
+            <span
+              className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+              style={{
+                background: "color-mix(in srgb, var(--color-bt-warning) 12%, transparent)",
+                color: "var(--color-bt-warning)",
+                border: "1px solid color-mix(in srgb, var(--color-bt-warning) 25%, transparent)",
+              }}
+            >
+              Pending
             </span>
           )}
 

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowRight,
   Calendar,
+  CalendarDays,
   CalendarRange,
   Check,
   ChevronRight,
@@ -18,6 +19,7 @@ import { formatDateRangeCompact, fmtTime12 } from "@/lib/dates";
 import type { TripData } from "../types";
 import type { TabProps } from "../types";
 import { DatePollCard } from "./DatePollCard";
+import { EmptyState } from "@/components/EmptyState";
 import { CrewTab } from "../CrewTab";
 import { LodgingTab } from "../LodgingTab";
 import { ScheduleTab } from "../ScheduleTab";
@@ -722,6 +724,15 @@ function DatesPanelContent({
               </button>
             )}
           </div>
+
+          {/* Empty state — only when no dates locked yet */}
+          {!datesLocked && (
+            <EmptyState
+              icon={<CalendarDays className="h-10 w-10" />}
+              headline="No dates set yet"
+              subtext="Pick a start and end date above to lock in your trip window."
+            />
+          )}
         </div>
       ) : hasCrew ? (
         <div className="space-y-3">

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -1442,19 +1442,16 @@ export function PlanningGrid({
           >
             {activePanel === "crew" && (crewState === "skipped" ? null : (
               <div className="px-4 py-4">
-                <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider" style={{ color: panelTitleColor(crewState) }}>Crew</h2>
                 <CrewTab trip={trip} role={null} canEdit={canEdit} isOwner={isOwner} embedded={true} />
               </div>
             ))}
             {activePanel === "lodging" && (lodgingState === "skipped" ? null : (
               <div className="px-4 py-4">
-                <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider" style={{ color: panelTitleColor(lodgingState) }}>Lodging</h2>
                 <LodgingTab trip={trip} role={null} canEdit={canEdit} isOwner={isOwner} embedded={true} />
               </div>
             ))}
             {activePanel === "schedule" && (scheduleState === "skipped" ? null : (
               <div className="px-4 py-4">
-                <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider" style={{ color: panelTitleColor(scheduleState) }}>Schedule</h2>
                 <ScheduleTab trip={trip} role={null} canEdit={canEdit} isOwner={isOwner} embedded={true} />
               </div>
             ))}
@@ -1537,7 +1534,6 @@ export function PlanningGrid({
               </div>
             ) : (
               <div className="px-4 py-4">
-                <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider" style={{ color: panelTitleColor(crewState) }}>Crew</h2>
                 <CrewTab trip={trip} role={null} canEdit={canEdit} isOwner={isOwner} embedded={true} />
                 {canEdit && (
                   <div className="mt-4 border-t pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
@@ -1563,7 +1559,6 @@ export function PlanningGrid({
               </div>
             ) : (
               <div className="px-4 py-4">
-                <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider" style={{ color: panelTitleColor(lodgingState) }}>Lodging</h2>
                 <LodgingTab trip={trip} role={null} canEdit={canEdit} isOwner={isOwner} embedded={true} />
                 {canEdit && (
                   <div className="mt-4 border-t pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
@@ -1589,7 +1584,6 @@ export function PlanningGrid({
               </div>
             ) : (
               <div className="px-4 py-4">
-                <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider" style={{ color: panelTitleColor(scheduleState) }}>Schedule</h2>
                 <ScheduleTab trip={trip} role={null} canEdit={canEdit} isOwner={isOwner} embedded={true} />
                 {canEdit && (
                   <div className="mt-4 border-t pt-3" style={{ borderColor: "var(--color-bt-border)" }}>

--- a/src/components/CrewSearchInput.tsx
+++ b/src/components/CrewSearchInput.tsx
@@ -311,17 +311,6 @@ export function CrewSearchInput({
                   <><UserPlus size={11} /> Invite to BuddyTrip</>
                 )}
               </button>
-              <button
-                onClick={handleCopyInvite}
-                className="flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-xs transition-opacity hover:opacity-80"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                {copied ? (
-                  <><Check size={11} /> Link copied!</>
-                ) : (
-                  <><Link size={11} /> Copy invite link instead</>
-                )}
-              </button>
             </>
           )}
 


### PR DESCRIPTION
## Summary

- **Idea stage**: Single-column layout with responsive card grid (`auto-fill/minmax`), `PlannersPanel` redesigned to match crew tab styling (teal rows, Crown badge, expandable rows, Pending badge for ghost planners), `Destination Ideas` section header, footers anchored to bottom of cards
- **Crew tab**: `CrewEmailPanel` moved from sidebar to modal; renamed to "Email the Crew"; prominent half-width button pair ("Add crew member" + "Email the Crew") below the planners blurb; `AddSomeoneRow` replaced with inline form lifted to top level; modal has blurb at top, Reset button pinned below it, Cancel footer
- **Nudge ordering fixed**: `PlanningGrid` was rendering section `<h2>` headers before tab components, pushing nudges below the header — fixed by removing headers from `PlanningGrid` and letting `CrewTab`, `LodgingTab`, `ScheduleTab` always render their own headers (nudge → header → content)
- **Empty states**: "Pick your Dates" and "Poll the Crew" tabs now have consistent `EmptyState` with big icon, headline, and subtext; poll tab has card-styled add button above the empty state
- **Misc**: Removed "Copy invite link instead" from `CrewSearchInput`; `CrewSearchInput` Cancel button moved inline

## Test plan

- [ ] Idea stage: PlannersPanel collapses/expands, Pending badge shows only for ghost planners, card footers align at bottom across varying content heights
- [ ] Crew tab (basic planning): nudge appears above "Crew" header, both action buttons render half-width, "Add crew member" expands inline form, "Email the Crew" opens modal with blurb → Reset → textarea → recipients → Cancel footer
- [ ] Lodging panel embedded in PlanningGrid: out-of-range nudge appears above "Lodging" header
- [ ] Dates panel: "Pick your Dates" shows empty state when no dates set; "Poll the Crew" shows add button above empty state when no windows exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)