### PR TITLE
Lodging: tile cards + URL → og:image auto-fill + smarter nudge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,24 @@ These patterns have been established through prior work. Follow them exactly —
 5. **Middleware auth** — `requireAuth` before any `requireTripMember`/`requireTripRole`
 6. **Test isolation** — 4 shared persistent users (`test-owner`, `test-planner`, `test-member`, `test-outsider`), unique trips per test
 
+## Migration Workflow
+
+Migrations are committed as files in `supabase/migrations/` and applied to the remote DB by CI's `supabase db push` step. The CLI compares the `supabase_migrations.schema_migrations` history table against local filenames and **fails when they don't match exactly**.
+
+**Don't apply migrations directly via the Supabase MCP tool** (`apply_migration`, raw `execute_sql` for DDL). It records the migration under the *apply timestamp*, which always differs from the local filename timestamp — guaranteeing the next CI push fails with "Remote migration versions not found in local migrations directory."
+
+**The right flow:**
+
+1. Write the migration file locally (`supabase/migrations/YYYYMMDDHHMMSS_NNN_name.sql`).
+2. Apply via the linked CLI so the recorded version matches the filename:
+   ```bash
+   supabase db push --linked   # applies any new local migrations to remote
+   ```
+   (Or commit and let CI apply it. Either is fine — both preserve the filename timestamp.)
+3. Never edit a migration after it's been applied anywhere — write a new one.
+
+**If you already applied via MCP** and CI complains about an unknown remote version, fix it by deleting the apply-timestamped row from `supabase_migrations.schema_migrations` (history table only — the schema change itself stays in place because migrations are idempotent: `ADD COLUMN IF NOT EXISTS`, `DROP POLICY IF EXISTS` + `CREATE POLICY`, etc.). CI's next push then sees the local file as new and re-applies it as a no-op.
+
 ## What "Done" Means for Any Task
 
 1. Feature implemented

