### PR TITLE
Crew + Receipts: name correctness, balances, opt-in/out legend

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -328,6 +328,36 @@ Schema: add last_read_at to trip_members or a separate message_reads table.
 
 ---
 
+### Unify receipt opt-in / opt-out (let anyone join a receipt they were left off)
+
+Today the opt-in/opt-out flow only covers members who were *included*
+in a receipt's split: they can opt out (drop themselves) and opt back
+in. A member who was **never** part of the split has no self-service
+path — only the Owner can add them via Edit splits.
+
+Two problems:
+- **Styling is misleading.** A receipt you're not part of still renders
+  at full opacity (not dimmed), so it looks like you're in the split
+  when you aren't. There's no visual signal that it doesn't involve you.
+- **No self opt-in.** You can't add yourself to a receipt you were left
+  off of — it's an owner-only capability via the edit-splits modal.
+
+Combine the two states into one consistent model:
+- Receipt where you have an active split → normal styling, "Opt out".
+- Receipt where you've opted out → dimmed, "Rejoin" (existing).
+- Receipt where you were never included → dimmed (so it reads as
+  "not yours"), with an "Opt in" / "Add me" action that creates a split
+  row for you. Same teal/gray legend grammar.
+
+Backend: `expenses.optOut` already lets any member toggle their own
+split via `requireTripMember`; extend it (or add `optIn`) to *create* a
+split row when one doesn't exist yet, not just flip `opted_out`.
+
+**Files:** `ExpensesSection.tsx` (row styling + the third state),
+`SplitPanel.tsx`, `src/server/routers/expenses.ts` (optOut/optIn).
+
+---
+
 ## UX Polish (Logged, Not Urgent)
 
 ### Field Mode (outdoor scoring)

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -177,94 +177,6 @@ function ReceiptExample() {
   );
 }
 
-// ── BalancesPreview ──────────────────────────────────────────────────────
-// Even on the empty Receipts state we render the live BALANCES section
-// pre-populated with every crew member at $0.00. This is REAL data
-// (not example), so it shows the user what the other half of the tab
-// does (squares up debts) before they've logged anything. Per
-// HANDOFF-gaps-receipts-empty.md §3.
-
-function BalancesPreview({
-  members,
-  currentUserId,
-}: {
-  members: ExpenseMember[];
-  currentUserId: string | null | undefined;
-}) {
-  // Order matches what the populated balances panel uses elsewhere:
-  // Owner first, Planners next, then everyone else by name.
-  const ROLE_ORDER: Record<string, number> = { Owner: 0, Planner: 1, Member: 2 };
-  const sorted = [...members].sort((a, b) => {
-    const aOrder = ROLE_ORDER[a.role ?? "Member"] ?? 2;
-    const bOrder = ROLE_ORDER[b.role ?? "Member"] ?? 2;
-    if (aOrder !== bOrder) return aOrder - bOrder;
-    if (a.isGuest !== b.isGuest) return a.isGuest ? 1 : -1;
-    return memberName(members, a.user_id).localeCompare(memberName(members, b.user_id));
-  });
-
-  if (sorted.length === 0) return null;
-
-  return (
-    <div className="mt-2">
-      <div
-        className="mb-2.5 text-[10px] font-bold uppercase tracking-[0.12em]"
-        style={{ color: "var(--color-bt-accent)" }}
-      >
-        Balances
-      </div>
-      <div
-        className="rounded-[10px] px-4"
-        style={{
-          background: "var(--color-bt-card)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        {sorted.map((m, idx) => {
-          const name = memberName(members, m.user_id);
-          const isYou = m.user_id === currentUserId;
-          return (
-            <div
-              key={m.user_id}
-              className="flex items-center justify-between py-3"
-              style={{
-                borderBottom:
-                  idx < sorted.length - 1
-                    ? "1px solid var(--color-bt-subtle-border)"
-                    : undefined,
-              }}
-            >
-              <span
-                className="text-sm font-semibold"
-                style={{ color: "var(--color-bt-text)" }}
-              >
-                {name}
-                {isYou && (
-                  <span style={{ color: "var(--color-bt-text-dim)", fontWeight: 400 }}>
-                    {" "}
-                    (you)
-                  </span>
-                )}
-              </span>
-              <span
-                className="font-mono text-sm font-semibold"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                $0.00
-              </span>
-            </div>
-          );
-        })}
-      </div>
-      <p
-        className="mt-2.5 text-[11px] italic"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        Everyone&apos;s even — no receipts logged yet.
-      </p>
-    </div>
-  );
-}
-
 // ── ReceiptLegend ────────────────────────────────────────────────────────
 // Explains the opt-in / opt-out icons that appear on each receipt row.
 // Wide layout: full card pinned to the top of the balances column.
