### PR TITLE
feat(modal-audit): Add Crew form fixes + display-name override + canonical modal pattern

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -238,6 +238,62 @@ stack — order them by priority.
 
 ---
 
+### Modal / Dialog
+
+The canonical structure for every modal and confirmation dialog in the
+app. Bottom-sheet variant rules follow the same tokens.
+
+```
+Structure:     header (title + close) / body / footer (actions)
+Background:    var(--color-bt-card)
+Border:        1px solid var(--color-bt-border)
+Border radius: rounded-xl (desktop) / rounded-t-2xl (mobile bottom sheet)
+Shadow:        var(--shadow-floating)
+Max width:     480px standard / 560px forms with multiple fields
+Backdrop:      var(--color-bt-overlay)
+
+Header:        px-5 py-4, border-bottom: 1px solid var(--color-bt-border)
+Title:         text-base font-semibold, var(--color-bt-text)
+Close button:  X icon, h-8 w-8 rounded-full,
+               var(--color-bt-card-raised) bg,
+               var(--color-bt-text-dim) icon,
+               hover:bg-[var(--color-bt-hover)]
+
+Body:          px-5 py-4, overflow-y: auto if scrollable;
+               max-height keeps the chrome anchored at 85dvh
+
+Footer:        px-5 py-4, border-top: 1px solid var(--color-bt-border),
+               buttons right-aligned with gap-3,
+               Medium size (px-4 py-2.5 text-sm)
+
+Button variants inside modals:
+  Primary confirm (Save/Add/Lock/Create)  Primary  var(--color-bt-accent) bg
+  Destructive confirm (Remove/Delete)     Danger   var(--color-bt-danger) bg, white text
+  Secondary action                        Secondary  var(--color-bt-card-raised) bg
+  Cancel / dismiss                        Ghost    transparent, var(--color-bt-border) border
+
+Destructive actions must show a confirmation dialog before executing —
+never fire directly on first tap.
+
+Bottom sheet (viewport < 640px):
+  Same tokens, plus a centred drag handle at the top:
+    width 40px, height 4px, border-radius 9999,
+    background var(--color-bt-border)
+  No close X — drag down or tap backdrop to dismiss.
+  Container uses rounded-t-2xl (top corners only).
+
+No footer variant (acceptable for single-outcome informational modals
+like the hero IntroModals):
+  Close button in the header is the only dismiss action.
+```
+
+**Token discipline inside modals:** `#fff` / `#ffffff` are not used for
+button text — write `white` instead. When a token surfaces for "text on
+filled accent" / "text on filled danger" in the future, swap the
+literal `white` calls for that token at the same time.
+
+---
+
 ### Collapsible planning panel (PlanningRow)
 
 ```

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { AlertCircle, Check, Loader2 } from "lucide-react";
 import { createClient } from "@/lib/supabase";
+import { trpc } from "@/lib/trpc-client";
 
 type InviteState =
   | { kind: "loading" }
@@ -36,6 +37,7 @@ function InviteContent() {
   const [state, setState] = useState<InviteState>(
     token ? { kind: "loading" } : { kind: "error", message: "No invite token provided." }
   );
+  const notifyInviteAccepted = trpc.tripMembers.notifyInviteAccepted.useMutation();
 
   useEffect(() => {
     if (!token) return;
@@ -111,6 +113,23 @@ function InviteContent() {
           role: invite.role,
           status: "in",
         });
+      } else {
+        // They were pre-seeded as an invited member (the typical path —
+        // inviteByEmail Path B writes a row up front). Flip status to
+        // 'in' so they appear as joined in the crew list.
+        await supabase
+          .from("trip_members")
+          .update({ status: "in" })
+          .eq("trip_id", invite.trip_id)
+          .eq("user_id", session.user.id);
+      }
+
+      // Lifecycle: post "X joined the trip" to Crew chat. Fire-and-forget;
+      // a failure here shouldn't block the accept flow.
+      try {
+        await notifyInviteAccepted.mutateAsync({ tripId: invite.trip_id });
+      } catch {
+        // Best-effort
       }
 
       setState({ kind: "success", tripId: invite.trip_id, tripName });

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -980,7 +980,7 @@ function DeleteAccountSheet({ onClose }: { onClose: () => void }) {
         disabled={!canDelete}
         onClick={deleteAccount}
         className="mt-4 w-full rounded-lg py-2.5 text-sm font-semibold transition-opacity disabled:opacity-30"
-        style={{ background: "var(--color-bt-danger)", color: "#ffffff" }}
+        style={{ background: "var(--color-bt-danger)", color: "white" }}
       >
         {status === "loading" ? "Working…" : "Permanently delete"}
       </button>

--- a/src/app/trips/[tripId]/components/AddPropertySheet.tsx
+++ b/src/app/trips/[tripId]/components/AddPropertySheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { Globe, Link, MapPin } from "lucide-react";
+import { Globe, Link, MapPin, X } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 
 // ── Platform detection (exported so parents can use it) ───────────────────
@@ -240,8 +240,12 @@ export function AddPropertySheet({
       onClick={onClose}
     >
       <div
-        className="max-h-[90vh] w-full max-w-[480px] overflow-y-auto rounded-t-2xl p-5 lg:rounded-2xl"
-        style={{ background: "var(--color-bt-card)" }}
+        className="relative max-h-[90vh] w-full max-w-[480px] overflow-y-auto rounded-t-2xl p-5 lg:rounded-2xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Handle bar (mobile) */}
@@ -250,8 +254,23 @@ export function AddPropertySheet({
           style={{ background: "var(--color-bt-border)" }}
         />
 
+        {/* Canonical close X (CC_MODAL_AUDIT.md Part 2.1) — absolute so
+            it lives in the corner without re-flowing the existing header
+            content beneath it. */}
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            color: "var(--color-bt-text-dim)",
+          }}
+        >
+          <X size={14} />
+        </button>
+
         {/* Header */}
-        <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
+        <h2 className="text-lg font-semibold pr-10" style={{ color: "var(--color-bt-text)" }}>
           {isEditing ? "Edit property" : "Add a property"}
         </h2>
         {!isEditing && !manualMode && (

--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -311,7 +311,7 @@ function IdeaCard({
           <div className="absolute right-3 top-3">
             <span
               className="rounded-full px-2.5 py-1 text-xs font-semibold"
-              style={{ background: "rgba(0,0,0,0.5)", color: "#fff" }}
+              style={{ background: "rgba(0,0,0,0.5)", color: "white" }}
             >
               {idea.cost_tier}
             </span>
@@ -866,7 +866,7 @@ function RemoveIdeaModal({
             disabled={isPending}
             onClick={handleDelete}
             className="rounded-lg py-2.5 text-sm font-medium disabled:opacity-40"
-            style={{ background: "var(--color-bt-danger)", color: "#fff" }}
+            style={{ background: "var(--color-bt-danger)", color: "white" }}
           >
             {removeIdea.isPending && !archiveIdea.isPending ? "Removing..." : "Delete permanently"}
           </button>

--- a/src/app/trips/[tripId]/components/TripInvitationModal.tsx
+++ b/src/app/trips/[tripId]/components/TripInvitationModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { RotateCcw, Send, Sparkles } from "lucide-react";
+import { RotateCcw, Send, Sparkles, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { buildCannedInvitation } from "@/lib/invitationDefault";
@@ -69,80 +69,114 @@ export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationMod
       style={{ background: "var(--color-bt-overlay)" }}
       onClick={onClose}
     >
+      {/* Canonical modal structure (CC_MODAL_AUDIT.md Part 2.1) */}
       <div
-        className="w-full max-w-[560px] rounded-t-2xl p-6 lg:rounded-2xl"
-        style={{ background: "var(--color-bt-card)" }}
+        className="flex w-full max-w-[560px] flex-col overflow-hidden rounded-t-2xl lg:rounded-2xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
+          maxHeight: "min(85dvh, 720px)",
+        }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-1 flex items-center gap-2">
-          <Sparkles size={16} style={{ color: "var(--color-bt-accent)" }} />
-          <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Trip Invitation
-          </h2>
+        {/* Header */}
+        <div
+          className="flex flex-shrink-0 items-center justify-between gap-2 px-5 py-4"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <Sparkles size={16} style={{ color: "var(--color-bt-accent)" }} />
+            <h2 className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              Trip Invitation
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            <X size={14} />
+          </button>
         </div>
-        <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          Tell the crew what this trip is about.
-        </p>
 
-        <textarea
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Three days in Charlotte, golf every morning, BBQ most evenings. Bring clubs and a jacket for the cold front coming through."
-          rows={6}
-          className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            borderColor: "var(--color-bt-border)",
-            color: "var(--color-bt-text)",
-          }}
-          data-testid="trip-invitation-message-input"
-        />
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <p className="mb-3 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+            Tell the crew what this trip is about.
+          </p>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Three days in Charlotte, golf every morning, BBQ most evenings. Bring clubs and a jacket for the cold front coming through."
+            rows={6}
+            className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+            data-testid="trip-invitation-message-input"
+          />
+        </div>
 
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          {canReset && (
+        {/* Footer — Reset (left-aligned ghost when applicable) + Cancel + Save (right) */}
+        <div
+          className="flex flex-shrink-0 items-center justify-between gap-3 px-5 py-4"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        >
+          {canReset ? (
             <button
               type="button"
               onClick={handleReset}
               disabled={update.isPending}
               data-testid="trip-invitation-reset-btn"
-              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-3 text-sm font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
               style={{
                 background: "transparent",
                 color: "var(--color-bt-text-dim)",
-                border: "1px solid var(--color-bt-border)",
+                border: "0.5px solid var(--color-bt-border)",
               }}
             >
-              <RotateCcw size={13} />
+              <RotateCcw size={11} />
               Reset to Default
             </button>
+          ) : (
+            <span />
           )}
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex-1 rounded-xl py-3 text-sm font-medium"
-            style={{
-              background: "transparent",
-              color: "var(--color-bt-text-dim)",
-              border: "1px solid var(--color-bt-border)",
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={update.isPending}
-            data-testid="trip-invitation-save-btn"
-            className="flex flex-1 items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
-            style={{
-              background: "var(--color-bt-accent)",
-              color: "var(--color-bt-base)",
-              border: "1px solid var(--color-bt-accent)",
-            }}
-          >
-            <Send size={14} />
-            {update.isPending ? "Saving…" : "Save invitation"}
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-xl px-4 py-2.5 text-sm font-medium"
+              style={{
+                background: "transparent",
+                color: "var(--color-bt-text-dim)",
+                border: "0.5px solid var(--color-bt-border)",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={update.isPending}
+              data-testid="trip-invitation-save-btn"
+              className="flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity disabled:opacity-50"
+              style={{
+                background: "var(--color-bt-accent)",
+                color: "var(--color-bt-base)",
+              }}
+            >
+              <Send size={14} />
+              {update.isPending ? "Saving…" : "Save invitation"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/trips/[tripId]/components/TripSummaryModal.tsx
+++ b/src/app/trips/[tripId]/components/TripSummaryModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, BedDouble, CalendarCheck, CalendarDays, MapPin, Send, Sparkles, Users } from "lucide-react";
+import { AlertTriangle, BedDouble, CalendarCheck, CalendarDays, MapPin, Send, Sparkles, Users, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { formatDateRange } from "@/lib/dates";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
@@ -98,115 +98,154 @@ export function TripSummaryModal({ tripId, trip, onClose, onAdvanced }: TripSumm
       style={{ background: "var(--color-bt-overlay)" }}
       onClick={onClose}
     >
+      {/* Canonical modal structure (CC_MODAL_AUDIT.md Part 2.1) —
+          header / body / footer split with the body taking the
+          scrollable middle section. */}
       <div
-        className="w-full max-w-[560px] rounded-t-2xl p-6 lg:rounded-2xl"
-        style={{ background: "var(--color-bt-card)" }}
+        className="flex w-full max-w-[560px] flex-col overflow-hidden rounded-t-2xl lg:rounded-2xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
+          maxHeight: "min(85dvh, 720px)",
+        }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-1 flex items-center gap-2">
-          <Sparkles size={16} style={{ color: "var(--color-bt-accent)" }} />
-          <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Trip Summary
-          </h2>
-        </div>
-        <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          Here&apos;s where things stand. When you&apos;re ready, we&apos;ll open up the
-          next set of planning features — no rush if your dates aren&apos;t locked
-          in yet, and nothing you&apos;ve already set up goes away.
-        </p>
-
-        {/* ── Basics panel — destination, dates, crew ─────────────────── */}
+        {/* Header */}
         <div
-          className="space-y-2 rounded-xl px-4 py-3 text-[13px]"
-          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
+          className="flex flex-shrink-0 items-center justify-between gap-2 px-5 py-4"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
         >
-          <SummaryRow
-            icon={<MapPin size={14} />}
-            label="Destination"
-            value={hasDestination ? destination : "Not set yet"}
-            needsAttention={!hasDestination}
-          />
-          <SummaryRow
-            icon={<CalendarDays size={14} />}
-            label="Dates"
-            value={hasLockedDate && dateRange ? dateRange : "Not locked yet"}
-            needsAttention={!hasLockedDate}
-          />
-          <SummaryRow
-            icon={<Users size={14} />}
-            label="Crew"
-            value={`${crewCount} ${crewCount === 1 ? "person" : "people"}`}
-          />
-        </div>
-
-        {/* ── Warning — wired back to the rows that need attention ────── */}
-        {!alreadyGoing && (!hasLockedDate || !hasDestination) && (
-          <div
-            className="mt-2 flex items-start gap-3 rounded-xl px-4 py-3"
-            style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
-          >
-            <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-warning)" }} />
-            <p className="text-sm" style={{ color: "var(--color-bt-warning)" }}>
-              {!hasLockedDate && !hasDestination
-                ? "Lock a destination and a date first — your crew will want to know where and when."
-                : !hasLockedDate
-                  ? "Lock a date first — your crew will want to know when."
-                  : "Lock a destination first — your crew will want to know where."}
-            </p>
+          <div className="flex min-w-0 items-center gap-2">
+            <Sparkles size={16} style={{ color: "var(--color-bt-accent)" }} />
+            <h2 className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              Trip Summary
+            </h2>
           </div>
-        )}
-
-        {/* ── Soft nudge + Pro Tip ─────────────────────────────────────── */}
-        <p className="mt-4 text-[13px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
-          Lodging and schedule don&apos;t have to be firm to continue — this is just
-          your starting point as the trip gets closer.
-        </p>
-        <p className="mt-2 text-[13px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
-          <span className="block font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Pro Tip:
-          </span>
-          Designate anyone in the crew to help plan and they can lock in any of
-          these items.
-        </p>
-
-        {/* ── Lodging + Schedule panel ─────────────────────────────────── */}
-        <div
-          className="mt-3 space-y-2 rounded-xl px-4 py-3 text-[13px]"
-          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
-        >
-          <CountRow
-            icon={<BedDouble size={14} />}
-            label="Lodging"
-            confirmed={lodgingConfirmed}
-            unconfirmed={lodgingUnconfirmed}
-          />
-          <CountRow
-            icon={<CalendarCheck size={14} />}
-            label="Schedule"
-            confirmed={scheduleConfirmed}
-            unconfirmed={scheduleUnconfirmed}
-          />
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            <X size={14} />
+          </button>
         </div>
 
-        {!alreadyGoing && (
-          <button
-            onClick={handleSend}
-            disabled={advance.isPending || !hasLockedDate}
-            data-testid="trip-summary-send-btn"
-            className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <p className="mb-4 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+            Here&apos;s where things stand. When you&apos;re ready, we&apos;ll open up the
+            next set of planning features — no rush if your dates aren&apos;t locked
+            in yet, and nothing you&apos;ve already set up goes away.
+          </p>
+
+          {/* ── Basics panel — destination, dates, crew ─────────────────── */}
+          <div
+            className="space-y-2 rounded-xl px-4 py-3 text-[13px]"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
           >
-            <Send size={15} />
-            {advance.isPending ? "Sending..." : "View Itinerary →"}
-          </button>
-        )}
-        <button
-          onClick={onClose}
-          className="mt-2 w-full rounded-xl py-2.5 text-sm transition-opacity hover:opacity-80"
-          style={{ color: "var(--color-bt-text-dim)" }}
+            <SummaryRow
+              icon={<MapPin size={14} />}
+              label="Destination"
+              value={hasDestination ? destination : "Not set yet"}
+              needsAttention={!hasDestination}
+            />
+            <SummaryRow
+              icon={<CalendarDays size={14} />}
+              label="Dates"
+              value={hasLockedDate && dateRange ? dateRange : "Not locked yet"}
+              needsAttention={!hasLockedDate}
+            />
+            <SummaryRow
+              icon={<Users size={14} />}
+              label="Crew"
+              value={`${crewCount} ${crewCount === 1 ? "person" : "people"}`}
+            />
+          </div>
+
+          {/* ── Warning — wired back to the rows that need attention ────── */}
+          {!alreadyGoing && (!hasLockedDate || !hasDestination) && (
+            <div
+              className="mt-2 flex items-start gap-3 rounded-xl px-4 py-3"
+              style={{ background: "var(--color-bt-warning-faint)" }}
+            >
+              <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-warning)" }} />
+              <p className="text-sm" style={{ color: "var(--color-bt-warning)" }}>
+                {!hasLockedDate && !hasDestination
+                  ? "Lock a destination and a date first — your crew will want to know where and when."
+                  : !hasLockedDate
+                    ? "Lock a date first — your crew will want to know when."
+                    : "Lock a destination first — your crew will want to know where."}
+              </p>
+            </div>
+          )}
+
+          {/* ── Soft nudge + Pro Tip ─────────────────────────────────────── */}
+          <p className="mt-4 text-[13px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
+            Lodging and schedule don&apos;t have to be firm to continue — this is just
+            your starting point as the trip gets closer.
+          </p>
+          <p className="mt-2 text-[13px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
+            <span className="block font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              Pro Tip:
+            </span>
+            Designate anyone in the crew to help plan and they can lock in any of
+            these items.
+          </p>
+
+          {/* ── Lodging + Schedule panel ─────────────────────────────────── */}
+          <div
+            className="mt-3 space-y-2 rounded-xl px-4 py-3 text-[13px]"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
+          >
+            <CountRow
+              icon={<BedDouble size={14} />}
+              label="Lodging"
+              confirmed={lodgingConfirmed}
+              unconfirmed={lodgingUnconfirmed}
+            />
+            <CountRow
+              icon={<CalendarCheck size={14} />}
+              label="Schedule"
+              confirmed={scheduleConfirmed}
+              unconfirmed={scheduleUnconfirmed}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex flex-shrink-0 items-center justify-end gap-3 px-5 py-4"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
         >
-          {alreadyGoing ? "Close" : "Not yet"}
-        </button>
+          <button
+            onClick={onClose}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-text-dim)",
+              border: "0.5px solid var(--color-bt-border)",
+            }}
+          >
+            {alreadyGoing ? "Close" : "Not yet"}
+          </button>
+          {!alreadyGoing && (
+            <button
+              onClick={handleSend}
+              disabled={advance.isPending || !hasLockedDate}
+              data-testid="trip-summary-send-btn"
+              className="flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
+              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            >
+              <Send size={15} />
+              {advance.isPending ? "Sending..." : "View Itinerary"}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/trips/[tripId]/tabs/AddExpenseModal.tsx
+++ b/src/app/trips/[tripId]/tabs/AddExpenseModal.tsx
@@ -127,25 +127,43 @@ export function AddExpenseModal({
         style={{ background: "var(--color-bt-overlay)" }}
         onClick={onClose}
       />
+      {/* Canonical modal structure (CC_MODAL_AUDIT.md Part 2.1):
+          header / body / footer split with border-bottom + border-top
+          dividers, max-w-[560px] for multi-field forms,
+          overflow-hidden so the borders extend edge-to-edge,
+          var(--shadow-floating) for elevation. */}
       <div
-        className="relative w-full max-w-lg rounded-2xl p-5"
-        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        className="relative flex w-full max-w-[560px] flex-col overflow-hidden rounded-xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
+          maxHeight: "min(85dvh, 720px)",
+        }}
       >
         {/* Header */}
-        <div className="mb-4 flex items-center justify-between">
+        <div
+          className="flex flex-shrink-0 items-center justify-between px-5 py-4"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        >
           <h2 className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
             Add Receipt
           </h2>
           <button
             onClick={onClose}
+            aria-label="Close"
             className="flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+            }}
           >
-            <X size={18} />
+            <X size={14} />
           </button>
         </div>
 
-        <div className="space-y-3">
+        {/* Body */}
+        <div className="flex-1 space-y-3 overflow-y-auto px-5 py-4">
           {/* Side-by-side Description + Amount */}
           <div className="flex gap-3">
             <div className="min-w-0 flex-1">
@@ -258,32 +276,41 @@ export function AddExpenseModal({
             />
           )}
 
-          {/* Action buttons */}
-          <div className="flex gap-2">
-            <button
-              onClick={onClose}
-              className="flex-1 rounded-lg border py-2 text-sm"
-              style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
-            >
-              Cancel
-            </button>
-            <button
-              data-testid="save-expense-btn"
-              disabled={
-                !title.trim() ||
-                !amount ||
-                amountNum <= 0 ||
-                !paidByUserId ||
-                (splitMode === "custom" && splitAmong.length === 0) ||
-                createExpense.isPending
-              }
-              onClick={handleCreate}
-              className="flex-1 rounded-lg py-2 text-sm font-medium disabled:opacity-40"
-              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-            >
-              Add Receipt
-            </button>
-          </div>
+        </div>
+
+        {/* Footer — canonical right-aligned actions with gap-3, Medium
+            button size (px-4 py-2.5 text-sm), Ghost + Primary variants. */}
+        <div
+          className="flex flex-shrink-0 items-center justify-end gap-3 px-5 py-4"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        >
+          <button
+            onClick={onClose}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-text-dim)",
+              border: "0.5px solid var(--color-bt-border)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            data-testid="save-expense-btn"
+            disabled={
+              !title.trim() ||
+              !amount ||
+              amountNum <= 0 ||
+              !paidByUserId ||
+              (splitMode === "custom" && splitAmong.length === 0) ||
+              createExpense.isPending
+            }
+            onClick={handleCreate}
+            className="rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-40"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+          >
+            Add Receipt
+          </button>
         </div>
       </div>
     </div>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -18,6 +18,7 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { TabHeader } from "@/components/TabHeader";
 import { TabFab } from "@/components/TabFab";
 import { AVATAR_ICON_COMPONENTS } from "@/lib/avatarIconComponents";
+import { relativeTime } from "@/lib/notificationText";
 import type { TabProps } from "./types";
 import { CrewEmailPanel } from "./components/CrewEmailPanel";
 import { AddCrewMemberSheet } from "./components/AddCrewMemberSheet";
@@ -31,6 +32,15 @@ type Member = {
   status: string | null;
   displayName: string;
   isGuest: boolean;
+  /**
+   * ISO timestamp of the most recent invite sent to this member, or
+   * NULL if they've never been invited. Stamped by
+   * tripMembers.inviteByEmail + tripMembers.resendInvite +
+   * sendInvitationBlast (per recipient). Surfaced on the expanded
+   * invited-row as a "Invited X ago" hint so owners can decide whether
+   * a resend is warranted.
+   */
+  last_invited_at?: string | null;
   user: {
     email: string | null;
     is_guest?: boolean;
@@ -105,17 +115,27 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
     return { organizers: orgs, crew: cw, justNames: jn };
   }, [members]);
 
-  const unlinkedCount = (members as Member[]).filter((m) => m.isGuest && m.status === "in").length;
+  // Outstanding invites: members with status='invited' who haven't
+  // accepted yet. This replaces the previous "X people haven't joined"
+  // nudge, which incorrectly counted Just Names (placeholder names with
+  // no email — they CAN'T join, by definition) and had no actionable
+  // path. The new filter only counts members with email + invited
+  // status, which is the genuinely actionable cohort.
+  const pendingInviteCount = (members as Member[]).filter(
+    (m) => m.status === "invited" && !!m.user?.email
+  ).length;
 
   return (
     // Nudge + TabHeader + buttons stay full-width; only the section list
-    // below is constrained / split into columns. Spec: "The 640px width
-    // should only wrap around the crew lists, not the top part of the
-    // crew tab."
+    // below is split into columns. Spec: "The 640px width should only
+    // wrap around the crew lists, not the top part of the crew tab."
     <div className={embedded ? "@container" : "@container px-4"}>
-      {/* ── Unlinked-crew nudge — surfaces at the very top of the tab so
-          it reads as a tab-level alert (Style Guide § Nudge banner). ── */}
-      {isOwner && unlinkedCount > 0 && (
+      {/* ── Pending-invites nudge — surfaces at the very top of the tab
+          so it reads as a tab-level alert (Style Guide § Nudge banner).
+          No CTA button here — the per-row "Resend invite" action lives in
+          the expanded invited-row, with the precise `last_invited_at`
+          context the owner needs to make the call. ── */}
+      {isOwner && pendingInviteCount > 0 && (
         <div
           className="mb-4 flex items-center gap-3 rounded-xl px-4 py-3"
           style={{
@@ -131,10 +151,10 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
           </span>
           <div>
             <p className="text-[13px] font-semibold leading-tight" style={{ color: "var(--color-bt-text)" }}>
-              {unlinkedCount} {unlinkedCount === 1 ? "person hasn't" : "people haven't"} joined yet
+              {pendingInviteCount} {pendingInviteCount === 1 ? "invite" : "invites"} not accepted yet
             </p>
             <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
-              Send them an email so they can see the plan
+              They got the email — open a row to see when it was sent or resend
             </p>
           </div>
         </div>
@@ -508,9 +528,11 @@ function CrewRow({
         </div>
       </button>
 
-      {/* Expanded body — state-specific UI */}
+      {/* Expanded body — state-specific UI. px-4 pb-4 pt-3 matches the
+          PlanningRow body padding pattern (Style Guide § Collapsible
+          panel) so all expanded surfaces share the same inset. */}
       {isExpanded && (
-        <div className="px-3 pb-3">
+        <div className="px-4 pb-4 pt-3">
           <ExpandedBody
             member={m}
             rowState={rowState}
@@ -837,6 +859,14 @@ function ExpandedBody({
       <>
         {displayNameField}
         <EmailReadOnly email={m.user?.email ?? null} />
+        {m.last_invited_at && (
+          <p
+            className="mt-2 text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Invited {relativeTime(m.last_invited_at)}
+          </p>
+        )}
         <div className="mt-2 flex flex-wrap gap-2">
           {canEdit && (
             <ResendInviteButton
@@ -953,7 +983,7 @@ function DisplayNameField({
   return (
     <div className="mb-2">
       <p
-        className="mb-1 text-[10px] font-semibold uppercase tracking-wider"
+        className="mb-1 text-[10px] font-medium uppercase tracking-[0.06em]"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         Display Name
@@ -1030,7 +1060,7 @@ function EmailReadOnly({ email }: { email: string | null }) {
   return (
     <div className="mt-1">
       <p
-        className="mb-1 text-[10px] font-semibold uppercase tracking-wider"
+        className="mb-1 text-[10px] font-medium uppercase tracking-[0.06em]"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         Email
@@ -1156,13 +1186,15 @@ function RemoveButton({
       </div>
     );
   }
+  // Small Danger variant per STYLE_GUIDE.md Section 5 — danger-faint bg
+  // makes the button read as a real action target, not a text link.
   return (
     <button
       type="button"
       onClick={() => setConfirm(true)}
-      className="rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors"
+      className="rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
       style={{
-        background: "transparent",
+        background: "var(--color-bt-danger-faint)",
         color: "var(--color-bt-danger)",
         border: "1px solid var(--color-bt-danger-border)",
       }}
@@ -1263,12 +1295,12 @@ function JustNameExpanded({
       {canEdit && (
         <>
           <p
-            className="text-[10px] font-semibold uppercase tracking-wider"
+            className="mb-1 text-[10px] font-medium uppercase tracking-[0.06em]"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             Add email to invite
           </p>
-          <div className="flex items-stretch gap-2">
+          <div className="flex items-center gap-2">
             <input
               type="email"
               value={email}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -248,14 +248,41 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         return (
           <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
             {leftColumn}
-            <SectionGroup
-              label="Just Names"
-              count={justNames.length}
-              tone="recessed"
-              subtext="Available for scheduling and scoring — add their email if they want to access the app."
-            >
-              {justNames.map(renderRow)}
-            </SectionGroup>
+            {/* Just Names sits in the right column without a panel
+                wrapper — they're more of a roster jot-list than a
+                first-class crew surface, so the bare header + rows
+                reads more honestly than another card. */}
+            <section>
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <span
+                  className="text-[11px] font-medium tabular-nums"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  {justNames.length}
+                </span>
+                <span
+                  className="text-[10px] font-semibold uppercase tracking-[0.08em]"
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-subtle-border)",
+                    padding: "3px 10px",
+                    borderRadius: 9999,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  Just Names
+                </span>
+              </div>
+              <p
+                className="mb-3 text-[11px] leading-snug"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Available for scheduling and scoring — add their email if
+                they want to access the app.
+              </p>
+              <div className="space-y-1">{justNames.map(renderRow)}</div>
+            </section>
           </div>
         );
       })()}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -222,14 +222,7 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         );
 
         const leftColumn = (
-          <div
-            className="space-y-5 rounded-2xl p-4"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              border: "1px solid var(--color-bt-border)",
-              boxShadow: "var(--shadow-card)",
-            }}
-          >
+          <div className="space-y-5">
             <SectionGroup
               label="Organizers"
               count={organizers.length}
@@ -354,50 +347,72 @@ function SectionGroup({
   subtext?: string;
   children: React.ReactNode;
 }) {
-  // tone → container styling. Rows inherit the tone via their own props
-  // so accent-tinted Organizer rows can sit inside an accent-bordered
-  // wrapper without doubling the tint.
-  const containerStyle: React.CSSProperties =
+  // Each section is its own self-contained card panel with a category
+  // pill in the top-right corner (modeled after the marketing trip-card
+  // "PLANNING" pill). The panel surface is consistent across sections;
+  // the pill's color carries the tone instead of the panel background.
+  const pillStyle: React.CSSProperties =
     tone === "accent"
       ? {
-          background: "var(--color-bt-tag-bg)",
+          background: "var(--color-bt-accent-faint)",
+          color: "var(--color-bt-accent)",
           border: "1px solid var(--color-bt-accent-border)",
         }
       : tone === "recessed"
-      ? {
-          background: "var(--color-bt-past-bg)",
-          border: "1px solid var(--color-bt-subtle-border)",
-        }
-      : {
-          background: "var(--color-bt-card)",
-          border: "1px solid var(--color-bt-border)",
-        };
+        ? {
+            background: "var(--color-bt-card-raised)",
+            color: "var(--color-bt-text-dim)",
+            border: "1px solid var(--color-bt-subtle-border)",
+          }
+        : {
+            background: "var(--color-bt-blue-bg)",
+            color: "var(--color-bt-planning)",
+            border: "1px solid var(--color-bt-planning-border)",
+          };
 
   return (
-    <section>
-      <div className="mb-2 flex items-baseline justify-between gap-3">
-        <h2
-          className="text-xs font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          {label}
-        </h2>
+    <section
+      className="rounded-2xl p-4"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+        boxShadow: "var(--shadow-card)",
+      }}
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
         <span
           className="text-[11px] font-medium tabular-nums"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
           {count}
         </span>
+        <span
+          className="text-[10px] font-semibold uppercase tracking-[0.08em]"
+          style={{
+            ...pillStyle,
+            padding: "3px 10px",
+            borderRadius: 9999,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {label}
+        </span>
       </div>
       {subtext && (
         <p
-          className="mb-2 text-[11px] leading-snug"
+          className="mb-3 text-[11px] leading-snug"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
           {subtext}
         </p>
       )}
-      <div className="overflow-hidden rounded-xl" style={containerStyle}>
+      <div
+        className="overflow-hidden rounded-xl"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
         {children}
       </div>
     </section>
@@ -464,11 +479,7 @@ function CrewRow({
   return (
     <div
       className="border-b last:border-b-0"
-      style={{
-        borderColor: rowState === "owner" || rowState === "organizer"
-          ? "var(--color-bt-accent-border)"
-          : "var(--color-bt-border)",
-      }}
+      style={{ borderColor: "var(--color-bt-border)" }}
       data-row-state={rowState}
       data-testid={`crew-row-${m.memberId}`}
     >
@@ -565,11 +576,7 @@ function CrewRow({
           className="px-4 pb-4 pt-3"
           style={{
             background: "var(--color-bt-card)",
-            borderTop: `1px solid ${
-              rowState === "owner" || rowState === "organizer"
-                ? "var(--color-bt-accent-border)"
-                : "var(--color-bt-border)"
-            }`,
+            borderTop: "1px solid var(--color-bt-border)",
           }}
         >
           <ExpandedBody

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 import {
   ChevronDown,
@@ -248,7 +247,7 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         }
 
         return (
-          <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
             {leftColumn}
             <SectionGroup
               label="Just Names"
@@ -511,7 +510,13 @@ function CrewRow({
           className="flex flex-shrink-0 items-center justify-end"
           style={{ width: BADGE_SLOT_WIDTH }}
         >
-          <RowBadge state={rowState} />
+          <RowBadge
+            state={rowState}
+            pendingInvite={
+              (rowState === "owner" || rowState === "organizer") &&
+              m.status === "invited"
+            }
+          />
         </div>
 
         {/* Chevron slot — fixed width */}
@@ -570,9 +575,12 @@ function CrewRow({
 // ── RowAvatar ───────────────────────────────────────────────────────────
 // Resolution chain (per CC_MODAL_AUDIT.md follow-up):
 //   1. just-name (ghost with no email)  → Ghost icon in dashed circle
-//   2. user.avatar_url present           → uploaded photo
-//   3. user.avatar_icon present          → Tabler icon on state-tinted bg
-//   4. otherwise                         → initials on state-tinted bg
+//   2. user.avatar_icon present          → Tabler icon on state-tinted bg
+//   3. otherwise                         → initials on state-tinted bg
+//
+// avatar_url (Google OAuth photo) is intentionally NOT in this chain —
+// the profile's chosen avatar_icon wins. "Use my Google photo" will be
+// an explicit option in the profile avatar chooser.
 //
 // State coloring (owner=teal, organizer/joined=blue, invited=amber) is
 // applied as the background tint when we're rendering an icon or
@@ -615,22 +623,11 @@ function RowAvatar({
     );
   }
 
-  // 2. Uploaded photo → render directly, no state tint underneath
-  //    (a state-tint border would compete with the photo).
-  if (m.user?.avatar_url) {
-    return (
-      <Image
-        src={m.user.avatar_url}
-        alt={`${m.displayName} avatar`}
-        width={SIZE}
-        height={SIZE}
-        className="flex-shrink-0 rounded-full object-cover"
-        unoptimized
-      />
-    );
-  }
-
-  // 3 / 4 — resolve state tint, then render icon or initials on top.
+  // 2 / 3 — resolve state tint, then render icon or initials on top.
+  // NOTE: avatar_url (e.g. Google OAuth photo) is intentionally NOT used as
+  // an automatic fallback here. The profile's chosen avatar_icon is the
+  // source of truth; "use my Google photo" will become an explicit option
+  // inside the profile avatar chooser.
   const stateTint: { bg: string; fg: string; border: string } =
     state === "owner"
       ? {
@@ -651,7 +648,7 @@ function RowAvatar({
             border: "var(--color-bt-planning-border)",
           };
 
-  // 3. avatar_icon set → render the Tabler glyph on the tinted circle.
+  // 2. avatar_icon set → render the Tabler glyph on the tinted circle.
   const IconComponent = m.user?.avatar_icon
     ? AVATAR_ICON_COMPONENTS[m.user.avatar_icon]
     : null;
@@ -673,7 +670,7 @@ function RowAvatar({
     );
   }
 
-  // 4. Initials fallback.
+  // 3. Initials fallback.
   return (
     <span
       className={`${baseClasses} text-[11px] font-semibold`}
@@ -694,7 +691,17 @@ function RowAvatar({
 // Five badge variants. Pill style + icon + label for the four labelled
 // states; Just Names returns null so the slot is empty (but width-fixed).
 
-function RowBadge({ state }: { state: RowState }) {
+function RowBadge({
+  state,
+  pendingInvite = false,
+}: {
+  state: RowState;
+  /** Owner/Organizer rows whose invite hasn't been accepted yet — we
+   *  elevate roles before sign-up to skip a step, so the Organizer pill
+   *  alone would hide that they haven't joined. Stacks an Invited pill
+   *  underneath the role pill. */
+  pendingInvite?: boolean;
+}) {
   const pillBase: React.CSSProperties = {
     fontSize: 10,
     borderRadius: 9999,
@@ -707,8 +714,21 @@ function RowBadge({ state }: { state: RowState }) {
     whiteSpace: "nowrap",
   };
 
+  const invitedPill = (
+    <span
+      style={{
+        ...pillBase,
+        background: "var(--color-bt-warning-faint)",
+        color: "var(--color-bt-warning)",
+        border: "1px solid var(--color-bt-warning-border)",
+      }}
+    >
+      Invited
+    </span>
+  );
+
   if (state === "owner") {
-    return (
+    const ownerPill = (
       <span
         style={{
           ...pillBase,
@@ -721,9 +741,18 @@ function RowBadge({ state }: { state: RowState }) {
         Owner
       </span>
     );
+    if (pendingInvite) {
+      return (
+        <span className="flex flex-col items-end gap-1">
+          {ownerPill}
+          {invitedPill}
+        </span>
+      );
+    }
+    return ownerPill;
   }
   if (state === "organizer") {
-    return (
+    const organizerPill = (
       <span
         style={{
           ...pillBase,
@@ -736,6 +765,15 @@ function RowBadge({ state }: { state: RowState }) {
         Organizer
       </span>
     );
+    if (pendingInvite) {
+      return (
+        <span className="flex flex-col items-end gap-1">
+          {organizerPill}
+          {invitedPill}
+        </span>
+      );
+    }
+    return organizerPill;
   }
   if (state === "invited") {
     return (

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -419,7 +419,11 @@ function EmptyHint({ text }: { text: string }) {
 // The badge slot is the only piece that varies in content; its width
 // stays pinned. The chevron rotates 180° when the row is expanded.
 
-const BADGE_SLOT_WIDTH = 82;
+// Widened so an Organizer (or Owner) pill can sit side-by-side with a
+// pending-Invited pill in the same slot. The single-pill rows center their
+// badge in the slot so the visual column reads as a single vertical stripe
+// down the panel.
+const BADGE_SLOT_WIDTH = 168;
 const CHEVRON_SLOT_WIDTH = 18;
 
 function CrewRow({
@@ -507,7 +511,7 @@ function CrewRow({
 
         {/* Badge slot — fixed width so rows align across states */}
         <div
-          className="flex flex-shrink-0 items-center justify-end"
+          className="flex flex-shrink-0 items-center justify-center"
           style={{ width: BADGE_SLOT_WIDTH }}
         >
           <RowBadge
@@ -698,8 +702,8 @@ function RowBadge({
   state: RowState;
   /** Owner/Organizer rows whose invite hasn't been accepted yet — we
    *  elevate roles before sign-up to skip a step, so the Organizer pill
-   *  alone would hide that they haven't joined. Stacks an Invited pill
-   *  underneath the role pill. */
+   *  alone would hide that they haven't joined. Renders an Invited pill
+   *  to the right of the role pill on the same horizontal line. */
   pendingInvite?: boolean;
 }) {
   const pillBase: React.CSSProperties = {
@@ -743,7 +747,7 @@ function RowBadge({
     );
     if (pendingInvite) {
       return (
-        <span className="flex flex-col items-end gap-1">
+        <span className="flex flex-row items-center gap-1.5">
           {ownerPill}
           {invitedPill}
         </span>
@@ -767,7 +771,7 @@ function RowBadge({
     );
     if (pendingInvite) {
       return (
-        <span className="flex flex-col items-end gap-1">
+        <span className="flex flex-row items-center gap-1.5">
           {organizerPill}
           {invitedPill}
         </span>

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -463,13 +463,17 @@ function CrewRow({
       data-row-state={rowState}
       data-testid={`crew-row-${m.memberId}`}
     >
-      {/* Main row */}
+      {/* Main row — header. The spec calls for the section's tint
+          (organizer = teal, standard = card) to read through the header
+          regardless of expand state, so the row keeps its identity. The
+          chevron rotation + the expanded body below are the visual
+          cues that the row is open. */}
       <button
         type="button"
         onClick={expandable ? onToggle : undefined}
         className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors"
         style={{
-          background: isExpanded ? "var(--color-bt-card-raised)" : "transparent",
+          background: "transparent",
           cursor: expandable ? "pointer" : "default",
         }}
       >
@@ -529,10 +533,25 @@ function CrewRow({
       </button>
 
       {/* Expanded body — state-specific UI. px-4 pb-4 pt-3 matches the
-          PlanningRow body padding pattern (Style Guide § Collapsible
-          panel) so all expanded surfaces share the same inset. */}
+          PlanningRow body padding pattern.
+          5.4: body always uses var(--color-bt-card) regardless of which
+          section the row sits in, so input fields, labels, and buttons
+          render on a neutral surface. The 1px separator above the body
+          uses the row state's border token (accent for organizers,
+          standard otherwise) so the divide reads as a continuation of
+          the row's identity. */}
       {isExpanded && (
-        <div className="px-4 pb-4 pt-3">
+        <div
+          className="px-4 pb-4 pt-3"
+          style={{
+            background: "var(--color-bt-card)",
+            borderTop: `1px solid ${
+              rowState === "owner" || rowState === "organizer"
+                ? "var(--color-bt-accent-border)"
+                : "var(--color-bt-border)"
+            }`,
+          }}
+        >
           <ExpandedBody
             member={m}
             rowState={rowState}
@@ -1007,7 +1026,10 @@ function DisplayNameField({
             maxLength={100}
             className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none focus:ring-1"
             style={{
-              background: "var(--color-bt-base)",
+              // 5.4: input fields inside expanded rows always use
+              // card-raised explicitly so the input is one elevation
+              // above the body card, regardless of section tint.
+              background: "var(--color-bt-card-raised)",
               borderColor: "var(--color-bt-border)",
               color: "var(--color-bt-text)",
             }}
@@ -1042,7 +1064,9 @@ function DisplayNameField({
         <div
           className="rounded-lg px-3 py-2 text-sm"
           style={{
-            background: "var(--color-bt-base)",
+            // Mirrors the input's card-raised bg so the read-only and
+            // editable variants visually align.
+            background: "var(--color-bt-card-raised)",
             border: "1px solid var(--color-bt-border)",
             color: "var(--color-bt-text)",
           }}
@@ -1068,7 +1092,8 @@ function EmailReadOnly({ email }: { email: string | null }) {
       <div
         className="rounded-lg px-3 py-2 text-sm"
         style={{
-          background: "var(--color-bt-base)",
+          // 5.4: matches the editable inputs' card-raised treatment.
+          background: "var(--color-bt-card-raised)",
           border: "1px solid var(--color-bt-border)",
           color: email ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
         }}
@@ -1308,7 +1333,7 @@ function JustNameExpanded({
               placeholder="brad@example.com"
               className="min-w-0 flex-1 rounded-lg border px-2.5 py-1.5 text-sm outline-none focus:ring-1"
               style={{
-                background: "var(--color-bt-base)",
+                background: "var(--color-bt-card-raised)",
                 borderColor: "var(--color-bt-border)",
                 color: "var(--color-bt-text)",
               }}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -223,7 +223,14 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         );
 
         const leftColumn = (
-          <div className="space-y-5">
+          <div
+            className="space-y-5 rounded-2xl p-4"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+              boxShadow: "var(--shadow-card)",
+            }}
+          >
             <SectionGroup
               label="Organizers"
               count={organizers.length}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ChevronDown,
   Crown,
@@ -98,7 +98,13 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
   const unlinkedCount = (members as Member[]).filter((m) => m.isGuest && m.status === "in").length;
 
   return (
+    // max-w-[640px] left-aligned constraint (CC_MODAL_AUDIT.md Part 4):
+    // wide viewports were stretching crew rows edge-to-edge so the name
+    // sat on the far left while the badge floated on the far right. The
+    // 640px cap keeps the row dense enough to read as a unit. Mobile is
+    // unaffected — narrow viewports already fit comfortably under 640px.
     <div className={embedded ? "@container" : "@container px-4"}>
+      <div className="max-w-[640px]">
       {/* ── Unlinked-crew nudge — surfaces at the very top of the tab so
           it reads as a tab-level alert (Style Guide § Nudge banner). ── */}
       {isOwner && unlinkedCount > 0 && (
@@ -290,7 +296,11 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         </div>
       )}
 
-      {/* ── Mobile FAB — primary "Add crew member" action ────────────── */}
+      </div>{/* /max-w-[640px] container */}
+
+      {/* ── Mobile FAB — primary "Add crew member" action ──────────────
+          Rendered outside the max-w wrapper because the FAB is fixed-
+          positioned and its DOM ancestor doesn't influence layout. */}
       {isOwner && (
         <TabFab
           onClick={() => setShowAddModal(true)}
@@ -694,18 +704,37 @@ function ExpandedBody({
   isMe: boolean;
   onClose: () => void;
 }) {
-  // Non-owners (and the user's own row) get a read-only detail view —
-  // never actionable. Owners get the state-specific action set.
+  // Non-owners get a read-only detail view (no remove/role-change
+  // actions). Anyone can edit their own display name; canEdit users can
+  // edit other members' display names (gated server-side too).
   const showActions = isOwnerView && !isMe;
+  const canEditDisplayName = isMe || canEdit;
+
+  // Display Name field is the FIRST thing in every expanded row
+  // regardless of state (CC_MODAL_AUDIT.md Part 1.4).
+  const displayNameField = (
+    <DisplayNameField
+      tripId={tripId}
+      userId={m.user_id ?? ""}
+      currentDisplayName={m.displayName}
+      canEdit={canEditDisplayName}
+    />
+  );
 
   if (rowState === "owner") {
-    // Owner row — read-only email display regardless of who's viewing.
-    return <EmailReadOnly email={m.user?.email ?? null} />;
+    // Owner row — Display Name (editable for self) + email read-only.
+    return (
+      <>
+        {displayNameField}
+        <EmailReadOnly email={m.user?.email ?? null} />
+      </>
+    );
   }
 
   if (rowState === "organizer") {
     return (
       <>
+        {displayNameField}
         <EmailReadOnly email={m.user?.email ?? null} />
         {showActions && (
           <div className="mt-2 flex flex-wrap gap-2">
@@ -731,6 +760,7 @@ function ExpandedBody({
   if (rowState === "joined") {
     return (
       <>
+        {displayNameField}
         <EmailReadOnly email={m.user?.email ?? null} />
         {showActions && (
           <div className="mt-2 flex flex-wrap gap-2">
@@ -756,6 +786,7 @@ function ExpandedBody({
   if (rowState === "invited") {
     return (
       <>
+        {displayNameField}
         <EmailReadOnly email={m.user?.email ?? null} />
         <div className="mt-2 flex flex-wrap gap-2">
           {canEdit && (
@@ -786,16 +817,161 @@ function ExpandedBody({
     );
   }
 
-  // just-name — name only on the row, expanded body lets the user (canEdit)
-  // attach an email + send invite, or the owner remove the placeholder.
+  // just-name — Display Name editor first, then the email+invite flow
+  // and remove affordance.
   return (
-    <JustNameExpanded
-      member={m}
-      tripId={tripId}
-      isOwnerView={isOwnerView}
-      canEdit={canEdit}
-      onClose={onClose}
-    />
+    <>
+      {displayNameField}
+      <JustNameExpanded
+        member={m}
+        tripId={tripId}
+        isOwnerView={isOwnerView}
+        canEdit={canEdit}
+        onClose={onClose}
+      />
+    </>
+  );
+}
+
+// ── DisplayNameField ────────────────────────────────────────────────────
+// Inline-edit field that sits at the top of every expanded crew row.
+// Save fires on blur OR on Enter; a brief checkmark confirms success.
+// When the user lacks edit permission (member viewing someone else),
+// renders as a read-only display of the current value.
+
+function DisplayNameField({
+  tripId,
+  userId,
+  currentDisplayName,
+  canEdit,
+}: {
+  tripId: string;
+  userId: string;
+  currentDisplayName: string;
+  canEdit: boolean;
+}) {
+  const utils = trpc.useUtils();
+  const [value, setValue] = useState(currentDisplayName);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  // Re-sync from props when the underlying displayName changes (e.g. another
+  // tab updated it via realtime invalidation). Skip when the user is in
+  // the middle of typing — don't blow away their unsaved input.
+  useEffect(() => {
+    setValue(currentDisplayName);
+  }, [currentDisplayName]);
+
+  const setDisplayName = trpc.tripMembers.setDisplayName.useMutation({
+    onMutate: async (vars) => {
+      // Optimistic update on the list cache so the row + downstream
+      // surfaces (schedule, scoring, expenses) reflect the change
+      // instantly. Rollback on error.
+      await utils.tripMembers.list.cancel({ tripId });
+      const prev = utils.tripMembers.list.getData({ tripId });
+      utils.tripMembers.list.setData({ tripId }, (old) =>
+        (old ?? []).map((m) =>
+          m.user_id === vars.userId
+            ? { ...m, displayName: vars.displayName?.trim() || m.displayName }
+            : m
+        )
+      );
+      return { prev };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) utils.tripMembers.list.setData({ tripId }, ctx.prev);
+    },
+    onSuccess: () => {
+      setSavedAt(Date.now());
+      setTimeout(() => setSavedAt(null), 1500);
+    },
+    onSettled: () => utils.tripMembers.list.invalidate({ tripId }),
+  });
+
+  const commit = () => {
+    const trimmed = value.trim();
+    // No-op if the user reset back to the original value (or just
+    // toggled focus without typing).
+    if (trimmed === currentDisplayName.trim()) return;
+    // Empty input clears the override; the server re-derives from the
+    // global fallback chain (users.nickname → users.name → email-stem).
+    setDisplayName.mutate({
+      tripId,
+      userId,
+      displayName: trimmed.length > 0 ? trimmed : null,
+    });
+  };
+
+  return (
+    <div className="mb-2">
+      <p
+        className="mb-1 text-[10px] font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Display Name
+      </p>
+      {canEdit ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                (e.currentTarget as HTMLInputElement).blur();
+              } else if (e.key === "Escape") {
+                setValue(currentDisplayName);
+                (e.currentTarget as HTMLInputElement).blur();
+              }
+            }}
+            maxLength={100}
+            className="min-w-0 flex-1 rounded-lg border px-3 py-2 text-sm outline-none focus:ring-1"
+            style={{
+              background: "var(--color-bt-base)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+            data-testid="display-name-input"
+          />
+          {/* Save confirmation — brief checkmark that fades after 1.5s.
+              Reserves a fixed slot so the input doesn't reflow when it
+              appears/disappears. */}
+          <span
+            className="flex h-6 w-6 flex-shrink-0 items-center justify-center transition-opacity"
+            style={{
+              color: "var(--color-bt-accent)",
+              opacity: savedAt ? 1 : 0,
+            }}
+            aria-hidden="true"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              width={14}
+              height={14}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 8.5L6.5 12L13 5" />
+            </svg>
+          </span>
+        </div>
+      ) : (
+        <div
+          className="rounded-lg px-3 py-2 text-sm"
+          style={{
+            background: "var(--color-bt-base)",
+            border: "1px solid var(--color-bt-border)",
+            color: "var(--color-bt-text)",
+          }}
+        >
+          {currentDisplayName}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -17,7 +17,6 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { TabHeader } from "@/components/TabHeader";
 import { TabFab } from "@/components/TabFab";
 import { AVATAR_ICON_COMPONENTS } from "@/lib/avatarIconComponents";
-import { relativeTime } from "@/lib/notificationText";
 import type { TabProps } from "./types";
 import { CrewEmailPanel } from "./components/CrewEmailPanel";
 import { AddCrewMemberSheet } from "./components/AddCrewMemberSheet";
@@ -426,11 +425,11 @@ function EmptyHint({ text }: { text: string }) {
 // The badge slot is the only piece that varies in content; its width
 // stays pinned. The chevron rotates 180° when the row is expanded.
 
-// Widened so an Organizer (or Owner) pill can sit side-by-side with a
-// pending-Invited pill in the same slot. The single-pill rows center their
-// badge in the slot so the visual column reads as a single vertical stripe
-// down the panel.
-const BADGE_SLOT_WIDTH = 168;
+// Status slot — holds the per-row state indicator (Invited pill, joined
+// checkmark, or nothing). Owner/Organizer role pills no longer live here;
+// they render inline next to the display name, so this slot can stay tight
+// and consistent across rows.
+const BADGE_SLOT_WIDTH = 72;
 const CHEVRON_SLOT_WIDTH = 18;
 
 function CrewRow({
@@ -490,20 +489,23 @@ function CrewRow({
         <RowAvatar state={rowState} initials={initials} member={m} />
 
         <div className="min-w-0 flex-1">
-          <p
-            className="truncate text-sm font-medium"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            {m.displayName}
-            {isMe && (
-              <span
-                className="ml-1 text-xs font-normal"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                (you)
-              </span>
-            )}
-          </p>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <p
+              className="truncate text-sm font-medium"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {m.displayName}
+              {isMe && (
+                <span
+                  className="ml-1 text-xs font-normal"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  (you)
+                </span>
+              )}
+            </p>
+            <InlineRolePill state={rowState} />
+          </div>
           {/* Sub-text — email for Owner/Organizer/Crew rows; nothing for
               Just Names per spec. */}
           {rowState !== "just-name" && m.user?.email && (
@@ -516,13 +518,15 @@ function CrewRow({
           )}
         </div>
 
-        {/* Badge slot — fixed width so rows align across states */}
+        {/* Status slot — fixed width so the column aligns down the panel.
+            Invited pill / joined check / nothing — the role pill itself
+            lives inline with the display name. */}
         <div
           className="flex flex-shrink-0 items-center justify-center"
           style={{ width: BADGE_SLOT_WIDTH }}
         >
-          <RowBadge
-            state={rowState}
+          <StatusBadge
+            rowState={rowState}
             pendingInvite={
               (rowState === "owner" || rowState === "organizer") &&
               m.status === "invited"
@@ -698,51 +702,34 @@ function RowAvatar({
   );
 }
 
-// ── RowBadge ────────────────────────────────────────────────────────────
-// Five badge variants. Pill style + icon + label for the four labelled
-// states; Just Names returns null so the slot is empty (but width-fixed).
+// ── Badges ──────────────────────────────────────────────────────────────
+// The row's identity is now split across two slots:
+//   • InlineRolePill — Owner / Organizer pill rendered next to the
+//     display name, since the role is part of who they are.
+//   • StatusBadge — the "have they actually joined?" indicator, in the
+//     fixed-width column on the right: Invited / joined check / nothing.
+// Splitting them keeps the right-hand column tight and consistent,
+// instead of needing to grow to fit two side-by-side pills on the rare
+// pending-organizer row.
 
-function RowBadge({
-  state,
-  pendingInvite = false,
-}: {
-  state: RowState;
-  /** Owner/Organizer rows whose invite hasn't been accepted yet — we
-   *  elevate roles before sign-up to skip a step, so the Organizer pill
-   *  alone would hide that they haven't joined. Renders an Invited pill
-   *  to the right of the role pill on the same horizontal line. */
-  pendingInvite?: boolean;
-}) {
-  const pillBase: React.CSSProperties = {
-    fontSize: 10,
-    borderRadius: 9999,
-    padding: "2px 8px",
-    display: "inline-flex",
-    alignItems: "center",
-    gap: 3,
-    fontWeight: 600,
-    letterSpacing: "0.02em",
-    whiteSpace: "nowrap",
-  };
+const PILL_BASE: React.CSSProperties = {
+  fontSize: 10,
+  borderRadius: 9999,
+  padding: "2px 8px",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 3,
+  fontWeight: 600,
+  letterSpacing: "0.02em",
+  whiteSpace: "nowrap",
+};
 
-  const invitedPill = (
-    <span
-      style={{
-        ...pillBase,
-        background: "var(--color-bt-warning-faint)",
-        color: "var(--color-bt-warning)",
-        border: "1px solid var(--color-bt-warning-border)",
-      }}
-    >
-      Invited
-    </span>
-  );
-
+function InlineRolePill({ state }: { state: RowState }) {
   if (state === "owner") {
-    const ownerPill = (
+    return (
       <span
         style={{
-          ...pillBase,
+          ...PILL_BASE,
           background: "var(--color-bt-warning-faint)",
           color: "var(--color-bt-owner)",
           border: "1px solid var(--color-bt-warning-border)",
@@ -752,21 +739,12 @@ function RowBadge({
         Owner
       </span>
     );
-    if (pendingInvite) {
-      return (
-        <span className="flex flex-row items-center gap-1.5">
-          {ownerPill}
-          {invitedPill}
-        </span>
-      );
-    }
-    return ownerPill;
   }
   if (state === "organizer") {
-    const organizerPill = (
+    return (
       <span
         style={{
-          ...pillBase,
+          ...PILL_BASE,
           background: "var(--color-bt-accent-faint)",
           color: "var(--color-bt-accent)",
           border: "1px solid var(--color-bt-accent-border)",
@@ -776,21 +754,30 @@ function RowBadge({
         Organizer
       </span>
     );
-    if (pendingInvite) {
-      return (
-        <span className="flex flex-row items-center gap-1.5">
-          {organizerPill}
-          {invitedPill}
-        </span>
-      );
-    }
-    return organizerPill;
   }
-  if (state === "invited") {
+  return null;
+}
+
+function StatusBadge({
+  rowState,
+  pendingInvite = false,
+}: {
+  rowState: RowState;
+  /** Owner/Organizer rows whose invite hasn't been accepted yet — we
+   *  elevate roles before sign-up to skip a step, so the inline role
+   *  pill alone would hide that they haven't joined. Surface the
+   *  Invited pill in the status slot. */
+  pendingInvite?: boolean;
+}) {
+  // Owner/Organizer rows: only render anything if the invite is still
+  // pending; otherwise leave the slot empty (the role pill inline next
+  // to the name already conveys their identity).
+  if (rowState === "owner" || rowState === "organizer") {
+    if (!pendingInvite) return null;
     return (
       <span
         style={{
-          ...pillBase,
+          ...PILL_BASE,
           background: "var(--color-bt-warning-faint)",
           color: "var(--color-bt-warning)",
           border: "1px solid var(--color-bt-warning-border)",
@@ -800,7 +787,21 @@ function RowBadge({
       </span>
     );
   }
-  if (state === "joined") {
+  if (rowState === "invited") {
+    return (
+      <span
+        style={{
+          ...PILL_BASE,
+          background: "var(--color-bt-warning-faint)",
+          color: "var(--color-bt-warning)",
+          border: "1px solid var(--color-bt-warning-border)",
+        }}
+      >
+        Invited
+      </span>
+    );
+  }
+  if (rowState === "joined") {
     return (
       <svg
         viewBox="0 0 16 16"
@@ -932,7 +933,16 @@ function ExpandedBody({
             className="mt-2 text-[11px]"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
-            Invited {relativeTime(m.last_invited_at)}
+            Invited on{" "}
+            {new Date(m.last_invited_at).toLocaleDateString(undefined, {
+              month: "short",
+              day: "numeric",
+              year:
+                new Date(m.last_invited_at).getFullYear() ===
+                new Date().getFullYear()
+                  ? undefined
+                  : "numeric",
+            })}
           </p>
         )}
         <div className="mt-2 flex flex-wrap gap-2">

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 import {
   ChevronDown,
   Crown,
+  Ghost,
   Mail,
   Plus,
   Send,
@@ -15,6 +17,7 @@ import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { TabHeader } from "@/components/TabHeader";
 import { TabFab } from "@/components/TabFab";
+import { AVATAR_ICON_COMPONENTS } from "@/lib/avatarIconComponents";
 import type { TabProps } from "./types";
 import { CrewEmailPanel } from "./components/CrewEmailPanel";
 import { AddCrewMemberSheet } from "./components/AddCrewMemberSheet";
@@ -28,7 +31,14 @@ type Member = {
   status: string | null;
   displayName: string;
   isGuest: boolean;
-  user: { email: string | null; is_guest?: boolean } | null;
+  user: {
+    email: string | null;
+    is_guest?: boolean;
+    /** Uploaded photo URL — wins over avatar_icon and initials. */
+    avatar_url?: string | null;
+    /** Tabler icon id the user picked in their profile — wins over initials. */
+    avatar_icon?: string | null;
+  } | null;
 };
 
 /**
@@ -98,13 +108,11 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
   const unlinkedCount = (members as Member[]).filter((m) => m.isGuest && m.status === "in").length;
 
   return (
-    // max-w-[640px] left-aligned constraint (CC_MODAL_AUDIT.md Part 4):
-    // wide viewports were stretching crew rows edge-to-edge so the name
-    // sat on the far left while the badge floated on the far right. The
-    // 640px cap keeps the row dense enough to read as a unit. Mobile is
-    // unaffected — narrow viewports already fit comfortably under 640px.
+    // Nudge + TabHeader + buttons stay full-width; only the section list
+    // below is constrained / split into columns. Spec: "The 640px width
+    // should only wrap around the crew lists, not the top part of the
+    // crew tab."
     <div className={embedded ? "@container" : "@container px-4"}>
-      <div className="max-w-[640px]">
       {/* ── Unlinked-crew nudge — surfaces at the very top of the tab so
           it reads as a tab-level alert (Style Guide § Nudge banner). ── */}
       {isOwner && unlinkedCount > 0 && (
@@ -174,77 +182,65 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         }
       />
 
-      {/* ── Sections ─────────────────────────────────────────────────── */}
-      <div className="space-y-5">
-        <SectionGroup
-          label="Organizers"
-          count={organizers.length}
-          tone="accent"
-        >
-          {organizers.map((m) => (
-            <CrewRow
-              key={m.memberId}
-              member={m}
-              tripId={tripId}
-              isOwnerView={!!isOwner}
-              canEdit={canEdit}
-              isMe={m.user_id === currentUser?.id}
-              isExpanded={expandedId === m.memberId}
-              onToggle={() =>
-                setExpandedId((cur) => (cur === m.memberId ? null : m.memberId))
-              }
-            />
-          ))}
-        </SectionGroup>
+      {/* ── Sections — 2-column grid at lg+; stacks single-column on
+              tablet and mobile. Left column carries Organizers and Crew
+              vertically; right column is Just Names. When Just Names is
+              empty the grid collapses to a single column so Organizers +
+              Crew take the full width. ── */}
+      {(() => {
+        const renderRow = (m: Member) => (
+          <CrewRow
+            key={m.memberId}
+            member={m}
+            tripId={tripId}
+            isOwnerView={!!isOwner}
+            canEdit={canEdit}
+            isMe={m.user_id === currentUser?.id}
+            isExpanded={expandedId === m.memberId}
+            onToggle={() =>
+              setExpandedId((cur) => (cur === m.memberId ? null : m.memberId))
+            }
+          />
+        );
 
-        <SectionGroup label="Crew" count={crew.length} tone="standard">
-          {crew.length === 0 ? (
-            <EmptyHint text="No crew members yet." />
-          ) : (
-            crew.map((m) => (
-              <CrewRow
-                key={m.memberId}
-                member={m}
-                tripId={tripId}
-                isOwnerView={!!isOwner}
-                canEdit={canEdit}
-                isMe={m.user_id === currentUser?.id}
-                isExpanded={expandedId === m.memberId}
-                onToggle={() =>
-                  setExpandedId((cur) => (cur === m.memberId ? null : m.memberId))
-                }
-              />
-            ))
-          )}
-        </SectionGroup>
+        const leftColumn = (
+          <div className="space-y-5">
+            <SectionGroup
+              label="Organizers"
+              count={organizers.length}
+              tone="accent"
+            >
+              {organizers.map(renderRow)}
+            </SectionGroup>
 
-        {/* Just Names section — only render if there's at least one. The
-            spec subtext is rendered inside the SectionGroup header slot
-            so the count badge stays right-aligned. */}
-        {justNames.length > 0 && (
-          <SectionGroup
-            label="Just Names"
-            count={justNames.length}
-            tone="recessed"
-            subtext="Available for scheduling and scoring — add their email if they want to access the app."
-          >
-            {justNames.map((m) => (
-              <CrewRow
-                key={m.memberId}
-                member={m}
-                tripId={tripId}
-                isOwnerView={!!isOwner}
-                canEdit={canEdit}
-                isMe={m.user_id === currentUser?.id}
-                isExpanded={expandedId === m.memberId}
-                onToggle={() =>
-                  setExpandedId((cur) => (cur === m.memberId ? null : m.memberId))
-                }
-              />
-            ))}
-          </SectionGroup>
-        )}
-      </div>
+            <SectionGroup label="Crew" count={crew.length} tone="standard">
+              {crew.length === 0 ? (
+                <EmptyHint text="No crew members yet." />
+              ) : (
+                crew.map(renderRow)
+              )}
+            </SectionGroup>
+          </div>
+        );
+
+        if (justNames.length === 0) {
+          return leftColumn;
+        }
+
+        return (
+          <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+            {leftColumn}
+            <SectionGroup
+              label="Just Names"
+              count={justNames.length}
+              tone="recessed"
+              subtext="Available for scheduling and scoring — add their email if they want to access the app."
+            >
+              {justNames.map(renderRow)}
+            </SectionGroup>
+          </div>
+        );
+      })()}
 
       {/* ── Add crew member modal/sheet ─────────────────────────────── */}
       {isOwner && (
@@ -296,11 +292,8 @@ export function CrewTab({ trip, canEdit, embedded }: TabProps & { embedded?: boo
         </div>
       )}
 
-      </div>{/* /max-w-[640px] container */}
-
-      {/* ── Mobile FAB — primary "Add crew member" action ──────────────
-          Rendered outside the max-w wrapper because the FAB is fixed-
-          positioned and its DOM ancestor doesn't influence layout. */}
+      {/* ── Mobile FAB — primary "Add crew member" action. fixed-positioned,
+          so its DOM placement doesn't affect layout. */}
       {isOwner && (
         <TabFab
           onClick={() => setShowAddModal(true)}
@@ -460,7 +453,7 @@ function CrewRow({
           cursor: expandable ? "pointer" : "default",
         }}
       >
-        <RowAvatar state={rowState} initials={initials} />
+        <RowAvatar state={rowState} initials={initials} member={m} />
 
         <div className="min-w-0 flex-1">
           <p
@@ -534,66 +527,122 @@ function CrewRow({
 }
 
 // ── RowAvatar ───────────────────────────────────────────────────────────
-// Five visual variants keyed by row state. Each renders as a 32×32
-// rounded-full circle so the layout doesn't shift when state changes.
+// Resolution chain (per CC_MODAL_AUDIT.md follow-up):
+//   1. just-name (ghost with no email)  → Ghost icon in dashed circle
+//   2. user.avatar_url present           → uploaded photo
+//   3. user.avatar_icon present          → Tabler icon on state-tinted bg
+//   4. otherwise                         → initials on state-tinted bg
+//
+// State coloring (owner=teal, organizer/joined=blue, invited=amber) is
+// applied as the background tint when we're rendering an icon or
+// initials — so customized avatars (photo) display as themselves, and
+// non-customized rows still carry their state-state at a glance.
 
-function RowAvatar({ state, initials }: { state: RowState; initials: string }) {
+function RowAvatar({
+  state,
+  initials,
+  member: m,
+}: {
+  state: RowState;
+  initials: string;
+  member: Member;
+}) {
+  const SIZE = 32;
   const baseClasses =
-    "flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-[11px] font-semibold";
+    "flex flex-shrink-0 items-center justify-center rounded-full overflow-hidden";
 
-  if (state === "owner") {
+  // 1. Just Names → Ghost icon in dashed circle. The spec explicitly calls
+  //    for the dashed border + ghost glyph treatment; we don't fall through
+  //    to avatar_url / avatar_icon here because the "just name" identity
+  //    IS "no real person yet".
+  if (state === "just-name") {
     return (
       <span
         className={baseClasses}
         style={{
-          background: "var(--color-bt-tag-bg)",
-          color: "var(--color-bt-accent)",
-          border: "1px solid var(--color-bt-accent-border)",
+          width: SIZE,
+          height: SIZE,
+          background: "transparent",
+          color: "var(--color-bt-text-dim)",
+          border: "1.5px dashed var(--color-bt-border)",
+          opacity: 0.85,
         }}
+        aria-hidden="true"
       >
-        {initials}
+        <Ghost size={14} />
       </span>
     );
   }
-  if (state === "organizer" || state === "joined") {
+
+  // 2. Uploaded photo → render directly, no state tint underneath
+  //    (a state-tint border would compete with the photo).
+  if (m.user?.avatar_url) {
+    return (
+      <Image
+        src={m.user.avatar_url}
+        alt={`${m.displayName} avatar`}
+        width={SIZE}
+        height={SIZE}
+        className="flex-shrink-0 rounded-full object-cover"
+        unoptimized
+      />
+    );
+  }
+
+  // 3 / 4 — resolve state tint, then render icon or initials on top.
+  const stateTint: { bg: string; fg: string; border: string } =
+    state === "owner"
+      ? {
+          bg: "var(--color-bt-tag-bg)",
+          fg: "var(--color-bt-accent)",
+          border: "var(--color-bt-accent-border)",
+        }
+      : state === "invited"
+        ? {
+            bg: "var(--color-bt-warning-faint)",
+            fg: "var(--color-bt-warning)",
+            border: "var(--color-bt-warning-border)",
+          }
+        : {
+            // organizer + joined share the blue tint
+            bg: "var(--color-bt-blue-bg)",
+            fg: "var(--color-bt-planning)",
+            border: "var(--color-bt-planning-border)",
+          };
+
+  // 3. avatar_icon set → render the Tabler glyph on the tinted circle.
+  const IconComponent = m.user?.avatar_icon
+    ? AVATAR_ICON_COMPONENTS[m.user.avatar_icon]
+    : null;
+  if (IconComponent) {
     return (
       <span
         className={baseClasses}
         style={{
-          background: "var(--color-bt-blue-bg)",
-          color: "var(--color-bt-planning)",
-          border: "1px solid var(--color-bt-planning-border)",
+          width: SIZE,
+          height: SIZE,
+          background: stateTint.bg,
+          color: stateTint.fg,
+          border: `1px solid ${stateTint.border}`,
         }}
+        aria-label={`${m.displayName} avatar`}
       >
-        {initials}
+        <IconComponent size={16} stroke={1.75} aria-hidden="true" />
       </span>
     );
   }
-  if (state === "invited") {
-    return (
-      <span
-        className={baseClasses}
-        style={{
-          background: "var(--color-bt-warning-faint)",
-          color: "var(--color-bt-warning)",
-          border: "1px solid var(--color-bt-warning-border)",
-        }}
-      >
-        {initials}
-      </span>
-    );
-  }
-  // just-name → dashed border placeholder with a tiny silhouette glyph
+
+  // 4. Initials fallback.
   return (
     <span
-      className={baseClasses}
+      className={`${baseClasses} text-[11px] font-semibold`}
       style={{
-        background: "transparent",
-        color: "var(--color-bt-text-dim)",
-        border: "1.5px dashed var(--color-bt-border)",
-        opacity: 0.85,
+        width: SIZE,
+        height: SIZE,
+        background: stateTint.bg,
+        color: stateTint.fg,
+        border: `1px solid ${stateTint.border}`,
       }}
-      aria-hidden="true"
     >
       {initials}
     </span>

--- a/src/app/trips/[tripId]/tabs/EditExpenseModal.tsx
+++ b/src/app/trips/[tripId]/tabs/EditExpenseModal.tsx
@@ -142,24 +142,41 @@ export function EditExpenseModal({
         style={{ background: "var(--color-bt-overlay)" }}
         onClick={onClose}
       />
+      {/* Canonical modal structure (CC_MODAL_AUDIT.md Part 2.1) —
+          matches AddExpenseModal so the two surfaces feel like the
+          same control under different labels. */}
       <div
-        className="relative w-full max-w-lg rounded-2xl p-5"
-        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        className="relative flex w-full max-w-[560px] flex-col overflow-hidden rounded-xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
+          maxHeight: "min(85dvh, 720px)",
+        }}
       >
         {/* Header */}
-        <div className="mb-4 flex items-center justify-between">
+        <div
+          className="flex flex-shrink-0 items-center justify-between px-5 py-4"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        >
           <h2 className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
             Edit Receipt
           </h2>
           <button
             onClick={onClose}
+            aria-label="Close"
             className="flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+            }}
           >
-            <X size={18} />
+            <X size={14} />
           </button>
         </div>
 
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
         {/* Editable expense info */}
         <div className="mb-4 space-y-2">
           <div className="flex gap-3">
@@ -237,19 +254,28 @@ export function EditExpenseModal({
           }
         />
 
-        {/* Action buttons */}
-        <div className="mt-4 flex gap-2">
+        </div>{/* /Body */}
+
+        {/* Footer */}
+        <div
+          className="flex flex-shrink-0 items-center justify-end gap-3 px-5 py-4"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        >
           <button
             onClick={onClose}
-            className="flex-1 rounded-lg border py-2 text-sm"
-            style={{ borderColor: "var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-text-dim)",
+              border: "0.5px solid var(--color-bt-border)",
+            }}
           >
             Cancel
           </button>
           <button
             disabled={updateSplits.isPending || includedIds.length === 0 || !title.trim() || amountNum <= 0}
             onClick={handleSave}
-            className="flex-1 rounded-lg py-2 text-sm font-medium disabled:opacity-40"
+            className="rounded-xl px-4 py-2.5 text-sm font-semibold disabled:opacity-40"
             style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
           >
             {updateSplits.isPending ? "Saving..." : "Save Changes"}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -1573,7 +1573,7 @@ export function ScheduleTab({
                 className="flex-1 rounded-xl py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
                 style={{
                   background: "var(--color-bt-danger)",
-                  color: "#fff",
+                  color: "white",
                 }}
               >
                 {removeItem.isPending ? "Deleting..." : "Delete"}

--- a/src/app/trips/[tripId]/tabs/components/AddCrewMemberSheet.tsx
+++ b/src/app/trips/[tripId]/tabs/components/AddCrewMemberSheet.tsx
@@ -281,10 +281,16 @@ export function AddCrewMemberSheet({
             <div>
               <label
                 htmlFor="add-crew-display-name"
-                className="mb-1.5 block text-xs font-semibold uppercase tracking-wider"
+                className="mb-1 block text-[10px] font-medium uppercase tracking-[0.06em]"
                 style={{ color: "var(--color-bt-text-dim)" }}
               >
-                Display Name
+                Display Name{" "}
+                <span
+                  className="font-normal normal-case"
+                  style={{ color: "var(--color-bt-text-dim)", letterSpacing: 0 }}
+                >
+                  — optional
+                </span>
               </label>
               <input
                 id="add-crew-display-name"
@@ -314,10 +320,16 @@ export function AddCrewMemberSheet({
             <div>
               <label
                 htmlFor="add-crew-email"
-                className="mb-1.5 block text-xs font-semibold uppercase tracking-wider"
+                className="mb-1 block text-[10px] font-medium uppercase tracking-[0.06em]"
                 style={{ color: "var(--color-bt-text-dim)" }}
               >
-                Email
+                Email{" "}
+                <span
+                  className="font-normal normal-case"
+                  style={{ color: "var(--color-bt-text-dim)", letterSpacing: 0 }}
+                >
+                  — optional
+                </span>
               </label>
               <input
                 id="add-crew-email"

--- a/src/app/trips/[tripId]/tabs/components/AddCrewMemberSheet.tsx
+++ b/src/app/trips/[tripId]/tabs/components/AddCrewMemberSheet.tsx
@@ -30,28 +30,38 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * AddCrewMemberSheet — modal (desktop) / bottom sheet (mobile) for adding
- * a crew member. Replaces the inline name-only field that lived in the
- * old CrewTab.
+ * a crew member.
  *
- * Form:
- *   Name *           — required, autofocused
- *   Email (optional) — debounced account lookup on change/blur
+ * Form (CC_MODAL_AUDIT.md Part 1.1):
+ *   Display Name — trip-local display label (not the user's BT account
+ *                  name); optional
+ *   Email        — optional
  *
- * The email-lookup note below the email input reflects one of four states
- * (see LookupState above). Add-to-crew is disabled when the email matches
- * an existing trip member.
+ *   Helper line below the body: "Enter a name, an email, or both."
  *
- * Outcomes on submit (CC_CREW_OVERHAUL.md Part 1.5):
- *   Name only                          → ghostCrew.create — "Just Names"
- *   Name + Email, account found        → tripMembers.inviteByEmail
- *                                        (Path A — added as joined Member)
- *   Name + Email, no account           → tripMembers.inviteByEmail
- *                                        (Path B — guest + invite sent)
+ * Submit is enabled as long as at least one field is filled in (display
+ * name OR a syntactically-valid email). Both empty → disabled.
  *
- * The user's typed name is carried through both paths via the optional
- * `name` argument added to inviteByEmail. For Path A the existing
- * account's stored name remains authoritative for the crew roster — the
- * typed name acts as confirmation copy inside the modal only.
+ * Account lookup (CC_MODAL_AUDIT.md Part 1.2):
+ *   - 500 ms debounce on the email input
+ *   - Lookup is purely informational. It NEVER writes into the Display
+ *     Name field. When the user hasn't typed a display name and an
+ *     account is found, the account's name surfaces as the field's
+ *     placeholder (HTML placeholder behaviour: greyed/italic by default,
+ *     instantly replaced the moment the user types).
+ *
+ * Outcomes on submit (CC_MODAL_AUDIT.md Part 1.3):
+ *   Display Name only                     ghostCrew.create — Just Names
+ *   Email only, account found             tripMembers.inviteByEmail Path A
+ *   Email only, no account                tripMembers.inviteByEmail Path B
+ *                                         (router falls back to email-stem
+ *                                          for users.name; display_name
+ *                                          stays NULL → roster shows the
+ *                                          email-stem in italic)
+ *   Both                                  trip-local display_name override
+ *                                         wins over any account name —
+ *                                         the typed name surfaces on the
+ *                                         crew list (Path A or B).
  */
 export function AddCrewMemberSheet({
   tripId,
@@ -60,7 +70,7 @@ export function AddCrewMemberSheet({
 }: AddCrewMemberSheetProps) {
   const utils = trpc.useUtils();
 
-  const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -68,7 +78,7 @@ export function AddCrewMemberSheet({
   // Reset form when the sheet closes so a re-open starts fresh.
   useEffect(() => {
     if (!isOpen) {
-      setName("");
+      setDisplayName("");
       setEmail("");
       setSubmitError(null);
       setSubmitting(false);
@@ -78,9 +88,6 @@ export function AddCrewMemberSheet({
   useModalBackButton(isOpen ? onClose : () => {});
 
   // ── Email account lookup (debounced + cancellable) ───────────────────
-  // Fires when the email field has a parseable value. State machine lives
-  // in `lookup`; the debounce timer + lastQueriedEmail are refs so quick
-  // typing doesn't fire stale requests.
 
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
   const existingMemberByEmail = useMemo(() => {
@@ -104,7 +111,6 @@ export function AddCrewMemberSheet({
 
   useEffect(() => {
     const trimmed = email.trim().toLowerCase();
-    // Empty or malformed → idle, nothing to look up.
     if (!trimmed) {
       setLookup({ kind: "idle" });
       return;
@@ -113,17 +119,13 @@ export function AddCrewMemberSheet({
       setLookup({ kind: "idle" });
       return;
     }
-    // Already a member of this trip — short-circuit; no need to hit the
-    // users.search endpoint.
     const existing = existingMemberByEmail.get(trimmed);
     if (existing) {
       setLookup({ kind: "already-member", displayName: existing.displayName });
       return;
     }
-    // Same email we last queried → keep showing the cached result.
     if (lastQueried.current === trimmed && lookup.kind !== "idle") return;
 
-    // 500ms debounce before firing users.search
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     setLookup({ kind: "looking" });
     debounceTimer.current = setTimeout(async () => {
@@ -146,9 +148,6 @@ export function AddCrewMemberSheet({
           setLookup({ kind: "no-account" });
         }
       } catch {
-        // Network/server error — fall back to "no-account" so the user
-        // can still proceed; server-side validation will catch any real
-        // issues at submit time.
         setLookup({ kind: "no-account" });
       }
     }, 500);
@@ -167,15 +166,28 @@ export function AddCrewMemberSheet({
     onSettled: () => utils.tripMembers.list.invalidate({ tripId }),
   });
 
-  const trimmedName = name.trim();
+  const trimmedName = displayName.trim();
   const trimmedEmail = email.trim().toLowerCase();
   const hasName = trimmedName.length > 0;
   const hasValidEmail = EMAIL_RE.test(trimmedEmail);
+  const hasInvalidEmail = trimmedEmail.length > 0 && !hasValidEmail;
+
+  // Validation rule per Part 1.1: at least one of {name, valid email}.
+  // Both empty → disabled. Invalid email format → disabled. Already a
+  // trip member → disabled.
   const canSubmit =
-    hasName &&
+    (hasName || hasValidEmail) &&
+    !hasInvalidEmail &&
     !submitting &&
     lookup.kind !== "looking" &&
     lookup.kind !== "already-member";
+
+  // Display Name placeholder per Part 1.2: when the user has NOT typed
+  // anything in the field, surface the account name (if found) as a
+  // greyed-out placeholder. The placeholder vanishes the moment they
+  // type — their input is authoritative.
+  const namePlaceholder =
+    lookup.kind === "found" ? lookup.accountName : "What you'll call them";
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -183,21 +195,22 @@ export function AddCrewMemberSheet({
     setSubmitting(true);
     try {
       if (!hasValidEmail) {
-        // Name only → Just Names
+        // Display Name only → ghostCrew.create — lands in Just Names.
         await createGuest.mutateAsync({
           tripId,
           name: trimmedName,
           role: "Member",
         });
       } else {
-        // Name + email — inviteByEmail handles both Path A (existing
-        // account) and Path B (guest + invite). The typed name carries
-        // through for Path B; Path A keeps the existing user's name.
+        // Email present (with or without typed name). inviteByEmail
+        // handles both Path A (existing account) and Path B
+        // (guest + invite); the typed name (if any) is carried through
+        // as a trip-local display_name override.
         await inviteByEmail.mutateAsync({
           tripId,
           email: trimmedEmail,
           role: "Member",
-          name: trimmedName,
+          ...(hasName ? { name: trimmedName } : {}),
         });
       }
       onClose();
@@ -224,7 +237,7 @@ export function AddCrewMemberSheet({
       aria-label="Add crew member"
     >
       <div
-        className="w-full max-w-[480px] overflow-hidden rounded-t-2xl sm:rounded-2xl"
+        className="flex w-full max-w-[480px] flex-col overflow-hidden rounded-t-2xl sm:rounded-2xl"
         style={{
           background: "var(--color-bt-card)",
           border: "1px solid var(--color-bt-border)",
@@ -234,15 +247,22 @@ export function AddCrewMemberSheet({
         onClick={(e) => e.stopPropagation()}
         data-testid="add-crew-member-sheet"
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 pb-3 pt-5">
-          <p className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
+        {/* Header — canonical modal pattern (CC_MODAL_AUDIT.md Part 2.1):
+            title + close X, px-5 py-4, border-bottom. */}
+        <div
+          className="flex flex-shrink-0 items-center justify-between px-5 py-4"
+          style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        >
+          <p
+            className="text-base font-semibold"
+            style={{ color: "var(--color-bt-text)" }}
+          >
             Add crew member
           </p>
           <button
             onClick={onClose}
             aria-label="Close"
-            className="flex h-8 w-8 items-center justify-center rounded-full"
+            className="flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
             style={{
               background: "var(--color-bt-card-raised)",
               color: "var(--color-bt-text-dim)",
@@ -255,117 +275,127 @@ export function AddCrewMemberSheet({
         </div>
 
         {/* Body */}
-        <div className="space-y-4 px-5 pb-5">
-          {/* Name */}
-          <div>
-            <label
-              htmlFor="add-crew-name"
-              className="mb-1.5 block text-xs font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              Name <span style={{ color: "var(--color-bt-danger)" }}>*</span>
-            </label>
-            <input
-              id="add-crew-name"
-              data-testid="add-crew-name-input"
-              type="text"
-              autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canSubmit) {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              maxLength={100}
-              placeholder="Brad"
-              className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-1"
-              style={{
-                background: "var(--color-bt-base)",
-                borderColor: "var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-          </div>
-
-          {/* Email */}
-          <div>
-            <label
-              htmlFor="add-crew-email"
-              className="mb-1.5 block text-xs font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              Email{" "}
-              <span
-                className="text-[10px] font-normal normal-case"
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div className="space-y-4">
+            {/* Display Name */}
+            <div>
+              <label
+                htmlFor="add-crew-display-name"
+                className="mb-1.5 block text-xs font-semibold uppercase tracking-wider"
                 style={{ color: "var(--color-bt-text-dim)" }}
               >
-                (optional)
-              </span>
-            </label>
-            <input
-              id="add-crew-email"
-              data-testid="add-crew-email-input"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && canSubmit) {
-                  e.preventDefault();
-                  handleSubmit();
-                }
-              }}
-              placeholder="brad@example.com"
-              className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-1"
-              style={{
-                background: "var(--color-bt-base)",
-                borderColor: "var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-            <LookupNote state={lookup} />
-          </div>
+                Display Name
+              </label>
+              <input
+                id="add-crew-display-name"
+                data-testid="add-crew-display-name-input"
+                type="text"
+                autoFocus
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && canSubmit) {
+                    e.preventDefault();
+                    handleSubmit();
+                  }
+                }}
+                maxLength={100}
+                placeholder={namePlaceholder}
+                className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-1"
+                style={{
+                  background: "var(--color-bt-base)",
+                  borderColor: "var(--color-bt-border)",
+                  color: "var(--color-bt-text)",
+                }}
+              />
+            </div>
 
-          {/* Submit error */}
-          {submitError && (
+            {/* Email */}
+            <div>
+              <label
+                htmlFor="add-crew-email"
+                className="mb-1.5 block text-xs font-semibold uppercase tracking-wider"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Email
+              </label>
+              <input
+                id="add-crew-email"
+                data-testid="add-crew-email-input"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && canSubmit) {
+                    e.preventDefault();
+                    handleSubmit();
+                  }
+                }}
+                placeholder="brad@example.com"
+                className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-1"
+                style={{
+                  background: "var(--color-bt-base)",
+                  borderColor: "var(--color-bt-border)",
+                  color: "var(--color-bt-text)",
+                }}
+              />
+              <LookupNote state={lookup} hasInvalid={hasInvalidEmail} />
+            </div>
+
+            {/* Helper text — guidance that replaces the old `*` required
+                indicator. Applies to the form as a whole (Part 1.1). */}
             <p
-              className="text-xs"
-              style={{ color: "var(--color-bt-danger)" }}
+              className="text-[11px]"
+              style={{ color: "var(--color-bt-text-dim)" }}
             >
-              {submitError}
+              Enter a name, an email, or both.
             </p>
-          )}
 
-          {/* Footer actions */}
-          <div className="flex items-center justify-end gap-2 pt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-xl px-4 py-2 text-sm font-medium"
-              style={{
-                background: "transparent",
-                color: "var(--color-bt-text-dim)",
-                border: "0.5px solid var(--color-bt-border)",
-              }}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={!canSubmit}
-              data-testid="add-crew-submit"
-              className="flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity disabled:opacity-40"
-              style={{
-                background: "var(--color-bt-accent)",
-                color: "var(--color-bt-base)",
-              }}
-            >
-              {submitting && <Loader2 size={14} className="animate-spin" />}
-              Add to crew
-            </button>
+            {/* Submit error */}
+            {submitError && (
+              <p
+                className="text-xs"
+                style={{ color: "var(--color-bt-danger)" }}
+              >
+                {submitError}
+              </p>
+            )}
           </div>
+        </div>
+
+        {/* Footer — canonical modal pattern: px-5 py-4, border-top, right-
+            aligned actions, gap-3, Medium button size, Ghost + Primary
+            variants. */}
+        <div
+          className="flex flex-shrink-0 items-center justify-end gap-3 px-5 py-4"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-text-dim)",
+              border: "0.5px solid var(--color-bt-border)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="add-crew-submit"
+            className="flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-base)",
+            }}
+          >
+            {submitting && <Loader2 size={14} className="animate-spin" />}
+            Add to crew
+          </button>
         </div>
       </div>
     </div>
@@ -373,10 +403,24 @@ export function AddCrewMemberSheet({
 }
 
 // ── LookupNote ───────────────────────────────────────────────────────────
-// Inline status message under the email input. Four states map 1:1 to
-// the spec's account-lookup states.
 
-function LookupNote({ state }: { state: LookupState }) {
+function LookupNote({
+  state,
+  hasInvalid,
+}: {
+  state: LookupState;
+  hasInvalid: boolean;
+}) {
+  if (hasInvalid) {
+    return (
+      <p
+        className="mt-1.5 text-[11px]"
+        style={{ color: "var(--color-bt-danger)" }}
+      >
+        Enter a valid email address.
+      </p>
+    );
+  }
   if (state.kind === "idle") return null;
 
   if (state.kind === "looking") {
@@ -410,7 +454,6 @@ function LookupNote({ state }: { state: LookupState }) {
       </p>
     );
   }
-  // already-member
   return (
     <p
       className="mt-1.5 text-[11px]"

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -47,6 +47,11 @@ interface TopNavProps {
   chatOpen?: boolean;
 }
 
+// Feature flag — the notifications surface is being rethought; hide the
+// bell from the TopNav for now without ripping out the wiring, so it can
+// come back once the next notifications design lands.
+const NOTIFICATIONS_ENABLED = false;
+
 const NOTIFICATION_ICONS: Record<string, typeof Bell> = {
   rsvp_response: UserCheck,
   destination_locked: MapPin,
@@ -177,6 +182,7 @@ export const TopNav: FC<TopNavProps> = ({
         {tripId && onOpenChat && (
           <ChatButton tripId={tripId} onClick={onOpenChat} isOpen={chatOpen} />
         )}
+        {NOTIFICATIONS_ENABLED && (
         <div ref={ref} className="relative">
           <button
             aria-label="Notifications"
@@ -319,6 +325,7 @@ export const TopNav: FC<TopNavProps> = ({
             </>
           )}
         </div>
+        )}
 
         <UserMenu />
       </div>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -190,7 +190,7 @@ export const TopNav: FC<TopNavProps> = ({
               <span
                 data-testid="notification-badge"
                 className="absolute right-1 top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-0.5 text-[10px] font-bold"
-                style={{ background: "var(--color-bt-warning)", color: "#fff" }}
+                style={{ background: "var(--color-bt-warning)", color: "white" }}
               >
                 {unreadCount > 9 ? "9+" : unreadCount}
               </span>
@@ -350,7 +350,7 @@ function ChatButton({ tripId, onClick, isOpen }: { tripId: string; onClick: () =
         <span
           data-testid="chat-unread-badge"
           className="absolute right-1 top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-0.5 text-[10px] font-bold"
-          style={{ background: "var(--color-bt-warning)", color: "#fff" }}
+          style={{ background: "var(--color-bt-warning)", color: "white" }}
         >
           {unread > 9 ? "9+" : unread}
         </span>

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -757,7 +757,7 @@ export function TripSettingsModal({
                     disabled={deleteMutation.isPending}
                     onClick={() => deleteMutation.mutate({ tripId })}
                     className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-40"
-                    style={{ background: "var(--color-bt-danger)", color: "#fff" }}
+                    style={{ background: "var(--color-bt-danger)", color: "white" }}
                   >
                     {deleteMutation.isPending ? "Deleting…" : "Delete trip"}
                   </button>

--- a/src/server/routers/ghostCrew.ts
+++ b/src/server/routers/ghostCrew.ts
@@ -97,11 +97,14 @@ export const ghostCrewRouter = router({
             });
           }
 
-          // Lifecycle system message — same wording as other "added"
-          // paths (tripMembers.add, inviteByEmail Path A).
+          // Lifecycle system message — Organizer chat only. Ghost crew
+          // (no real account yet) don't have access to the crew chat,
+          // so adding them isn't crew-visible. If/when they later link
+          // to a real BuddyTrip account the link path posts the
+          // "joined the trip" message.
           await postSystemMessage({
             tripId: ctx.tripId,
-            visibility: "crew",
+            visibility: "planning",
             text: `${input.nickname ?? input.name} was added to the trip`,
           });
 
@@ -162,12 +165,13 @@ export const ghostCrewRouter = router({
         });
       }
 
-      // Lifecycle system message. "Just Names" (no email) are still real
-      // members of the trip and show in the roster, so we post the same
-      // "added to the trip" wording as other paths.
+      // Lifecycle system message — Organizer chat only. Ghost crew
+      // (Just Names and unresolved emails alike) don't have crew-chat
+      // access, so the crew chat doesn't surface their add. If they
+      // later link to a real account, the link path posts "joined".
       await postSystemMessage({
         tripId: ctx.tripId,
-        visibility: "crew",
+        visibility: "planning",
         text: `${input.nickname ?? input.name} was added to the trip`,
       });
 
@@ -252,6 +256,18 @@ export const ghostCrewRouter = router({
             });
           }
 
+          // Lifecycle: the ghost just resolved to a real account, which
+          // is the moment they "join" — post to Crew chat. Organizer
+          // chat already saw the original "added" event when the ghost
+          // was created.
+          const linkedDisplayName =
+            existingUser.nickname ?? existingUser.name ?? input.email;
+          await postSystemMessage({
+            tripId: ctx.tripId,
+            visibility: "crew",
+            text: `${linkedDisplayName} joined the trip`,
+          });
+
           return { ...existingUser, linked: true as const };
         }
       }
@@ -325,9 +341,13 @@ export const ghostCrewRouter = router({
         });
       }
 
+      // Ghosts don't have crew-chat access, so removing one is an
+      // organizer-only event. (A removed ghost who had previously
+      // resolved to a real account would have been handled by
+      // tripMembers.remove instead.)
       await postSystemMessage({
         tripId: ctx.tripId,
-        visibility: "crew",
+        visibility: "planning",
         text: `${displayName} was removed from the trip`,
       });
 

--- a/src/server/routers/ghostCrew.ts
+++ b/src/server/routers/ghostCrew.ts
@@ -69,8 +69,12 @@ export const ghostCrewRouter = router({
             });
           }
 
-          // Reuse the existing ghost user — just add them to this trip
+          // Reuse the existing ghost user — just add them to this trip.
+          // display_name override pins the typed/passed name to this
+          // trip so re-adding the same ghost elsewhere doesn't drag the
+          // first trip's display value back.
           const now = new Date().toISOString();
+          const displayLabel = input.nickname?.trim() ?? input.name.trim();
           const { error: memberError } = await ctx.supabase
             .from("trip_members")
             .insert({
@@ -83,6 +87,7 @@ export const ghostCrewRouter = router({
               ...(input.role === "Planner"
                 ? { planning_visible_from: now }
                 : {}),
+              ...(displayLabel ? { display_name: displayLabel } : {}),
             });
 
           if (memberError) {
@@ -128,8 +133,11 @@ export const ghostCrewRouter = router({
 
       // Insert trip_members row (guests are always "in"). Visibility
       // floor pins them at NOW so a later real-account link doesn't drag
-      // pre-existing chat history into their view.
+      // pre-existing chat history into their view. display_name override
+      // mirrors the new guest's chosen name so the row is editable
+      // per-trip via the expanded-row inline edit affordance.
       const ghostNow = new Date().toISOString();
+      const displayLabel = input.nickname?.trim() ?? input.name.trim();
       const { error: memberError } = await ctx.supabase
         .from("trip_members")
         .insert({
@@ -142,6 +150,7 @@ export const ghostCrewRouter = router({
           ...(input.role === "Planner"
             ? { planning_visible_from: ghostNow }
             : {}),
+          ...(displayLabel ? { display_name: displayLabel } : {}),
         });
 
       if (memberError) {

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -35,7 +35,7 @@ export async function listMembers(
   const { data, error } = await ctx.supabase
     .from("trip_members")
     .select(
-      "id, trip_id, user_id, role, status, joined_at, travel_mode, travel_detail, flight_airline, flight_number, flight_arrival_time, flight_airport, travel_shared, last_invited_at",
+      "id, trip_id, user_id, role, status, joined_at, travel_mode, travel_detail, flight_airline, flight_number, flight_arrival_time, flight_airport, travel_shared, last_invited_at, display_name",
     )
     .eq("trip_id", tripId)
     .order("joined_at", { ascending: true });
@@ -73,9 +73,18 @@ export async function listMembers(
     const user = m.user_id ? userMap.get(m.user_id) ?? null : null;
     const isGuest = user?.is_guest ?? false;
     const memberId = m.user_id as string;
-    const displayName = user
-      ? user.nickname ?? user.name ?? user.email ?? `User ${memberId.slice(0, 6)}`
-      : `Unknown ${memberId.slice(0, 6)}`;
+    // Display name resolution order (CC_MODAL_AUDIT.md Part 1.4):
+    //   1. trip_members.display_name — trip-local override
+    //   2. users.nickname            — preferred personal name
+    //   3. users.name                — full name
+    //   4. users.email               — fallback for users with no name
+    //   5. "Unknown <id-prefix>"     — never expected, defensive
+    const trimmedOverride = m.display_name?.trim();
+    const displayName =
+      trimmedOverride ||
+      (user
+        ? user.nickname ?? user.name ?? user.email ?? `User ${memberId.slice(0, 6)}`
+        : `Unknown ${memberId.slice(0, 6)}`);
 
     return { ...m, user, memberId, isGuest, displayName };
   });
@@ -339,7 +348,13 @@ export const tripMembersRouter = router({
         // Add to trip with status 'in'. Visibility floor pins them at
         // NOW so they don't see prior Crew chat history (and prior
         // Organizers chat if they're added as a Planner).
+        //
+        // Trip-local display_name override: write what the caller typed
+        // (if anything) so the typed value beats the linked account's
+        // global name. Spec 1.2 — display name typed by user is always
+        // preserved.
         const now = new Date().toISOString();
+        const trimmedTypedName = input.name?.trim();
         await ctx.supabase.from("trip_members").insert({
           trip_id: ctx.tripId,
           user_id: existing.id,
@@ -347,6 +362,7 @@ export const tripMembersRouter = router({
           status: "in",
           chat_visible_from: now,
           ...(input.role === "Planner" ? { planning_visible_from: now } : {}),
+          ...(trimmedTypedName ? { display_name: trimmedTypedName } : {}),
         });
 
         // Lifecycle system message to Crew. If they came in as a Planner
@@ -488,8 +504,11 @@ export const tripMembersRouter = router({
       }
 
       // Add to trip_members with status 'invited'. Visibility floor
-      // pins them at NOW for the same reason as Path A.
+      // pins them at NOW for the same reason as Path A. Display-name
+      // override carries the typed name so the crew list shows what
+      // the inviter wrote.
       const inviteNow = new Date().toISOString();
+      const trimmedTypedNameB = input.name?.trim();
       await ctx.supabase.from("trip_members").insert({
         trip_id: ctx.tripId,
         user_id: guestUserId,
@@ -499,6 +518,7 @@ export const tripMembersRouter = router({
         ...(input.role === "Planner"
           ? { planning_visible_from: inviteNow }
           : {}),
+        ...(trimmedTypedNameB ? { display_name: trimmedTypedNameB } : {}),
       });
 
       // Lifecycle system message — "invite sent" rather than "added"
@@ -758,6 +778,56 @@ export const tripMembersRouter = router({
         .eq("id", ctx.tripId);
 
       return { sent: sentIds.length };
+    }),
+
+  // -----------------------------------------------------------------------
+  // setDisplayName — sets the trip-local display_name override on a
+  // member row. Spec: CC_MODAL_AUDIT.md Part 1.4.
+  //
+  // Permissions:
+  //   - Anyone can edit their own row (own user_id, "I want to be called
+  //     X on this trip")
+  //   - canEdit (Owner/Planner) can edit anyone else's display name
+  // -----------------------------------------------------------------------
+  setDisplayName: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        userId: z.string(),
+        /** Pass null/empty to clear the override and fall back to global. */
+        displayName: z.string().max(100).nullable(),
+      })
+    )
+    .use(requireTripMember)
+    .mutation(async ({ ctx, input }) => {
+      const isSelf = input.userId === ctx.user!.id;
+      if (!isSelf) {
+        const role = ctx.membershipCache.get(ctx.tripId);
+        if (role !== "Owner" && role !== "Planner") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Only organizers can edit another member's display name.",
+          });
+        }
+      }
+
+      const normalized = input.displayName?.trim();
+      const value = normalized && normalized.length > 0 ? normalized : null;
+
+      const { error } = await ctx.supabase
+        .from("trip_members")
+        .update({ display_name: value })
+        .eq("trip_id", ctx.tripId)
+        .eq("user_id", input.userId);
+
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to update display name: ${error.message}`,
+        });
+      }
+
+      return { success: true, displayName: value };
     }),
 
   // -----------------------------------------------------------------------

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -158,13 +158,26 @@ export const tripMembersRouter = router({
         });
       }
 
