### PR TITLE
ux(competition): action bar, drop-to-unassign, 1/3+2/3 layout, loading gate

### DIFF
--- a/src/app/trips/[tripId]/tabs/CompTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CompTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Trophy } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CompetitionSetupPanel } from "@/components/competition/CompetitionSetupPanel";
@@ -85,6 +86,55 @@ function ExistingCompetitionView({
   isOwner: boolean;
   onCompetitionDeleted?: () => void;
 }) {
+  // Creation state lives at this level so the +Team / +Event / +Venue
+  // buttons in CompetitionHeader can drive the same sheets that the
+  // panels' empty-state CTAs trigger. The actual sheet/modal markup
+  // still lives inside each panel — they just consume the prop.
+  const [creatingTeam, setCreatingTeam] = useState(false);
+  const [creatingEvent, setCreatingEvent] = useState(false);
+  const [creatingManualVenue, setCreatingManualVenue] = useState(false);
+
+  // Prefetch every query the inner panels and the header read so we
+  // can gate rendering on a single combined loading flag. Without this
+  // each panel falls through to its empty-state branch on the very
+  // first render (default `data = []`) and the user sees a "No teams /
+  // events / venues yet" flash before the data lands a tick later.
+  // tRPC + TanStack Query dedupe by query key, so the children's own
+  // useQuery calls reuse these cached results — no extra network hits.
+  const teamsQ = trpc.teams.list.useQuery(
+    { tripId, competitionId: competition.id },
+    { enabled: !!competition.id }
+  );
+  const assignmentsQ = trpc.teamAssignments.list.useQuery(
+    { tripId, competitionId: competition.id },
+    { enabled: !!competition.id }
+  );
+  const membersQ = trpc.tripMembers.list.useQuery({ tripId });
+  const eventsQ = trpc.events.list.useQuery(
+    { tripId, competitionId: competition.id },
+    { enabled: !!competition.id }
+  );
+  const venuesQ = trpc.venues.list.useQuery(
+    { tripId, competitionId: competition.id },
+    { enabled: !!competition.id }
+  );
+  const golfQ = trpc.schedule.listGolf.useQuery(
+    { tripId },
+    { enabled: !!competition.id }
+  );
+
+  const isHydrating =
+    teamsQ.isLoading ||
+    assignmentsQ.isLoading ||
+    membersQ.isLoading ||
+    eventsQ.isLoading ||
+    venuesQ.isLoading ||
+    golfQ.isLoading;
+
+  if (isHydrating) {
+    return <SkeletonPanels />;
+  }
+
   return (
     <div className="space-y-3 px-4">
       <CompetitionHeader
@@ -93,17 +143,26 @@ function ExistingCompetitionView({
         canEdit={canEdit}
         isOwner={isOwner}
         onDeleted={onCompetitionDeleted}
+        onAddTeam={() => setCreatingTeam(true)}
+        onAddEvent={() => setCreatingEvent(true)}
+        onAddVenue={() => setCreatingManualVenue(true)}
       />
       <TeamsPanel
         competitionId={competition.id}
         tripId={tripId}
         canEdit={canEdit}
         isOwner={isOwner}
+        creating={creatingTeam}
+        onCreatingChange={setCreatingTeam}
       />
       <MatchupPanel
         competitionId={competition.id}
         tripId={tripId}
         canEdit={canEdit}
+        creatingEvent={creatingEvent}
+        onCreatingEventChange={setCreatingEvent}
+        creatingManualVenue={creatingManualVenue}
+        onCreatingManualVenueChange={setCreatingManualVenue}
       />
     </div>
   );

--- a/src/components/competition/CompetitionHeader.tsx
+++ b/src/components/competition/CompetitionHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil, Trash2, Trophy } from "lucide-react";
+import { Flag, MapPin, Pencil, Plus, Trash2, Trophy, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CompetitionSetupPanel } from "./CompetitionSetupPanel";
 
@@ -48,6 +48,12 @@ interface Props {
    * tab fully disappears (not just for the rest of the crew).
    */
   onDeleted?: () => void;
+  /** Action-bar handlers — when provided, the header renders +Team /
+   *  +Event / +Venue affordances inline below the title strip so the
+   *  inner panels don't have to surface them. */
+  onAddTeam?: () => void;
+  onAddEvent?: () => void;
+  onAddVenue?: () => void;
 }
 
 /**
@@ -63,6 +69,9 @@ export function CompetitionHeader({
   canEdit,
   isOwner,
   onDeleted,
+  onAddTeam,
+  onAddEvent,
+  onAddVenue,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [confirming, setConfirming] = useState(false);
@@ -186,23 +195,50 @@ export function CompetitionHeader({
         )}
       </div>
 
-      {/* Progress strip — divider above */}
+      {/* Action bar — three columns combining a status line with an
+          add affordance. Replaces the old plain ProgressPill strip and
+          centralizes the +Team / +Event / +Venue buttons that used to
+          live inside the inner panels. */}
       <div
-        className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5"
+        className="grid grid-cols-1 gap-2 px-3 py-2.5 sm:grid-cols-3 sm:gap-2"
         style={{ borderTop: "1px solid var(--color-bt-border)" }}
       >
-        <ProgressPill
-          label={
+        <ActionTile
+          icon={<Users size={14} />}
+          label="Team"
+          status={
             totalMembers > 0
-              ? `Teams: ${assignedCount}/${totalMembers} assigned`
-              : "Teams: not set up"
+              ? `${assignedCount}/${totalMembers} assigned`
+              : "Not set up"
           }
           complete={teamsComplete}
+          onAdd={canEdit ? onAddTeam : undefined}
         />
-        <ProgressPill label={`Events: ${scoredEvents}`} complete={eventsComplete} />
-        <ProgressPill
-          label={`Venues: ${venuesLinked} linked`}
+        <ActionTile
+          icon={<Flag size={14} />}
+          label="Event"
+          status={
+            eventsTyped.length === 0
+              ? "Not set up"
+              : `${scoredEvents} scored${
+                  eventsTyped.length - scoredEvents > 0
+                    ? ` · ${eventsTyped.length - scoredEvents} practice`
+                    : ""
+                }`
+          }
+          complete={eventsComplete}
+          onAdd={canEdit ? onAddEvent : undefined}
+        />
+        <ActionTile
+          icon={<MapPin size={14} />}
+          label="Venue"
+          status={
+            venuesTyped.length === 0
+              ? "Not set up"
+              : `${venuesLinked}/${scoredEvents || venuesTyped.length} linked`
+          }
           complete={venuesComplete}
+          onAdd={canEdit ? onAddVenue : undefined}
         />
       </div>
 
@@ -358,21 +394,73 @@ function StatusBadge({ status }: { status: Competition["status"] }) {
   );
 }
 
-function ProgressPill({
+function ActionTile({
+  icon,
   label,
+  status,
   complete,
+  onAdd,
 }: {
+  icon: React.ReactNode;
   label: string;
+  status: string;
   complete: boolean;
+  /** Undefined → render the tile as a non-interactive status block
+   *  (read-only members or unsupported state). */
+  onAdd?: () => void;
 }) {
+  const accent = complete
+    ? "var(--color-bt-accent)"
+    : "var(--color-bt-text-dim)";
+  const content = (
+    <>
+      <span style={{ color: accent }}>{icon}</span>
+      <div className="min-w-0 flex-1 text-left">
+        <p
+          className="flex items-center gap-1 text-[12px] font-semibold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          <span>{label}</span>
+          {onAdd && (
+            <Plus size={11} style={{ color: "var(--color-bt-text-dim)" }} />
+          )}
+        </p>
+        <p
+          className="mt-0.5 text-[11px] leading-tight"
+          style={{ color: accent }}
+        >
+          {status}
+        </p>
+      </div>
+    </>
+  );
+
+  if (!onAdd) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-lg px-2.5 py-2"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {content}
+      </div>
+    );
+  }
+
   return (
-    <span
-      className="text-[11px] font-medium"
+    <button
+      type="button"
+      onClick={onAdd}
+      aria-label={`Add ${label.toLowerCase()}`}
+      className="flex items-center gap-2 rounded-lg px-2.5 py-2 transition-colors hover:brightness-105"
       style={{
-        color: complete ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+        background: "var(--color-bt-card-raised)",
+        border: "1px solid var(--color-bt-border)",
       }}
     >
-      {label}
-    </span>
+      {content}
+    </button>
   );
 }

--- a/src/components/competition/EventsPanel.tsx
+++ b/src/components/competition/EventsPanel.tsx
@@ -91,11 +91,36 @@ export function EventsPanel({ competitionId, tripId, canEdit, bare }: Props) {
   const [open, setOpen] = useState(true);
   const [editing, setEditing] = useState<EventRow | null>(null);
   const [creating, setCreating] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
 
+  const utils = trpc.useUtils();
   const { data: events = [] } = trpc.events.list.useQuery(
     { tripId, competitionId },
     { enabled: !!competitionId }
   );
+
+  // Drop-to-unassign: a LinkedEventDetails chip dragged out of a venue
+  // card lands here and we look up which venue currently holds it, then
+  // call venues.unassignEvent. Mirrors the crew column's unassign drop.
+  const unassign = trpc.venues.unassignEvent.useMutation({
+    onMutate: async (vars) => {
+      await utils.venues.list.cancel({ tripId, competitionId });
+      const previous = utils.venues.list.getData({ tripId, competitionId });
+      utils.venues.list.setData({ tripId, competitionId }, (old) => {
+        const list = (old as Array<{ id: string; event_id: string | null; is_anytime: boolean }> | undefined) ?? [];
+        return list.map((v) =>
+          v.id === vars.venueId ? { ...v, event_id: null, is_anytime: false } : v
+        ) as never;
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        utils.venues.list.setData({ tripId, competitionId }, ctx.previous);
+      }
+    },
+    onSettled: () => utils.venues.list.invalidate({ tripId, competitionId }),
+  });
 
   // Venue linkage drives the per-card status line. The venues router is
   // optional — if it isn't loaded yet (cold cache) we just render the
@@ -128,35 +153,97 @@ export function EventsPanel({ competitionId, tripId, canEdit, bare }: Props) {
       }`;
   const headerState = totalEvents === 0 ? "todo" : "inProgress";
 
+  // The bare-mode column itself acts as a drop target so an event chip
+  // dragged off a venue card can be returned to the unassigned pool.
+  const handleUnassignDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const eventId = e.dataTransfer.getData(DND_EVENT_KEY);
+    if (!eventId) return;
+    const venue = venuesTyped.find((v) => v.event_id === eventId) as
+      | { id?: string }
+      | undefined;
+    if (!venue?.id) return;
+    unassign.mutate({ tripId, venueId: venue.id });
+  };
+
+  const allAssigned =
+    bare && eventsTyped.length > 0 && visibleEvents.length === 0;
+
+  // In bare mode the events column is always a card-shaped drop target —
+  // mirrors the crew column treatment so the "drop here to unassign"
+  // affordance is visually consistent across the comp tab.
+  const bareDropStyle: React.CSSProperties | undefined = bare
+    ? {
+        background: "var(--color-bt-card-raised)",
+        border: `${dragOver ? "1.5px" : "1px"} ${dragOver ? "dashed" : "solid"} ${
+          dragOver ? "var(--color-bt-accent)" : "var(--color-bt-border)"
+        }`,
+      }
+    : undefined;
+
+  const inner = (
+    <>
+      {visibleEvents.length === 0 && !allAssigned && !bare && (
+        <EventsEmptyState
+          canEdit={canEdit && !bare}
+          onAdd={() => setCreating(true)}
+        />
+      )}
+
+      {bare && visibleEvents.length === 0 && (
+        <p
+          className="text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {allAssigned
+            ? canEdit
+              ? "All events assigned to venues. Drop here to unassign."
+              : "All events assigned to venues."
+            : canEdit
+              ? "No unassigned events. Drop here to unassign."
+              : "No unassigned events."}
+        </p>
+      )}
+
+      {visibleEvents.map((event) => (
+        <EventCard
+          key={event.id}
+          event={event}
+          venue={venuesTyped.find((v) => v.event_id === event.id) ?? null}
+          canEdit={canEdit}
+          tripId={tripId}
+          onEdit={() => setEditing(event)}
+        />
+      ))}
+
+      {/* Bottom Add Event button is hidden in bare mode — the +Event
+          affordance lives in CompetitionHeader's action bar now. */}
+      {!bare && visibleEvents.length > 0 && canEdit && (
+        <AddEventButton onClick={() => setCreating(true)} />
+      )}
+    </>
+  );
+
   const body = (
     <>
-      <div className="space-y-2">
-        {visibleEvents.length === 0 && (
-          <EventsEmptyState
-            canEdit={canEdit && !bare}
-            onAdd={() => setCreating(true)}
-            assignedCount={
-              bare ? eventsTyped.length - visibleEvents.length : 0
-            }
-          />
-        )}
-
-        {visibleEvents.map((event) => (
-          <EventCard
-            key={event.id}
-            event={event}
-            venue={venuesTyped.find((v) => v.event_id === event.id) ?? null}
-            canEdit={canEdit}
-            tripId={tripId}
-            onEdit={() => setEditing(event)}
-          />
-        ))}
-
-        {/* Bottom Add Event button is hidden in bare mode — MatchupPanel
-            renders its own above the column header instead. */}
-        {!bare && visibleEvents.length > 0 && canEdit && (
-          <AddEventButton onClick={() => setCreating(true)} />
-        )}
+      <div
+        className={`${bare ? "rounded-xl p-3" : ""} space-y-2 transition-colors`}
+        style={bareDropStyle}
+        onDragOver={
+          bare && canEdit
+            ? (e) => {
+                if (!e.dataTransfer.types.includes(DND_EVENT_KEY)) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+                setDragOver(true);
+              }
+            : undefined
+        }
+        onDragLeave={bare && canEdit ? () => setDragOver(false) : undefined}
+        onDrop={bare && canEdit ? handleUnassignDrop : undefined}
+      >
+        {inner}
       </div>
 
       {(creating || editing) && (
@@ -270,23 +357,14 @@ function CollapsiblePanel({
 function EventsEmptyState({
   canEdit,
   onAdd,
-  assignedCount,
 }: {
   canEdit: boolean;
   onAdd: () => void;
-  /** When called from bare mode (MatchupPanel), how many events are
-   *  already assigned to venues — drives a subtler "all assigned" copy
-   *  instead of the cold "no events yet" message. */
-  assignedCount: number;
 }) {
-  const message = assignedCount > 0
-    ? `All ${assignedCount} event${assignedCount === 1 ? "" : "s"} assigned. Add another?`
-    : "No events yet. Add the rounds and activities you’ll compete in.";
-
   return (
     <div className="py-2 text-center">
       <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-        {message}
+        No events yet. Add the rounds and activities you&rsquo;ll compete in.
       </p>
       {canEdit && <AddEventButton onClick={onAdd} className="mx-auto mt-3" />}
     </div>
@@ -471,7 +549,7 @@ function EventCard({
             onClick={() => setConfirmingDelete(true)}
             aria-label={`Delete ${event.title}`}
             className="flex h-7 w-7 items-center justify-center rounded-lg"
-            style={{ color: "var(--color-bt-danger)" }}
+            style={{ color: "var(--color-bt-text-dim)" }}
           >
             <Trash2 size={13} />
           </button>

--- a/src/components/competition/MatchupPanel.tsx
+++ b/src/components/competition/MatchupPanel.tsx
@@ -3,13 +3,20 @@
 import { useState } from "react";
 import { ArrowRight, ChevronDown, Flag, MapPin, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { AddEventButton, EventSheet, EventsPanel } from "./EventsPanel";
-import { AddVenueButton, ManualVenueSheet, VenuesPanel } from "./VenuesPanel";
+import { EventSheet, EventsPanel } from "./EventsPanel";
+import { ManualVenueSheet, VenuesPanel } from "./VenuesPanel";
 
 interface Props {
   competitionId: string;
   tripId: string;
   canEdit: boolean;
+  /** When provided, the parent (CompTab) drives the +Event / +Venue
+   *  create state via CompetitionHeader's action bar. Local state is
+   *  used as a fallback so this panel still works standalone. */
+  creatingEvent?: boolean;
+  onCreatingEventChange?: (v: boolean) => void;
+  creatingManualVenue?: boolean;
+  onCreatingManualVenueChange?: (v: boolean) => void;
 }
 
 /**
@@ -23,13 +30,32 @@ interface Props {
  * queries inside each are still independent (and TanStack Query
  * dedupes them across renders), so there's no extra fetch overhead.
  */
-export function MatchupPanel({ competitionId, tripId, canEdit }: Props) {
+export function MatchupPanel({
+  competitionId,
+  tripId,
+  canEdit,
+  creatingEvent: creatingEventProp,
+  onCreatingEventChange,
+  creatingManualVenue: creatingManualVenueProp,
+  onCreatingManualVenueChange,
+}: Props) {
   const [open, setOpen] = useState(true);
-  // Add buttons live above each column header here in MatchupPanel so
-  // they're the first thing the user sees in the panel; the children
-  // bare-mode panels below skip their own bottom Add buttons.
-  const [creatingEvent, setCreatingEvent] = useState(false);
-  const [creatingManualVenue, setCreatingManualVenue] = useState(false);
+  // The +Event / +Venue affordances live in CompetitionHeader's action
+  // bar now — this panel just consumes the create state via props.
+  // Local state stays as a standalone-mode fallback.
+  const [creatingEventLocal, setCreatingEventLocal] = useState(false);
+  const [creatingManualVenueLocal, setCreatingManualVenueLocal] = useState(false);
+  const creatingEvent = creatingEventProp ?? creatingEventLocal;
+  const creatingManualVenue =
+    creatingManualVenueProp ?? creatingManualVenueLocal;
+  const setCreatingEvent = (v: boolean) => {
+    if (onCreatingEventChange) onCreatingEventChange(v);
+    else setCreatingEventLocal(v);
+  };
+  const setCreatingManualVenue = (v: boolean) => {
+    if (onCreatingManualVenueChange) onCreatingManualVenueChange(v);
+    else setCreatingManualVenueLocal(v);
+  };
 
   // Combined status string for the header — keeps the user oriented
   // without having to expand to see "anything to do here?"
@@ -77,45 +103,31 @@ export function MatchupPanel({ competitionId, tripId, canEdit }: Props) {
           onAdd={() => setCreatingEvent(true)}
         />
       ) : (
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 md:gap-4">
-          <div>
-            {canEdit && (
-              <div className="mb-3">
-                <AddEventButton onClick={() => setCreatingEvent(true)} />
-              </div>
-            )}
-            <Column
-              icon={<Flag size={12} />}
-              label="Unassigned Events"
-              hint={canEdit ? "Drag a card onto a venue to assign" : undefined}
-            >
-              <EventsPanel
-                competitionId={competitionId}
-                tripId={tripId}
-                canEdit={canEdit}
-                bare
-              />
-            </Column>
-          </div>
-          <div>
-            {canEdit && (
-              <div className="mb-3">
-                <AddVenueButton onClick={() => setCreatingManualVenue(true)} />
-              </div>
-            )}
-            <Column
-              icon={<MapPin size={12} />}
-              label="Confirmed Venues"
-              hint={canEdit ? "Drop a dragged event here" : undefined}
-            >
-              <VenuesPanel
-                competitionId={competitionId}
-                tripId={tripId}
-                canEdit={canEdit}
-                bare
-              />
-            </Column>
-          </div>
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_2fr] lg:gap-4">
+          <Column
+            icon={<Flag size={12} />}
+            label="Unassigned Events"
+            hint={canEdit ? "Drag onto a venue to assign" : undefined}
+          >
+            <EventsPanel
+              competitionId={competitionId}
+              tripId={tripId}
+              canEdit={canEdit}
+              bare
+            />
+          </Column>
+          <Column
+            icon={<MapPin size={12} />}
+            label="Confirmed Venues"
+            hint={canEdit ? "Drop an event here" : undefined}
+          >
+            <VenuesPanel
+              competitionId={competitionId}
+              tripId={tripId}
+              canEdit={canEdit}
+              bare
+            />
+          </Column>
         </div>
       )}
 
@@ -202,15 +214,17 @@ function Column({
   icon,
   label,
   hint,
+  className,
   children,
 }: {
   icon: React.ReactNode;
   label: string;
   hint?: string;
+  className?: string;
   children: React.ReactNode;
 }) {
   return (
-    <section>
+    <section className={className}>
       <div className="mb-2 flex items-baseline gap-2">
         <span style={{ color: "var(--color-bt-text-dim)" }}>{icon}</span>
         <h4

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -20,6 +20,11 @@ interface Props {
   tripId: string;
   canEdit: boolean;
   isOwner?: boolean;
+  /** When provided, the parent (CompTab) drives create state via the
+   *  CompetitionHeader's +Team button. Local state is used as a
+   *  fallback so this panel still works standalone. */
+  creating?: boolean;
+  onCreatingChange?: (v: boolean) => void;
 }
 
 interface Team {
@@ -179,9 +184,21 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
 
 // ── TeamsPanel ──────────────────────────────────────────────────────────────
 
-export function TeamsPanel({ competitionId, tripId, canEdit, isOwner }: Props) {
+export function TeamsPanel({
+  competitionId,
+  tripId,
+  canEdit,
+  isOwner,
+  creating: creatingProp,
+  onCreatingChange,
+}: Props) {
   const [editingTeam, setEditingTeam] = useState<Team | null>(null);
-  const [creating, setCreating] = useState(false);
+  const [creatingLocal, setCreatingLocal] = useState(false);
+  const creating = creatingProp ?? creatingLocal;
+  const setCreating = (v: boolean) => {
+    if (onCreatingChange) onCreatingChange(v);
+    else setCreatingLocal(v);
+  };
 
   const { data: teams = [] } = trpc.teams.list.useQuery(
     { tripId, competitionId },
@@ -245,8 +262,9 @@ export function TeamsPanel({ competitionId, tripId, canEdit, isOwner }: Props) {
         )}
 
         {teamsExist && (
-          <div className="grid gap-4 lg:grid-cols-[260px_1fr]">
-            {/* Crew roster: desktop column / mobile section below teams */}
+          <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
+            {/* Crew roster: desktop column 1 (1/3 width) / mobile
+                section below teams */}
             <CrewRoster
               tripId={tripId}
               competitionId={competitionId}
@@ -257,12 +275,29 @@ export function TeamsPanel({ competitionId, tripId, canEdit, isOwner }: Props) {
               order="lg-first"
             />
 
-            {/* Teams column */}
-            <div className="space-y-3">
-              {/* Add Team sits above the team cards, matching the
-                  Add Event / Add Venue buttons in MatchupPanel. */}
-              {canEdit && <AddTeamButton onClick={handleOpenAddTeam} />}
-
+            {/* Teams column — 2/3 of the panel width on desktop. The
+                +Team button moved up to CompetitionHeader's action bar. */}
+            <div>
+              <div className="mb-2 flex items-baseline gap-2">
+                <span style={{ color: "var(--color-bt-text-dim)" }}>
+                  <Users size={12} />
+                </span>
+                <h4
+                  className="text-[11px] font-semibold uppercase tracking-wider"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  Teams
+                </h4>
+                {canEdit && (
+                  <span
+                    className="text-[10px] italic"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    Drop a crew member here
+                  </span>
+                )}
+              </div>
+              <div className="space-y-3">
               {teamsTyped.map((team) => (
                 <TeamCard
                   key={team.id}
@@ -276,6 +311,7 @@ export function TeamsPanel({ competitionId, tripId, canEdit, isOwner }: Props) {
                   competitionId={competitionId}
                 />
               ))}
+              </div>
             </div>
           </div>
         )}
@@ -318,14 +354,13 @@ function CollapsiblePanel({
   testId?: string;
   children: React.ReactNode;
 }) {
-  const labelColor =
-    state === "todo" ? "var(--color-bt-text-dim)" : "var(--color-bt-accent)";
-  const borderColor =
-    state === "todo" ? "var(--color-bt-border)" : "var(--color-bt-accent-border)";
-  // Done state: subtle accent-faint tint instead of the saturated tag-bg
-  // teal — the inner card-raised swatches don't need to fight the panel
-  // background for contrast.
-  const bg = state === "done" ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)";
+  // Always neutral — matches the Events & Venues panel. The panel doesn't
+  // need to flip teal once everyone's on a team; confirmation is conveyed
+  // by the populated team chips inside.
+  void state;
+  const labelColor = "var(--color-bt-text-dim)";
+  const borderColor = "var(--color-bt-border)";
+  const bg = "var(--color-bt-card)";
 
   return (
     <div
@@ -428,28 +463,6 @@ function NoTeamsEmptyState({
   );
 }
 
-// ── AddTeamButton ───────────────────────────────────────────────────────────
-// Matches the Lodging/Schedule "+ Property / + Item" affordance and the
-// Add Event / Add Venue buttons in MatchupPanel: card-raised bg, regular
-// border, icon-then-Plus-then-noun.
-
-function AddTeamButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
-      style={{
-        background: "var(--color-bt-card-raised)",
-        color: "var(--color-bt-text)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-    >
-      <Users size={15} />
-      <Plus size={12} /> Team
-    </button>
-  );
-}
 
 // ── TeamCard (also a drop target on desktop) ────────────────────────────────
 
@@ -572,7 +585,7 @@ function TeamCard({
             onClick={() => setConfirming(true)}
             aria-label={`Delete ${team.name}`}
             className="flex h-7 w-7 items-center justify-center rounded-lg"
-            style={{ color: "var(--color-bt-danger)" }}
+            style={{ color: "var(--color-bt-text-dim)" }}
           >
             <Trash2 size={13} />
           </button>
@@ -594,7 +607,7 @@ function TeamCard({
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             {canEdit
-              ? "Drop members here, or assign from the crew list"
+              ? "Drop a crew member here"
               : "No members assigned"}
           </p>
         )}
@@ -801,33 +814,46 @@ function CrewRoster({
   return (
     <>
       {/* ── Desktop column: drag-and-drop unassigned roster ─────────── */}
-      <div
-        className="hidden rounded-xl p-3 transition-colors lg:block"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          border: `${dragOver ? "1.5px" : "1px"} ${dragOver ? "dashed" : "solid"} ${
-            dragOver ? "var(--color-bt-accent)" : "var(--color-bt-border)"
-          }`,
-          alignSelf: "start",
-        }}
-        onDragOver={
-          canEdit
-            ? (e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                setDragOver(true);
-              }
-            : undefined
-        }
-        onDragLeave={canEdit ? () => setDragOver(false) : undefined}
-        onDrop={canEdit ? handleDropToUnassign : undefined}
-      >
-        <p
-          className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
+      <section className="hidden lg:block" style={{ alignSelf: "start" }}>
+        <div className="mb-2 flex items-baseline gap-2">
+          <span style={{ color: "var(--color-bt-text-dim)" }}>
+            <User size={12} />
+          </span>
+          <h4
+            className="text-[11px] font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Unassigned Crew
+          </h4>
+          {canEdit && (
+            <span
+              className="text-[10px] italic"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Drag onto a team to assign
+            </span>
+          )}
+        </div>
+        <div
+          className="rounded-xl p-3 transition-colors"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            border: `${dragOver ? "1.5px" : "1px"} ${dragOver ? "dashed" : "solid"} ${
+              dragOver ? "var(--color-bt-accent)" : "var(--color-bt-border)"
+            }`,
+          }}
+          onDragOver={
+            canEdit
+              ? (e) => {
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = "move";
+                  setDragOver(true);
+                }
+              : undefined
+          }
+          onDragLeave={canEdit ? () => setDragOver(false) : undefined}
+          onDrop={canEdit ? handleDropToUnassign : undefined}
         >
-          Crew · Unassigned
-        </p>
         {unassigned.length === 0 ? (
           <p
             className="text-[11px]"
@@ -871,7 +897,8 @@ function CrewRoster({
             })}
           </div>
         )}
-      </div>
+        </div>
+      </section>
 
       {/* ── Mobile fallback: full member list with dropdown / unassign ─ */}
       <div className="lg:hidden">

--- a/src/components/competition/VenuesPanel.tsx
+++ b/src/components/competition/VenuesPanel.tsx
@@ -892,11 +892,22 @@ function LinkedEventDetails({
 
   return (
     <div
-      className="mt-2 rounded-lg px-2.5 py-2"
+      className={`mt-2 rounded-lg px-2.5 py-2 ${
+        canEdit ? "cursor-grab active:cursor-grabbing" : ""
+      }`}
       style={{
         background: "var(--color-bt-accent-faint)",
         border: "1px solid var(--color-bt-accent-border)",
       }}
+      draggable={canEdit}
+      onDragStart={
+        canEdit
+          ? (e) => {
+              e.dataTransfer.setData(DND_EVENT_KEY, event.id);
+              e.dataTransfer.effectAllowed = "move";
+            }
+          : undefined
+      }
     >
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- **Action bar in CompetitionHeader.** +Team / +Event / +Venue moved out of the inner panels into a 3-tile bar that doubles as the status pills. Creation state is lifted to `CompTab` so the same sheets the empty-state CTAs trigger are now driven by the header buttons too.
- **Drop-to-unassign for events.** The unassigned-events column is now a card-shaped drop target. `LinkedEventDetails` (the chip rendered inside a venue card) is draggable, so an event can be returned to the unassigned pool the same way crew members can be dropped back into the unassigned column.
- **Layout polish.** Each panel renders as a two-column grid on `lg+` at a 1/3 + 2/3 split (source list narrow, destination wide). Mobile stacks single-column. Section headers ("Unassigned Crew", "Teams", "Unassigned Events", "Confirmed Venues") with dim italic drag/drop hints — wording trimmed to "Drag onto a venue to assign" / "Drop an event here". Trash icons standardized: gray for record-level deletes (team/event/venue), red reserved for the parent-level competition cascade.
- **Loading gate.** `ExistingCompetitionView` prefetches every panel query and gates render on a single `isHydrating` flag, eliminating the "No teams / events / venues yet" flash that used to appear before data resolved. tRPC batch link + TanStack Query dedupe means zero extra network calls. Perf follow-ups (per-request membership cache, drop redundant `assertCompetitionInTrip`, single hydrate procedure, server-render) are scoped for a later refactor.
- **Removed clutter:** "All N events assigned. Add another?" empty-state, the never-flipping teal panel chrome on Players & Teams, the inline AddTeam/AddEvent/AddVenue buttons that the action bar now replaces.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `vitest run CompTab.test.tsx` — 9/9 passing
- [ ] Manual: comp tab on a fresh page load shows skeletons (no empty-state flash)
- [ ] Manual: drag a crew chip out of a team → lands in Unassigned Crew
- [ ] Manual: drag an event chip off a venue card → lands in Unassigned Events
- [ ] Manual: +Team / +Event / +Venue buttons in the header open the right sheets
- [ ] Manual: 1/3 + 2/3 split renders correctly at lg, stacks at mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)