### PR TITLE
perf(server): cache trip membership + competition→trip per request

### DIFF
--- a/src/__tests__/helpers/test-setup.ts
+++ b/src/__tests__/helpers/test-setup.ts
@@ -78,14 +78,14 @@ function createAuthenticatedClient(shared: SharedUser): SupabaseClient {
 function createCallerForUser(shared: SharedUser) {
   const client = createAuthenticatedClient(shared);
   const user = { id: shared.id, email: shared.email } as User;
-  const ctx: TRPCContext = { supabase: client, user };
+  const ctx: TRPCContext = { supabase: client, user, membershipCache: new Map(), competitionTripCache: new Map() };
   return factory(ctx);
 }
 
 /** tRPC caller with unauthenticated (anon) Supabase client. */
 export function createAnonCaller() {
   const client = createClient(SUPABASE_URL, ANON_KEY);
-  const ctx: TRPCContext = { supabase: client, user: null };
+  const ctx: TRPCContext = { supabase: client, user: null, membershipCache: new Map(), competitionTripCache: new Map() };
   return factory(ctx);
 }
 

--- a/src/server/competition-guards.ts
+++ b/src/server/competition-guards.ts
@@ -1,0 +1,64 @@
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Confirm the given competitionId belongs to ctx.tripId.
+ *
+ * This is defense in depth: requireTripMember/requireTripRole already
+ * authorize the user against the trip, but procedures also accept a
+ * competitionId in their input that an attacker could swap to point
+ * at a different trip's competition. RLS would still block reads, but
+ * we want a clear NOT_FOUND/FORBIDDEN at the API boundary.
+ *
+ * Result is cached on `ctx.competitionTripCache` so repeated calls in
+ * the same request batch (e.g. comp-tab loads with several procedures
+ * targeting the same competitionId) collapse to a single SELECT.
+ */
+export async function assertCompetitionInTrip(
+  ctx: {
+    supabase: { from: (t: string) => unknown };
+    tripId?: string;
+    competitionTripCache: Map<string, string>;
+  },
+  competitionId: string,
+): Promise<void> {
+  const cached = ctx.competitionTripCache.get(competitionId);
+  if (cached !== undefined) {
+    if (cached !== ctx.tripId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Competition does not belong to this trip",
+      });
+    }
+    return;
+  }
+
+  const { data, error } = await (
+    ctx.supabase.from("competitions") as unknown as {
+      select: (s: string) => {
+        eq: (
+          c: string,
+          v: string,
+        ) => {
+          single: () => Promise<{
+            data: { trip_id: string } | null;
+            error: unknown;
+          }>;
+        };
+      };
+    }
+  )
+    .select("trip_id")
+    .eq("id", competitionId)
+    .single();
+
+  if (error || !data) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Competition not found" });
+  }
+  ctx.competitionTripCache.set(competitionId, data.trip_id);
+  if (data.trip_id !== ctx.tripId) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Competition does not belong to this trip",
+    });
+  }
+}

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -32,25 +32,13 @@ export const requireTripMember = middleware(async ({ ctx, getRawInput, next }) =
   }
   const { tripId } = parsed.data;
 
-  const { data: member, error } = await ctx.supabase
-    .from("trip_members")
-    .select("role")
-    .eq("trip_id", tripId)
-    .eq("user_id", ctx.user!.id)
-    .single();
-
-  if (error || !member) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "You are not a member of this trip",
-    });
-  }
+  const role = await resolveTripRole(ctx, tripId);
 
   return next({
     ctx: {
       ...ctx,
       tripId,
-      tripRole: member.role as TripRole,
+      tripRole: role,
     },
   });
 });
@@ -77,21 +65,7 @@ export function requireTripRole(minRole: TripRole) {
     }
     const { tripId } = parsed.data;
 