--- a/src/app/api/lodging-meta/route.ts
+++ b/src/app/api/lodging-meta/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * POST /api/lodging-meta — fetch a listing URL and extract OpenGraph
+ * metadata (title, description, image) for the Add Property modal.
+ *
+ * Why server-side: VRBO / Airbnb pages block client-side fetches via
+ * CORS, and shipping a parsing library to the browser is overkill for
+ * a simple meta tag pluck. We fetch with a realistic User-Agent so the
+ * host returns the public HTML, then regex out a handful of og:* tags.
+ *
+ * Best-effort: any failure (network, non-2xx, no tags found) returns
+ * `{ ok: false, reason }`. The client treats that as "user fills the
+ * form by hand" and doesn't surface the error loudly.
+ */
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const url = typeof body?.url === "string" ? body.url.trim() : "";
+
+  // Cheap validation — bail before opening a socket on garbage input.
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return NextResponse.json({ ok: false, reason: "invalid_url" }, { status: 400 });
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return NextResponse.json({ ok: false, reason: "invalid_protocol" }, { status: 400 });
+  }
+
+  // SSRF guard — the caller controls the URL, so refuse anything that
+  // could point at our own infrastructure (loopback, private RFC-1918,
+  // link-local, IPv6 loopback / unique-local). Edge runtime has no DNS
+  // module so this is a hostname-string check only; good enough to
+  // block the obvious cases (localhost, 127.x, 10.x, 192.168.x, etc.)
+  // — DNS rebinding is a separate concern we punt on.
+  const host = parsed.hostname.toLowerCase();
+  const blockedHost =
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    host.endsWith(".internal") ||
+    /^127\./.test(host) ||
+    /^0\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    host === "::1" ||
+    host.startsWith("fe80:") ||
+    host.startsWith("fc") ||
+    host.startsWith("fd");
+  if (blockedHost) {
+    return NextResponse.json({ ok: false, reason: "blocked_host" }, { status: 400 });
+  }
+
+  // Hard cap the fetch so a slow / hung host can't pin a route handler
+  // open. 6s is generous for og-tag pluck; if a host is slower than
+  // that the user will fill the form anyway.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 6000);
+
+  let html: string;
+  try {
+    const res = await fetch(parsed.toString(), {
+      method: "GET",
+      headers: {
+        // Many travel sites (VRBO especially) return a stripped page or
+        // a captcha to obvious bots. A modern desktop UA gets the same
+        // HTML a real visitor sees, including <meta property="og:*">.
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      return NextResponse.json(
+        { ok: false, reason: `http_${res.status}` },
+        { status: 200 }
+      );
+    }
+    // Only read the first ~256KB — og tags live in <head>, anything
+    // past that is page body we'd discard anyway. Caps memory if a
+    // host returns a megabytes-long HTML doc.
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json({ ok: false, reason: "no_body" }, { status: 200 });
+    }
+    const chunks: Uint8Array[] = [];
+    let bytes = 0;
+    const cap = 256 * 1024;
+    while (bytes < cap) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      bytes += value.byteLength;
+    }
+    reader.cancel().catch(() => {});
+    html = new TextDecoder("utf-8").decode(
+      chunks.reduce((acc, c) => {
+        const combined = new Uint8Array(acc.length + c.length);
+        combined.set(acc, 0);
+        combined.set(c, acc.length);
+        return combined;
+      }, new Uint8Array())
+    );
+  } catch (err) {
+    clearTimeout(timer);
+    const reason =
+      err instanceof Error && err.name === "AbortError" ? "timeout" : "fetch_error";
+    return NextResponse.json({ ok: false, reason }, { status: 200 });
+  }
+  clearTimeout(timer);
+
+  // ── Tag pluck. ────────────────────────────────────────────────────
+  //
+  // We deliberately don't pull in a full HTML parser; the og:* tags we
+  // need follow a tight enough pattern that regex is faster + lighter.
+  // Strategy:
+  //   1. og:* — preferred (explicit, what publishers maintain)
+  //   2. <meta name="twitter:..."> — common fallback
+  //   3. <title>...</title> — last-resort name source
+  const ogTag = (prop: string) => {
+    // Match either property=".." content=".." or content=".." property=".."
+    const a = new RegExp(
+      `<meta[^>]+(?:property|name)=["']${prop}["'][^>]+content=["']([^"']+)["']`,
+      "i"
+    );
+    const b = new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']${prop}["']`,
+      "i"
+    );
+    return html.match(a)?.[1] ?? html.match(b)?.[1] ?? null;
+  };
+
+  const title =
+    ogTag("og:title") ??
+    ogTag("twitter:title") ??
+    html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim() ??
+    null;
+
+  const description =
+    ogTag("og:description") ??
+    ogTag("twitter:description") ??
+    ogTag("description") ??
+    null;
+
+  // og:image can be either a property or itemprop tag; prefer the
+  // explicit og:image and ignore obvious placeholders (1x1 trackers,
+  // sprite sheets, etc. — rough check on filename).
+  let image = ogTag("og:image") ?? ogTag("twitter:image") ?? null;
+  if (image && /\.(svg|gif)(\?|$)/i.test(image)) image = null;
+
+  // siteName helps the client pick a nice "this looks like a VRBO link"
+  // label even when og:title is generic ("Vacation Rental").
+  const siteName = ogTag("og:site_name") ?? null;
+
+  // HTML-entity decode the bits we hand back — og:title often contains
+  // &amp; / &#x27; / &quot; literals that read as garbage in an input.
+  const decode = (s: string | null) =>
+    s
+      ? s
+          .replace(/&amp;/g, "&")
+          .replace(/&#39;|&apos;|&#x27;/gi, "'")
+          .replace(/&quot;/g, '"')
+          .replace(/&lt;/g, "<")
+          .replace(/&gt;/g, ">")
+      : s;
+
+  return NextResponse.json({
+    ok: true,
+    title: decode(title),
+    description: decode(description),
+    image,
+    siteName: decode(siteName),
+  });
+}

--- a/src/app/trips/[tripId]/components/AddPropertySheet.tsx
+++ b/src/app/trips/[tripId]/components/AddPropertySheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { Globe, Link, MapPin } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { Globe, Hotel, Link, MapPin } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 
 // ── Platform detection (exported so parents can use it) ───────────────────
@@ -58,6 +58,8 @@ export interface PropertyFormValues {
   checkOut: string;  // planning only — YYYY-MM-DD
   checkInTimeOfDay: string;  // planning only — HH:MM, optional
   checkOutTimeOfDay: string; // planning only — HH:MM, optional
+  /** og:image fetched from /api/lodging-meta when the URL is pasted. */
+  imageUrl: string;
 }
 
 // ── Props ─────────────────────────────────────────────────────────────────
@@ -122,7 +124,21 @@ function Field({
 
 // ── Link preview card ─────────────────────────────────────────────────────
 
-function LinkPreviewCard({ url, name }: { url: string; name: string }) {
+function LinkPreviewCard({
+  url,
+  name,
+  imageUrl,
+  loading,
+}: {
+  url: string;
+  name: string;
+  /** og:image fetched from /api/lodging-meta. Renders as the preview
+   *  photo strip when present; falls back to the placeholder gradient
+   *  while loading or when the host doesn't expose an og:image. */
+  imageUrl?: string | null;
+  /** True while /api/lodging-meta is in flight for this URL. */
+  loading?: boolean;
+}) {
   const platform = detectPlatform(url);
   const domain = extractDomain(url);
   const label = PLATFORM_LABEL[platform];
@@ -132,6 +148,45 @@ function LinkPreviewCard({ url, name }: { url: string; name: string }) {
       className="overflow-hidden rounded-xl"
       style={{ border: "1px solid var(--color-bt-accent-border)" }}
     >
+      {/* Photo strip — real listing image if fetched, placeholder
+          gradient + generic-property icon otherwise. Matches the
+          LodgingCard photo strip so the preview reads like what the
+          saved card will look like (no blank panel). */}
+      <div
+        className="relative h-32 w-full"
+        style={{
+          backgroundImage: imageUrl
+            ? `url("${imageUrl}")`
+            : "linear-gradient(135deg, #0d2c3a 0%, #0d3a4f 100%)",
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      >
+        {!imageUrl && !loading && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
+            <Hotel size={44} strokeWidth={1.5} style={{ color: "rgba(255,255,255,0.22)" }} />
+          </div>
+        )}
+        {loading && !imageUrl && (
+          <div
+            className="absolute inset-0 flex items-center justify-center text-[11px] font-medium"
+            style={{ color: "#e2e8f0" }}
+          >
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1"
+              style={{ background: "rgba(0,0,0,0.45)" }}
+            >
+              <span
+                className="inline-block h-2 w-2 animate-pulse rounded-full"
+                style={{ background: "var(--color-bt-accent)" }}
+                aria-hidden
+              />
+              Fetching listing…
+            </span>
+          </div>
+        )}
+      </div>
+
       <div
         className="flex items-center gap-1.5 px-3 py-2"
         style={{ background: "var(--color-bt-tag-bg)" }}
@@ -152,7 +207,9 @@ function LinkPreviewCard({ url, name }: { url: string; name: string }) {
           <p className="text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>{name}</p>
         ) : (
           <p className="text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
-            Add a nickname in the fields below
+            {loading
+              ? "Pulling the title from the listing…"
+              : "Add a nickname in the fields below"}
           </p>
         )}
         <p className="mt-0.5 truncate text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -185,9 +242,76 @@ export function AddPropertySheet({
   const [checkOut, setCheckOut] = useState(initialValues.checkOut ?? "");
   const [checkInTimeOfDay, setCheckInTimeOfDay] = useState(initialValues.checkInTimeOfDay ?? "");
   const [checkOutTimeOfDay, setCheckOutTimeOfDay] = useState(initialValues.checkOutTimeOfDay ?? "");
+  const [imageUrl, setImageUrl] = useState(initialValues.imageUrl ?? "");
 
   // Manual mode — expand the form without requiring a valid URL
   const [manualMode, setManualMode] = useState(isEditing && !(initialValues.url ?? ""));
+
+  // ── Listing-metadata fetch (Task 68) ──────────────────────────────
+  //
+  // When the URL turns into a valid http(s) URL, fire /api/lodging-meta
+  // to pull og:title / og:image / og:description from the listing.
+  // Pre-fills `name` (empty fields only — never overwrite something the
+  // user typed) and `imageUrl` so the LodgingCard renders the real
+  // photo instead of the placeholder gradient.
+  //
+  // Debounced (500ms) so each keystroke doesn't kick off a fetch. The
+  // fetch itself bails fast on a non-success response — surfacing
+  // failures inline would be more noise than signal, the user can
+  // always type the fields by hand.
+  const [metaLoading, setMetaLoading] = useState(false);
+  const [metaFetchedFor, setMetaFetchedFor] = useState<string | null>(null);
+  const metaTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    const trimmed = url.trim();
+    if (metaTimer.current) clearTimeout(metaTimer.current);
+    if (!isValidUrl(trimmed) || trimmed === metaFetchedFor) return;
+
+    metaTimer.current = setTimeout(async () => {
+      setMetaLoading(true);
+      try {
+        const res = await fetch("/api/lodging-meta", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url: trimmed }),
+        });
+        const data: {
+          ok: boolean;
+          title?: string | null;
+          description?: string | null;
+          image?: string | null;
+        } = await res.json();
+        if (data.ok) {
+          // Only fill empty fields — preserve anything the user typed.
+          if (data.title && !name.trim()) setName(data.title);
+          if (data.description && !notes.trim()) {
+            // Trim to ~240 chars; full og:description is often a long
+            // marketing blurb the user wouldn't paste themselves.
+            const trimmedDesc =
+              data.description.length > 240
+                ? data.description.slice(0, 237).trimEnd() + "…"
+                : data.description;
+            setNotes(trimmedDesc);
+          }
+          if (data.image && !imageUrl) setImageUrl(data.image);
+        }
+        setMetaFetchedFor(trimmed);
+      } catch {
+        // Best-effort — silent failure, user fills the form manually.
+      } finally {
+        setMetaLoading(false);
+      }
+    }, 500);
+
+    return () => {
+      if (metaTimer.current) clearTimeout(metaTimer.current);
+    };
+    // We intentionally don't depend on name/notes/imageUrl — those
+    // can be set by this very effect, which would re-trigger. The
+    // metaFetchedFor guard handles "URL hasn't changed, skip."
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, metaFetchedFor]);
 
   // Address autocomplete
   const [addressDropdown, setAddressDropdown] = useState<PlacePrediction[]>([]);
@@ -237,7 +361,19 @@ export function AddPropertySheet({
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    onSubmit({ url, name, sleeps, price, notes, address, checkIn, checkOut, checkInTimeOfDay, checkOutTimeOfDay });
+    onSubmit({
+      url,
+      name,
+      sleeps,
+      price,
+      notes,
+      address,
+      checkIn,
+      checkOut,
+      checkInTimeOfDay,
+      checkOutTimeOfDay,
+      imageUrl,
+    });
   };
 
   return (
@@ -343,7 +479,7 @@ export function AddPropertySheet({
             <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
               Preview
             </p>
-            <LinkPreviewCard url={url} name={name} />
+            <LinkPreviewCard url={url} name={name} imageUrl={imageUrl} loading={metaLoading} />
           </div>
         )}
 

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -62,6 +62,10 @@ interface LodgingItemFull {
   total_price?: string | null;
   notes?: string | null;
   is_confirmed?: boolean | null;
+  /** og:image fetched from the listing URL (or empty when unavailable).
+   *  When set, surfaces as the LodgingCard photo strip instead of the
+   *  placeholder gradient. */
+  image_url?: string | null;
 }
 
 // ── LodgingCard ───────────────────────────────────────────────────────────
@@ -101,126 +105,168 @@ function LodgingCard({
 
   return (
     <div
-      className="flex items-start gap-2 rounded-xl px-4 py-3 transition-all"
+      className="flex flex-col gap-2 rounded-xl p-3 transition-all"
       style={{
         background: confirmed ? "var(--color-bt-tag-bg)" : "var(--color-bt-card)",
         border: `1px solid ${confirmed ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
       }}
     >
