### PR TITLE
UX polish: Travel Plans toggle, Agenda rebrand, Receipts layout, tab badge tiers

### DIFF
--- a/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
+++ b/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
@@ -97,7 +97,10 @@ export function AddScheduleItemSheet({
   useModalBackButton(onClose);
   const utils = trpc.useUtils();
   const isEditing = !!editItem;
-  const isGolf = itemType === "golf";
+  // In add mode the user can switch between Activity and Golf Round via a
+  // segmented control inside the sheet. In edit mode the type is locked.
+  const [activeType, setActiveType] = useState<"general" | "golf">(itemType);
+  const isGolf = activeType === "golf";
 
   // General fields
   const [title, setTitle] = useState(editItem?.title ?? "");
@@ -153,6 +156,22 @@ export function AddScheduleItemSheet({
   );
   const [showLocationSearch, setShowLocationSearch] = useState(false);
   const locationSearch = usePlacesSearch();
+
+  // Reset type-specific fields when the user switches between Activity and Golf Round.
+  // Only runs in add mode — edit mode type is locked.
+  useEffect(() => {
+    if (isEditing) return;
+    setTitle("");
+    setDetail("");
+    setSelectedCourse(null);
+    setShowSearch(activeType === "golf");
+    setTeeTimes([""]);
+    setSelectedLocation(null);
+    setShowLocationSearch(false);
+    placesSearch.clear();
+    locationSearch.clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeType]);
 
   // Mutations
   const create = trpc.schedule.create.useMutation({
@@ -333,9 +352,51 @@ export function AddScheduleItemSheet({
           style={{ color: "var(--color-bt-text)" }}
         >
           {isEditing
-            ? isGolf ? "Edit Golf Round" : "Edit Schedule Item"
-            : isGolf ? "Add Golf Round" : "Add Schedule Item"}
+            ? isGolf ? "Edit Golf Round" : "Edit Activity"
+            : "Add to Agenda"}
         </h2>
+
+        {/* ── Type selector (add mode only) ────────────────────────────── */}
+        {!isEditing && (
+          <div
+            className="mt-4 inline-flex rounded-xl p-1"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            {(
+              [
+                { value: "general" as const, label: "Activity" },
+                { value: "golf"    as const, label: "Golf Round" },
+              ] as const
+            ).map(({ value, label }) => {
+              const active = activeType === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setActiveType(value)}
+                  className="rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors"
+                  style={
+                    active
+                      ? {
+                          background: "var(--color-bt-card)",
+                          color: "var(--color-bt-text)",
+                          boxShadow: "var(--shadow-card)",
+                        }
+                      : {
+                          background: "transparent",
+                          color: "var(--color-bt-text-dim)",
+                        }
+                  }
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        )}
 
         {/* ── Golf: course search ──────────────────────────────────────── */}
         {isGolf && (
@@ -608,7 +669,7 @@ export function AddScheduleItemSheet({
             ? isEditing ? "Saving..." : "Adding..."
             : isEditing
             ? "Save changes"
-            : isGolf ? "Add golf round" : "Add item"}
+            : isGolf ? "Add Golf Round" : "Add Activity"}
         </button>
         <button
           onClick={onClose}

--- a/src/app/trips/[tripId]/components/itinerary.ts
+++ b/src/app/trips/[tripId]/components/itinerary.ts
@@ -205,10 +205,10 @@ export function buildItinerary(input: {
 
   // ── 3. Shared member arrivals ──
   for (const m of input.members) {
-    // Guest (non-BuddyTrip) members can't actually share travel for
-    // themselves — skip even if a stale travel_shared flag is set.
-    if (m.isGuest) continue;
-    if (!m.travel_shared) continue;
+    // Guests can't log in to share their own travel, but the owner can
+    // now enter it on their behalf — include them if travel_mode is set.
+    if (m.isGuest && !m.travel_mode) continue;
+    if (!m.isGuest && !m.travel_shared) continue;
     if (!m.flight_arrival_time) continue;
 
     const date = localDateOfTimestamp(m.flight_arrival_time);

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -53,7 +53,7 @@ export default function TripDetailPage() {
   const { isLoading: ideasLoading } = trpc.ideas.list.useQuery({ tripId });
   const { data: poll, isLoading: pollLoading } = trpc.datePoll.get.useQuery({ tripId });
   const { data: members = [], isLoading: membersLoading } = trpc.tripMembers.list.useQuery({ tripId });
-  const { isLoading: reservationsLoading } = trpc.reservations.list.useQuery({ tripId });
+  const { data: prefetchedReservations = [], isLoading: reservationsLoading } = trpc.reservations.list.useQuery({ tripId });
   const { isLoading: tilesLoading } = trpc.quickInfoTiles.list.useQuery({ tripId });
 
   // Competition: drives the showComp gate + the bottom-nav "Live" entry.
@@ -162,9 +162,19 @@ export default function TripDetailPage() {
     (prefetchedSchedule as Array<{ is_confirmed: boolean; scheduled_date?: string | null }>).some(
       (item) => !item.scheduled_date || !item.is_confirmed
     );
+  // lodgingDot: fires when the editor has lodging items that haven't been
+  // confirmed yet — mirrors the scheduleDot pattern so the owner is nudged
+  // to lock in where everyone is staying.
+  const lodgingDot =
+    effectiveCanEdit &&
+    (prefetchedReservations as Array<{ is_confirmed?: boolean | null }>).length > 0 &&
+    (prefetchedReservations as Array<{ is_confirmed?: boolean | null }>).some(
+      (item) => !item.is_confirmed
+    );
   const tabBadges: Partial<Record<TabId, boolean>> = {};
   if (crewDot) tabBadges.crew = true;
   if (scheduleDot) tabBadges.schedule = true;
+  if (lodgingDot) tabBadges.lodging = true;
 
   // Settings gear is now rendered INSIDE TripHeader (top-right). The header
   // calls `onSettingsClick` when tapped — pass it through only when the owner

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -53,7 +53,7 @@ export default function TripDetailPage() {
   const { isLoading: ideasLoading } = trpc.ideas.list.useQuery({ tripId });
   const { data: poll, isLoading: pollLoading } = trpc.datePoll.get.useQuery({ tripId });
   const { data: members = [], isLoading: membersLoading } = trpc.tripMembers.list.useQuery({ tripId });
-  const { data: prefetchedReservations = [], isLoading: reservationsLoading } = trpc.reservations.list.useQuery({ tripId });
+  const { isLoading: reservationsLoading } = trpc.reservations.list.useQuery({ tripId });
   const { isLoading: tilesLoading } = trpc.quickInfoTiles.list.useQuery({ tripId });
 
   // Competition: drives the showComp gate + the bottom-nav "Live" entry.
@@ -67,6 +67,7 @@ export default function TripDetailPage() {
   // ── Background prefetch for tab badge conditions ───────────────────────
   // Not added to dataLoading — loads in parallel, dot appears when ready.
   const { data: prefetchedSchedule = [] } = trpc.schedule.list.useQuery({ tripId });
+  const { data: prefetchedLogistics = [] } = trpc.logistics.list.useQuery({ tripId });
 
   const dataLoading = isLoading || ideasLoading || pollLoading || membersLoading
     || reservationsLoading || tilesLoading || competitionLoading;
@@ -162,19 +163,38 @@ export default function TripDetailPage() {
     (prefetchedSchedule as Array<{ is_confirmed: boolean; scheduled_date?: string | null }>).some(
       (item) => !item.scheduled_date || !item.is_confirmed
     );
-  // lodgingDot: fires when the editor has lodging items that haven't been
-  // confirmed yet — mirrors the scheduleDot pattern so the owner is nudged
-  // to lock in where everyone is staying.
-  const lodgingDot =
+  // lodging badge: two tiers.
+  //  "warning" — one or more lodging properties have check-in/out dates
+  //              that fall outside the trip date range (likely a typo).
+  //  "info"    — all dates are in range but at least one property hasn't
+  //              been confirmed yet (normal planning-stage action item).
+  // Warning takes priority; only shown to editors.
+  const lodgingItems = (prefetchedLogistics as Array<{
+    type?: string | null;
+    is_confirmed?: boolean | null;
+    check_in_time?: string | null;
+    check_out_time?: string | null;
+  }>).filter((i) => i.type === "lodging");
+  const tripStart = (trip as { start_date?: string | null }).start_date ?? null;
+  const tripEnd   = (trip as { end_date?: string | null }).end_date ?? null;
+  const lodgingOutOfRange =
     effectiveCanEdit &&
-    (prefetchedReservations as Array<{ is_confirmed?: boolean | null }>).length > 0 &&
-    (prefetchedReservations as Array<{ is_confirmed?: boolean | null }>).some(
-      (item) => !item.is_confirmed
-    );
-  const tabBadges: Partial<Record<TabId, boolean>> = {};
-  if (crewDot) tabBadges.crew = true;
-  if (scheduleDot) tabBadges.schedule = true;
-  if (lodgingDot) tabBadges.lodging = true;
+    tripStart && tripEnd &&
+    lodgingItems.some((i) => {
+      const ci = i.check_in_time?.slice(0, 10) ?? null;
+      const co = i.check_out_time?.slice(0, 10) ?? null;
+      return (ci && (ci < tripStart || ci > tripEnd)) ||
+             (co && (co < tripStart || co > tripEnd));
+    });
+  const lodgingUnconfirmed =
+    effectiveCanEdit &&
+    lodgingItems.length > 0 &&
+    lodgingItems.some((i) => !i.is_confirmed);
+  const tabBadges: Partial<Record<TabId, "info" | "warning">> = {};
+  if (crewDot) tabBadges.crew = "info";
+  if (scheduleDot) tabBadges.schedule = "info";
+  if (lodgingOutOfRange) tabBadges.lodging = "warning";
+  else if (lodgingUnconfirmed) tabBadges.lodging = "info";
 
   // Settings gear is now rendered INSIDE TripHeader (top-right). The header
   // calls `onSettingsClick` when tapped — pass it through only when the owner

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -200,34 +200,28 @@ export function ExpensesSection({
 
   return (
     <div className="space-y-3">
-      {/* Add receipt button — matches the Schedule/Lodging add-on-top
-          button styling (rounded-xl, card-raised bg, subtle border,
-          icon + Plus + label). */}
-      {canEdit && (
-        <button
-          data-testid="show-add-expense-btn"
-          onClick={() => setShowAdd(true)}
-          className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            color: "var(--color-bt-text)",
-            border: "1px solid var(--color-bt-border)",
-          }}
-        >
-          <Receipt size={15} />
-          <Plus size={12} /> Receipt
-        </button>
-      )}
+      {/* Add receipt button — any trip member can log a receipt (server
+          enforces requireTripMember). canEdit gates only the split-edit
+          and delete actions below. */}
+      <button
+        data-testid="show-add-expense-btn"
+        onClick={() => setShowAdd(true)}
+        className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          color: "var(--color-bt-text)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        <Receipt size={15} />
+        <Plus size={12} /> Receipt
+      </button>
 
       {!hasExpenses ? (
         <EmptyState
           icon={<Receipt className="h-10 w-10" />}
           headline="No receipts yet"
-          subtext={
-            canEdit
-              ? "Add receipts to track who paid for what so we can square everyone up at the end of the trip."
-              : "Nobody has logged a receipt for this trip yet."
-          }
+          subtext="Add receipts to track who paid for what so we can square everyone up at the end of the trip."
         />
       ) : (
         <>

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -199,149 +199,168 @@ export function ExpensesSection({
     });
 
   return (
-    <div className="space-y-3">
-      {/* Add receipt button — any trip member can log a receipt (server
-          enforces requireTripMember). canEdit gates only the split-edit
-          and delete actions below. */}
-      <button
-        data-testid="show-add-expense-btn"
-        onClick={() => setShowAdd(true)}
-        className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          color: "var(--color-bt-text)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        <Receipt size={15} />
-        <Plus size={12} /> Receipt
-      </button>
+    <>
+      {/* ── Two-column layout: receipts (2/3) | balances (1/3) ──────────
+          Stacks single-column on mobile — receipts first, balances below.
+          minmax(0,…) prevents min-content from pushing column widths. */}
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
 
-      {!hasExpenses ? (
-        <EmptyState
-          icon={<Receipt className="h-10 w-10" />}
-          headline="No receipts yet"
-          subtext="Add receipts to track who paid for what so we can square everyone up at the end of the trip."
-        />
-      ) : (
-        <>
-          <div className="space-y-2">
-            {(expenses as ExpenseItem[]).map((expense) => {
-              const userSplit = currentUser
-                ? expense.splits.find((s) => s.user_id === currentUser.id)
-                : null;
-              const isOptedOut = userSplit?.opted_out === true;
-              const activeSplitCount = expense.splits.filter((s) => !s.opted_out).length;
-              const userShare = currentUser
-                ? computeUserShare(expense, currentUser.id)
-                : null;
+        {/* ── Left: add button + receipt list ─────────────────────────── */}
+        <div className="space-y-3">
+          {/* Add receipt button — any trip member can log a receipt (server
+              enforces requireTripMember). canEdit gates only the split-edit
+              and delete actions below. */}
+          <button
+            data-testid="show-add-expense-btn"
+            onClick={() => setShowAdd(true)}
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            <Receipt size={15} />
+            <Plus size={12} /> Receipt
+          </button>
 
-              return (
-                <div
-                  key={expense.id}
-                  data-testid={`expense-row-${expense.id}`}
-                  className="flex items-center gap-3 rounded-xl px-3 py-2.5"
-                  style={{
-                    background: isOptedOut ? "var(--color-bt-base)" : "var(--color-bt-card)",
-                    border: "1px solid var(--color-bt-border)",
-                    opacity: isOptedOut ? 0.7 : 1,
-                  }}
-                >
-                  <DollarSign size={14} style={{ color: "var(--color-bt-accent)" }} />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline gap-2">
-                      <p className="truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
-                        {expense.title}
-                      </p>
-                      {expense.date && (
-                        <span className="flex-shrink-0 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                          {new Date(expense.date + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-                        </span>
+          {!hasExpenses ? (
+            <EmptyState
+              icon={<Receipt className="h-10 w-10" />}
+              headline="No receipts yet"
+              subtext="Add receipts to track who paid for what so we can square everyone up at the end of the trip."
+            />
+          ) : (
+            <div className="space-y-2">
+              {(expenses as ExpenseItem[]).map((expense) => {
+                const userSplit = currentUser
+                  ? expense.splits.find((s) => s.user_id === currentUser.id)
+                  : null;
+                const isOptedOut = userSplit?.opted_out === true;
+                const activeSplitCount = expense.splits.filter((s) => !s.opted_out).length;
+                const userShare = currentUser
+                  ? computeUserShare(expense, currentUser.id)
+                  : null;
+
+                return (
+                  <div
+                    key={expense.id}
+                    data-testid={`expense-row-${expense.id}`}
+                    className="flex items-center gap-3 rounded-xl px-3 py-2.5"
+                    style={{
+                      background: isOptedOut ? "var(--color-bt-base)" : "var(--color-bt-card)",
+                      border: "1px solid var(--color-bt-border)",
+                      opacity: isOptedOut ? 0.7 : 1,
+                    }}
+                  >
+                    <DollarSign size={14} style={{ color: "var(--color-bt-accent)" }} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline gap-2">
+                        <p className="truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
+                          {expense.title}
+                        </p>
+                        {expense.date && (
+                          <span className="flex-shrink-0 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                            {new Date(expense.date + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap gap-x-2 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                        <span>Paid by {memberName(members, expense.paid_by_user_id)}</span>
+                        <span>split {activeSplitCount} ways</span>
+                      </div>
+                      {userSplit && (
+                        <p className="mt-0.5 text-xs" style={{
+                          color: isOptedOut ? "var(--color-bt-text-dim)" : "var(--color-bt-accent)",
+                        }}>
+                          {isOptedOut
+                            ? "Opted out"
+                            : userShare !== null
+                              ? `Your share: $${userShare.toFixed(2)}`
+                              : null}
+                        </p>
                       )}
                     </div>
-                    <div className="flex flex-wrap gap-x-2 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                      <span>Paid by {memberName(members, expense.paid_by_user_id)}</span>
-                      <span>split {activeSplitCount} ways</span>
-                    </div>
+                    <span className="flex-shrink-0 text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                      ${expense.amount.toFixed(2)}
+                    </span>
                     {userSplit && (
-                      <p className="mt-0.5 text-xs" style={{
-                        color: isOptedOut ? "var(--color-bt-text-dim)" : "var(--color-bt-accent)",
-                      }}>
-                        {isOptedOut
-                          ? "Opted out"
-                          : userShare !== null
-                            ? `Your share: $${userShare.toFixed(2)}`
-                            : null}
-                      </p>
+                      <button
+                        onClick={() =>
+                          optOutMutation.mutate({
+                            tripId,
+                            expenseId: expense.id,
+                            optOut: !isOptedOut,
+                          })
+                        }
+                        disabled={optOutMutation.isPending}
+                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70 disabled:opacity-40"
+                        style={{ color: isOptedOut ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+                        title={isOptedOut ? "Rejoin" : "Opt out"}
+                      >
+                        {isOptedOut ? <UserPlus size={13} /> : <UserMinus size={13} />}
+                      </button>
+                    )}
+                    {isOwner && (
+                      <button
+                        data-testid={`edit-splits-${expense.id}`}
+                        onClick={() => setEditingExpense(expense)}
+                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70"
+                        style={{ color: "var(--color-bt-text-dim)" }}
+                      >
+                        <Pencil size={13} />
+                      </button>
+                    )}
+                    {canEdit && (
+                      <button
+                        data-testid={`remove-expense-${expense.id}`}
+                        onClick={() =>
+                          removeExpense.mutate({ tripId, expenseId: expense.id })
+                        }
+                        disabled={removeExpense.isPending}
+                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full disabled:opacity-40"
+                        style={{ color: "var(--color-bt-text-dim)" }}
+                      >
+                        <Trash2 size={13} />
+                      </button>
                     )}
                   </div>
-                  <span className="flex-shrink-0 text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                    ${expense.amount.toFixed(2)}
-                  </span>
-                  {userSplit && (
-                    <button
-                      onClick={() =>
-                        optOutMutation.mutate({
-                          tripId,
-                          expenseId: expense.id,
-                          optOut: !isOptedOut,
-                        })
-                      }
-                      disabled={optOutMutation.isPending}
-                      className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70 disabled:opacity-40"
-                      style={{ color: isOptedOut ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
-                      title={isOptedOut ? "Rejoin" : "Opt out"}
-                    >
-                      {isOptedOut ? <UserPlus size={13} /> : <UserMinus size={13} />}
-                    </button>
-                  )}
-                  {isOwner && (
-                    <button
-                      data-testid={`edit-splits-${expense.id}`}
-                      onClick={() => setEditingExpense(expense)}
-                      className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70"
-                      style={{ color: "var(--color-bt-text-dim)" }}
-                    >
-                      <Pencil size={13} />
-                    </button>
-                  )}
-                  {canEdit && (
-                    <button
-                      data-testid={`remove-expense-${expense.id}`}
-                      onClick={() =>
-                        removeExpense.mutate({ tripId, expenseId: expense.id })
-                      }
-                      disabled={removeExpense.isPending}
-                      className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full disabled:opacity-40"
-                      style={{ color: "var(--color-bt-text-dim)" }}
-                    >
-                      <Trash2 size={13} />
-                    </button>
-                  )}
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
-          {/* ── Balances ──────────────────────────────────────────────── */}
-          {balanceRows.length > 0 && (
-            <div>
-              <h2
-                className="mb-2 text-xs font-semibold uppercase tracking-wider"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Balances
-              </h2>
+        {/* ── Right: balances ──────────────────────────────────────────── */}
+        {/* alignSelf start keeps the panel pinned at the top of the row
+            while the left column grows with more receipts. Hidden on
+            mobile when empty to avoid dead whitespace. */}
+        <div style={{ alignSelf: "start" }}>
+          <h2
+            className="mb-2 text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Balances
+          </h2>
+          {balanceRows.length > 0 ? (
+            <div
+              className="rounded-xl overflow-hidden"
+              style={{ border: "1px solid var(--color-bt-border)" }}
+            >
               {balanceRows.map((m, i) => {
                 const bal = balances.get(m.user_id) ?? 0;
                 const isCurrentUser = m.user_id === currentUser?.id;
                 return (
                   <div
                     key={m.user_id}
-                    className="flex items-center justify-between border-b px-1 py-2.5"
+                    className="flex items-center justify-between px-3 py-2.5"
                     style={{
-                      borderColor: "var(--color-bt-border)",
-                      background: i % 2 === 1 ? (isDark ? "rgba(255,255,255,0.025)" : "rgba(0,0,0,0.025)") : undefined,
+                      background: i % 2 === 0
+                        ? "var(--color-bt-card)"
+                        : isDark ? "rgba(255,255,255,0.025)" : "rgba(0,0,0,0.018)",
+                      borderBottom: i < balanceRows.length - 1
+                        ? "1px solid var(--color-bt-border)"
+                        : undefined,
                     }}
                   >
                     <span className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
@@ -350,16 +369,25 @@ export function ExpensesSection({
                         <span className="ml-1 text-xs font-normal" style={{ color: "var(--color-bt-text-dim)" }}>(you)</span>
                       )}
                     </span>
-                    <span className="text-sm font-medium" style={{ color: bal > 0 ? "var(--color-bt-accent)" : "var(--color-bt-danger)" }}>
+                    <span className="text-sm font-semibold tabular-nums" style={{ color: bal > 0 ? "var(--color-bt-accent)" : "var(--color-bt-danger)" }}>
                       {bal > 0 ? `+$${bal.toFixed(2)}` : `-$${Math.abs(bal).toFixed(2)}`}
                     </span>
                   </div>
                 );
               })}
             </div>
+          ) : hasExpenses ? (
+            <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              All settled up 🎉
+            </p>
+          ) : (
+            <p className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              Balances appear once receipts are added.
+            </p>
           )}
-        </>
-      )}
+        </div>
+
+      </div>
 
       {/* ── Add Expense Modal ─────────────────────────────────────────── */}
       {showAdd && (
@@ -379,6 +407,6 @@ export function ExpensesSection({
           onClose={() => setEditingExpense(null)}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -99,20 +99,38 @@ export function HomeTab({
             isDismissed={!!trip.quick_info_dismissed}
           />
 
-          {/* Two-column layout: Getting There (1/3) + Itinerary (2/3).
-              Stacks single-column on mobile — Getting There appears first. */}
-          <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
-            <div style={{ alignSelf: "start" }}>
-              <GettingTherePanel
-                tripId={trip.id}
-                trip={trip}
-                isOwner={!!isOwner}
-                isActivated={!!trip.getting_there_enabled}
-                hasDates={!!trip.start_date}
-                onOpenDatesModal={() => onTabChange?.("schedule")}
-              />
-            </div>
-            <div>
+          {/* Two-column layout: Travel Plans (1/3) + Itinerary (2/3).
+              Stacks single-column on mobile — Travel Plans appears first.
+              When the owner has hidden Travel Plans from crew the left column
+              is omitted entirely so Itinerary expands to full width.
+              minmax(0,…) stops filter-pill min-content from widening columns. */}
+          {(() => {
+            const showTravelColumn =
+              !!isOwner ||
+              (trip as { travel_plans_crew_visible?: boolean | null }).travel_plans_crew_visible !== false;
+            return showTravelColumn ? (
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+                <div style={{ alignSelf: "start" }}>
+                  <GettingTherePanel
+                    tripId={trip.id}
+                    trip={trip}
+                    isOwner={!!isOwner}
+                    isActivated={!!trip.getting_there_enabled}
+                    hasDates={!!trip.start_date}
+                    onOpenDatesModal={() => onTabChange?.("schedule")}
+                  />
+                </div>
+                <div>
+                  <ItineraryPanel
+                    tripId={trip.id}
+                    trip={trip}
+                    isOwner={!!isOwner}
+                    isActivated={!!trip.itinerary_enabled}
+                    hasContent={hasItineraryContent}
+                  />
+                </div>
+              </div>
+            ) : (
               <ItineraryPanel
                 tripId={trip.id}
                 trip={trip}
@@ -120,8 +138,8 @@ export function HomeTab({
                 isActivated={!!trip.itinerary_enabled}
                 hasContent={hasItineraryContent}
               />
-            </div>
-          </div>
+            );
+          })()}
 
           <CompetitionInvitationCard
             canEdit={canEditProp}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -701,7 +701,7 @@ export function ScheduleTab({
             subtext={canEdit ? "Add activities, golf rounds, and ideas — then drag them onto days to build the schedule." : "The organizer hasn't added anything yet."}
           />
         ) : (
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="grid gap-5 lg:grid-cols-2">
 
             {/* ── Column 1: Unscheduled Items ──────────────────────── */}
             <section style={{ alignSelf: "start" }}>

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -701,7 +701,7 @@ export function ScheduleTab({
             subtext={canEdit ? "Add activities, golf rounds, and ideas — then drag them onto days to build the schedule." : "The organizer hasn't added anything yet."}
           />
         ) : (
-          <div className="grid gap-5 lg:grid-cols-[1fr_2fr]">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
 
             {/* ── Column 1: Unscheduled Items ──────────────────────── */}
             <section style={{ alignSelf: "start" }}>

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -469,7 +469,14 @@ export function ScheduleTab({
       utils.schedule.list.setData({ tripId }, (old) =>
         old?.map((item) =>
           item.id === vars.itemId
-            ? { ...item, scheduled_date: vars.scheduledDate ?? item.scheduled_date }
+            ? {
+                ...item,
+                // Use !== undefined so null is treated as "clear the date"
+                // (drops item back to On Deck). ?? would fall through on null.
+                scheduled_date: vars.scheduledDate !== undefined
+                  ? vars.scheduledDate
+                  : item.scheduled_date,
+              }
             : item
         )
       );

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -579,10 +579,10 @@ export function ScheduleTab({
             </span>
             <div>
               <p className="text-[13px] font-semibold leading-tight" style={{ color: "var(--color-bt-text)" }}>
-                Items are unscheduled
+                Set dates to schedule your agenda
               </p>
               <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
-                Set trip dates to assign items to specific days
+                Trip dates let you assign agenda items to specific days
               </p>
             </div>
           </div>
@@ -634,7 +634,7 @@ export function ScheduleTab({
               {unconfirmedCount} item{unconfirmedCount !== 1 ? "s" : ""} still need confirmation
             </p>
             <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
-              Confirm items to lock them into the schedule
+              Confirm items to lock them onto the official itinerary
             </p>
           </div>
         </div>
@@ -672,36 +672,24 @@ export function ScheduleTab({
           style={{ color: "var(--color-bt-text-dim)" }}
         >
           {stage === "planning"
-            ? "Start adding items to your schedule — you can edit and reorganize at any time. All confirmed items will appear on the official schedule for the crew once the trip has been officially kicked off."
-            : "Keep your schedule up to date — any confirmed items will be shown on the crew's official schedule."}
+            ? "Add ideas and activities to your agenda — you can reorder and schedule them at any time. Confirmed items appear on the crew's itinerary once the trip kicks off."
+            : "Keep your agenda up to date — confirmed items are shown on the crew's itinerary."}
         </p>
 
-        {/* Add buttons — full-width above the two-column grid */}
+        {/* Add button — full-width above the two-column grid */}
         {canEdit && (
-          <div className="mb-4 flex gap-2">
+          <div className="mb-4">
             <button
               onClick={() => setAddMode("general")}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
+              className="flex w-full items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
               style={{
                 background: "var(--color-bt-card-raised)",
                 color: "var(--color-bt-text)",
                 border: "1px solid var(--color-bt-border)",
               }}
             >
-              <ClipboardList size={15} />
-              <Plus size={12} /> Item
-            </button>
-            <button
-              onClick={() => setAddMode("golf")}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl py-2.5 text-sm font-medium transition-all"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-border)",
-              }}
-            >
-              <Flag size={15} />
-              <Plus size={12} /> Golf
+              <Plus size={14} />
+              Add to Agenda
             </button>
           </div>
         )}
@@ -709,8 +697,8 @@ export function ScheduleTab({
         {allItems.length === 0 ? (
           <EmptyState
             icon={<CalendarDays className="h-10 w-10" />}
-            headline="No schedule items yet"
-            subtext={canEdit ? "Add items to plan your trip's agenda." : "The organizer hasn't added any schedule items yet."}
+            headline="Your agenda is empty"
+            subtext={canEdit ? "Add activities, golf rounds, and ideas — then drag them onto days to build the schedule." : "The organizer hasn't added anything yet."}
           />
         ) : (
           <div className="grid gap-5 lg:grid-cols-[1fr_2fr]">
@@ -726,7 +714,7 @@ export function ScheduleTab({
                     className="text-[11px] font-semibold uppercase tracking-wider"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    Unscheduled Items
+                    On Deck
                   </h4>
                 </div>
                 {canEdit && (
@@ -734,7 +722,7 @@ export function ScheduleTab({
                     className="mt-0.5 text-[10px] italic"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    Drag onto a day to schedule
+                    Ideas &amp; unscheduled items — drag onto a day
                   </p>
                 )}
               </div>
@@ -783,7 +771,7 @@ export function ScheduleTab({
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
                     {canEdit
-                      ? "All items have been scheduled. Drag here to remove from the official schedule."
+                      ? "All items have been scheduled. Drag here to move something back to the idea pool."
                       : "All items have been scheduled."}
                   </p>
                 ) : (
@@ -842,7 +830,7 @@ export function ScheduleTab({
                     className="text-[11px] font-semibold uppercase tracking-wider"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    Schedule
+                    Day-by-Day
                   </h4>
                 </div>
                 {canEdit && (
@@ -861,8 +849,8 @@ export function ScheduleTab({
                   style={{ color: "var(--color-bt-text-dim)" }}
                 >
                   {trip.start_date
-                    ? "No items scheduled yet — drag from the left column onto a day."
-                    : "Set trip dates to see the calendar."}
+                    ? "Nothing on the schedule yet — drag from On Deck onto a day."
+                    : "Set trip dates to see the day-by-day schedule."}
                 </p>
               ) : (
                 <div className="space-y-5">
@@ -1012,11 +1000,8 @@ export function ScheduleTab({
         )}
       </section>
 
-      {addMode === "general" && (
+      {addMode !== null && (
         <AddScheduleItemSheet tripId={tripId} itemType="general" onClose={() => setAddMode(null)} />
-      )}
-      {addMode === "golf" && (
-        <AddScheduleItemSheet tripId={tripId} itemType="golf" onClose={() => setAddMode(null)} />
       )}
 
       {/* Edit sheet */}
@@ -1045,10 +1030,10 @@ export function ScheduleTab({
               className="text-base font-semibold"
               style={{ color: "var(--color-bt-text)" }}
             >
-              Delete schedule item?
+              Remove from agenda?
             </p>
             <p className="mt-1 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-              &ldquo;{confirmDelete.title}&rdquo; will be permanently removed from the schedule.
+              &ldquo;{confirmDelete.title}&rdquo; will be permanently removed.
             </p>
             <div className="mt-4 flex gap-3">
               <button

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -476,6 +476,14 @@ export function ScheduleTab({
                 scheduled_date: vars.scheduledDate !== undefined
                   ? vars.scheduledDate
                   : item.scheduled_date,
+                // Clearing the date moves the item to On Deck — unconfirm it
+                // immediately so the confirmed badge disappears without waiting
+                // for the server round-trip.
+                ...(vars.scheduledDate === null && {
+                  is_confirmed: false,
+                  confirmed_at: null,
+                  confirmed_by: null,
+                }),
               }
             : item
         )

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -883,14 +883,14 @@ export function ScheduleTab({
                           handleDragDrop(group.date, group.items, group.items.length);
                         }
                       } : undefined}
-                      className="rounded-xl px-3 py-2 -mx-3 transition-colors"
+                      className="rounded-xl p-3 transition-colors"
                       style={{
                         background: dragOverGroup === group.date
                           ? "var(--color-bt-accent-faint, rgba(13,148,136,0.06))"
                           : "transparent",
                         border: dragOverGroup === group.date
-                          ? "1.5px dashed var(--color-bt-accent-border)"
-                          : "1.5px dashed transparent",
+                          ? "1.5px dashed var(--color-bt-accent)"
+                          : "1px dashed var(--color-bt-border)",
                       }}
                     >
                       <div className="mb-2 flex items-center gap-2">

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -106,7 +106,7 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
           className="text-xs font-semibold uppercase tracking-wider"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
-          Getting there
+          Travel Plans
         </h2>
       )}
 
@@ -155,11 +155,11 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
                   <button
                     type="button"
                     onClick={() => setPendingOpen((v) => !v)}
-                    className="flex w-full items-center gap-3 border-t px-4 py-2.5 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+                    className="flex w-full items-center gap-3 border-t px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
                     style={{ borderColor: "var(--color-bt-border)" }}
                   >
                     <span
-                      className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
+                      className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold"
                       style={{
                         background: "var(--color-bt-card-raised)",
                         color: "var(--color-bt-text-dim)",
@@ -168,8 +168,8 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
                     >
                       {pendingOthers.length}
                     </span>
-                    <span className="flex-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                      {pendingOthers.length === 1 ? "person" : "people"} without travel info
+                    <span className="flex-1 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+                      {pendingOthers.length === 1 ? "hasn't" : "haven't"} confirmed their travel plans
                     </span>
                     <ChevronDown
                       size={14}

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -17,6 +17,7 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { UserAvatar } from "@/components/UserAvatar";
 
 type TravelMode = "driving" | "flying" | "other";
+type TravelFilterKey = "all" | "driving" | "flying" | "other";
 
 interface TripMemberLite {
   memberId: string;
@@ -37,6 +38,60 @@ export interface GettingThereSectionProps {
   /** When provided (owner only), shows an X on the empty-state mock-up
       that backs out of the activation entirely. */
   onCancel?: () => void;
+}
+
+// ── TravelFilterPill ──────────────────────────────────────────────────────
+// Same shape as ItineraryView's FilterPill — tones match TravelModeBadge.
+
+const TRAVEL_PILL_TONES: Record<TravelFilterKey, { bg: string; color: string; border: string }> = {
+  all: {
+    bg: "var(--color-bt-accent-faint)",
+    color: "var(--color-bt-accent)",
+    border: "var(--color-bt-accent-border)",
+  },
+  driving: {
+    bg: "var(--color-bt-warning-faint)",
+    color: "var(--color-bt-warning)",
+    border: "var(--color-bt-warning-border)",
+  },
+  flying: {
+    bg: "var(--color-bt-accent-faint)",
+    color: "var(--color-bt-accent)",
+    border: "var(--color-bt-accent-border)",
+  },
+  other: {
+    bg: "var(--color-bt-card-raised)",
+    color: "var(--color-bt-text-dim)",
+    border: "var(--color-bt-border)",
+  },
+};
+
+function TravelFilterPill({
+  label,
+  filterKey,
+  active,
+  onClick,
+}: {
+  label: string;
+  filterKey: TravelFilterKey;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const cfg = TRAVEL_PILL_TONES[filterKey];
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-full px-3 py-1.5 text-xs font-semibold"
+      style={
+        active
+          ? { background: cfg.bg, color: cfg.color, border: `1px solid ${cfg.border}` }
+          : { background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }
+      }
+    >
+      {label}
+    </button>
+  );
 }
 
 /**
@@ -85,6 +140,25 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const [expanded, setExpanded] = useState(false);
   // "No travel yet" section starts collapsed in owner view.
   const [pendingOpen, setPendingOpen] = useState(false);
+  // Filter pills — same multi-select pattern as ItineraryView.
+  const [activeFilters, setActiveFilters] = useState<Set<TravelFilterKey>>(new Set(["all"]));
+
+  const toggleFilter = (key: TravelFilterKey) => {
+    setActiveFilters((prev) => {
+      if (key === "all") return new Set<TravelFilterKey>(["all"]);
+      const next = new Set(prev);
+      next.delete("all");
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next.size === 0 ? new Set<TravelFilterKey>(["all"]) : next;
+    });
+  };
+
+  const matchesFilter = (mode: string | null | undefined) => {
+    if (activeFilters.has("all")) return true;
+    if (!mode) return false;
+    return activeFilters.has(mode as TravelFilterKey);
+  };
 
   const hasMyTravel = !!myMember?.travel_mode;
   // Empty-state mock-up only shows when nobody on the trip has shared
@@ -93,6 +167,14 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const anyoneElseShared = allOtherMembers.some((m) => !!m.travel_mode);
   const someoneShared = hasMyTravel || anyoneElseShared;
   const showEmptyState = !!myMember && !someoneShared && !expanded;
+
+  // Only show pills once there are multiple distinct modes in use.
+  const allConfirmedMembers = [
+    ...(myMember?.travel_mode ? [myMember] : []),
+    ...confirmedOthers,
+  ];
+  const modesInUse = new Set(allConfirmedMembers.map((m) => m.travel_mode));
+  const showFilterPills = !showEmptyState && modesInUse.size > 1;
 
   // ── Render ──────────────────────────────────────────────────────────────
   // GETTING THERE header sits OUTSIDE the rows card so the card always
@@ -112,6 +194,15 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
 
       {showEmptyState && <EmptyArrivalsState onCancel={onCancel} />}
 
+      {showFilterPills && (
+        <div className="flex flex-wrap items-center gap-2">
+          <TravelFilterPill label="All"     filterKey="all"     active={activeFilters.has("all")}     onClick={() => toggleFilter("all")} />
+          {modesInUse.has("driving") && <TravelFilterPill label="Driving" filterKey="driving" active={activeFilters.has("driving")} onClick={() => toggleFilter("driving")} />}
+          {modesInUse.has("flying")  && <TravelFilterPill label="Flying"  filterKey="flying"  active={activeFilters.has("flying")}  onClick={() => toggleFilter("flying")} />}
+          {modesInUse.has("other")   && <TravelFilterPill label="Other"   filterKey="other"   active={activeFilters.has("other")}   onClick={() => toggleFilter("other")} />}
+        </div>
+      )}
+
       {!showEmptyState && (
         <div
           className="overflow-hidden rounded-xl"
@@ -120,7 +211,7 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
             border: "1px solid var(--color-bt-border)",
           }}
         >
-          {myMember && (
+          {myMember && matchesFilter(myMember.travel_mode) && (
             <YourTravelRow
               tripId={tripId}
               member={myMember}
@@ -139,7 +230,7 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
               Non-owner: read-only rows for members who've shared, plus a tally. */}
           {isOwner ? (
             <>
-              {confirmedOthers.map((m) => (
+              {confirmedOthers.filter((m) => matchesFilter(m.travel_mode)).map((m) => (
                 <OtherMemberTravelRow
                   key={m.memberId}
                   tripId={tripId}
@@ -196,7 +287,7 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
               )}
             </>
           ) : (
-            sharedOthers.map((m) => (
+            sharedOthers.filter((m) => matchesFilter(m.travel_mode)).map((m) => (
               <CrewTravelRow key={m.memberId} member={m} />
             ))
           )}

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   Car,
   ChevronDown,
+  Ghost,
   HelpCircle,
   Plane,
   Plus,
@@ -64,13 +65,12 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const myMember = (members as TripMemberLite[]).find(
     (m) => m.user_id === currentUser?.id,
   );
-  // Travel coordination is for real BuddyTrip members — guests can't
-  // log in to share their plans, so excluding them from the pending
-  // tally and the read-only rows keeps the panel focused on actionable
-  // people. They'll still appear in the Crew tab; just not here.
+  // Real BuddyTrip members (excluding viewer) — used for the pending tally.
   const otherMembers = (members as TripMemberLite[]).filter(
     (m) => m.user_id !== currentUser?.id && !m.isGuest,
   );
+  // Ghost crew — the owner can set their travel; everyone can see it once set.
+  const guestMembers = (members as TripMemberLite[]).filter((m) => m.isGuest);
   // Crew (excluding the viewer and guests) who have shared their travel.
   const sharedOthers = otherMembers.filter((m) => !!m.travel_mode);
 
@@ -130,7 +130,21 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
             <CrewTravelRow key={m.memberId} member={m} />
           ))}
 
-          {/* Owner-only pending tally */}
+          {/* Ghost crew — owner can set their travel; read-only for everyone once set */}
+          {guestMembers.map((m) =>
+            isOwner ? (
+              <GhostTravelRow
+                key={m.memberId}
+                tripId={tripId}
+                member={m}
+                onSaved={() => utils.tripMembers.list.invalidate({ tripId })}
+              />
+            ) : m.travel_mode ? (
+              <CrewTravelRow key={m.memberId} member={m} />
+            ) : null
+          )}
+
+          {/* Owner-only pending tally (real members only — ghosts are always shown above) */}
           {isOwner && <PendingTravelRow members={otherMembers} />}
         </div>
       )}
@@ -161,6 +175,228 @@ function CrewTravelRow({ member }: { member: TripMemberLite }) {
       </div>
 
       <TravelModeBadge mode={member.travel_mode as TravelMode | null} />
+    </div>
+  );
+}
+
+// ── GhostTravelRow ────────────────────────────────────────────────────────
+// Owner-editable row for ghost crew members. Renders a slim inline form
+// (mode select + details text) instead of the full TravelExpandForm — no
+// date/time picker since the owner is filling in on someone else's behalf
+// and we want to keep it quick. Everyone can see it read-only once set.
+
+type GuestTravelMode = "driving" | "flying" | "other";
+
+function GhostTravelRow({
+  tripId,
+  member: m,
+  onSaved,
+}: {
+  tripId: string;
+  member: TripMemberLite;
+  onSaved: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const hasTravel = !!m.travel_mode;
+  const [editing, setEditing] = useState(false);
+  const [mode, setMode] = useState<GuestTravelMode>(
+    (m.travel_mode as GuestTravelMode) ?? "driving",
+  );
+  const [details, setDetails] = useState(
+    m.travel_mode === "flying"
+      ? [m.flight_airline, m.flight_number].filter(Boolean).join(" ")
+      : m.travel_detail ?? "",
+  );
+
+  const updateGuestTravel = trpc.tripMembers.updateGuestTravel.useMutation({
+    onMutate: async (vars) => {
+      await utils.tripMembers.list.cancel({ tripId });
+      const prev = utils.tripMembers.list.getData({ tripId });
+      utils.tripMembers.list.setData({ tripId }, (old) =>
+        (old ?? []).map((row) =>
+          row.user_id === vars.guestUserId
+            ? { ...row, travel_mode: vars.travelMode, travel_detail: vars.travelDetail ?? null }
+            : row
+        )
+      );
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) utils.tripMembers.list.setData({ tripId }, ctx.prev);
+    },
+    onSuccess: () => {
+      setEditing(false);
+      onSaved();
+    },
+    onSettled: () => utils.tripMembers.list.invalidate({ tripId }),
+  });
+
+  const handleSave = () => {
+    if (!m.user_id) return;
+    updateGuestTravel.mutate({
+      tripId,
+      guestUserId: m.user_id,
+      travelMode: mode,
+      travelDetail: mode !== "flying" ? details.trim() || null : null,
+    });
+  };
+
+  const handleClear = () => {
+    if (!m.user_id) return;
+    updateGuestTravel.mutate({
+      tripId,
+      guestUserId: m.user_id,
+      travelMode: null,
+      travelDetail: null,
+    });
+    setMode("driving");
+    setDetails("");
+    setEditing(false);
+  };
+
+  const openEdit = () => {
+    setMode((m.travel_mode as GuestTravelMode) ?? "driving");
+    setDetails(
+      m.travel_mode === "flying"
+        ? [m.flight_airline, m.flight_number].filter(Boolean).join(" ")
+        : m.travel_detail ?? "",
+    );
+    setEditing(true);
+  };
+
+  return (
+    <div
+      className="border-t"
+      style={{ borderColor: "var(--color-bt-border)" }}
+    >
+      {/* ── Collapsed row ── */}
+      {!editing && (
+        <button
+          type="button"
+          onClick={openEdit}
+          className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+        >
+          {/* Ghost avatar */}
+          <div
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
+            style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+          >
+            <Ghost size={14} />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {m.displayName}
+            </p>
+            {hasTravel ? (
+              <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                {summarizeTravel(m)}
+              </p>
+            ) : (
+              <p className="truncate text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
+                Tap to add travel info
+              </p>
+            )}
+          </div>
+
+          {hasTravel ? (
+            <TravelModeBadge mode={m.travel_mode as GuestTravelMode} />
+          ) : (
+            <Plus size={14} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+          )}
+        </button>
+      )}
+
+      {/* ── Inline edit form — slim: mode select + details only ── */}
+      {editing && (
+        <div
+          className="flex flex-wrap items-center gap-2 px-4 py-3"
+          style={{ background: "var(--color-bt-card-raised)" }}
+        >
+          {/* Ghost label */}
+          <div className="flex items-center gap-2" style={{ flex: "0 0 auto" }}>
+            <div
+              className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full"
+              style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+            >
+              <Ghost size={12} />
+            </div>
+            <span className="text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {m.displayName}
+            </span>
+          </div>
+
+          {/* Mode select */}
+          <select
+            value={mode}
+            onChange={(e) => setMode(e.target.value as GuestTravelMode)}
+            className="rounded-lg border px-2 py-1.5 text-xs outline-none"
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+              flex: "0 0 auto",
+            }}
+          >
+            <option value="driving">Driving</option>
+            <option value="flying">Flying</option>
+            <option value="other">Other</option>
+          </select>
+
+          {/* Details */}
+          <input
+            type="text"
+            value={details}
+            onChange={(e) => setDetails(e.target.value)}
+            placeholder={mode === "flying" ? "e.g. Delta 1733" : "e.g. from Charlotte"}
+            className="min-w-0 rounded-lg border px-2.5 py-1.5 text-xs outline-none"
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+              flex: "1 1 140px",
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSave();
+              if (e.key === "Escape") setEditing(false);
+            }}
+          />
+
+          {/* Save */}
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={updateGuestTravel.isPending}
+            className="rounded-lg px-3 py-1.5 text-xs font-bold disabled:opacity-40"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)", flexShrink: 0 }}
+          >
+            {updateGuestTravel.isPending ? "…" : "Save"}
+          </button>
+
+          {/* Clear — only if travel was already set */}
+          {hasTravel && (
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={updateGuestTravel.isPending}
+              className="rounded-lg border px-2.5 py-1.5 text-xs disabled:opacity-40"
+              style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+            >
+              Clear
+            </button>
+          )}
+
+          {/* Cancel */}
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="rounded-lg border px-2.5 py-1.5 text-xs"
+            style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -65,14 +65,15 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const myMember = (members as TripMemberLite[]).find(
     (m) => m.user_id === currentUser?.id,
   );
-  // Real BuddyTrip members (excluding viewer) — used for the pending tally.
-  const otherMembers = (members as TripMemberLite[]).filter(
-    (m) => m.user_id !== currentUser?.id && !m.isGuest,
+  // All crew except the viewer — shown to the owner (expandable) or as
+  // read-only rows for non-owners who've shared their travel.
+  const allOtherMembers = (members as TripMemberLite[]).filter(
+    (m) => m.user_id !== currentUser?.id,
   );
-  // Ghost crew — the owner can set their travel; everyone can see it once set.
-  const guestMembers = (members as TripMemberLite[]).filter((m) => m.isGuest);
-  // Crew (excluding the viewer and guests) who have shared their travel.
-  const sharedOthers = otherMembers.filter((m) => !!m.travel_mode);
+  // Non-owner view: real members who've shared (pending tally counts the rest)
+  const sharedOthers = allOtherMembers.filter((m) => !!m.travel_mode && !m.isGuest);
+  // Real members only for the pending tally (ghosts are always shown in owner view)
+  const realOtherMembers = allOtherMembers.filter((m) => !m.isGuest);
 
   // Always start collapsed — the user opens the row deliberately by
   // tapping. Auto-expanding when empty was visually noisy and made the
@@ -83,7 +84,8 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   // Empty-state mock-up only shows when nobody on the trip has shared
   // travel yet. As soon as anyone shares (the viewer or another crew
   // member), real rows take its place.
-  const someoneShared = hasMyTravel || sharedOthers.length > 0;
+  const anyoneElseShared = allOtherMembers.some((m) => !!m.travel_mode);
+  const someoneShared = hasMyTravel || anyoneElseShared;
   const showEmptyState = !!myMember && !someoneShared && !expanded;
 
   // ── Render ──────────────────────────────────────────────────────────────
@@ -126,26 +128,23 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
             />
           )}
 
-          {sharedOthers.map((m) => (
-            <CrewTravelRow key={m.memberId} member={m} />
-          ))}
+          {/* Owner: every other member gets a full editable row.
+              Non-owner: read-only rows for members who've shared, plus a tally. */}
+          {isOwner
+            ? allOtherMembers.map((m) => (
+                <OtherMemberTravelRow
+                  key={m.memberId}
+                  tripId={tripId}
+                  member={m}
+                  tripStartDate={tripStartDate}
+                  onSaved={() => utils.tripMembers.list.invalidate({ tripId })}
+                />
+              ))
+            : sharedOthers.map((m) => (
+                <CrewTravelRow key={m.memberId} member={m} />
+              ))}
 
-          {/* Ghost crew — owner can set their travel; read-only for everyone once set */}
-          {guestMembers.map((m) =>
-            isOwner ? (
-              <GhostTravelRow
-                key={m.memberId}
-                tripId={tripId}
-                member={m}
-                onSaved={() => utils.tripMembers.list.invalidate({ tripId })}
-              />
-            ) : m.travel_mode ? (
-              <CrewTravelRow key={m.memberId} member={m} />
-            ) : null
-          )}
-
-          {/* Owner-only pending tally (real members only — ghosts are always shown above) */}
-          {isOwner && <PendingTravelRow members={otherMembers} />}
+          {!isOwner && <PendingTravelRow members={realOtherMembers} />}
         </div>
       )}
     </div>
@@ -179,281 +178,107 @@ function CrewTravelRow({ member }: { member: TripMemberLite }) {
   );
 }
 
-// ── GhostTravelRow ────────────────────────────────────────────────────────
-// Owner-editable row for ghost crew members. Renders a slim inline form
-// (mode select + details text) instead of the full TravelExpandForm — no
-// date/time picker since the owner is filling in on someone else's behalf
-// and we want to keep it quick. Everyone can see it read-only once set.
+// ── OtherMemberTravelRow ──────────────────────────────────────────────────
+// Owner-expandable row for every other crew member (real and ghost alike).
+// Same expand/collapse pattern as YourTravelRow but uses updateMemberTravel.
+// Ghost members get a Ghost avatar; real members get UserAvatar.
 
-type GuestTravelMode = "driving" | "flying" | "other";
-
-function GhostTravelRow({
+function OtherMemberTravelRow({
   tripId,
   member: m,
+  tripStartDate,
   onSaved,
 }: {
   tripId: string;
   member: TripMemberLite;
+  tripStartDate: string | null;
   onSaved: () => void;
 }) {
-  const utils = trpc.useUtils();
+  const [expanded, setExpanded] = useState(false);
   const hasTravel = !!m.travel_mode;
-  const [editing, setEditing] = useState(false);
-  const [mode, setMode] = useState<GuestTravelMode>(
-    (m.travel_mode as GuestTravelMode) ?? "driving",
-  );
-  const [details, setDetails] = useState(
-    m.travel_mode === "flying"
-      ? [m.flight_airline, m.flight_number].filter(Boolean).join(" ")
-      : m.travel_detail ?? "",
-  );
-  const [arrivalDate, setArrivalDate] = useState(() => parseArrivalDate(m.flight_arrival_time));
-  const [arrivalTime, setArrivalTime] = useState(() => parseArrivalTime(m.flight_arrival_time));
 
-  const updateGuestTravel = trpc.tripMembers.updateGuestTravel.useMutation({
-    onMutate: async (vars) => {
-      await utils.tripMembers.list.cancel({ tripId });
-      const prev = utils.tripMembers.list.getData({ tripId });
-      utils.tripMembers.list.setData({ tripId }, (old) =>
-        (old ?? []).map((row) =>
-          row.user_id === vars.guestUserId
-            ? {
-                ...row,
-                travel_mode: vars.travelMode,
-                travel_detail: vars.travelDetail ?? null,
-                flight_airline: vars.flightAirline ?? null,
-                flight_arrival_time: vars.flightArrivalTime ?? null,
-              }
-            : row
-        )
-      );
-      return { prev };
-    },
-    onError: (_e, _v, ctx) => {
-      if (ctx?.prev) utils.tripMembers.list.setData({ tripId }, ctx.prev);
-    },
-    onSuccess: () => {
-      setEditing(false);
-      onSaved();
-    },
-    onSettled: () => utils.tripMembers.list.invalidate({ tripId }),
-  });
-
-  const buildArrivalISO = (): string | null => {
-    if (!arrivalDate) return null;
-    return arrivalTime
-      ? `${arrivalDate}T${arrivalTime}:00`
-      : `${arrivalDate}T00:00:00`;
-  };
-
-  const handleSave = () => {
-    if (!m.user_id) return;
-    updateGuestTravel.mutate({
-      tripId,
-      guestUserId: m.user_id,
-      travelMode: mode,
-      travelDetail: mode !== "flying" ? details.trim() || null : null,
-      flightAirline: mode === "flying" ? details.trim() || null : null,
-      flightArrivalTime: buildArrivalISO(),
-    });
-  };
-
-  const handleClear = () => {
-    if (!m.user_id) return;
-    updateGuestTravel.mutate({
-      tripId,
-      guestUserId: m.user_id,
-      travelMode: null,
-      travelDetail: null,
-      flightAirline: null,
-      flightArrivalTime: null,
-    });
-    setMode("driving");
-    setDetails("");
-    setArrivalDate("");
-    setArrivalTime("");
-    setEditing(false);
-  };
-
-  const openEdit = () => {
-    setMode((m.travel_mode as GuestTravelMode) ?? "driving");
-    setDetails(
-      m.travel_mode === "flying"
-        ? [m.flight_airline, m.flight_number].filter(Boolean).join(" ")
-        : m.travel_detail ?? "",
-    );
-    setArrivalDate(parseArrivalDate(m.flight_arrival_time));
-    setArrivalTime(parseArrivalTime(m.flight_arrival_time));
-    setEditing(true);
-  };
-
-  return (
+  const avatar = m.isGuest ? (
     <div
-      className="border-t"
-      style={{ borderColor: "var(--color-bt-border)" }}
+      className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
+      style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
     >
-      {/* ── Collapsed row ── */}
-      {!editing && (
-        <button
-          type="button"
-          onClick={openEdit}
-          className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
-        >
-          <div
-            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
-            style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+      <Ghost size={14} />
+    </div>
+  ) : (
+    <UserAvatar name={m.displayName} avatarUrl={null} size="md" />
+  );
+
+  if (!hasTravel) {
+    return (
+      <div className="border-t px-4 py-3" style={{ borderColor: "var(--color-bt-border)" }}>
+        {expanded ? (
+          <TravelExpandForm
+            tripId={tripId}
+            member={m}
+            tripStartDate={tripStartDate}
+            targetUserId={m.user_id ?? undefined}
+            onSaved={() => { onSaved(); setExpanded(false); }}
+            onCancel={() => setExpanded(false)}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="flex w-full items-center gap-3 text-left"
           >
-            <Ghost size={14} />
-          </div>
-
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-              {m.displayName}
-            </p>
-            {hasTravel ? (
-              <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                {summarizeTravel(m)}
-              </p>
-            ) : (
-              <p className="truncate text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
-                Tap to add travel info
-              </p>
-            )}
-          </div>
-
-          {hasTravel ? (
-            <TravelModeBadge mode={m.travel_mode as GuestTravelMode} />
-          ) : (
-            <Plus size={14} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
-          )}
-        </button>
-      )}
-
-      {/* ── Inline edit form ── */}
-      {editing && (
-        <div
-          className="space-y-2.5 px-4 py-3"
-          style={{ background: "var(--color-bt-card-raised)" }}
-        >
-          {/* Row 1: ghost label + mode select + details */}
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="flex items-center gap-2" style={{ flex: "0 0 auto" }}>
-              <div
-                className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full"
-                style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-              >
-                <Ghost size={12} />
-              </div>
-              <span className="text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            {avatar}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
                 {m.displayName}
-              </span>
+              </p>
+              <p className="truncate text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
+                No travel info yet — tap to add
+              </p>
             </div>
+            <Plus size={14} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+          </button>
+        )}
+      </div>
+    );
+  }
 
-            <select
-              value={mode}
-              onChange={(e) => setMode(e.target.value as GuestTravelMode)}
-              className="rounded-lg border px-2 py-1.5 text-xs outline-none"
-              style={{
-                background: "var(--color-bt-base)",
-                borderColor: "var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-                flex: "0 0 auto",
-              }}
-            >
-              <option value="driving">Driving</option>
-              <option value="flying">Flying</option>
-              <option value="other">Other</option>
-            </select>
-
-            <input
-              type="text"
-              value={details}
-              onChange={(e) => setDetails(e.target.value)}
-              placeholder={mode === "flying" ? "e.g. Delta 1733" : "e.g. from Charlotte"}
-              className="min-w-0 rounded-lg border px-2.5 py-1.5 text-xs outline-none"
-              style={{
-                background: "var(--color-bt-base)",
-                borderColor: "var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-                flex: "1 1 140px",
-              }}
-            />
-          </div>
-
-          {/* Row 2: arrival date + time + action buttons */}
-          <div className="flex flex-wrap items-center gap-2">
-            <div style={{ flex: "1 1 120px" }}>
-              <label
-                className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Arriving
-              </label>
-              <input
-                type="date"
-                value={arrivalDate}
-                onChange={(e) => setArrivalDate(e.target.value)}
-                className="w-full rounded-lg border px-2.5 py-1.5 text-xs outline-none"
-                style={{
-                  background: "var(--color-bt-base)",
-                  borderColor: "var(--color-bt-border)",
-                  color: "var(--color-bt-text)",
-                  colorScheme: "dark",
-                }}
-              />
-            </div>
-            <div style={{ flex: "1 1 100px" }}>
-              <label
-                className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Time
-              </label>
-              <input
-                type="time"
-                value={arrivalTime}
-                onChange={(e) => setArrivalTime(e.target.value)}
-                className="w-full rounded-lg border px-2.5 py-1.5 text-xs outline-none"
-                style={{
-                  background: "var(--color-bt-base)",
-                  borderColor: "var(--color-bt-border)",
-                  color: "var(--color-bt-text)",
-                  colorScheme: "dark",
-                }}
-              />
-            </div>
-
-            <div className="flex flex-shrink-0 items-end gap-2 pb-0">
-              <button
-                type="button"
-                onClick={handleSave}
-                disabled={updateGuestTravel.isPending}
-                className="rounded-lg px-3 py-1.5 text-xs font-bold disabled:opacity-40"
-                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-              >
-                {updateGuestTravel.isPending ? "…" : "Save"}
-              </button>
-              {hasTravel && (
-                <button
-                  type="button"
-                  onClick={handleClear}
-                  disabled={updateGuestTravel.isPending}
-                  className="rounded-lg border px-2.5 py-1.5 text-xs disabled:opacity-40"
-                  style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-                >
-                  Clear
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => setEditing(false)}
-                className="rounded-lg border px-2.5 py-1.5 text-xs"
-                style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
+  // Has travel — same collapsible row pattern as YourTravelRow
+  return (
+    <div className="border-t" style={{ borderColor: "var(--color-bt-border)" }}>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+      >
+        {avatar}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            {m.displayName}
+          </p>
+          <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+            {summarizeTravel(m)}
+          </p>
+        </div>
+        <TravelModeBadge mode={m.travel_mode as TravelMode | null} />
+        <ChevronDown
+          size={16}
+          className="flex-shrink-0 transition-transform"
+          style={{
+            color: "var(--color-bt-text-dim)",
+            transform: expanded ? "rotate(180deg)" : undefined,
+          }}
+        />
+      </button>
+      {expanded && (
+        <div className="border-t px-4 pb-4 pt-3" style={{ borderColor: "var(--color-bt-border)" }}>
+          <TravelExpandForm
+            tripId={tripId}
+            member={m}
+            tripStartDate={tripStartDate}
+            targetUserId={m.user_id ?? undefined}
+            onSaved={() => { onSaved(); setExpanded(false); }}
+            onCancel={() => setExpanded(false)}
+          />
         </div>
       )}
     </div>
@@ -683,12 +508,16 @@ function TravelExpandForm({
   tripId,
   member,
   tripStartDate,
+  targetUserId,
   onSaved,
   onCancel,
 }: {
   tripId: string;
   member: TripMemberLite;
   tripStartDate: string | null;
+  /** When set, the owner is editing on behalf of another member.
+   *  Uses updateMemberTravel instead of updateTravel. */
+  targetUserId?: string;
   onSaved: () => void;
   onCancel: () => void;
 }) {
@@ -711,9 +540,11 @@ function TravelExpandForm({
     parseArrivalTime(member.flight_arrival_time),
   );
 
-  const updateTravel = trpc.tripMembers.updateTravel.useMutation({
-    onSuccess: onSaved,
-  });
+  // Both mutations are always called (React hook rules). Only one fires per save.
+  const updateTravel = trpc.tripMembers.updateTravel.useMutation({ onSuccess: onSaved });
+  const updateMemberTravel = trpc.tripMembers.updateMemberTravel.useMutation({ onSuccess: onSaved });
+
+  const isPending = targetUserId ? updateMemberTravel.isPending : updateTravel.isPending;
 
   const handleSave = () => {
     // Combine arrival date + time into a local ISO timestamp (no TZ
@@ -726,12 +557,26 @@ function TravelExpandForm({
         : `${arrivalDate}T00:00:00`;
     }
 
-    if (mode === "flying") {
+    const flightAirline = mode === "flying" ? details.trim() || null : null;
+    const travelDetail = mode !== "flying" ? details.trim() || null : null;
+
+    if (targetUserId) {
+      updateMemberTravel.mutate({
+        tripId,
+        targetUserId,
+        travelMode: mode,
+        travelDetail,
+        flightAirline,
+        flightNumber: null,
+        flightArrivalTime: arrivalISO,
+        flightAirport: null,
+      });
+    } else if (mode === "flying") {
       updateTravel.mutate({
         tripId,
         travelMode: mode,
         travelDetail: null,
-        flightAirline: details.trim() || null,
+        flightAirline,
         flightNumber: null,
         flightArrivalTime: arrivalISO,
         flightAirport: null,
@@ -744,7 +589,7 @@ function TravelExpandForm({
       updateTravel.mutate({
         tripId,
         travelMode: mode,
-        travelDetail: details.trim() || null,
+        travelDetail,
         flightAirline: null,
         flightNumber: null,
         flightArrivalTime: arrivalISO,
@@ -893,7 +738,7 @@ function TravelExpandForm({
         <button
           type="button"
           onClick={onCancel}
-          disabled={updateTravel.isPending}
+          disabled={isPending}
           className="flex-shrink-0 rounded-lg border px-3 py-2 text-xs disabled:opacity-40"
           style={{
             borderColor: "var(--color-bt-border)",
@@ -907,7 +752,7 @@ function TravelExpandForm({
         <button
           type="button"
           onClick={handleSave}
-          disabled={updateTravel.isPending}
+          disabled={isPending}
           className="flex-shrink-0 rounded-lg px-4 py-2 text-xs font-bold disabled:opacity-40"
           style={{
             background: "var(--color-bt-accent)",
@@ -915,7 +760,7 @@ function TravelExpandForm({
             whiteSpace: "nowrap",
           }}
         >
-          {updateTravel.isPending ? "Saving…" : "Save"}
+          {isPending ? "Saving…" : "Save"}
         </button>
       </div>
     </div>

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -140,21 +140,21 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   // Pending tally counts only real (non-guest) members — guests can't share their own.
   const realOtherMembers = allOtherMembers.filter((m) => !m.isGuest);
 
+  // All hooks must be called before any early return (rules-of-hooks).
+  // Always start collapsed — the user opens the row deliberately by
+  // tapping. Auto-expanding when empty was visually noisy.
+  const [expanded, setExpanded] = useState(false);
+  // "No travel yet" section starts collapsed in owner view.
+  const [pendingOpen, setPendingOpen] = useState(false);
+  // Filter pills — radio (single-select): clicking the active pill resets to All.
+  const [activeFilter, setActiveFilter] = useState<TravelFilterKey>("all");
+
   // Non-owners are locked out entirely when the owner has hidden this panel.
   if (!isOwner && !crewVisible) return null;
 
   // Owner view: split other members by whether travel is confirmed.
   const confirmedOthers = allOtherMembers.filter((m) => !!m.travel_mode);
   const pendingOthers = allOtherMembers.filter((m) => !m.travel_mode);
-
-  // Always start collapsed — the user opens the row deliberately by
-  // tapping. Auto-expanding when empty was visually noisy and made the
-  // panel default to a half-filled form for users who hadn't engaged yet.
-  const [expanded, setExpanded] = useState(false);
-  // "No travel yet" section starts collapsed in owner view.
-  const [pendingOpen, setPendingOpen] = useState(false);
-  // Filter pills — radio (single-select): clicking the active pill resets to All.
-  const [activeFilter, setActiveFilter] = useState<TravelFilterKey>("all");
 
   const toggleFilter = (key: TravelFilterKey) => {
     setActiveFilter((prev) => (prev === key ? "all" : key));

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -205,7 +205,7 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
               style={{ color: crewVisible ? "var(--color-bt-text-dim)" : "var(--color-bt-warning)" }}
             >
               {crewVisible ? <Eye size={11} /> : <EyeOff size={11} />}
-              {crewVisible ? "Crew visible" : "Hidden from crew"}
+              {crewVisible ? "Visible to crew" : "Hidden from crew"}
             </button>
           )}
         </div>

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -5,6 +5,8 @@ import {
   AlertTriangle,
   Car,
   ChevronDown,
+  Eye,
+  EyeOff,
   Ghost,
   HelpCircle,
   Plane,
@@ -117,6 +119,14 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const { data: trip } = trpc.trips.getById.useQuery({ tripId });
   const tripStartDate = trip?.start_date ?? null;
 
+  // Visibility toggle — owner controls whether non-owners see this panel.
+  // Defaults to true (visible) when the column hasn't been set.
+  const crewVisible = (trip as { travel_plans_crew_visible?: boolean | null } | undefined)
+    ?.travel_plans_crew_visible !== false;
+  const setTravelPlansVisible = trpc.trips.setTravelPlansVisible.useMutation({
+    onSuccess: () => utils.trips.getById.invalidate({ tripId }),
+  });
+
   const myMember = (members as TripMemberLite[]).find(
     (m) => m.user_id === currentUser?.id,
   );
@@ -125,10 +135,13 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const allOtherMembers = (members as TripMemberLite[]).filter(
     (m) => m.user_id !== currentUser?.id,
   );
-  // Non-owner view: real members who've shared (pending tally counts the rest)
-  const sharedOthers = allOtherMembers.filter((m) => !!m.travel_mode && !m.isGuest);
-  // Real members only for the pending tally (ghosts are always shown in owner view)
+  // Non-owner view: all members (including guests) who've confirmed travel.
+  const sharedOthers = allOtherMembers.filter((m) => !!m.travel_mode);
+  // Pending tally counts only real (non-guest) members — guests can't share their own.
   const realOtherMembers = allOtherMembers.filter((m) => !m.isGuest);
+
+  // Non-owners are locked out entirely when the owner has hidden this panel.
+  if (!isOwner && !crewVisible) return null;
 
   // Owner view: split other members by whether travel is confirmed.
   const confirmedOthers = allOtherMembers.filter((m) => !!m.travel_mode);
@@ -174,12 +187,28 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   return (
     <div className="space-y-3" data-testid="getting-there-section">
       {!showEmptyState && (
-        <h2
-          className="text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Travel Plans
-        </h2>
+        <div className="flex items-center justify-between">
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Travel Plans
+          </h2>
+          {isOwner && (
+            <button
+              type="button"
+              onClick={() =>
+                setTravelPlansVisible.mutate({ tripId, visible: !crewVisible })
+              }
+              disabled={setTravelPlansVisible.isPending}
+              className="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider disabled:opacity-40 transition-colors"
+              style={{ color: crewVisible ? "var(--color-bt-text-dim)" : "var(--color-bt-warning)" }}
+            >
+              {crewVisible ? <Eye size={11} /> : <EyeOff size={11} />}
+              {crewVisible ? "Crew visible" : "Hidden from crew"}
+            </button>
+          )}
+        </div>
       )}
 
       {showEmptyState && <EmptyArrivalsState onCancel={onCancel} />}
@@ -295,12 +324,23 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
 // without the chevron / expand affordance.
 
 function CrewTravelRow({ member }: { member: TripMemberLite }) {
+  const avatar = member.isGuest ? (
+    <div
+      className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
+      style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+    >
+      <Ghost size={14} />
+    </div>
+  ) : (
+    <UserAvatar name={member.displayName} avatarUrl={null} size="md" />
+  );
+
   return (
     <div
       className="flex w-full items-center gap-3 border-t px-4 py-3"
       style={{ borderColor: "var(--color-bt-border)" }}
     >
-      <UserAvatar name={member.displayName} avatarUrl={null} size="md" />
+      {avatar}
 
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -207,6 +207,8 @@ function GhostTravelRow({
       ? [m.flight_airline, m.flight_number].filter(Boolean).join(" ")
       : m.travel_detail ?? "",
   );
+  const [arrivalDate, setArrivalDate] = useState(() => parseArrivalDate(m.flight_arrival_time));
+  const [arrivalTime, setArrivalTime] = useState(() => parseArrivalTime(m.flight_arrival_time));
 
   const updateGuestTravel = trpc.tripMembers.updateGuestTravel.useMutation({
     onMutate: async (vars) => {
@@ -215,7 +217,13 @@ function GhostTravelRow({
       utils.tripMembers.list.setData({ tripId }, (old) =>
         (old ?? []).map((row) =>
           row.user_id === vars.guestUserId
-            ? { ...row, travel_mode: vars.travelMode, travel_detail: vars.travelDetail ?? null }
+            ? {
+                ...row,
+                travel_mode: vars.travelMode,
+                travel_detail: vars.travelDetail ?? null,
+                flight_airline: vars.flightAirline ?? null,
+                flight_arrival_time: vars.flightArrivalTime ?? null,
+              }
             : row
         )
       );
@@ -231,6 +239,13 @@ function GhostTravelRow({
     onSettled: () => utils.tripMembers.list.invalidate({ tripId }),
   });
 
+  const buildArrivalISO = (): string | null => {
+    if (!arrivalDate) return null;
+    return arrivalTime
+      ? `${arrivalDate}T${arrivalTime}:00`
+      : `${arrivalDate}T00:00:00`;
+  };
+
   const handleSave = () => {
     if (!m.user_id) return;
     updateGuestTravel.mutate({
@@ -238,6 +253,8 @@ function GhostTravelRow({
       guestUserId: m.user_id,
       travelMode: mode,
       travelDetail: mode !== "flying" ? details.trim() || null : null,
+      flightAirline: mode === "flying" ? details.trim() || null : null,
+      flightArrivalTime: buildArrivalISO(),
     });
   };
 
@@ -248,9 +265,13 @@ function GhostTravelRow({
       guestUserId: m.user_id,
       travelMode: null,
       travelDetail: null,
+      flightAirline: null,
+      flightArrivalTime: null,
     });
     setMode("driving");
     setDetails("");
+    setArrivalDate("");
+    setArrivalTime("");
     setEditing(false);
   };
 
@@ -261,6 +282,8 @@ function GhostTravelRow({
         ? [m.flight_airline, m.flight_number].filter(Boolean).join(" ")
         : m.travel_detail ?? "",
     );
+    setArrivalDate(parseArrivalDate(m.flight_arrival_time));
+    setArrivalTime(parseArrivalTime(m.flight_arrival_time));
     setEditing(true);
   };
 
@@ -276,7 +299,6 @@ function GhostTravelRow({
           onClick={openEdit}
           className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
         >
-          {/* Ghost avatar */}
           <div
             className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full"
             style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
@@ -307,94 +329,131 @@ function GhostTravelRow({
         </button>
       )}
 
-      {/* ── Inline edit form — slim: mode select + details only ── */}
+      {/* ── Inline edit form ── */}
       {editing && (
         <div
-          className="flex flex-wrap items-center gap-2 px-4 py-3"
+          className="space-y-2.5 px-4 py-3"
           style={{ background: "var(--color-bt-card-raised)" }}
         >
-          {/* Ghost label */}
-          <div className="flex items-center gap-2" style={{ flex: "0 0 auto" }}>
-            <div
-              className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full"
-              style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-            >
-              <Ghost size={12} />
+          {/* Row 1: ghost label + mode select + details */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex items-center gap-2" style={{ flex: "0 0 auto" }}>
+              <div
+                className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full"
+                style={{ background: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+              >
+                <Ghost size={12} />
+              </div>
+              <span className="text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                {m.displayName}
+              </span>
             </div>
-            <span className="text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
-              {m.displayName}
-            </span>
+
+            <select
+              value={mode}
+              onChange={(e) => setMode(e.target.value as GuestTravelMode)}
+              className="rounded-lg border px-2 py-1.5 text-xs outline-none"
+              style={{
+                background: "var(--color-bt-base)",
+                borderColor: "var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+                flex: "0 0 auto",
+              }}
+            >
+              <option value="driving">Driving</option>
+              <option value="flying">Flying</option>
+              <option value="other">Other</option>
+            </select>
+
+            <input
+              type="text"
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              placeholder={mode === "flying" ? "e.g. Delta 1733" : "e.g. from Charlotte"}
+              className="min-w-0 rounded-lg border px-2.5 py-1.5 text-xs outline-none"
+              style={{
+                background: "var(--color-bt-base)",
+                borderColor: "var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+                flex: "1 1 140px",
+              }}
+            />
           </div>
 
-          {/* Mode select */}
-          <select
-            value={mode}
-            onChange={(e) => setMode(e.target.value as GuestTravelMode)}
-            className="rounded-lg border px-2 py-1.5 text-xs outline-none"
-            style={{
-              background: "var(--color-bt-base)",
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-              flex: "0 0 auto",
-            }}
-          >
-            <option value="driving">Driving</option>
-            <option value="flying">Flying</option>
-            <option value="other">Other</option>
-          </select>
+          {/* Row 2: arrival date + time + action buttons */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div style={{ flex: "1 1 120px" }}>
+              <label
+                className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Arriving
+              </label>
+              <input
+                type="date"
+                value={arrivalDate}
+                onChange={(e) => setArrivalDate(e.target.value)}
+                className="w-full rounded-lg border px-2.5 py-1.5 text-xs outline-none"
+                style={{
+                  background: "var(--color-bt-base)",
+                  borderColor: "var(--color-bt-border)",
+                  color: "var(--color-bt-text)",
+                  colorScheme: "dark",
+                }}
+              />
+            </div>
+            <div style={{ flex: "1 1 100px" }}>
+              <label
+                className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Time
+              </label>
+              <input
+                type="time"
+                value={arrivalTime}
+                onChange={(e) => setArrivalTime(e.target.value)}
+                className="w-full rounded-lg border px-2.5 py-1.5 text-xs outline-none"
+                style={{
+                  background: "var(--color-bt-base)",
+                  borderColor: "var(--color-bt-border)",
+                  color: "var(--color-bt-text)",
+                  colorScheme: "dark",
+                }}
+              />
+            </div>
 
-          {/* Details */}
-          <input
-            type="text"
-            value={details}
-            onChange={(e) => setDetails(e.target.value)}
-            placeholder={mode === "flying" ? "e.g. Delta 1733" : "e.g. from Charlotte"}
-            className="min-w-0 rounded-lg border px-2.5 py-1.5 text-xs outline-none"
-            style={{
-              background: "var(--color-bt-base)",
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-              flex: "1 1 140px",
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleSave();
-              if (e.key === "Escape") setEditing(false);
-            }}
-          />
-
-          {/* Save */}
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={updateGuestTravel.isPending}
-            className="rounded-lg px-3 py-1.5 text-xs font-bold disabled:opacity-40"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)", flexShrink: 0 }}
-          >
-            {updateGuestTravel.isPending ? "…" : "Save"}
-          </button>
-
-          {/* Clear — only if travel was already set */}
-          {hasTravel && (
-            <button
-              type="button"
-              onClick={handleClear}
-              disabled={updateGuestTravel.isPending}
-              className="rounded-lg border px-2.5 py-1.5 text-xs disabled:opacity-40"
-              style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)", flexShrink: 0 }}
-            >
-              Clear
-            </button>
-          )}
-
-          {/* Cancel */}
-          <button
-            type="button"
-            onClick={() => setEditing(false)}
-            className="rounded-lg border px-2.5 py-1.5 text-xs"
-            style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)", flexShrink: 0 }}
-          >
-            Cancel
-          </button>
+            <div className="flex flex-shrink-0 items-end gap-2 pb-0">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={updateGuestTravel.isPending}
+                className="rounded-lg px-3 py-1.5 text-xs font-bold disabled:opacity-40"
+                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+              >
+                {updateGuestTravel.isPending ? "…" : "Save"}
+              </button>
+              {hasTravel && (
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  disabled={updateGuestTravel.isPending}
+                  className="rounded-lg border px-2.5 py-1.5 text-xs disabled:opacity-40"
+                  style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+                >
+                  Clear
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setEditing(false)}
+                className="rounded-lg border px-2.5 py-1.5 text-xs"
+                style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -60,9 +60,9 @@ const TRAVEL_PILL_TONES: Record<TravelFilterKey, { bg: string; color: string; bo
     border: "var(--color-bt-accent-border)",
   },
   other: {
-    bg: "var(--color-bt-card-raised)",
-    color: "var(--color-bt-text-dim)",
-    border: "var(--color-bt-border)",
+    bg: "var(--color-bt-blue-bg)",
+    color: "var(--color-bt-planning)",
+    border: "var(--color-bt-planning-border)",
   },
 };
 
@@ -140,25 +140,15 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   const [expanded, setExpanded] = useState(false);
   // "No travel yet" section starts collapsed in owner view.
   const [pendingOpen, setPendingOpen] = useState(false);
-  // Filter pills — same multi-select pattern as ItineraryView.
-  const [activeFilters, setActiveFilters] = useState<Set<TravelFilterKey>>(new Set(["all"]));
+  // Filter pills — radio (single-select): clicking the active pill resets to All.
+  const [activeFilter, setActiveFilter] = useState<TravelFilterKey>("all");
 
   const toggleFilter = (key: TravelFilterKey) => {
-    setActiveFilters((prev) => {
-      if (key === "all") return new Set<TravelFilterKey>(["all"]);
-      const next = new Set(prev);
-      next.delete("all");
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next.size === 0 ? new Set<TravelFilterKey>(["all"]) : next;
-    });
+    setActiveFilter((prev) => (prev === key ? "all" : key));
   };
 
-  const matchesFilter = (mode: string | null | undefined) => {
-    if (activeFilters.has("all")) return true;
-    if (!mode) return false;
-    return activeFilters.has(mode as TravelFilterKey);
-  };
+  const matchesFilter = (mode: string | null | undefined) =>
+    activeFilter === "all" || mode === activeFilter;
 
   const hasMyTravel = !!myMember?.travel_mode;
   // Empty-state mock-up only shows when nobody on the trip has shared
@@ -196,10 +186,10 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
 
       {showFilterPills && (
         <div className="flex flex-wrap items-center gap-2">
-          <TravelFilterPill label="All"     filterKey="all"     active={activeFilters.has("all")}     onClick={() => toggleFilter("all")} />
-          {modesInUse.has("driving") && <TravelFilterPill label="Driving" filterKey="driving" active={activeFilters.has("driving")} onClick={() => toggleFilter("driving")} />}
-          {modesInUse.has("flying")  && <TravelFilterPill label="Flying"  filterKey="flying"  active={activeFilters.has("flying")}  onClick={() => toggleFilter("flying")} />}
-          {modesInUse.has("other")   && <TravelFilterPill label="Other"   filterKey="other"   active={activeFilters.has("other")}   onClick={() => toggleFilter("other")} />}
+          <TravelFilterPill label="All"     filterKey="all"     active={activeFilter === "all"}     onClick={() => toggleFilter("all")} />
+          {modesInUse.has("driving") && <TravelFilterPill label="Driving" filterKey="driving" active={activeFilter === "driving"} onClick={() => toggleFilter("driving")} />}
+          {modesInUse.has("flying")  && <TravelFilterPill label="Flying"  filterKey="flying"  active={activeFilter === "flying"}  onClick={() => toggleFilter("flying")} />}
+          {modesInUse.has("other")   && <TravelFilterPill label="Other"   filterKey="other"   active={activeFilter === "other"}   onClick={() => toggleFilter("other")} />}
         </div>
       )}
 
@@ -935,9 +925,9 @@ function TravelModeBadge({ mode }: { mode: TravelMode | null }) {
     label = "Driving";
     Icon = Car;
   } else {
-    style.background = "var(--color-bt-card-raised)";
-    style.color = "var(--color-bt-text-dim)";
-    style.border = "1px solid var(--color-bt-border)";
+    style.background = "var(--color-bt-blue-bg)";
+    style.color = "var(--color-bt-planning)";
+    style.border = "1px solid var(--color-bt-planning-border)";
     label = "Other";
     Icon = HelpCircle;
   }

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -75,10 +75,16 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
   // Real members only for the pending tally (ghosts are always shown in owner view)
   const realOtherMembers = allOtherMembers.filter((m) => !m.isGuest);
 
+  // Owner view: split other members by whether travel is confirmed.
+  const confirmedOthers = allOtherMembers.filter((m) => !!m.travel_mode);
+  const pendingOthers = allOtherMembers.filter((m) => !m.travel_mode);
+
   // Always start collapsed — the user opens the row deliberately by
   // tapping. Auto-expanding when empty was visually noisy and made the
   // panel default to a half-filled form for users who hadn't engaged yet.
   const [expanded, setExpanded] = useState(false);
+  // "No travel yet" section starts collapsed in owner view.
+  const [pendingOpen, setPendingOpen] = useState(false);
 
   const hasMyTravel = !!myMember?.travel_mode;
   // Empty-state mock-up only shows when nobody on the trip has shared
@@ -128,10 +134,12 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
             />
           )}
 
-          {/* Owner: every other member gets a full editable row.
+          {/* Owner: confirmed travel rows first, then a collapsible
+              "no travel yet" section for those who haven't added info.
               Non-owner: read-only rows for members who've shared, plus a tally. */}
-          {isOwner
-            ? allOtherMembers.map((m) => (
+          {isOwner ? (
+            <>
+              {confirmedOthers.map((m) => (
                 <OtherMemberTravelRow
                   key={m.memberId}
                   tripId={tripId}
@@ -139,10 +147,59 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
                   tripStartDate={tripStartDate}
                   onSaved={() => utils.tripMembers.list.invalidate({ tripId })}
                 />
-              ))
-            : sharedOthers.map((m) => (
-                <CrewTravelRow key={m.memberId} member={m} />
               ))}
+
+              {pendingOthers.length > 0 && (
+                <>
+                  {/* Collapsed header */}
+                  <button
+                    type="button"
+                    onClick={() => setPendingOpen((v) => !v)}
+                    className="flex w-full items-center gap-3 border-t px-4 py-2.5 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+                    style={{ borderColor: "var(--color-bt-border)" }}
+                  >
+                    <span
+                      className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
+                      style={{
+                        background: "var(--color-bt-card-raised)",
+                        color: "var(--color-bt-text-dim)",
+                        border: "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      {pendingOthers.length}
+                    </span>
+                    <span className="flex-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                      {pendingOthers.length === 1 ? "person" : "people"} without travel info
+                    </span>
+                    <ChevronDown
+                      size={14}
+                      style={{
+                        color: "var(--color-bt-text-dim)",
+                        transform: pendingOpen ? "rotate(180deg)" : "rotate(0deg)",
+                        transition: "transform 150ms",
+                        flexShrink: 0,
+                      }}
+                    />
+                  </button>
+
+                  {/* Expanded pending rows */}
+                  {pendingOpen && pendingOthers.map((m) => (
+                    <OtherMemberTravelRow
+                      key={m.memberId}
+                      tripId={tripId}
+                      member={m}
+                      tripStartDate={tripStartDate}
+                      onSaved={() => utils.tripMembers.list.invalidate({ tripId })}
+                    />
+                  ))}
+                </>
+              )}
+            </>
+          ) : (
+            sharedOthers.map((m) => (
+              <CrewTravelRow key={m.memberId} member={m} />
+            ))
+          )}
 
           {!isOwner && <PendingTravelRow members={realOtherMembers} />}
         </div>

--- a/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
+++ b/src/app/trips/[tripId]/tabs/components/PlanningGrid.tsx
@@ -822,7 +822,7 @@ const PLANNING_MOBILE_TABS = [
   { id: "dates" as const, label: "Dates", Icon: CalendarRange },
   { id: "crew" as const, label: "Crew", Icon: Users },
   { id: "lodging" as const, label: "Lodging", Icon: Hotel },
-  { id: "schedule" as const, label: "Schedule", Icon: Calendar },
+  { id: "schedule" as const, label: "Agenda", Icon: Calendar },
 ];
 
 // ── Main grid ─────────────────────────────────────────────────────────────
@@ -1426,13 +1426,13 @@ export function PlanningGrid({
         <Tile
           testId="planning-tile-schedule"
           icon={Calendar}
-          label="Schedule"
+          label="Agenda"
           state={scheduleState}
           isActive={activePanel === "schedule"}
           emptyDescription="Nothing planned yet"
           emptyCTA="Add items"
           completeValue={`${scheduleCount} ${scheduleCount === 1 ? "item" : "items"}`}
-          editLabel="Manage schedule"
+          editLabel="Manage agenda"
           preview={schedulePreview}
           anyPanelOpen={!!activePanel}
 
@@ -1585,7 +1585,7 @@ export function PlanningGrid({
           {mobileActiveTab === "schedule" && (
             scheduleState === "skipped" ? (
               <div className="flex flex-col items-center gap-3 px-6 py-8">
-                <p className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>Opted out of schedule</p>
+                <p className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>Opted out of agenda</p>
                 {canEdit && (
                   <button type="button" onClick={() => handleUnskip("schedule")} disabled={pendingTile === "schedule"}
                     className="rounded-lg px-4 py-1.5 text-sm font-semibold disabled:opacity-40"

--- a/src/app/trips/[tripId]/tabs/types.ts
+++ b/src/app/trips/[tripId]/tabs/types.ts
@@ -28,6 +28,8 @@ export interface TripData {
   /** Panel activation flags — owner taps the invitation card to flip these on. */
   itinerary_enabled?: boolean | null;
   getting_there_enabled?: boolean | null;
+  /** When false, the Travel Plans panel is hidden from non-owners. Defaults to true. */
+  travel_plans_crew_visible?: boolean | null;
   /** Set true when owner Xs out the Quick Info empty state on the home tab. */
   quick_info_dismissed?: boolean | null;
   owner_alert?: string | null;

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -14,7 +14,7 @@ const ALL_TABS: TabDef[] = [
   { id: "home",     label: "Home",        Icon: House       },
   { id: "crew",     label: "Crew",        Icon: Users       },
   { id: "lodging",  label: "Lodging",     Icon: Hotel       },
-  { id: "schedule", label: "Schedule",    Icon: Calendar    },
+  { id: "schedule", label: "Agenda",      Icon: Calendar    },
   { id: "expenses", label: "Receipts",    Icon: DollarSign  },
   { id: "comp",     label: "Competition", Icon: Trophy      },
 ];

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -26,8 +26,12 @@ interface TripTabBarProps {
   canEdit?: boolean;
   /** Trip stage — used to disable Expenses in PLANNING and hide Competition */
   stage?: string;
-  /** Tabs that have a notification dot. Dot is hidden when the tab is active. */
-  badges?: Partial<Record<TabId, boolean>>;
+  /**
+   * Tabs that have a notification dot. Dot is hidden when the tab is active.
+   * "info"    → teal  (normal action item, e.g. unconfirmed items)
+   * "warning" → yellow (needs attention, e.g. dates out of range)
+   */
+  badges?: Partial<Record<TabId, "info" | "warning">>;
 }
 
 export const TripTabBar: FC<TripTabBarProps> = ({
@@ -78,7 +82,7 @@ export const TripTabBar: FC<TripTabBarProps> = ({
     >
       {tabs.map(({ id, label, Icon }) => {
         const active = activeTab === id;
-        const hasBadge = !!badges?.[id];
+        const badgeTier = badges?.[id];
         return (
           <button
             key={id}
@@ -97,10 +101,14 @@ export const TripTabBar: FC<TripTabBarProps> = ({
                 visual consistency between basic and advanced modes. */}
             <span className="relative inline-flex items-center justify-center">
               <Icon size={iconMode ? 20 : 16} strokeWidth={1.75} />
-              {hasBadge && (
+              {badgeTier && !active && (
                 <span
                   className="absolute -right-1.5 -top-1 h-2 w-2 rounded-full"
-                  style={{ background: "var(--color-bt-accent)" }}
+                  style={{
+                    background: badgeTier === "warning"
+                      ? "var(--color-bt-warning)"
+                      : "var(--color-bt-accent)",
+                  }}
                 />
               )}
             </span>

--- a/src/lib/notificationText.ts
+++ b/src/lib/notificationText.ts
@@ -64,7 +64,7 @@ export function getNotificationText(notification: NotificationEvent): string {
         ? `You've been added to ${p.trip_name} by ${p.adder_name}`
         : `${p.member_name} joined ${p.trip_name}`;
     case "stage_advanced":
-      return `${p.trip_name} is official — check your RSVP`;
+      return `${p.trip_name} is a go — check the Home tab for the latest`;
     case "idea_voted":
       return `${p.voter_name} and others voted on destination ideas for ${p.trip_name}`;
     case "date_poll_voted":

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -141,7 +141,16 @@ export const scheduleRouter = router({
       const update: Record<string, unknown> = {};
       if (input.title !== undefined) update.title = input.title;
       if (input.detail !== undefined) update.detail = input.detail;
-      if (input.scheduledDate !== undefined) update.scheduled_date = input.scheduledDate;
+      if (input.scheduledDate !== undefined) {
+        update.scheduled_date = input.scheduledDate;
+        // Clearing the date moves the item back to On Deck — it can no longer
+        // be "confirmed" without a day assigned, so unconfirm it automatically.
+        if (input.scheduledDate === null) {
+          update.is_confirmed = false;
+          update.confirmed_at = null;
+          update.confirmed_by = null;
+        }
+      }
       if (input.scheduledTime !== undefined) update.scheduled_time = input.scheduledTime;
       if (input.sortOrder !== undefined) update.sort_order = input.sortOrder;
       if (input.courseName !== undefined) update.course_name = input.courseName;

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -481,6 +481,59 @@ export const tripMembersRouter = router({
     }),
 
   // -----------------------------------------------------------------------
+  // updateGuestTravel — Owner sets travel info for a ghost crew member.
+  //
+  // Ghost members can't log in so they can't use updateTravel themselves.
+  // The owner fills it in on their behalf — this keeps the Getting There
+  // panel useful even when some crew haven't joined BuddyTrip yet.
+  // -----------------------------------------------------------------------
+  updateGuestTravel: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        guestUserId: z.string(),
+        travelMode: z.enum(["driving", "flying", "other"]).nullable(),
+        travelDetail: z.string().max(500).nullable().optional(),
+      })
+    )
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      // Confirm the target is actually a member of this trip
+      const { data: member } = await ctx.supabase
+        .from("trip_members")
+        .select("id")
+        .eq("trip_id", ctx.tripId)
+        .eq("user_id", input.guestUserId)
+        .maybeSingle();
+
+      if (!member) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Member not found in this trip",
+        });
+      }
+
+      const { error } = await ctx.supabase
+        .from("trip_members")
+        .update({
+          travel_mode: input.travelMode,
+          travel_detail: input.travelDetail ?? null,
+          travel_shared: true,
+        })
+        .eq("trip_id", ctx.tripId)
+        .eq("user_id", input.guestUserId);
+
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to update travel info",
+        });
+      }
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
   // sendInvitationBlast — Owner sends the trip invitation email to a
   // selected subset of crew members. Updates last_invited_at per recipient
   // and last_blast_sent_at on the trip.

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -494,6 +494,8 @@ export const tripMembersRouter = router({
         guestUserId: z.string(),
         travelMode: z.enum(["driving", "flying", "other"]).nullable(),
         travelDetail: z.string().max(500).nullable().optional(),
+        flightAirline: z.string().max(100).nullable().optional(),
+        flightArrivalTime: z.string().nullable().optional(),
       })
     )
     .use(requireTripRole("Owner"))
@@ -518,6 +520,8 @@ export const tripMembersRouter = router({
         .update({
           travel_mode: input.travelMode,
           travel_detail: input.travelDetail ?? null,
+          flight_airline: input.flightAirline ?? null,
+          flight_arrival_time: input.flightArrivalTime ?? null,
           travel_shared: true,
         })
         .eq("trip_id", ctx.tripId)

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -487,51 +487,55 @@ export const tripMembersRouter = router({
   // The owner fills it in on their behalf — this keeps the Getting There
   // panel useful even when some crew haven't joined BuddyTrip yet.
   // -----------------------------------------------------------------------
-  updateGuestTravel: authedProcedure
+  // updateMemberTravel — Owner sets travel info for any crew member.
+  //
+  // Ghost members can't log in so the owner fills in their travel.
+  // Owners can also correct/fill in for any real member who hasn't yet.
+  // -----------------------------------------------------------------------
+  updateMemberTravel: authedProcedure
     .input(
       z.object({
         tripId: z.string(),
-        guestUserId: z.string(),
+        targetUserId: z.string(),
         travelMode: z.enum(["driving", "flying", "other"]).nullable(),
         travelDetail: z.string().max(500).nullable().optional(),
         flightAirline: z.string().max(100).nullable().optional(),
+        flightNumber: z.string().max(50).nullable().optional(),
         flightArrivalTime: z.string().nullable().optional(),
+        flightAirport: z.string().max(100).nullable().optional(),
       })
     )
     .use(requireTripRole("Owner"))
     .mutation(async ({ ctx, input }) => {
-      // Confirm the target is actually a member of this trip
       const { data: member } = await ctx.supabase
         .from("trip_members")
         .select("id")
         .eq("trip_id", ctx.tripId)
-        .eq("user_id", input.guestUserId)
+        .eq("user_id", input.targetUserId)
         .maybeSingle();
 
       if (!member) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Member not found in this trip",
-        });
+        throw new TRPCError({ code: "NOT_FOUND", message: "Member not found in this trip" });
       }
+
+      const update: Record<string, unknown> = {
+        travel_mode: input.travelMode,
+        travel_shared: true,
+      };
+      if (input.travelDetail !== undefined) update.travel_detail = input.travelDetail;
+      if (input.flightAirline !== undefined) update.flight_airline = input.flightAirline;
+      if (input.flightNumber !== undefined) update.flight_number = input.flightNumber;
+      if (input.flightArrivalTime !== undefined) update.flight_arrival_time = input.flightArrivalTime;
+      if (input.flightAirport !== undefined) update.flight_airport = input.flightAirport;
 
       const { error } = await ctx.supabase
         .from("trip_members")
-        .update({
-          travel_mode: input.travelMode,
-          travel_detail: input.travelDetail ?? null,
-          flight_airline: input.flightAirline ?? null,
-          flight_arrival_time: input.flightArrivalTime ?? null,
-          travel_shared: true,
-        })
+        .update(update)
         .eq("trip_id", ctx.tripId)
-        .eq("user_id", input.guestUserId);
+        .eq("user_id", input.targetUserId);
 
       if (error) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to update travel info",
-        });
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Failed to update travel info" });
       }
 
       return { success: true };

--- a/src/server/routers/trips.ts
+++ b/src/server/routers/trips.ts
@@ -827,6 +827,30 @@ export const tripsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
+  // setTravelPlansVisible — owner toggles whether non-owners can see the
+  // Travel Plans panel. Defaults to true; owner can hide it once the trip
+  // is underway (the itinerary carries the same info).
+  // -----------------------------------------------------------------------
+  setTravelPlansVisible: authedProcedure
+    .input(z.object({ tripId: z.string(), visible: z.boolean() }))
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ input, ctx }) => {
+      const { error } = await ctx.supabase
+        .from("trips")
+        .update({ travel_plans_crew_visible: input.visible })
+        .eq("id", ctx.tripId);
+
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to update travel plans visibility: ${error.message}`,
+        });
+      }
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
   // dismissQuickInfo — owner taps the X on the Quick Info empty state.
   // Flag stays set until restored. Idempotent.
   // -----------------------------------------------------------------------

--- a/supabase/migrations/20260509000000_066_travel_plans_crew_visible.sql
+++ b/supabase/migrations/20260509000000_066_travel_plans_crew_visible.sql
@@ -1,0 +1,10 @@
+-- Migration 066 — travel_plans_crew_visible flag
+--
+-- Owners can hide the Travel Plans panel from non-owners once the trip is
+-- underway. The itinerary carries the same info, so the panel becomes
+-- redundant during the trip itself.
+--
+-- Defaults to true so all existing trips continue showing the panel to crew.
+
+ALTER TABLE trips
+  ADD COLUMN IF NOT EXISTS travel_plans_crew_visible boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary

This branch covers a batch of UX polish work across several surfaces. The target branch in the command says `fix/schedule-tab-build-errors` but all work is on `feat/ghost-travel-info` — opening against main.

### Travel Plans (Getting There panel)
- Owner can show/hide the Travel Plans panel from non-owners via an inline Eye/EyeOff toggle next to the section heading; copy reads **Visible to crew** / **Hidden from crew**
- When hidden, the Home tab collapses the left column entirely so Itinerary expands to full width (no blank space)
- Travel column is fixed at `minmax(0,1fr)` so filter pills can't push it wider
- Ghost crew members with travel info now visible to non-owners (was accidentally filtered out)
- Rules-of-hooks fix: `useState` calls moved above the early-return guard (was causing Vercel build failure)
- New DB column: `trips.travel_plans_crew_visible boolean NOT NULL DEFAULT true` (migration `066`)

### Schedule → Agenda rebrand
- Tab label: **Schedule → Agenda** (internal `"schedule"` ID untouched everywhere — test IDs, routing, DB all unchanged)
- Two add buttons (+ Item / + Golf) merged into a single **Add to Agenda** button; type is chosen via segmented control (Activity / Golf Round) inside the sheet; edit mode locks the type
- Left column: **On Deck** with hint "Ideas & unscheduled items — drag onto a day"
- Right column: **Day-by-Day**
- Column layout: 50/50 split; each day group gets the same dashed border as the On Deck drop zone
- All empty states, nudge copy, and delete dialog updated to match the Agenda framing
- PlanningGrid tile updated to "Agenda"

### Agenda drag-drop fixes
- Optimistic update now correctly clears `scheduled_date` when an item is dropped to On Deck (`null ?? x` was falling through; switched to `!== undefined`)
- Dropping an item back to On Deck now immediately unconfirms it — both server-side (auto-sets `is_confirmed=false` when `scheduled_date` is cleared) and optimistically on the client

### Tab badge tiers
- `TripTabBar` badges changed from `boolean` to `"info" | "warning"` — **info** renders teal, **warning** renders yellow
- Lodging badge now reads from `trpc.logistics.list` (was incorrectly pointing at `reservations`, a different table)
- Lodging badge tiers: **warning** (yellow) when a property's check-in/out date falls outside the trip date range; **info** (teal) when properties exist but none are confirmed yet
- Crew and Agenda dots updated to `"info"` tier

### Receipts
- Non-owners can now add receipts — the server already used `requireTripMember` but the UI was gating the button on `canEdit`; edit-splits and delete remain owner/planner-only
- Two-column layout: receipt list + add button in the left 2/3 column, Balances panel sticky in the right 1/3 column (stacks on mobile)
- Balances card uses alternating row shading inside a rounded border; shows "All settled up 🎉" / "Balances appear once receipts are added" placeholder states

## Test plan

- [ ] Travel Plans toggle (owner view): tap Eye icon — copy switches, non-owner no longer sees the panel; Itinerary expands to full width
- [ ] Ghost crew member with travel_mode shows in Travel Plans for non-owners
- [ ] Agenda tab label visible in tab bar; `data-testid="tab-schedule"` still in DOM
- [ ] "Add to Agenda" button opens sheet titled "Add to Agenda" with Activity selected; switch to Golf Round — form changes; submit each type
- [ ] Edit existing item → no type selector; title reads "Edit Activity" or "Edit Golf Round"
- [ ] Drag item from a day to On Deck → item moves instantly (optimistic), confirmed badge disappears instantly
- [ ] Lodging tab: yellow dot when a property date is out of range; teal dot when unconfirmed; no dot when all confirmed
- [ ] Any crew member (non-owner) can add a receipt; delete button not shown to members
- [ ] Receipts tab: two-column layout on desktop, single column on mobile; Balances column updates live as receipts are added
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)