-    const { data: member, error } = await ctx.supabase
-      .from("trip_members")
-      .select("role")
-      .eq("trip_id", tripId)
-      .eq("user_id", ctx.user!.id)
-      .single();
-
-    if (error || !member) {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message: "You are not a member of this trip",
-      });
-    }
-
-    const role = member.role as TripRole;
+    const role = await resolveTripRole(ctx, tripId);
     if (ROLE_LEVEL[role] < ROLE_LEVEL[minRole]) {
       throw new TRPCError({
         code: "FORBIDDEN",
@@ -107,4 +81,61 @@ export function requireTripRole(minRole: TripRole) {
       },
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// resolveTripRole — internal shared lookup with request-scoped cache.
+//
+// Every batched procedure that uses requireTripMember / requireTripRole
+// against the same tripId reuses the first SELECT's result. The cache
+// lives on ctx and dies with the request, so it can't drift across
+// trips or sessions.
+// ---------------------------------------------------------------------------
+
+async function resolveTripRole(
+  ctx: {
+    supabase: { from: (t: string) => unknown };
+    user: { id: string } | null;
+    membershipCache: Map<string, TripRole>;
+  },
+  tripId: string
+): Promise<TripRole> {
+  const cached = ctx.membershipCache.get(tripId);
+  if (cached) return cached;
+
+  const { data: member, error } = await (
+    ctx.supabase.from("trip_members") as unknown as {
+      select: (s: string) => {
+        eq: (
+          c: string,
+          v: string
+        ) => {
+          eq: (
+            c: string,
+            v: string
+          ) => {
+            single: () => Promise<{
+              data: { role: TripRole } | null;
+              error: unknown;
+            }>;
+          };
+        };
+      };
+    }
+  )
+    .select("role")
+    .eq("trip_id", tripId)
+    .eq("user_id", ctx.user!.id)
+    .single();
+
+  if (error || !member) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You are not a member of this trip",
+    });
+  }
+
+  const role = member.role as TripRole;
+  ctx.membershipCache.set(tripId, role);
+  return role;
 }

--- a/src/server/routers/events.ts
+++ b/src/server/routers/events.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
+import { assertCompetitionInTrip } from "../competition-guards";
 
 /**
  * events — scored activities within a competition (golf rounds, side games).
@@ -22,40 +23,6 @@ const SCORING_FORMAT = z.enum([
 ]);
 const EVENT_STATUS = z.enum(["upcoming", "active", "completed"]);
 
-// Helper: confirm the competitionId belongs to ctx.tripId. Used as an extra
-// guard in mutations because requireTripRole checks the trip but the route
-// also accepts a competitionId that an attacker could swap.
-async function assertCompetitionInTrip(
-  ctx: {
-    supabase: { from: (t: string) => unknown };
-    tripId?: string;
-  },
-  competitionId: string
-) {
-  const { data, error } = await (
-    ctx.supabase.from("competitions") as unknown as {
-      select: (s: string) => {
-        eq: (
-          c: string,
-          v: string
-        ) => { single: () => Promise<{ data: { trip_id: string } | null; error: unknown }> };
-      };
-    }
-  )
-    .select("trip_id")
-    .eq("id", competitionId)
-    .single();
-
-  if (error || !data) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Competition not found" });
-  }
-  if (data.trip_id !== ctx.tripId) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "Competition does not belong to this trip",
-    });
-  }
-}
 
 export const eventsRouter = router({
   // -----------------------------------------------------------------------

--- a/src/server/routers/teamAssignments.ts
+++ b/src/server/routers/teamAssignments.ts
@@ -2,41 +2,13 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
+import { assertCompetitionInTrip } from "../competition-guards";
 
 /**
  * team_assignments — composite PK (competition_id, user_id) means a user
  * is on at most one team per competition. assign() upserts that pairing;
  * remove() deletes it (Owner only per spec).
  */
