### PR TITLE
Align app shell with marketing page (palette, fonts, nav, login polish)

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -22,7 +22,7 @@ these tokens.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-base` | `--color-bt-base` |
-| Value | `#d8e0e8` (cool grey — noticeably grey on any display) | `#0a1628` |
+| Value | `#d8e0e8` (cool grey — noticeably grey on any display) | `#0a0e1a` |
 
 **Use:** outermost page/layout background. Applied to `body`.
 **Examples:** trip page, dashboard, login page.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -494,6 +494,7 @@ dark image-overlay contexts where tokens don't apply. No migration needed.
 | `--color-bt-state-stroke` | `rgba(0,0,0,0.15)` | `rgba(255,255,255,0.20)` | Toggle/state border |
 | `--color-bt-tile-bg` | `transparent` | `transparent` | Schedule tile bg |
 | `--color-bt-past-bg` | `#f8fafc` | `#161c2b` | Past schedule bg |
+| `--color-bt-nav-bg` | `rgba(244,247,250,0.85)` | `rgba(10,14,26,0.85)` | Sticky top nav bg (use with `backdrop-filter: blur(14px)`) |
 | `--shadow-card` | light shadow | heavier shadow | Card elevation |
 | `--shadow-raised` | medium shadow | heavier shadow | Expanded panels |
 | `--shadow-floating` | strong shadow | heavier shadow | Tooltips, popovers |

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -32,7 +32,7 @@ these tokens.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card` | `--color-bt-card` |
-| Value | `#ffffff` (white) | `#111f36` |
+| Value | `#ffffff` (white) | `#111827` |
 
 **Use:** collapsible panels, card containers, modals, bottom sheets —
 anything that floats above the page.
@@ -44,7 +44,7 @@ TripCard, AddDateSheet, LockConfirmDialog, TripSettingsModal.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card-raised` | `--color-bt-card-raised` |
-| Value | `#f4f7fa` | `#1a2d4a` |
+| Value | `#f4f7fa` | `#1a2130` |
 
 **Use:** elements sitting ON a card/panel — inactive buttons, zebra
 table rows, input backgrounds, inactive compact chips.
@@ -56,7 +56,7 @@ in the dates response grid, inactive filter chips.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card-float` | `--color-bt-card-float` |
-| Value | `#e8edf5` | `#243656` |
+| Value | `#e8edf5` | `#222b3d` |
 
 **Use:** deeply nested elevated elements, tooltips, popovers.
 **Examples:** reserved for future nesting needs.
@@ -71,7 +71,7 @@ content panels. They frame the app — they don't contain content.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card` | `--color-bt-card` |
-| Value | `#ffffff` (white) | `#111f36` |
+| Value | `#ffffff` (white) | `#111827` |
 
 **Separation:** border only, no shadow. Content panels use `--shadow-raised`
 for elevation; chrome uses `1px solid var(--color-bt-border)` for definition.
@@ -89,12 +89,12 @@ for elevation; chrome uses `1px solid var(--color-bt-border)` for definition.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-border` | `--color-bt-border` |
-| Value | `#c8d0da` | `#1e3a5f` |
+| Value | `#c8d0da` | `rgba(148, 163, 184, 0.15)` |
 
 **Use:** panel outlines, dividers, card edges. Every bordered surface component
 uses this token for its `border-color`.
 
-> **Note:** `--color-bt-subtle-border` (`#e2e8f0` light / `#1e293b` dark) is a
+> **Note:** `--color-bt-subtle-border` (`#e2e8f0` light / `rgba(148,163,184,0.08)` dark) is a
 > separate token that intentionally diverges from `--color-bt-border`. It is used
 > as a **background fill** in scoring-format components (zebra stripes, inactive
 > chips), not as a CSS border. Do not replace it with `--color-bt-border`.
@@ -488,12 +488,12 @@ dark image-overlay contexts where tokens don't apply. No migration needed.
 |-------|-------|------|-----|
 | `--color-bt-hover` | `rgba(0,0,0,0.04)` | `rgba(255,255,255,0.06)` | Hover highlight |
 | `--color-bt-overlay` | `rgba(0,0,0,0.5)` | `rgba(0,0,0,0.7)` | Modal backdrop |
