### PR TITLE
fix(schedule): restore eslint-disable comments, drop undatedCount

### DIFF
--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -406,9 +406,6 @@ export function ScheduleTab({
   const unscheduledItems = dayGroups.find((g) => g.date === null)?.items ?? [];
   const scheduledGroups = dayGroups.filter((g) => g.date !== null);
 
-  // Items that exist but haven't been dragged to a specific day yet
-  // (trip has dates, but item.scheduled_date is still null).
-  const undatedCount = allItems.filter((i) => !i.scheduled_date).length;
   // Items assigned to a day but not yet confirmed.
   const unconfirmedCount = allItems.filter((i) => !i.is_confirmed && !!i.scheduled_date).length;
   // Items with a scheduled_date that falls outside the trip date range —
@@ -791,6 +788,7 @@ export function ScheduleTab({
                   </p>
                 ) : (
                   <div className="space-y-1.5">
+                    {/* eslint-disable react-hooks/refs */}
                     {unscheduledItems.map((item, idx) => (
                       <ScheduleItemRow
                         key={item.id}
@@ -827,6 +825,7 @@ export function ScheduleTab({
                         }}
                       />
                     ))}
+                    {/* eslint-enable react-hooks/refs */}
                   </div>
                 )}
               </div>
@@ -867,6 +866,7 @@ export function ScheduleTab({
                 </p>
               ) : (
                 <div className="space-y-5">
+                  {/* eslint-disable react-hooks/refs */}
                   {scheduledGroups.map((group) => (
                     <div
                       key={group.date!}
@@ -1003,6 +1003,7 @@ export function ScheduleTab({
                       )}
                     </div>
                   ))}
+                  {/* eslint-enable react-hooks/refs */}
                 </div>
               )}
             </section>


### PR DESCRIPTION
## Summary

- Restored `{/* eslint-disable react-hooks/refs */}` / `{/* eslint-enable */}` comments around both `unscheduledItems.map` and `scheduledGroups.map` — the two-column refactor accidentally dropped them, causing two build-breaking ESLint errors (`Cannot access refs during render`)
- Removed the now-unused `undatedCount` variable; the nudge banner that used it was replaced by the dedicated Unscheduled Items column

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] Schedule tab drag-and-drop still works (unscheduled → day, day → unscheduled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)