-
-async function assertCompetitionInTrip(
-  ctx: { supabase: { from: (t: string) => unknown }; tripId?: string },
-  competitionId: string
-) {
-  const { data, error } = await (
-    ctx.supabase.from("competitions") as unknown as {
-      select: (s: string) => {
-        eq: (
-          c: string,
-          v: string
-        ) => { single: () => Promise<{ data: { trip_id: string } | null; error: unknown }> };
-      };
-    }
-  )
-    .select("trip_id")
-    .eq("id", competitionId)
-    .single();
-
-  if (error || !data) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Competition not found" });
-  }
-  if (data.trip_id !== ctx.tripId) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "Competition does not belong to this trip",
-    });
-  }
-}
 
 export const teamAssignmentsRouter = router({
   // -----------------------------------------------------------------------

--- a/src/server/routers/teams.ts
+++ b/src/server/routers/teams.ts
@@ -2,40 +2,12 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
+import { assertCompetitionInTrip } from "../competition-guards";
 
 /**
  * teams — competition-scoped teams.
  * The competition_id ties teams to a trip via the competitions row.
  */
-
-async function assertCompetitionInTrip(
-  ctx: { supabase: { from: (t: string) => unknown }; tripId?: string },
-  competitionId: string
-) {
-  const { data, error } = await (
-    ctx.supabase.from("competitions") as unknown as {
-      select: (s: string) => {
-        eq: (
-          c: string,
-          v: string
-        ) => { single: () => Promise<{ data: { trip_id: string } | null; error: unknown }> };
-      };
-    }
-  )
-    .select("trip_id")
-    .eq("id", competitionId)
-    .single();
-
-  if (error || !data) {
-    throw new TRPCError({ code: "NOT_FOUND", message: "Competition not found" });
-  }
-  if (data.trip_id !== ctx.tripId) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "Competition does not belong to this trip",
-    });
-  }
-}
 
 export const teamsRouter = router({
   // -----------------------------------------------------------------------

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -6,9 +6,27 @@ import superjson from "superjson";
 // Context
 // ---------------------------------------------------------------------------
 
+/**
+ * Request-scoped cache of trip memberships keyed by tripId.
+ *
+ * Populated by `requireTripMember` / `requireTripRole`. With
+ * httpBatchLink, all procedures in a batched request share one ctx,
+ * so a comp-tab load that fires 6 procedures against the same trip
+ * collapses 6 `SELECT FROM trip_members` calls into 1.
+ *
+ * Stays per-request — never reused across HTTP requests, never used as
+ * a security shortcut beyond the lifetime of a single batch.
+ */
+export type TripRoleString = "Owner" | "Planner" | "Member";
+
 export interface TRPCContext {
   supabase: SupabaseClient;
   user: User | null;
+  membershipCache: Map<string, TripRoleString>;
+  /** Request-scoped cache of `competitionId → tripId`. Lets the
+   *  duplicated `assertCompetitionInTrip` guard collapse to a single
+   *  SELECT per competition per request batch. */
+  competitionTripCache: Map<string, string>;
 }
 
 /**
@@ -25,7 +43,12 @@ export const createTRPCContext = async (): Promise<TRPCContext> => {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  return { supabase, user };
+  return {
+    supabase,
+    user,
+    membershipCache: new Map(),
+    competitionTripCache: new Map(),
+  };
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Two request-scoped caches on `TRPCContext` to eliminate redundant Supabase round trips during batched tRPC requests (the comp tab in particular):

- **`membershipCache: Map<tripId, role>`** — `requireTripMember` and `requireTripRole` now go through a shared `resolveTripRole` helper. First call in a batch hits `trip_members`; the rest read from the cache. With httpBatchLink, all batched procedures share one ctx, so one comp-tab load with 6 procedures collapses 6 membership SELECTs into 1.

- **`competitionTripCache: Map<competitionId, tripId>`** — the duplicated `assertCompetitionInTrip` helper is now lifted into `src/server/competition-guards.ts`. `events.ts`, `teams.ts`, and `teamAssignments.ts` all import the shared version instead of carrying their own inline copy. Same caching pattern: first call queries `competitions`, rest of the batch reads from ctx.

Both maps are created fresh in `createTRPCContext` and die with the response — no cross-request, cross-user, or cross-trip leakage possible.

For a typical comp tab load (6 procedures targeting one trip, 4 of them gated on a competitionId) this drops ~10 redundant sequential Supabase round trips down to 2.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `vitest run src/server/routers/` — **253/253 passing** (covers requireTripMember, requireTripRole, assertCompetitionInTrip via every router that uses them)
- [ ] Manual: comp tab loads visibly faster on a fresh page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)