-      {/* Content */}
-      <div className="min-w-0 flex-1">
-        {/* Line 1: Name · sleeps · price */}
-        <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
-          <span className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
-            {name}
-          </span>
-          {item.property_name && (
-            <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-              · Sleeps {item.property_name}
-            </span>
-          )}
-          {price && (
-            <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-              · {price}
-            </span>
-          )}
-        </div>
-
-        {/* Line 2: Thoughts/notes */}
-        {item.notes && (
-          <p className="mt-0.5 text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
-            {item.notes}
-          </p>
+      {/* Photo strip — real listing photo (og:image) when we have one,
+          placeholder gradient otherwise. Mirrors PropertyExample so the
+          populated tiles match the empty-state preview promised.
+          Carries the Confirmed pill / Confirm button bottom-right and
+          the edit/delete actions top-right when canEdit. Gradient hex
+          literals are spec-explicit (HANDOFF rule 4 exception). */}
+      <div
+        className="relative flex items-end justify-end rounded-lg p-2"
+        style={{
+          height: 80,
+          backgroundImage: item.image_url
+            ? `url("${item.image_url}")`
+            : "linear-gradient(135deg, #0d2c3a 0%, #0d3a4f 100%)",
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      >
+        {/* Generic-property placeholder icon — centered, low opacity.
+            Shows only when we don't have a real listing photo, so the
+            tile never reads as a blank panel waiting to load. */}
+        {!item.image_url && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
+            <Hotel size={36} strokeWidth={1.5} style={{ color: "rgba(255,255,255,0.22)" }} />
+          </div>
         )}
 
-        {/* Line 3: Address → Map */}
-        {item.address && (
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-            <span>{item.address}</span>
-            <a
-              href={mapsUrl(item.address)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-0.5"
-              style={{ color: "var(--color-bt-accent)" }}
-              onClick={(e) => e.stopPropagation()}
+        {/* Edit / delete — top-right overlay on the photo strip */}
+        {canEdit && (
+          <div className="absolute right-1.5 top-1.5 flex items-center gap-1">
+            <button
+              onClick={onEdit}
+              aria-label="Edit property"
+              className="flex h-6 w-6 items-center justify-center rounded transition-colors hover:bg-black/30"
+              style={{ background: "rgba(0,0,0,0.35)", color: "#e2e8f0" }}
             >
-              <MapPin size={10} />
-              Map
-            </a>
+              <Pencil size={12} strokeWidth={2.25} />
+            </button>
+            <button
+              onClick={onRemove}
+              disabled={removing}
+              aria-label="Remove property"
+              className="flex h-6 w-6 items-center justify-center rounded transition-colors hover:bg-black/30 disabled:opacity-40"
+              style={{ background: "rgba(0,0,0,0.35)", color: "#e2e8f0" }}
+            >
+              <Trash2 size={12} strokeWidth={2.25} />
+            </button>
           </div>
         )}
 
-        {/* Line 4: Check-in / check-out */}
-        {dateRange && (
-          <div className="mt-1 flex items-center gap-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-            <Clock size={10} />
-            {dateRange}
-          </div>
-        )}
-
+        {/* Confirmed / Confirm — bottom-right matches PropertyExample */}
+        {confirmed ? (
+          <button
+            onClick={onConfirmToggle}
+            disabled={!canEdit}
+            aria-label={canEdit ? "Mark as not confirmed" : undefined}
+            className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em] transition-opacity hover:opacity-85 disabled:cursor-default"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-on-accent)",
+            }}
+          >
+            <Check size={9} strokeWidth={3.5} />
+            Confirmed
+          </button>
+        ) : canEdit ? (
+          <button
+            onClick={onConfirmToggle}
+            className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em] transition-opacity hover:opacity-85"
+            style={{
+              background: "rgba(0,0,0,0.45)",
+              color: "#e2e8f0",
+              border: "1px solid rgba(255,255,255,0.18)",
+            }}
+          >
+            Confirm
+          </button>
+        ) : null}
       </div>
 
-      {/* Right column: actions (top) + listing link (bottom) */}
-      <div className="flex flex-shrink-0 flex-col items-end justify-between gap-2 self-stretch">
-        <div className="flex items-center gap-1">
-          {canEdit && (
-            confirmed ? (
-              <button
-                onClick={onConfirmToggle}
-                aria-label="Mark as not confirmed"
-                className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.08em] transition-opacity hover:opacity-80"
-                style={{
-                  background: "var(--color-bt-accent)",
-                  color: "var(--color-bt-on-accent)",
-                }}
-              >
-                <Check size={11} strokeWidth={3} />
-                Confirmed
-              </button>
-            ) : (
-              <button
-                onClick={onConfirmToggle}
-                className="rounded-lg px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                Confirm
-              </button>
-            )
-          )}
-          {canEdit && (
-            <>
-              <button
-                onClick={onEdit}
-                className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded"
-                aria-label="Edit property"
-              >
-                <Pencil size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-              </button>
-              <button
-                onClick={onRemove}
-                disabled={removing}
-                className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded disabled:opacity-40"
-                aria-label="Remove property"
-              >
-                <Trash2 size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-              </button>
-            </>
-          )}
+      {/* Name + monospace meta line — same hierarchy as PropertyExample */}
+      <div className="flex flex-col gap-0.5">
+        <div
+          className="truncate text-sm font-semibold"
+          style={{ color: "var(--color-bt-text)" }}
+          title={name}
+        >
+          {name}
         </div>
-        {url && (
+        <div
+          className="font-mono text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {[
+            price ? price : null,
+            item.property_name ? `sleeps ${item.property_name}` : null,
+          ]
+            .filter(Boolean)
+            .join(" · ") || "—"}
+        </div>
+      </div>
+
+      {/* Notes — italic, smaller */}
+      {item.notes && (
+        <p
+          className="m-0 line-clamp-2 text-[11px] italic leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {item.notes}
+        </p>
+      )}
+
+      {/* Address + Map link */}
+      {item.address && (
+        <div
+          className="flex flex-wrap items-center gap-1.5 text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <span className="truncate" title={item.address}>{item.address}</span>
           <a
-            href={url}
+            href={mapsUrl(item.address)}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-0.5 no-underline"
+            className="inline-flex items-center gap-0.5"
             style={{ color: "var(--color-bt-accent)" }}
+            onClick={(e) => e.stopPropagation()}
           >
-            <ExternalLink size={10} />
-            <span className="text-[11px] font-medium">→ {platform.label}</span>
+            <MapPin size={10} />
+            Map
           </a>
-        )}
-      </div>
+        </div>
+      )}
+
+      {/* Date range */}
+      {dateRange && (
+        <div
+          className="inline-flex items-center gap-1 text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <Clock size={10} />
+          {dateRange}
+        </div>
+      )}
+
+      {/* Listing link — anchored to the tile's bottom row */}
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-auto inline-flex items-center gap-0.5 self-start pt-1 no-underline"
+          style={{ color: "var(--color-bt-accent)" }}
+        >
+          <ExternalLink size={10} />
+          <span className="text-[11px] font-medium">→ {platform.label}</span>
+        </a>
+      )}
     </div>
   );
 }