-      // Lifecycle system message to Crew (and Organizers if Planner).
+      // Lifecycle system messages.
+      //   Crew chat → only when the member actually joins (status='in'),
+      //   wording is "joined the trip" (not "added"). Pending invitees
+      //   don't get a crew-chat post here — the invite-acceptance flow
+      //   posts that when they sign up.
+      //   Organizer chat → every add (regardless of status), plus a
+      //   separate "made an organizer" note when role=Planner.
       const displayName = await getDisplayName(ctx.supabase, input.userId);
       await postSystemMessage({
         tripId: ctx.tripId,
-        visibility: "crew",
+        visibility: "planning",
         text: `${displayName} was added to the trip`,
       });
+      if (input.status === "in") {
+        await postSystemMessage({
+          tripId: ctx.tripId,
+          visibility: "crew",
+          text: `${displayName} joined the trip`,
+        });
+      }
       if (input.role === "Planner") {
         await postSystemMessage({
           tripId: ctx.tripId,
@@ -269,6 +282,25 @@ export const tripMembersRouter = router({
       // on this trip when they were removed".
       const displayName = await getDisplayName(ctx.supabase, input.userId);
 
+      // Capture the member's pre-delete status + email-presence so we can
+      // decide whether the removal warrants a Crew-chat post. Removing a
+      // pending invitee (or a Just Name with no email) is an organizer-
+      // only concern; Crew chat only cares about people who actually had
+      // chat access.
+      const { data: outgoing } = await ctx.supabase
+        .from("trip_members")
+        .select("status")
+        .eq("trip_id", ctx.tripId)
+        .eq("user_id", input.userId)
+        .maybeSingle();
+      const { data: outgoingUser } = await ctx.supabase
+        .from("users")
+        .select("email")
+        .eq("id", input.userId)
+        .maybeSingle();
+      const hadChatAccess =
+        outgoing?.status === "in" && !!outgoingUser?.email;
+
       const { error } = await ctx.supabase
         .from("trip_members")
         .delete()
@@ -282,12 +314,45 @@ export const tripMembersRouter = router({
         });
       }
 
+      // Organizer chat sees every removal regardless of status.
+      await postSystemMessage({
+        tripId: ctx.tripId,
+        visibility: "planning",
+        text: `${displayName} was removed from the trip`,
+      });
+      // Crew chat only sees removals of members who actually had access
+      // to the crew chat (status='in' AND had an email/account).
+      if (hadChatAccess) {
+        await postSystemMessage({
+          tripId: ctx.tripId,
+          visibility: "crew",
+          text: `${displayName} was removed from the trip`,
+        });
+      }
+
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
+  // notifyInviteAccepted — fired by the invite-acceptance flow once the
+  // signed-up user has been linked into trip_members with status='in'.
+  // Posts the "X joined the trip" lifecycle message to Crew chat so the
+  // rest of the crew sees the new arrival.
+  //
+  // Self-call only: the caller must be the user whose invite was just
+  // accepted, and they must already be a member of the trip. We don't
+  // re-validate the invite token here — that lives in the invite page.
+  // -----------------------------------------------------------------------
+  notifyInviteAccepted: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripMember)
+    .mutation(async ({ ctx }) => {
+      const displayName = await getDisplayName(ctx.supabase, ctx.user!.id);
       await postSystemMessage({
         tripId: ctx.tripId,
         visibility: "crew",
-        text: `${displayName} was removed from the trip`,
+        text: `${displayName} joined the trip`,
       });
-
       return { success: true };
     }),
 
@@ -366,14 +431,22 @@ export const tripMembersRouter = router({
           ...(trimmedTypedName ? { display_name: trimmedTypedName } : {}),
         });
 
-        // Lifecycle system message to Crew. If they came in as a Planner
-        // we also post a corresponding "made an organizer" to Organizers.
+        // Lifecycle system messages.
+        //   Crew chat → status='in' on this path (they have a real
+        //   account so they joined immediately), wording is "joined".
+        //   Organizer chat → "added" regardless, plus "made an organizer"
+        //   when role=Planner.
         const memberDisplayName =
           existing.nickname ?? existing.name ?? email.split("@")[0];
         await postSystemMessage({
           tripId: ctx.tripId,
-          visibility: "crew",
+          visibility: "planning",
           text: `${memberDisplayName} was added to the trip`,
+        });
+        await postSystemMessage({
+          tripId: ctx.tripId,
+          visibility: "crew",
+          text: `${memberDisplayName} joined the trip`,
         });
         if (input.role === "Planner") {
           await postSystemMessage({
@@ -522,11 +595,11 @@ export const tripMembersRouter = router({
         ...(trimmedTypedNameB ? { display_name: trimmedTypedNameB } : {}),
       });
 
-      // Lifecycle system message — "invite sent" rather than "added"
-      // because the invitee hasn't accepted yet. Caller-supplied name
-      // wins for the new-guest case so the system message matches the
-      // typed display name; otherwise fall through to existing user's
-      // name / email stem.
+      // Lifecycle system message — Organizer chat only. The invitee
+      // hasn't accepted yet so they have no access to crew chat, and
+      // crew chat shouldn't surface invite traffic. A "joined" message
+      // will land in crew chat once they accept (see
+      // tripMembers.notifyInviteAccepted).
       const inviteeName =
         input.name?.trim() ??
         existing?.nickname ??
@@ -534,8 +607,8 @@ export const tripMembersRouter = router({
         email.split("@")[0];
       await postSystemMessage({
         tripId: ctx.tripId,
-        visibility: "crew",
-        text: `An invite was sent to ${inviteeName}`,
+        visibility: "planning",
+        text: `${inviteeName} was invited to the trip`,
       });
 
       // Send invite email (best effort)

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -589,6 +589,10 @@ export const tripMembersRouter = router({
         role: input.role,
         status: "invited",
         chat_visible_from: inviteNow,
+        // Stamp the first invite send so the crew tab's expanded
+        // panel can show "Invited on Mon DD" right away — without this
+        // last_invited_at stays NULL until the organizer hits Resend.
+        last_invited_at: inviteNow,
         ...(input.role === "Planner"
           ? { planning_visible_from: inviteNow }
           : {}),

--- a/src/server/routers/tripMembers.ts
+++ b/src/server/routers/tripMembers.ts
@@ -54,7 +54,7 @@ export async function listMembers(
     userIds.length > 0
       ? await ctx.supabase
           .from("users")
-          .select("id, name, nickname, email, is_guest, avatar_url")
+          .select("id, name, nickname, email, is_guest, avatar_url, avatar_icon")
           .in("id", userIds)
       : {
           data: [] as {
@@ -64,6 +64,7 @@ export async function listMembers(
             email: string | null;
             is_guest: boolean;
             avatar_url: string | null;
+            avatar_icon: string | null;
           }[],
         };
 

--- a/supabase/migrations/20260521094916_006_trip_member_display_name.sql
+++ b/supabase/migrations/20260521094916_006_trip_member_display_name.sql
@@ -1,0 +1,22 @@
+-- Migration 006 — trip-local display name override
+-- Spec: CC_MODAL_AUDIT.md Part 1.4
+--
+-- Adds `trip_members.display_name` so each trip can have its own per-member
+-- display label without touching the user's global `users.name` /
+-- `users.nickname` fields. The crew roster, schedule, scoring, and expenses
+-- all read displayName via listMembers() which now prefers this override.
+--
+-- NULL = use the existing global fallback chain
+--   (users.nickname → users.name → email-stem → "Unknown <id>").
+--
+-- The override is set:
+--   - on tripMembers.inviteByEmail when caller passes `name` (Path A
+--     account-add + Path B guest-create both write it)
+--   - on ghostCrew.create when caller passes `name`
+--   - via the new tripMembers.setDisplayName mutation (user-driven edits
+--     from the expanded crew row).
+ALTER TABLE trip_members
+  ADD COLUMN IF NOT EXISTS display_name text;
+
+COMMENT ON COLUMN trip_members.display_name IS
+  'Trip-local display name override. NULL = fall through to users.nickname / users.name. Set by Add Crew Member modal + the expanded-row inline-edit affordance.';


### PR DESCRIPTION
Stacked on top of #266 (`feature/crew-overhaul`). Implements `CC_MODAL_AUDIT.md` end-to-end.

## What's in here

### Part 1 — Add Crew Member form fixes + trip-local display name override (`e2ecf26`, `273ece5`)

**Migration 006** adds `trip_members.display_name` — a per-trip display label that wins over the global `users.nickname` / `users.name` fallback chain. Applied to live DB via Supabase MCP.

**Backend wiring**:
- `listMembers` resolves `displayName` via override → nickname → name → email-stem
- `tripMembers.inviteByEmail` writes `display_name` on both Path A (existing account) and Path B (guest + invite). Fixes the bug where adding `jason@…` (Jason's account) under the typed name "Bob" surfaced "Jason Miller" in the roster
- `ghostCrew.create` (both branches) writes `display_name` so the typed name pins to the trip even if the same ghost is reused
- New `tripMembers.setDisplayName` mutation: self-edit OR canEdit (Owner/Planner)

**AddCrewMemberSheet** (Parts 1.1 / 1.2 / 1.3):
- "Name" → "Display Name". Removed the `*` indicator
- Helper text: "Enter a name, an email, or both."
- Either-field validation — both empty disables submit; invalid email format inline-errors
- Lookup is purely informational. When an account is found and the user hasn't typed a display name, the field's `placeholder` attribute surfaces the account name (greyed/italic by default, instantly replaced when they type). It NEVER writes into the field's value
- Already canonical modal structure (header/body/footer)

### Part 1.4 — Inline Display Name edit on every expanded crew row (`82d3122`)

Every expanded row in CrewTab now opens with an editable Display Name field at the top — owner, organizer, joined, invited, just-name. Saves on blur or Enter; brief teal checkmark confirms; optimistic cache update so every downstream surface (schedule, scoring, expenses) re-renders with the new label immediately.

Empty value clears the override (NULL) and the row falls back to the global chain.

### Part 4 — CrewTab max-w-[640px] constraint (`82d3122`)

Wraps the entire crew list (nudge + sections + email modal trigger) in a `max-w-[640px]` left-aligned container so wide viewports don't stretch the rows into long flat bars. Only CrewTab is constrained.

### Part 2 — Modal audit + canonical pattern (`e46c1c7`)

Five modals brought into line with the canonical structure from Part 2.1: **header (px-5 py-4, border-bottom, title + X) / body (px-5 py-4, overflow-y-auto) / footer (px-5 py-4, border-top, right-aligned actions with gap-3, Medium button size)**.

| Modal | Changes |
|---|---|
| `AddExpenseModal` | Restructured to header/body/footer, added border dividers, canonical X close, right-aligned footer, button variant + sizing fixes |
| `EditExpenseModal` | Same treatment — matches AddExpenseModal |
| `TripSummaryModal` | Added canonical X close, restructured to 3-region split, right-aligned footer (Ghost + Primary), replaced hardcoded `rgba(217,119,6,0.1)` warning bg with `var(--color-bt-warning-faint)` |
| `TripInvitationModal` | Added canonical X close, 3-region split, footer becomes `justify-between` with Reset pinned left + Cancel/Save right |
| `AddPropertySheet` | Added canonical X close (absolute top-right); container gains border + `var(--shadow-floating)` for parity |

**Already canonical, left untouched**: `AddCrewMemberSheet` (just rebuilt), `DatesSheet`, `ConfirmDatesModal`, and the three hero `IntroModals` (Itinerary / GettingThere / QuickInfo — Part 2.1 allows the "no footer variant" for single-outcome informational dialogs; hero gradient is intentional product design).

**Hardcoded color cleanup** flagged in `STYLE_GUIDE.md` Section 7:
- All `#fff` / `#ffffff` on token-driven button backgrounds → `white` keyword across 6 files. Visual identical; literal hex is gone

### Part 3 — STYLE_GUIDE.md (`7a706b3`)

New `### Modal / Dialog` subsection in Section 4 documenting the canonical pattern, all token references, the bottom-sheet variant, the "no footer" carve-out, and the `white`-vs-`#fff` discipline rule.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 349 / 349 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)