-| `--color-bt-subtle-border` | `#e2e8f0` | `#1e293b` | Secondary borders |
+| `--color-bt-subtle-border` | `#e2e8f0` | `rgba(148,163,184,0.08)` | Secondary borders |
 | `--color-bt-dim-faint` | `rgba(100,116,139,0.12)` | `rgba(148,163,184,0.12)` | Disabled/inactive fill |
 | `--color-bt-state-fill` | `rgba(0,0,0,0.08)` | `rgba(255,255,255,0.13)` | State silhouette watermark fill (LocationHero) |
 | `--color-bt-state-stroke` | `rgba(0,0,0,0.15)` | `rgba(255,255,255,0.20)` | Toggle/state border |
 | `--color-bt-tile-bg` | `transparent` | `transparent` | Schedule tile bg |
-| `--color-bt-past-bg` | `#f8fafc` | `#1e293b` | Past schedule bg |
+| `--color-bt-past-bg` | `#f8fafc` | `#161c2b` | Past schedule bg |
 | `--shadow-card` | light shadow | heavier shadow | Card elevation |
 | `--shadow-raised` | medium shadow | heavier shadow | Expanded panels |
 | `--shadow-floating` | strong shadow | heavier shadow | Tooltips, popovers |

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -50,7 +50,7 @@ export default function ResetPasswordPage() {
         <div className="space-y-5">
           <div className="text-center">
             <h1
-              className="flex items-center justify-center gap-2 font-display text-2xl font-semibold tracking-wider"
+              className="flex items-center justify-center gap-2 text-2xl font-semibold tracking-wider"
               style={{ color: "var(--color-bt-text)" }}
             >
               <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,8 +79,8 @@
 .dark {
   --color-bt-base: #0a0e1a;          /* deep navy — matches marketing page */
   --color-bt-base-alt: #0a0e1a;
-  --color-bt-card: #111f36;          /* navy card — noticeably different from base */
-  --color-bt-border: #1e3a5f;        /* navy border */
+  --color-bt-card: #111827;          /* gray-900 — matches marketing page cards */
+  --color-bt-border: rgba(148, 163, 184, 0.15); /* slate/translucent — matches marketing */
   --color-bt-text: #f1f5f9;          /* slate-100 */
   --color-bt-text-dim: #94a3b8;      /* slate-400 — warmer than current #8b949e */
 
@@ -122,17 +122,17 @@
   --shadow-card: 0 1px 3px rgba(0,0,0,.3), 0 1px 2px rgba(0,0,0,.2);
   --shadow-raised: 0 4px 12px rgba(0,0,0,.4), 0 2px 4px rgba(0,0,0,.25);
   --shadow-floating: 0 8px 24px rgba(0,0,0,.5), 0 4px 8px rgba(0,0,0,.3);
-  --color-bt-card-raised: #1a2d4a;
-  --color-bt-card-float: #243656;
+  --color-bt-card-raised: #1a2130;   /* one step above card */
+  --color-bt-card-float: #222b3d;   /* two steps above card — modals, dropdowns */
 
   --color-bt-hover: rgba(255, 255, 255, 0.06);
   --color-bt-overlay: rgba(0, 0, 0, 0.7);
-  --color-bt-subtle-border: #1e293b;
+  --color-bt-subtle-border: rgba(148, 163, 184, 0.08); /* matches marketing dividers */
   --color-bt-dim-faint: rgba(148, 163, 184, 0.12);
   --color-bt-state-fill: rgba(255, 255, 255, 0.13);
   --color-bt-state-stroke: rgba(255, 255, 255, 0.20);
   --color-bt-tile-bg: transparent;
-  --color-bt-past-bg: #1e293b;
+  --color-bt-past-bg: #161c2b;
   --color-bt-surface-invitation: rgba(255, 255, 255, 0.03);
   color-scheme: dark;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,9 +153,8 @@
   --color-bt-border: var(--color-bt-border);
   --color-bt-text: var(--color-bt-text);
   --color-bt-text-dim: var(--color-bt-text-dim);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-display: Georgia, "Times New Roman", serif;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
 html {
@@ -165,7 +164,8 @@ html {
 body {
   background: var(--color-bt-base);
   color: var(--color-bt-text);
-  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
 }
 
 button,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,7 @@
   --color-bt-tile-bg: transparent;
   --color-bt-past-bg: #f8fafc;
   --color-bt-surface-invitation: rgba(255, 255, 255, 0.6);
+  --color-bt-nav-bg: rgba(244, 247, 250, 0.85); /* translucent base for sticky chrome */
 
   /* Vote answer colors — semantic, mode-independent (same in light & dark) */
   --color-bt-vote-yes: #00d4aa;
@@ -134,6 +135,7 @@
   --color-bt-tile-bg: transparent;
   --color-bt-past-bg: #161c2b;
   --color-bt-surface-invitation: rgba(255, 255, 255, 0.03);
+  --color-bt-nav-bg: rgba(10, 14, 26, 0.85); /* matches marketing page nav */
   color-scheme: dark;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,8 +77,8 @@
 
 /* ── Dark mode ────────────────────────────────────────────────────────── */
 .dark {
-  --color-bt-base: #0a1628;          /* navy base — richer than slate-900 */
-  --color-bt-base-alt: #0a1628;
+  --color-bt-base: #0a0e1a;          /* deep navy — matches marketing page */
+  --color-bt-base-alt: #0a0e1a;
   --color-bt-card: #111f36;          /* navy card — noticeably different from base */
   --color-bt-border: #1e3a5f;        /* navy border */
   --color-bt-text: #f1f5f9;          /* slate-100 */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { Providers } from "@/lib/providers";
 import "./globals.css";
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-geist-sans",
-});
 
 export const metadata: Metadata = {
   title: "BuddyTrip",
@@ -27,9 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${inter.variable} ${inter.className} antialiased`}
-      >
+      <body className="antialiased">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -84,8 +84,17 @@ function Input({
 }
 
 // ── Main component ─────────────────────────────────────────────────────
-export default function LoginClient() {
-  const [mode, setMode] = useState<Mode>("signin");
+export default function LoginClient({
+  initialMode = "signin",
+}: {
+  initialMode?: "signin" | "signup";
+}) {
+  const [mode, setMode] = useState<Mode>(initialMode);
+  // Tracks which primary panel (signin | signup) opened the magic-link flow
+  // so the back button returns to the right place.
+  const [magicLinkReturn, setMagicLinkReturn] = useState<"signin" | "signup">(
+    initialMode === "signup" ? "signup" : "signin"
+  );
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
@@ -101,6 +110,11 @@ export default function LoginClient() {
     setMode(m);
     setError("");
     setResetSent(false);
+  }
+
+  function enterMagicLink(from: "signin" | "signup") {
+    setMagicLinkReturn(from);
+    switchMode("magic-link");
   }
 
   // ── Google OAuth ─────────────────────────────────────────────────────
@@ -261,7 +275,7 @@ export default function LoginClient() {
             {/* Magic link */}
             <button
               type="button"
-              onClick={() => switchMode("magic-link")}
+              onClick={() => enterMagicLink("signin")}
               className="flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm transition-opacity hover:opacity-90"
               style={{
                 background: "transparent",
@@ -350,6 +364,23 @@ export default function LoginClient() {
 
             <Divider text="or" />
 
+            {/* Magic link */}
+            <button
+              type="button"
+              onClick={() => enterMagicLink("signup")}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm transition-opacity hover:opacity-90"
+              style={{
+                background: "transparent",
+                borderColor: "var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              <Mail size={16} />
+              Continue with a magic link
+            </button>
+
+            <Divider text="or" />
+
             {/* Signup form */}
             <form onSubmit={handleSignUp} className="space-y-4">
               <Input id="signup-name" label="Full Name" value={name} onChange={setName} placeholder="Zach Grether" />
@@ -385,7 +416,7 @@ export default function LoginClient() {
           <div className="space-y-5">
             <button
               type="button"
-              onClick={() => switchMode("signin")}
+              onClick={() => switchMode(magicLinkReturn)}
               className="flex items-center gap-1 text-sm hover:opacity-80"
               style={{ color: "var(--color-bt-text-dim)" }}
             >
@@ -458,7 +489,7 @@ export default function LoginClient() {
               </button>
               <button
                 type="button"
-                onClick={() => switchMode("signin")}
+                onClick={() => switchMode(magicLinkReturn)}
                 className="w-full text-sm hover:underline"
                 style={{ color: "var(--color-bt-text-dim)" }}
               >

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -232,8 +232,8 @@ export default function LoginClient({
       <div
         className="w-full max-w-[400px] rounded-xl border px-6 py-8"
         style={{
-          background: "var(--color-bt-card)",
-          borderColor: "var(--color-bt-border)",
+          background: "#111827",
+          borderColor: "rgba(148, 163, 184, 0.1)",
         }}
       >
         {/* ── signin mode ─────────────────────────────────────────── */}
@@ -241,7 +241,7 @@ export default function LoginClient({
           <div className="space-y-5">
             <div className="text-center">
               <h1
-                className="flex items-center justify-center gap-2 font-display text-2xl font-semibold tracking-wider"
+                className="flex items-center justify-center gap-2 text-2xl font-semibold tracking-wider"
                 style={{ color: "var(--color-bt-text)" }}
               >
                 <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>
@@ -333,7 +333,7 @@ export default function LoginClient({
           <div className="space-y-5">
             <div className="text-center">
               <h1
-                className="flex items-center justify-center gap-2 font-display text-2xl font-semibold tracking-wider"
+                className="flex items-center justify-center gap-2 text-2xl font-semibold tracking-wider"
                 style={{ color: "var(--color-bt-text)" }}
               >
                 <svg width="24" height="24" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -98,7 +98,6 @@ export default function LoginClient({
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
-  const [nickname, setNickname] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [resetSent, setResetSent] = useState(false);
@@ -152,7 +151,7 @@ export default function LoginClient({
       const { data, error: signUpError } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: { name, nickname } },
+        options: { data: { name } },
       });
       if (signUpError) throw signUpError;
 
@@ -383,8 +382,7 @@ export default function LoginClient({
 
             {/* Signup form */}
             <form onSubmit={handleSignUp} className="space-y-4">
-              <Input id="signup-name" label="Full Name" value={name} onChange={setName} placeholder="Zach Grether" />
-              <Input id="signup-nickname" label="Nickname" value={nickname} onChange={setNickname} placeholder="What your crew calls you" required={false} />
+              <Input id="signup-name" label="Full Name" value={name} onChange={setName} placeholder="John Smith" />
               <Input id="signup-email" label="Email" type="email" value={email} onChange={setEmail} placeholder="you@example.com" />
               <Input id="signup-password" label="Password" type="password" value={password} onChange={setPassword} placeholder="••••••••" minLength={6} />
 

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -232,8 +232,8 @@ export default function LoginClient({
       <div
         className="w-full max-w-[400px] rounded-xl border px-6 py-8"
         style={{
-          background: "#111827",
-          borderColor: "rgba(148, 163, 184, 0.1)",
+          background: "var(--color-bt-card)",
+          borderColor: "var(--color-bt-border)",
         }}
       >
         {/* ── signin mode ─────────────────────────────────────────── */}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,12 @@ export const dynamic = "force-dynamic";
 
 import LoginClient from "./LoginClient";
 
-export default function LoginPage() {
-  return <LoginClient />;
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ mode?: string }>;
+}) {
+  const params = await searchParams;
+  const initialMode = params.mode === "signup" ? "signup" : "signin";
+  return <LoginClient initialMode={initialMode} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,7 +105,7 @@ function FullScreenLoader() {
     <div
       style={{
         minHeight: "100vh",
-        background: "#0a1628",
+        background: "#0a0e1a",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -237,7 +237,7 @@ export default function ProfilePage() {
                   type="text"
                   value={nickname}
                   onChange={(e) => setNickname(e.target.value)}
-                  placeholder="e.g. Grether"
+                  placeholder="What your crew calls you"
                   className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
                   style={{
                     background: "var(--color-bt-base)",

--- a/src/components/AuthenticatedEmptyState.tsx
+++ b/src/components/AuthenticatedEmptyState.tsx
@@ -18,7 +18,7 @@ export function AuthenticatedEmptyState() {
       <div className="w-full max-w-[320px] text-center">
         {/* BuddyTrip mark — matches TopNav exactly */}
         <div
-          className="mb-6 flex items-center justify-center gap-[7px] font-display text-lg font-semibold tracking-wider"
+          className="mb-6 flex items-center justify-center gap-[7px] text-lg font-semibold tracking-wider"
           style={{ color: "var(--color-bt-text)" }}
         >
           <svg

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -121,7 +121,12 @@ export const TopNav: FC<TopNavProps> = ({
       <button
         onClick={() => router.push("/")}
         className="flex items-center gap-[7px] text-[18px] font-semibold transition-opacity hover:opacity-80"
-        style={{ color: "var(--color-bt-text)", letterSpacing: "0.06em" }}
+        style={{
+          color: "var(--color-bt-text)",
+          letterSpacing: "0.06em",
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+        }}
         aria-label="Go to dashboard"
       >
         <svg width="18" height="18" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -121,12 +121,7 @@ export const TopNav: FC<TopNavProps> = ({
       <button
         onClick={() => router.push("/")}
         className="flex items-center gap-[7px] text-[18px] font-semibold transition-opacity hover:opacity-80"
-        style={{
-          color: "var(--color-bt-text)",
-          letterSpacing: "0.06em",
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-        }}
+        style={{ color: "var(--color-bt-text)", letterSpacing: "0.06em" }}
         aria-label="Go to dashboard"
       >
         <svg width="18" height="18" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -110,16 +110,21 @@ export const TopNav: FC<TopNavProps> = ({
 
   return (
     <header
-      className="sticky top-0 z-40 flex h-14 items-center justify-between px-4"
-      style={{ background: "var(--color-bt-card)", borderBottom: "1px solid var(--color-bt-border)" }}
+      className="sticky top-0 z-40 flex h-14 items-center justify-between px-6"
+      style={{
+        background: "var(--color-bt-nav-bg)",
+        backdropFilter: "blur(14px)",
+        WebkitBackdropFilter: "blur(14px)",
+        borderBottom: "1px solid var(--color-bt-subtle-border)",
+      }}
     >
       <button
         onClick={() => router.push("/")}
-        className="flex items-center gap-2 font-display font-semibold text-lg tracking-wider transition-opacity hover:opacity-80"
-        style={{ color: "var(--color-bt-text)" }}
+        className="flex items-center gap-[7px] text-[18px] font-semibold transition-opacity hover:opacity-80"
+        style={{ color: "var(--color-bt-text)", letterSpacing: "0.06em" }}
         aria-label="Go to dashboard"
       >
-        <svg width="20" height="20" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>
+        <svg width="18" height="18" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>
           <path d="M 28 8 L 38 8 L 76 26 L 38 44 L 38 75 L 33 92 L 28 75 Z" fill="currentColor"/>
         </svg>
         {title}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -29,7 +29,8 @@ export function UserMenu() {
     setSigningOut(true);
     const supabase = createClient();
     await supabase.auth.signOut();
-    router.push("/login");
+    router.push("/");
+    router.refresh();
   };
 
   return (

--- a/src/components/marketing/CtaSection.tsx
+++ b/src/components/marketing/CtaSection.tsx
@@ -16,7 +16,7 @@ export function CtaSection() {
         your next trip planned by the end of the day.
       </p>
       <div className="bt-mkt-cta-row">
-        <Link href="/login" className="bt-mkt-btn-primary">Plan your trip free</Link>
+        <Link href="/login?mode=signup" className="bt-mkt-btn-primary">Plan your trip free</Link>
         <a href="#how-it-works" className="bt-mkt-btn-ghost">See how it works</a>
       </div>
     </section>

--- a/src/components/marketing/HeroSection.tsx
+++ b/src/components/marketing/HeroSection.tsx
@@ -13,7 +13,7 @@ export function HeroSection() {
       </p>
 
       <div className="bt-mkt-cta-row">
-        <Link href="/login" className="bt-mkt-btn-primary">Plan your trip free</Link>
+        <Link href="/login?mode=signup" className="bt-mkt-btn-primary">Plan your trip free</Link>
         <a href="#how-it-works" className="bt-mkt-btn-ghost">See how it works</a>
       </div>
 

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -29,7 +29,7 @@ export function MarketingNav() {
         <a href="#how-it-works" className="bt-mkt-nav-link">How it works</a>
         <a href="#about" className="bt-mkt-nav-link">About</a>
         <Link href="/login" className="bt-mkt-nav-link">Sign in</Link>
-        <Link href="/login" className="bt-mkt-nav-cta">Get started free</Link>
+        <Link href="/login?mode=signup" className="bt-mkt-nav-cta">Get started free</Link>
       </div>
     </nav>
   );

--- a/src/components/marketing/MarketingPage.tsx
+++ b/src/components/marketing/MarketingPage.tsx
@@ -38,7 +38,7 @@ const MARKETING_CSS = `
   background: #0a0e1a;
   color: #f1f5f9;
   min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   scroll-behavior: smooth;
 }

--- a/src/components/marketing/MarketingPage.tsx
+++ b/src/components/marketing/MarketingPage.tsx
@@ -35,7 +35,7 @@ export function MarketingPage() {
 const MARKETING_CSS = `
 /* ───────────── Root + page shell ───────────── */
 .bt-mkt-root {
-  background: #0a1628;
+  background: #0a0e1a;
   color: #f1f5f9;
   min-height: 100vh;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;


### PR DESCRIPTION
## Summary

Brings the in-app experience visually in line with the public marketing page. Same color palette, same nav chrome, same typography. Also folds in a handful of login-flow improvements that came out of the same pass.

## What changed

### Palette unification (dark mode)
Marketing page used a gray/navy palette (`#0a0e1a` base, `#111827` cards) while the app used a more navy-tinted set (`#0f172a` base, `#111f36` cards). Tokens now agree:

| Token | Before | After |
|---|---|---|
| `--color-bt-base` | `#0f172a` (then `#0a1628`) | `#0a0e1a` |
| `--color-bt-card` | `#111f36` | `#111827` |
| `--color-bt-card-raised` | `#1a2d4a` | `#1a2130` |
| `--color-bt-card-float` | `#243656` | `#222b3d` |
| `--color-bt-border` | `#1e3a5f` (solid navy) | `rgba(148,163,184,0.15)` |
| `--color-bt-subtle-border` | `#1e293b` | `rgba(148,163,184,0.08)` |
| `--color-bt-past-bg` | `#1e293b` | `#161c2b` |

Plus a new `--color-bt-nav-bg` (translucent base in both modes) for the frosted-glass sticky nav.

### Top nav: matches marketing nav
- Frosted-glass background (`--color-bt-nav-bg` + `backdrop-filter: blur(14px)`)
- Subtle border-bottom (`rgba(148,163,184,0.08)`)
- Wordmark: 18px / weight 600 / `letter-spacing: 0.06em` — pixel-identical to `.bt-mkt-nav-logo`
- Flag SVG resized 20px → 18px, gap 8px → 7px
- Auth-side controls (chat, bell, theme, user menu) untouched

### Font standardization
The app was loading Inter (aliased misleadingly as `--font-geist-sans`) while the marketing page used the system UI stack. Same `font-weight: 600` rendered visibly different. Unified on the marketing stack:
- `--font-sans` → `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`
- `--font-display` (Georgia serif) **removed entirely** — 3 callers updated
- Inter dropped from `layout.tsx` (zero web-font requests now)
- Marketing CSS switched from a hard-coded stack to `var(--font-sans)` so it's driven from the same token

### Login page
- Reads `?mode=signup` from the URL to land users on the right panel (`page.tsx` now a Server Component awaiting `searchParams`)
- Added "Continue with a magic link" button to the signup panel; `enterMagicLink(from)` tracks origin so back-nav returns to the right panel
- Nickname field removed from signup (kept in profile settings, where the placeholder is now \"What your crew calls you\")
- Full Name placeholder \"Zach Grether\" → \"John Smith\"
- Panel background + border now use the unified tokens

### Marketing CTAs
\"Get started free\" (nav) and \"Plan your trip free\" (hero + CTA section) now link to `/login?mode=signup` instead of `/login`. \"Sign in\" links untouched.

### Sign out
`UserMenu.handleSignOut` now redirects to `/` (marketing page) instead of `/login`. Signed-out users land where the \"Sign in\" / \"Get started free\" affordances live anyway.

## Reviewer notes

- All changes are theme/token-level or surface polish — no schema, no tRPC, no business logic touched.
- The `font-display` token (Georgia) is gone. If you were planning to use it for headlines somewhere, that's no longer available — flag it and we'll decide on a replacement display treatment.
- The new translucent nav requires `backdrop-filter` support. Vendor-prefixed for Safari. Falls back gracefully (background just becomes more opaque without blur) on browsers that don't support it.
- `STYLE_GUIDE.md` updated to reflect every token change.

## Test plan

- [ ] Visit `/` while signed out → marketing page renders, no flash
- [ ] Visit `/` while signed in → redirected to most-relevant trip (or empty state if none)
- [ ] TopNav wordmark on a trip page reads identical weight/family to the marketing nav wordmark
- [ ] Light mode: surfaces look the same as before (only dark mode tokens changed)
- [ ] Dark mode: panels feel lighter/grayer (intended), not navy
- [ ] `/login` → signin panel; `/login?mode=signup` → signup panel
- [ ] Sign up via signup panel → no nickname field; submit succeeds
- [ ] Profile page → nickname placeholder reads \"What your crew calls you\"
- [ ] Sign out → lands on `/`, not `/login`
- [ ] Marketing nav CTAs (\"Get started free\", \"Plan your trip free\") all land on signup panel
- [ ] `npx tsc --noEmit` clean