@@ -247,15 +293,20 @@ function PropertyExample() {
         border: "1px solid var(--color-bt-accent-border)",
       }}
     >
-      {/* Photo placeholder — fixed-height gradient strip. Hex literals
-          are spec-explicit gradient stops (HANDOFF rule 4 exception). */}
+      {/* Photo placeholder — gradient strip + centered generic-property
+          icon so the preview never looks like a missing photo. Hex
+          literals are spec-explicit gradient stops (HANDOFF rule 4
+          exception). */}
       <div
-        className="flex items-end justify-end rounded-lg p-2"
+        className="relative flex items-end justify-end rounded-lg p-2"
         style={{
           height: 80,
           backgroundImage: "linear-gradient(135deg, #0d2c3a 0%, #0d3a4f 100%)",
         }}
       >
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
+          <Hotel size={32} strokeWidth={1.5} style={{ color: "rgba(255,255,255,0.22)" }} />
+        </div>
         <span
           className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em]"
           style={{
@@ -428,6 +479,7 @@ export function LodgingPanel({
       checkInTimeOfDay: values.checkInTimeOfDay || undefined,
       checkOutTimeOfDay: values.checkOutTimeOfDay || undefined,
       transportType: platform,
+      imageUrl: values.imageUrl || undefined,
     });
   };
 
@@ -449,6 +501,7 @@ export function LodgingPanel({
       checkInTimeOfDay: values.checkInTimeOfDay || null,
       checkOutTimeOfDay: values.checkOutTimeOfDay || null,
       transportType: platform,
+      imageUrl: values.imageUrl || null,
     });
   };
 
