### PR TITLE
chore(db): drop orphaned trip_members.display_name column

### DIFF
--- a/supabase/migrations/20260529154208_009_drop_trip_member_display_name.sql
+++ b/supabase/migrations/20260529154208_009_drop_trip_member_display_name.sql
@@ -1,0 +1,9 @@
+-- Drop the orphaned trip_members.display_name column.
+--
+-- Background: the closed feature/crew-overhaul branch (PR #266) added this
+-- column as a trip-scoped display-name override. main standardized on
+-- trip_members.nickname for the same purpose (PR #268, migration 004), and
+-- dropped users.nickname (migration 005). display_name is unused by all
+-- application code on main. No data is preserved: the single populated value
+-- duplicated the user's users.name, so nothing is lost.
+ALTER TABLE trip_members DROP COLUMN IF EXISTS display_name;


### PR DESCRIPTION
## Summary
- Drops the unused `trip_members.display_name` column from the schema.
- It was added by the closed crew-overhaul branch (#266) as a trip-scoped display-name override. main standardized on `trip_members.nickname` for the exact same purpose (#268), leaving `display_name` orphaned: present in the live DB but referenced by zero application code and untracked by any migration in the current history.

## Context
- Verified before dropping: only one of 17 `trip_members` rows had `display_name` set, and its value (`"Zach"`) was identical to that user's `users.name` — so the fallback chain (`nickname → users.name → email`) produces the same result. No data lost.
- **Already applied to the remote DB** via Supabase MCP (migration version `20260529154208`). This PR just lands the matching migration file so local/remote history stay aligned and `supabase db push` remains a no-op.

## Test plan
- [ ] `supabase db push` is a no-op against remote
- [ ] `npx tsc --noEmit` passes (no code referenced `display_name`)