@@ -774,22 +686,15 @@ export function ExpensesSection({
             // state shows for everyone — no more read-only EmptyState
             // for plain members.
             (
-              // Empty-state grid. Three pieces — sample, composer,
-              // balances — placed differently per breakpoint so the
-              // composer ("Add your first receipt") is always reachable:
-              //   lg+      [ sample  | composer ]   composer top-right
-              //            [ balances |    —     ]
-              //   md–lg    [ sample (full width)  ]  composer drops to the
-              //            [ composer | balances ]   bottom row, LEFT of
-              //                                       balances (not below)
-              //   <md      sample → balances; composer hidden (TabFab is
-              //            the mobile add affordance).
-              <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_300px]">
-                {/* Sample — top. Full width at md, left column at lg. */}
-                <div
-                  className="flex flex-col gap-3.5 md:col-span-2 md:row-start-1 lg:col-span-1 lg:col-start-1 lg:row-start-1"
-                  style={{ maxWidth: 540 }}
-                >
+              // Empty-state grid — just the sample + composer. Balances
+              // are hidden until there's an actual receipt to balance
+              // (the live BALANCES panel shows in the populated state).
+              //   lg+   [ sample (1fr) | composer (300px) ]  composer right
+              //   md–lg  sample on top, composer below it
+              //   <md   sample only; composer hidden (TabFab adds).
+              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+                {/* Sample — "how a receipt will look". */}
+                <div className="flex flex-col gap-3.5" style={{ maxWidth: 540 }}>
                   <SampleHeader label="How a receipt will look" />
                   <SampleCard>
                     <ReceiptExample />
@@ -807,13 +712,10 @@ export function ExpensesSection({
                   </p>
                 </div>
 
-                {/* Composer — top-right rail at lg; drops to the bottom
-                    row's LEFT cell at md (beside balances, never below).
-                    Hidden on phones (<md). */}
-                <aside
-                  className="hidden md:block md:col-start-1 md:row-start-2 lg:col-start-2 lg:row-start-1"
-                  style={{ maxWidth: 540 }}
-                >
+                {/* Composer — top-right rail at lg, stacks under the
+                    sample below lg. Hidden on phones (<md); the TabFab
+                    is the mobile add affordance. */}
+                <aside className="hidden md:block" style={{ maxWidth: 540 }}>
                   <AddReceiptFullComposer
                     tripId={tripId}
                     members={members}
@@ -821,16 +723,6 @@ export function ExpensesSection({
                     onOpenFull={() => onAddOpenChange(true)}
                   />
                 </aside>
-
-                {/* Live balances — under the sample at lg; bottom-right
-                    cell beside the composer at md; stacked under the
-                    sample on phones. */}
-                <div className="md:col-start-2 md:row-start-2 lg:col-start-1 lg:row-start-2">
-                  <BalancesPreview
-                    members={members}
-                    currentUserId={currentUser?.id}
-                  />
-                </div>
               </div>
             )
           ) : (

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -11,7 +11,6 @@ import {
   UserPlus,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { EmptyState } from "@/components/EmptyState";
 import { SampleHeader, SampleCard } from "@/components/SampleSection";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { trpc } from "@/lib/trpc-client";
@@ -262,6 +261,106 @@ function BalancesPreview({
       >
         Everyone&apos;s even — no receipts logged yet.
       </p>
+    </div>
+  );
+}
+
+// ── ReceiptLegend ────────────────────────────────────────────────────────
+// Explains the opt-in / opt-out icons that appear on each receipt row.
+// Wide layout: full card pinned to the top of the balances column.
+// Mirrors the Crew tab's StatusLegend so the two tabs feel consistent.
+
+const RECEIPT_LEGEND_ROWS = [
+  {
+    key: "out",
+    icon: UserMinus,
+    label: "Opt out",
+    body: "You're in this split. Tap to drop yourself from a receipt you didn't share in — your share gets spread across everyone else.",
+  },
+  {
+    key: "in",
+    icon: UserPlus,
+    label: "Opt in",
+    body: "You've opted out. Tap to rejoin the split and take your share again.",
+  },
+] as const;
+
+function ReceiptLegend() {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div
+        className="mb-3 text-[11px] font-bold uppercase tracking-[0.12em]"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        What these mean
+      </div>
+      <div className="space-y-2.5 text-[11px]" style={{ color: "var(--color-bt-text)" }}>
+        {RECEIPT_LEGEND_ROWS.map((r) => {
+          const Icon = r.icon;
+          return (
+            <div key={r.key} className="flex items-start gap-2.5">
+              <span
+                className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+                style={{
+                  background: "var(--color-bt-card-raised)",
+                  border: "1px solid var(--color-bt-border)",
+                  color: "var(--color-bt-accent)",
+                }}
+                aria-hidden
+              >
+                <Icon size={14} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="font-semibold">{r.label}</div>
+                <div className="leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
+                  {r.body}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p
+        className="mt-3 text-[11px] leading-snug"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        The icon shows on each receipt next to your share — only on your own row.
+      </p>
+    </div>
+  );
+}
+
+// ── CompactReceiptLegend ──────────────────────────────────────────────────
+// Single-row variant rendered below the receipts list at narrow widths
+// where the balances column has stacked underneath. Same morph behavior
+// as the Crew tab's CompactStatusLegend.
+
+function CompactReceiptLegend() {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px]"
+      style={{ color: "var(--color-bt-text)" }}
+    >
+      {RECEIPT_LEGEND_ROWS.map((r) => {
+        const Icon = r.icon;
+        return (
+          <span key={r.key} className="inline-flex items-center gap-1.5">
+            <Icon
+              size={13}
+              className="flex-shrink-0"
+              style={{ color: "var(--color-bt-accent)" }}
+              aria-hidden
+            />
+            <span className="font-semibold">{r.label}</span>
+          </span>
+        );
+      })}
     </div>
   );
 }
@@ -663,7 +762,7 @@ export function ExpensesSection({
       <div
         className={
           hasExpenses
-            ? "grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]"
+            ? "grid gap-4 min-[900px]:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]"
             : ""
         }
       >
@@ -672,7 +771,11 @@ export function ExpensesSection({
             TabHeader / TabFab, not inline here) ─────────────────────── */}
         <div className="space-y-3">
           {!hasExpenses ? (
-            canEdit ? (
+            // Any member can log a receipt (expenses.create is gated to
+            // requireTripMember, not Planner), so the composer empty
+            // state shows for everyone — no more read-only EmptyState
+            // for plain members.
+            (
               <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
                 {/* Main column — SampleHeader + example card + standalone
                     caption + live BALANCES preview. Caption sits BETWEEN
@@ -715,12 +818,6 @@ export function ExpensesSection({
                   />
                 </aside>
               </div>
-            ) : (
-              <EmptyState
-                icon={<Receipt className="h-10 w-10" />}
-                headline="No receipts yet"
-                subtext="The crew hasn't logged any receipts yet."
-              />
             )
           ) : (
             <div className="space-y-2">
@@ -733,6 +830,7 @@ export function ExpensesSection({
                 const userShare = currentUser
                   ? computeUserShare(expense, currentUser.id)
                   : null;
+                const paidByYou = !!currentUser && expense.paid_by_user_id === currentUser.id;
 
                 return (
                   <div
@@ -742,40 +840,61 @@ export function ExpensesSection({
                     style={{
                       background: isOptedOut ? "var(--color-bt-base)" : "var(--color-bt-card)",
                       border: "1px solid var(--color-bt-border)",
-                      opacity: isOptedOut ? 0.7 : 1,
+                      // Teal left accent marks receipts you paid for — a
+                      // highlight, not a fill (STYLE_GUIDE: teal fills are
+                      // reserved for Primary buttons). 3px so it reads at
+                      // a glance down the list.
+                      borderLeft: paidByYou
+                        ? "3px solid var(--color-bt-accent)"
+                        : "1px solid var(--color-bt-border)",
                     }}
                   >
-                    <DollarSign size={14} style={{ color: "var(--color-bt-accent)" }} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-baseline gap-2">
-                        <p className="truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
-                          {expense.title}
-                        </p>
-                        {expense.date && (
-                          <span className="flex-shrink-0 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                            {new Date(expense.date + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                    {/* Content group — dimmed when opted out. The action
+                        buttons live OUTSIDE this wrapper so the opt-in
+                        button stays full opacity (opacity on a parent
+                        can't be undone by a child). */}
+                    <div
+                      className="flex min-w-0 flex-1 items-center gap-3"
+                      style={{ opacity: isOptedOut ? 0.55 : 1 }}
+                    >
+                      <DollarSign size={14} className="flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-2">
+                          <p className="truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
+                            {expense.title}
+                          </p>
+                          {expense.date && (
+                            <span className="flex-shrink-0 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                              {new Date(expense.date + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-x-1.5 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                          <span>
+                            Paid by{" "}
+                            <span style={{ color: "var(--color-bt-text)" }}>
+                              {paidByYou ? "you" : memberName(members, expense.paid_by_user_id)}
+                            </span>
                           </span>
+                          <span aria-hidden>·</span>
+                          <span>split {activeSplitCount} ways</span>
+                        </div>
+                        {userSplit && (
+                          <p className="mt-0.5 text-xs" style={{
+                            color: isOptedOut ? "var(--color-bt-text-dim)" : "var(--color-bt-accent)",
+                          }}>
+                            {isOptedOut
+                              ? "Opted out"
+                              : userShare !== null
+                                ? `Your share: $${userShare.toFixed(2)}`
+                                : null}
+                          </p>
                         )}
                       </div>
-                      <div className="flex flex-wrap gap-x-2 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                        <span>Paid by {memberName(members, expense.paid_by_user_id)}</span>
-                        <span>split {activeSplitCount} ways</span>
-                      </div>
-                      {userSplit && (
-                        <p className="mt-0.5 text-xs" style={{
-                          color: isOptedOut ? "var(--color-bt-text-dim)" : "var(--color-bt-accent)",
-                        }}>
-                          {isOptedOut
-                            ? "Opted out"
-                            : userShare !== null
-                              ? `Your share: $${userShare.toFixed(2)}`
-                              : null}
-                        </p>
-                      )}
+                      <span className="flex-shrink-0 text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                        ${expense.amount.toFixed(2)}
+                      </span>
                     </div>
-                    <span className="flex-shrink-0 text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                      ${expense.amount.toFixed(2)}
-                    </span>
                     {userSplit && (
                       <button
                         onClick={() =>
@@ -821,15 +940,51 @@ export function ExpensesSection({
               })}
             </div>
           )}
+
+          {/* Compact opt-in/out legend — only below 640px (true mobile),
+              where the legend panel collapses to text. Between 640 and
+              900 the full legend panel sits beside Balances under the
+              receipts; at ≥900 it moves into the right rail. Morphs to
+              icon + label like the Crew tab. */}
+          {hasExpenses && (
+            <div className="min-[640px]:hidden pt-1">
+              <CompactReceiptLegend />
+            </div>
+          )}
         </div>
 
-        {/* ── Right: balances ──────────────────────────────────────────── */}
+        {/* ── Right: legend + balances ─────────────────────────────────── */}
         {/* Only render when there's at least one receipt to balance —
             otherwise the column is just a "Balances appear once receipts
             are added" placeholder, which is noise. alignSelf start keeps
             the panel pinned at the top while the left column grows. */}
         {hasExpenses && (
-          <div style={{ alignSelf: "start" }}>
+          <aside
+            style={{ alignSelf: "start" }}
+            className={[
+              // Right rail — legend + balances. Three states, mirroring
+              // the Crew tab's stacked-rail morph:
+              //   <640   single column; legend collapses to the compact
+              //          text under the receipts (hidden here), balances
+              //          full width below.
+              //   640-899 two side-by-side panels under the receipts
+              //          (legend | balances).
+              //   ≥900   stacked in the narrow right rail track of the
+              //          main grid (legend panel on top, balances below).
+              // Arbitrary min-[…] variants on both edges so Tailwind v4
+              // sorts the cascade numerically.
+              "grid gap-4",
+              "min-[640px]:grid-cols-2",
+              "min-[900px]:flex min-[900px]:flex-col",
+            ].join(" ")}
+          >
+            {/* Full opt-in/out legend panel — shown at ≥640. Below that
+                the CompactReceiptLegend under the receipts takes over. */}
+            <div className="hidden min-[640px]:block">
+              <ReceiptLegend />
+            </div>
+
+            <div>
             <h2
               className="mb-2 text-xs font-semibold uppercase tracking-wider"
               style={{ color: "var(--color-bt-text-dim)" }}
@@ -889,7 +1044,8 @@ export function ExpensesSection({
                 All settled up 🎉
               </p>
             )}
-          </div>
+            </div>
+          </aside>
         )}
 
       </div>

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -906,7 +906,10 @@ export function ExpensesSection({
                         }
                         disabled={optOutMutation.isPending}
                         className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70 disabled:opacity-40"
-                        style={{ color: isOptedOut ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+                        // Teal in both states so the row icon matches the
+                        // legend (both opt-out and opt-in are teal there)
+                        // — the +/− glyph carries the meaning, not the color.
+                        style={{ color: "var(--color-bt-accent)" }}
                         title={isOptedOut ? "Rejoin" : "Opt out"}
                       >
                         {isOptedOut ? <UserPlus size={13} /> : <UserMinus size={13} />}

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -275,12 +275,16 @@ const RECEIPT_LEGEND_ROWS = [
     key: "out",
     icon: UserMinus,
     label: "Opt out",
+    // Matches the receipt row: opt-out is the quiet gray action.
+    color: "var(--color-bt-text-dim)",
     body: "You're in this split. Tap to drop yourself from a receipt you didn't share in — your share gets spread across everyone else.",
   },
   {
     key: "in",
     icon: UserPlus,
     label: "Opt in",
+    // Matches the receipt row: rejoin is teal to invite you back in.
+    color: "var(--color-bt-accent)",
     body: "You've opted out. Tap to rejoin the split and take your share again.",
   },
 ] as const;
@@ -310,7 +314,7 @@ function ReceiptLegend() {
                 style={{
                   background: "var(--color-bt-card-raised)",
                   border: "1px solid var(--color-bt-border)",
-                  color: "var(--color-bt-accent)",
+                  color: r.color,
                 }}
                 aria-hidden
               >
@@ -354,7 +358,7 @@ function CompactReceiptLegend() {
             <Icon
               size={13}
               className="flex-shrink-0"
-              style={{ color: "var(--color-bt-accent)" }}
+              style={{ color: r.color }}
               aria-hidden
             />
             <span className="font-semibold">{r.label}</span>
@@ -906,10 +910,10 @@ export function ExpensesSection({
                         }
                         disabled={optOutMutation.isPending}
                         className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70 disabled:opacity-40"
-                        // Teal in both states so the row icon matches the
-                        // legend (both opt-out and opt-in are teal there)
-                        // — the +/− glyph carries the meaning, not the color.
-                        style={{ color: "var(--color-bt-accent)" }}
+                        // Opt out (you're in) reads as a quiet gray action;
+                        // rejoin (you're out) is teal to invite you back in.
+                        // The legend mirrors these two colors exactly.
+                        style={{ color: isOptedOut ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
                         title={isOptedOut ? "Rejoin" : "Opt out"}
                       >
                         {isOptedOut ? <UserPlus size={13} /> : <UserMinus size={13} />}

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -638,15 +638,19 @@ export function ExpensesSection({
 
   const hasExpenses = expenses.length > 0;
   const ROLE_ORDER: Record<string, number> = { Owner: 0, Planner: 1, Member: 2 };
-  const balanceRows = members
-    .filter((m) => Math.abs(balances.get(m.user_id) ?? 0) >= 0.01)
-    .sort((a, b) => {
-      const aOrder = ROLE_ORDER[a.role ?? "Member"] ?? 2;
-      const bOrder = ROLE_ORDER[b.role ?? "Member"] ?? 2;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      if (a.isGuest !== b.isGuest) return a.isGuest ? 1 : -1;
-      return memberName(members, a.user_id).localeCompare(memberName(members, b.user_id));
-    });
+  // Show every current crew member — including anyone added after the
+  // receipts were logged (they sit at $0.00 until a split pulls them
+  // in). Previously this filtered to members with a non-zero balance,
+  // so a freshly-added member never appeared until their first receipt.
+  // Matches the empty-state BalancesPreview, which already lists
+  // everyone at $0.00.
+  const balanceRows = [...members].sort((a, b) => {
+    const aOrder = ROLE_ORDER[a.role ?? "Member"] ?? 2;
+    const bOrder = ROLE_ORDER[b.role ?? "Member"] ?? 2;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    if (a.isGuest !== b.isGuest) return a.isGuest ? 1 : -1;
+    return memberName(members, a.user_id).localeCompare(memberName(members, b.user_id));
+  });
 
   return (
     <>
@@ -859,8 +863,22 @@ export function ExpensesSection({
                           <span className="ml-1 text-xs font-normal" style={{ color: "var(--color-bt-text-dim)" }}>(you)</span>
                         )}
                       </span>
-                      <span className="text-sm font-semibold tabular-nums" style={{ color: bal > 0 ? "var(--color-bt-accent)" : "var(--color-bt-danger)" }}>
-                        {bal > 0 ? `+$${bal.toFixed(2)}` : `-$${Math.abs(bal).toFixed(2)}`}
+                      <span
+                        className="text-sm font-semibold tabular-nums"
+                        style={{
+                          color:
+                            Math.abs(bal) < 0.01
+                              ? "var(--color-bt-text-dim)"
+                              : bal > 0
+                                ? "var(--color-bt-accent)"
+                                : "var(--color-bt-danger)",
+                        }}
+                      >
+                        {Math.abs(bal) < 0.01
+                          ? "$0.00"
+                          : bal > 0
+                            ? `+$${bal.toFixed(2)}`
+                            : `-$${Math.abs(bal).toFixed(2)}`}
                       </span>
                     </div>
                   );

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -693,8 +693,10 @@ export function ExpensesSection({
               //   md–lg  sample on top, composer below it
               //   <md   sample only; composer hidden (TabFab adds).
               <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
-                {/* Sample — "how a receipt will look". */}
-                <div className="flex flex-col gap-3.5" style={{ maxWidth: 540 }}>
+                {/* Sample — "how a receipt will look". Fills the full
+                    width of its column (no max-width cap) so the example
+                    receipt spans the left column. */}
+                <div className="flex flex-col gap-3.5">
                   <SampleHeader label="How a receipt will look" />
                   <SampleCard>
                     <ReceiptExample />

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -681,18 +681,16 @@ export function ExpensesSection({
             TabHeader / TabFab, not inline here) ─────────────────────── */}
         <div className="space-y-3">
           {!hasExpenses ? (
-            // Any member can log a receipt (expenses.create is gated to
+            // Any member can log a receipt (expenses.create is
             // requireTripMember, not Planner), so the composer empty
-            // state shows for everyone — no more read-only EmptyState
-            // for plain members.
-            (
-              // Empty-state grid — just the sample + composer. Balances
-              // are hidden until there's an actual receipt to balance
-              // (the live BALANCES panel shows in the populated state).
-              //   lg+   [ sample (1fr) | composer (300px) ]  composer right
-              //   md–lg  sample on top, composer below it
-              //   <md   sample only; composer hidden (TabFab adds).
-              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+            // state shows for everyone — no read-only EmptyState fork.
+            // Empty-state grid — just the sample + composer. Balances
+            // are hidden until there's an actual receipt to balance
+            // (the live BALANCES panel shows in the populated state).
+            //   lg+   [ sample (1fr) | composer (300px) ]  composer right
+            //   md–lg  sample on top, composer below it
+            //   <md   sample only; composer hidden (TabFab adds).
+            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
                 {/* Sample — "how a receipt will look". Fills the full
                     width of its column (no max-width cap) so the example
                     receipt spans the left column. */}
@@ -726,7 +724,6 @@ export function ExpensesSection({
                   />
                 </aside>
               </div>
-            )
           ) : (
             <div className="space-y-2">
               {(expenses as ExpenseItem[]).map((expense) => {

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -774,11 +774,22 @@ export function ExpensesSection({
             // state shows for everyone — no more read-only EmptyState
             // for plain members.
             (
-              <div className="flex flex-col gap-5">
-                {/* Sample — illustrative "how a receipt will look", on top.
-                    Caption sits between the example and the composer/
-                    balances row. */}
-                <div className="flex flex-col gap-3.5" style={{ maxWidth: 540 }}>
+              // Empty-state grid. Three pieces — sample, composer,
+              // balances — placed differently per breakpoint so the
+              // composer ("Add your first receipt") is always reachable:
+              //   lg+      [ sample  | composer ]   composer top-right
+              //            [ balances |    —     ]
+              //   md–lg    [ sample (full width)  ]  composer drops to the
+              //            [ composer | balances ]   bottom row, LEFT of
+              //                                       balances (not below)
+              //   <md      sample → balances; composer hidden (TabFab is
+              //            the mobile add affordance).
+              <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_300px]">
+                {/* Sample — top. Full width at md, left column at lg. */}
+                <div
+                  className="flex flex-col gap-3.5 md:col-span-2 md:row-start-1 lg:col-span-1 lg:col-start-1 lg:row-start-1"
+                  style={{ maxWidth: 540 }}
+                >
                   <SampleHeader label="How a receipt will look" />
                   <SampleCard>
                     <ReceiptExample />
@@ -796,28 +807,29 @@ export function ExpensesSection({
                   </p>
                 </div>
 
-                {/* Composer (left) + live balances (right). Composer is
-                    the primary CTA, so it stays on the LEFT of the
-                    balances at every width — a long crew list can't push
-                    "Add your first receipt" off-screen below the balances
-                    (the previous layout stacked composer beneath them).
-                    Composer hidden on phones (<md); the TabFab is the
-                    mobile add affordance and balances still shows. */}
-                <div className="grid gap-5 md:grid-cols-2">
-                  <aside className="hidden md:block" style={{ maxWidth: 540 }}>
-                    <AddReceiptFullComposer
-                      tripId={tripId}
-                      members={members}
-                      currentUserId={currentUser?.id}
-                      onOpenFull={() => onAddOpenChange(true)}
-                    />
-                  </aside>
-                  <div>
-                    <BalancesPreview
-                      members={members}
-                      currentUserId={currentUser?.id}
-                    />
-                  </div>
+                {/* Composer — top-right rail at lg; drops to the bottom
+                    row's LEFT cell at md (beside balances, never below).
+                    Hidden on phones (<md). */}
+                <aside
+                  className="hidden md:block md:col-start-1 md:row-start-2 lg:col-start-2 lg:row-start-1"
+                  style={{ maxWidth: 540 }}
+                >
+                  <AddReceiptFullComposer
+                    tripId={tripId}
+                    members={members}
+                    currentUserId={currentUser?.id}
+                    onOpenFull={() => onAddOpenChange(true)}
+                  />
+                </aside>
+
+                {/* Live balances — under the sample at lg; bottom-right
+                    cell beside the composer at md; stacked under the
+                    sample on phones. */}
+                <div className="md:col-start-2 md:row-start-2 lg:col-start-1 lg:row-start-2">
+                  <BalancesPreview
+                    members={members}
+                    currentUserId={currentUser?.id}
+                  />
                 </div>
               </div>
             )

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -330,12 +330,6 @@ function ReceiptLegend() {
           );
         })}
       </div>
-      <p
-        className="mt-3 text-[11px] leading-snug"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        The icon shows on each receipt next to your share — only on your own row.
-      </p>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -774,12 +774,11 @@ export function ExpensesSection({
             // state shows for everyone — no more read-only EmptyState
             // for plain members.
             (
-              <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
-                {/* Main column — SampleHeader + example card + standalone
-                    caption + live BALANCES preview. Caption sits BETWEEN
-                    the example and BALANCES per spec; previously it lived
-                    inside the composer's hint, wrong placement. */}
-                <div className="flex flex-col gap-3.5">
+              <div className="flex flex-col gap-5">
+                {/* Sample — illustrative "how a receipt will look", on top.
+                    Caption sits between the example and the composer/
+                    balances row. */}
+                <div className="flex flex-col gap-3.5" style={{ maxWidth: 540 }}>
                   <SampleHeader label="How a receipt will look" />
                   <SampleCard>
                     <ReceiptExample />
@@ -795,26 +794,31 @@ export function ExpensesSection({
                     Log who paid and how to split it. By default everyone
                     splits evenly — tap a receipt later to customize.
                   </p>
-                  <BalancesPreview
-                    members={members}
-                    currentUserId={currentUser?.id}
-                  />
                 </div>
 
-                {/* Right rail (lg+) / stacked composer (md ≤ x < lg).
-                    Hidden on phones (<md) — the TabFab is the mobile add
-                    affordance. Capped at 540px when stacked. */}
-                <aside
-                  className="hidden md:block"
-                  style={{ maxWidth: 540 }}
-                >
-                  <AddReceiptFullComposer
-                    tripId={tripId}
-                    members={members}
-                    currentUserId={currentUser?.id}
-                    onOpenFull={() => onAddOpenChange(true)}
-                  />
-                </aside>
+                {/* Composer (left) + live balances (right). Composer is
+                    the primary CTA, so it stays on the LEFT of the
+                    balances at every width — a long crew list can't push
+                    "Add your first receipt" off-screen below the balances
+                    (the previous layout stacked composer beneath them).
+                    Composer hidden on phones (<md); the TabFab is the
+                    mobile add affordance and balances still shows. */}
+                <div className="grid gap-5 md:grid-cols-2">
+                  <aside className="hidden md:block" style={{ maxWidth: 540 }}>
+                    <AddReceiptFullComposer
+                      tripId={tripId}
+                      members={members}
+                      currentUserId={currentUser?.id}
+                      onOpenFull={() => onAddOpenChange(true)}
+                    />
+                  </aside>
+                  <div>
+                    <BalancesPreview
+                      members={members}
+                      currentUserId={currentUser?.id}
+                    />
+                  </div>
+                </div>
               </div>
             )
           ) : (

--- a/src/app/trips/[tripId]/tabs/ExpensesTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesTab.tsx
@@ -29,9 +29,11 @@ export function ExpensesTab({ trip, canEdit, isOwner }: TabProps) {
   const [addOpen, setAddOpen] = useState(false);
   const openAdd = () => setAddOpen(true);
 
-  // On the empty state, the boosted RailComposer becomes the primary CTA;
-  // hide the redundant header pill so the eye lands on the right rail.
-  const showHeaderAction = canEdit && expenses.length > 0;
+  // Anyone can log a receipt (expenses.create is requireTripMember, not
+  // Planner), so the header pill isn't gated by canEdit. On the empty
+  // state the boosted rail composer is the primary CTA, so the redundant
+  // header pill only appears once there's at least one receipt.
+  const showHeaderAction = expenses.length > 0;
 
   return (
     <div className="px-4">

--- a/src/app/trips/[tripId]/tabs/SplitPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/SplitPanel.tsx
@@ -75,7 +75,12 @@ export function SplitPanel({
 
   const memberName = (uid: string) => {
     const m = members.find((x) => x.user_id === uid);
-    return m?.user?.name ?? m?.user?.email ?? uid.slice(0, 6);
+    // displayName first — it carries the trip-scoped nickname
+    // (trip_members.nickname) so an Owner-renamed member shows their
+    // trip name here, not the stale account name. Was reading
+    // m.user.name directly, which surfaced the original users.name
+    // even after a rename (e.g. "Tak" lingering after editing to "Taj").
+    return m?.displayName ?? m?.user?.name ?? m?.user?.email ?? uid.slice(0, 6);
   };
 
   return (

--- a/src/app/trips/[tripId]/tabs/components/MemberEditor.tsx
+++ b/src/app/trips/[tripId]/tabs/components/MemberEditor.tsx
@@ -157,36 +157,50 @@ export function MemberEditor({ tripId, member, canManageRoles, onClose }: Member
       return;
     }
 
-    // Diff against the resolved initialNickname (what the input was
-    // pre-filled with) rather than the override-only value. Without
-    // this, opening the editor on a placeholder whose display name
-    // comes from users.name would mark the input "dirty" against an
-    // empty override and enable Save before the user typed anything.
-    // The mutation still writes trip-scoped: empty → null (falls back
-    // to users.name); non-empty → sets the override.
-    const nicknameChanged = nickname.trim() !== initialNickname.trim();
+    const nameChanged = nickname.trim() !== initialNickname.trim();
     const emailChanged = email.trim() !== (member.user?.email ?? "");
-
     const tasks: Promise<unknown>[] = [];
-    if (nicknameChanged) {
-      tasks.push(
-        updateNickname.mutateAsync({
-          tripId,
-          userId: member.user_id,
-          nickname: nickname.trim(),
-        })
-      );
-    }
-    // Email is still a users-table concern, so it only applies to guest rows
-    // (real-account users manage their own email through account settings).
-    if (member.isGuest && emailChanged) {
-      tasks.push(
-        updateGuest.mutateAsync({
-          tripId,
-          guestUserId: member.user_id,
-          email: email.trim() || null,
-        })
-      );
+
+    if (member.isGuest) {
+      // ── Ghost (placeholder / invited) ──────────────────────────────
+      // A ghost has no real account and no profile to self-edit, so the
+      // name field edits users.name *directly* — it's the single source
+      // of truth, not a trip-scoped override. (Renaming a ghost via the
+      // nickname override left the original typo frozen in users.name;
+      // now we just fix the name.) Name + email both flow through one
+      // ghostCrew.update call.
+      const guestUpdate: {
+        tripId: string;
+        guestUserId: string;
+        name?: string;
+        email?: string | null;
+      } = { tripId, guestUserId: member.user_id };
+      if (nameChanged && nickname.trim()) guestUpdate.name = nickname.trim();
+      if (emailChanged) guestUpdate.email = email.trim() || null;
+      if (guestUpdate.name !== undefined || guestUpdate.email !== undefined) {
+        tasks.push(updateGuest.mutateAsync(guestUpdate));
+      }
+      // Clear any legacy trip-nickname override so users.name is the only
+      // name in play (older ghosts renamed under the previous model still
+      // carry one; without this, the stale override would keep winning).
+      if (member.nickname) {
+        tasks.push(
+          updateNickname.mutateAsync({ tripId, userId: member.user_id, nickname: "" })
+        );
+      }
+    } else {
+      // ── Real account ───────────────────────────────────────────────
+      // Never touch their users.name (they own it via their profile);
+      // the name field edits the trip-scoped nickname override only.
+      if (nameChanged) {
+        tasks.push(
+          updateNickname.mutateAsync({
+            tripId,
+            userId: member.user_id,
+            nickname: nickname.trim(),
+          })
+        );
+      }
     }
 
     if (tasks.length > 0) {


### PR DESCRIPTION
## Summary

A cluster of crew/receipts data-correctness and UX fixes (started as the crew-name bug, grew from there).

**Crew names**
- SplitPanel's local `memberName()` skipped the trip-scoped `displayName`, so a renamed member showed the stale account name in the custom-split picker. Now prefers `displayName` like every other surface.
- Ghost renames now edit `users.name` directly (a ghost has no profile to self-edit) instead of stacking a `trip_members.nickname` override on a frozen typo. Real accounts still use the override. Existing single-trip ghost overrides were backfilled out-of-band.

**Balances**
- Lists every current crew member, not just those with a non-zero balance — a member added after the first receipts now shows at $0.00 (neutral dim) instead of being hidden until a later receipt pulls them in.

**Receipts**
- **Opt-in/out legend** (Crew-tab pattern): full panel atop the balances column at ≥900, two side-by-side panels (legend | balances) under the receipts at 640-899, compact icon+text row under the receipts on mobile (<640).
- Receipts you paid for get a **teal left accent border** (highlight, not a fill — STYLE_GUIDE reserves teal fills for Primary buttons).
- **"Paid by you"** on your own receipts; payee name in white; **"·"** between payer and "split N ways".
- Opt-out dims only the content group — the **opt-in/rejoin button stays full opacity** instead of fading with the row.
- Legend icon colors mirror the row: opt-out gray, opt-in teal.
- **Add-receipt ungated** for all members (header pill + empty-state composer); `expenses.create` is `requireTripMember`, so this was over-restricted.

## Test plan
- [ ] Rename a real-account member → trip nickname override; shows everywhere incl. custom split + balances.
- [ ] Rename a ghost → `users.name` updated, no override, shows everywhere.
- [ ] Add a crew member after logging receipts → appears in Balances at $0.00.
- [ ] Receipts tab at 1100 / 800 / 500 → legend morphs (right-rail stack → 2 panels under receipts → compact text); add-receipt available as a plain member.
- [ ] A receipt you paid shows teal left border + "Paid by you"; opt-out gray, rejoin teal; opted-out row dims but rejoin button stays bright.
- [ ] `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)