@@ -511,13 +564,17 @@ export function LodgingPanel({
             </div>
           </div>
         )}
-        {/* Unconfirmed-properties nudge — pairs with the info dot
-            (lodgingUnconfirmed in page.tsx). Suppressed when the
-            warning nudge above is showing so we don't stack two cards
-            for the same tab. */}
+        {/* Unconfirmed-properties nudge — only fires when nothing has
+            been confirmed yet (Task 70). Once at least one property is
+            locked in, the rest can sit unconfirmed as "considered but
+            not booked" without nagging. Also suppressed when the
+            warning nudge above is showing so two cards don't stack on
+            the same tab. Pairs with lodgingUnconfirmed in page.tsx,
+            which uses the same `confirmedCount === 0` test for the
+            info dot. */}
         {canEdit &&
           outOfRangeCount === 0 &&
-          confirmedCount < totalCount &&
+          confirmedCount === 0 &&
           totalCount > 0 && (
             <div
               className="mb-4 flex items-center gap-3 rounded-xl px-4 py-3"
@@ -540,8 +597,8 @@ export function LodgingPanel({
                   className="text-[13px] font-semibold leading-tight"
                   style={{ color: "var(--color-bt-text)" }}
                 >
-                  {totalCount - confirmedCount}{" "}
-                  {totalCount - confirmedCount === 1 ? "property is" : "properties are"} still
+                  {totalCount}{" "}
+                  {totalCount === 1 ? "property is" : "properties are"} still
                   being considered
                 </p>
                 <p
@@ -688,7 +745,15 @@ export function LodgingPanel({
               />
             )
           ) : (
-            <div className="flex flex-col gap-2">
+            // Tile grid (Task 67) — properties stack horizontally as
+            // feature-rich cards instead of full-width rows, matching
+            // the PropertyExample preview. Breakpoints:
+            //   <500px (phone)  : single column
+            //   500-799px       : two-column grid
+            //   ≥800px          : three-column grid
+            // Items shrink to fit; the gradient strip + meta + actions
+            // stay readable down to ~220px tile widths.
+            <div className="grid gap-3 min-[500px]:grid-cols-2 min-[800px]:grid-cols-3">
               {lodgingItems.map((item) => (
                 <LodgingCard
                   key={item.id}
@@ -739,6 +804,7 @@ export function LodgingPanel({
               checkOut: editingItem.check_out_time ?? "",
               checkInTimeOfDay: editingItem.check_in_time_of_day ?? "",
               checkOutTimeOfDay: editingItem.check_out_time_of_day ?? "",
+              imageUrl: editingItem.image_url ?? "",
             }}
             isPending={updateItem.isPending}
             onSubmit={handleUpdate}
@@ -827,24 +893,29 @@ export function LodgingPanel({
         onToggle={onToggle}
         noExpand={true}
       >
-        <div className="flex flex-col gap-2">
-          {lodgingItems.map((item) => (
-            <LodgingCard
-              key={item.id}
-              item={item}
-              canEdit={canEdit}
-              onEdit={() => setEditingItem(item)}
-              onRemove={() => removeItem.mutate({ tripId, itemId: item.id })}
-              onConfirmToggle={() =>
-                item.is_confirmed
-                  ? unconfirmItem.mutate({ tripId, itemId: item.id })
-                  : confirmItem.mutate({ tripId, itemId: item.id })
-              }
-              removing={removeItem.isPending}
-            />
-          ))}
+        <div className="flex flex-col gap-3">
+          {/* Same tile grid as the inline LodgingTab path (Task 67). */}
+          <div className="grid gap-3 min-[500px]:grid-cols-2 min-[800px]:grid-cols-3">
+            {lodgingItems.map((item) => (
+              <LodgingCard
+                key={item.id}
+                item={item}
+                canEdit={canEdit}
+                onEdit={() => setEditingItem(item)}
+                onRemove={() => removeItem.mutate({ tripId, itemId: item.id })}
+                onConfirmToggle={() =>
+                  item.is_confirmed
+                    ? unconfirmItem.mutate({ tripId, itemId: item.id })
+                    : confirmItem.mutate({ tripId, itemId: item.id })
+                }
+                removing={removeItem.isPending}
+              />
+            ))}
+          </div>
 
-          {/* Add property — dashed/add style, bottom of list, canEdit only */}
+          {/* Add property — dashed/add style, full-width below the tile
+              grid, canEdit only. Kept at full width so the affordance
+              reads as a list-level CTA rather than another card. */}
           {canEdit && (
             <button
               onClick={() => setShowAddLodging(true)}
@@ -888,6 +959,7 @@ export function LodgingPanel({
             checkOut: editingItem.check_out_time ?? "",
             checkInTimeOfDay: editingItem.check_in_time_of_day ?? "",
             checkOutTimeOfDay: editingItem.check_out_time_of_day ?? "",
+            imageUrl: editingItem.image_url ?? "",
           }}
           isPending={updateItem.isPending}
           onSubmit={handleUpdate}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -277,10 +277,14 @@ export default function TripDetailPage() {
       return (ci && (ci < tripStart || ci > tripEnd)) ||
              (co && (co < tripStart || co > tripEnd));
     });
+  // Task 70: the dot fires only when NOTHING is confirmed yet. Once at
+  // least one property is locked in we consider the lodging decided —
+  // any leftover unconfirmed entries are "considered but not booked"
+  // (parallel options the crew can still browse), not a nag.
   const lodgingUnconfirmed =
     effectiveCanEdit &&
     lodgingItems.length > 0 &&
-    lodgingItems.some((i) => !i.is_confirmed);
+    !lodgingItems.some((i) => i.is_confirmed);
   const scheduleOutOfRange =
     effectiveCanEdit &&
     tripStart && tripEnd &&

--- a/src/server/routers/logistics.ts
+++ b/src/server/routers/logistics.ts
@@ -53,6 +53,8 @@ export const logisticsRouter = router({
         transportType: z.string().max(100).optional(),
         pickupLocation: z.string().max(500).optional(),
         pickupTime: z.string().max(50).optional(),
+        // Lodging photo URL (og:image fetched in AddPropertySheet).
+        imageUrl: z.string().url().max(2048).optional(),
         // Ordering
         sortOrder: z.number().int().default(0),
       })
@@ -78,6 +80,7 @@ export const logisticsRouter = router({
           transport_type: input.transportType ?? null,
           pickup_location: input.pickupLocation ?? null,
           pickup_time: input.pickupTime ?? null,
+          image_url: input.imageUrl ?? null,
           sort_order: input.sortOrder,
           created_by: ctx.user!.id,
         })
@@ -116,6 +119,7 @@ export const logisticsRouter = router({
         transportType: z.string().max(100).nullable().optional(),
         pickupLocation: z.string().max(500).nullable().optional(),
         pickupTime: z.string().max(50).nullable().optional(),
+        imageUrl: z.string().url().max(2048).nullable().optional(),
         sortOrder: z.number().int().optional(),
       })
     )
@@ -136,6 +140,7 @@ export const logisticsRouter = router({
       if (input.transportType !== undefined) update.transport_type = input.transportType;
       if (input.pickupLocation !== undefined) update.pickup_location = input.pickupLocation;
       if (input.pickupTime !== undefined) update.pickup_time = input.pickupTime;
+      if (input.imageUrl !== undefined) update.image_url = input.imageUrl;
       if (input.sortOrder !== undefined) update.sort_order = input.sortOrder;
 
       if (Object.keys(update).length === 0) {

--- a/supabase/migrations/20260527064332_007_logistics_image_url.sql
+++ b/supabase/migrations/20260527064332_007_logistics_image_url.sql
@@ -1,0 +1,15 @@
+-- Migration 007 — logistics_items.image_url
+-- Adds a photo URL column so we can store the og:image fetched from
+-- VRBO / Airbnb / Booking listings (or any manually-pasted image URL)
+-- and render it as the LodgingCard's photo strip — replacing the
+-- placeholder gradient with the real listing photo when available.
+--
+-- Server-side fetch + parse lives in /api/lodging-meta. The column
+-- is plain text; we don't validate URL shape at the DB layer, the
+-- API + form gate that.
+
+ALTER TABLE logistics_items
+  ADD COLUMN IF NOT EXISTS image_url text;
+
+COMMENT ON COLUMN logistics_items.image_url IS
+  'Optional listing photo URL (typically og:image from VRBO / Airbnb / hotel listings). Surfaced on LodgingCard as the photo strip; falls back to the placeholder gradient when null.';


### PR DESCRIPTION
## Summary

- **Tiles, not rows** — LodgingCard becomes a photo-strip tile matching the empty-state PropertyExample. Lists flow as a responsive 1/2/3-column grid (`min-[500px]:grid-cols-2 min-[800px]:grid-cols-3`) so properties read as a comparison gallery instead of stacking full-width.
- **Paste a URL, get a real preview** — new `POST /api/lodging-meta` fetches the listing server-side, plucks `og:title` / `og:description` / `og:image`, and AddPropertySheet auto-fills empty fields + shows the real photo in the link preview. Migration 007 adds `logistics_items.image_url` so the photo persists on the saved card. SSRF guard blocks loopback / RFC-1918 / link-local hostnames.
- **No more blank panels** — when there's no real listing photo, a centered low-opacity Hotel icon sits over the gradient placeholder on LodgingCard, PropertyExample, and LinkPreviewCard.
- **Less nagging** — "X properties are still being considered" nudge + the Lodging tab info dot now fire only when nothing is confirmed. Once one property is locked in, the rest stay visible as considered-but-not-booked options without prompting.

## Test plan
- [ ] Paste a VRBO URL into Add Property → preview photo + title fill within ~500ms; save → tile shows the real photo.
- [ ] Paste an Airbnb URL → same flow.
- [ ] Paste a bogus URL (e.g. `https://example.com/`) → graceful fallback, fields stay empty, no error toast.
- [ ] Localhost URLs / `127.0.0.1` are refused (SSRF guard).
- [ ] Tiles flow as 1 / 2 / 3 columns at viewports 375 / 700 / 1100.
- [ ] Manually clear a saved card's URL or use a host with no og:image → Hotel placeholder icon centered on gradient.
- [ ] Trip with 0 confirmed properties → nudge + tab dot both visible.
- [ ] Confirm one property → nudge + tab dot both gone; remaining unconfirmed tiles still render.

## Migrations applied to remote
- `007_logistics_image_url` — `ALTER TABLE logistics_items ADD COLUMN IF NOT EXISTS image_url text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)