### PR TITLE
Tap-to-edit rows + multi-photo lodging + modal pattern convergence

### DIFF
--- a/src/app/trips/[tripId]/components/AddPropertySheet.tsx
+++ b/src/app/trips/[tripId]/components/AddPropertySheet.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import { Globe, Hotel, Link, MapPin } from "lucide-react";
+import { useState, useRef, useEffect, useMemo } from "react";
+import { Hotel, Link, MapPin, ImagePlus, X } from "lucide-react";
+import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { createClient } from "@/lib/supabase";
 
 // ── Platform detection (exported so parents can use it) ───────────────────
 
@@ -58,9 +60,12 @@ export interface PropertyFormValues {
   checkOut: string;  // planning only — YYYY-MM-DD
   checkInTimeOfDay: string;  // planning only — HH:MM, optional
   checkOutTimeOfDay: string; // planning only — HH:MM, optional
-  /** og:image fetched from /api/lodging-meta when the URL is pasted. */
-  imageUrl: string;
+  /** Up to 3 photo URLs (public Storage URLs and/or an og:image). The
+   *  first entry is the cover the LodgingCard renders. */
+  imageUrls: string[];
 }
+
+const MAX_PHOTOS = 3;
 
 // ── Props ─────────────────────────────────────────────────────────────────
 
@@ -72,6 +77,8 @@ export interface AddPropertySheetProps {
   isPending: boolean;
   onSubmit: (values: PropertyFormValues) => void;
   onClose: () => void;
+  /** When editing, wires the footer "Remove property" danger button. */
+  onRemove?: () => void;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -93,7 +100,7 @@ interface PlacePrediction {
 
 const inputCls = "w-full rounded-xl border px-3 py-2.5 text-sm outline-none";
 const inputStyle = {
-  background: "var(--color-bt-card-raised)",
+  background: "var(--color-bt-card)",
   borderColor: "var(--color-bt-border)",
   color: "var(--color-bt-text)",
 };
@@ -101,121 +108,32 @@ const inputStyle = {
 function Field({
   label,
   hint,
+  required,
   children,
 }: {
   label: string;
   hint?: string;
+  required?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
+      <label className="mb-1.5 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
         {label}
+        {required && (
+          <span
+            className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle"
+            style={{ background: "var(--color-bt-danger)" }}
+            aria-hidden
+          />
+        )}
         {hint && (
-          <span className="ml-1.5 font-normal" style={{ opacity: 0.75 }}>
+          <span className="ml-1.5 font-medium normal-case tracking-normal" style={{ opacity: 0.75 }}>
             ({hint})
           </span>
         )}
       </label>
       {children}
-    </div>
-  );
-}
-
-// ── Link preview card ─────────────────────────────────────────────────────
-
-function LinkPreviewCard({
-  url,
-  name,
-  imageUrl,
-  loading,
-}: {
-  url: string;
-  name: string;
-  /** og:image fetched from /api/lodging-meta. Renders as the preview
-   *  photo strip when present; falls back to the placeholder gradient
-   *  while loading or when the host doesn't expose an og:image. */
-  imageUrl?: string | null;
-  /** True while /api/lodging-meta is in flight for this URL. */
-  loading?: boolean;
-}) {
-  const platform = detectPlatform(url);
-  const domain = extractDomain(url);
-  const label = PLATFORM_LABEL[platform];
-
-  return (
-    <div
-      className="overflow-hidden rounded-xl"
-      style={{ border: "1px solid var(--color-bt-accent-border)" }}
-    >
-      {/* Photo strip — real listing image if fetched, placeholder
-          gradient + generic-property icon otherwise. Matches the
-          LodgingCard photo strip so the preview reads like what the
-          saved card will look like (no blank panel). */}
-      <div
-        className="relative h-32 w-full"
-        style={{
-          backgroundImage: imageUrl
-            ? `url("${imageUrl}")`
-            : "linear-gradient(135deg, #0d2c3a 0%, #0d3a4f 100%)",
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-        }}
-      >
-        {!imageUrl && !loading && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
-            <Hotel size={44} strokeWidth={1.5} style={{ color: "rgba(255,255,255,0.22)" }} />
-          </div>
-        )}
-        {loading && !imageUrl && (
-          <div
-            className="absolute inset-0 flex items-center justify-center text-[11px] font-medium"
-            style={{ color: "#e2e8f0" }}
-          >
-            <span
-              className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1"
-              style={{ background: "rgba(0,0,0,0.45)" }}
-            >
-              <span
-                className="inline-block h-2 w-2 animate-pulse rounded-full"
-                style={{ background: "var(--color-bt-accent)" }}
-                aria-hidden
-              />
-              Fetching listing…
-            </span>
-          </div>
-        )}
-      </div>
-
-      <div
-        className="flex items-center gap-1.5 px-3 py-2"
-        style={{ background: "var(--color-bt-tag-bg)" }}
-      >
-        <Globe size={11} style={{ color: "var(--color-bt-accent)" }} />
-        <span className="text-[11px] font-medium" style={{ color: "var(--color-bt-accent)" }}>
-          {domain}
-        </span>
-        <span
-          className="ml-auto rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
-          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-        >
-          {label}
-        </span>
-      </div>
-      <div className="px-3 py-2.5" style={{ background: "var(--color-bt-card-raised)" }}>
-        {name ? (
-          <p className="text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>{name}</p>
-        ) : (
-          <p className="text-xs italic" style={{ color: "var(--color-bt-text-dim)" }}>
-            {loading
-              ? "Pulling the title from the listing…"
-              : "Add a nickname in the fields below"}
-          </p>
-        )}
-        <p className="mt-0.5 truncate text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          {url.length > 55 ? url.slice(0, 52) + "…" : url}
-        </p>
-      </div>
     </div>
   );
 }
@@ -229,6 +147,7 @@ export function AddPropertySheet({
   isPending,
   onSubmit,
   onClose,
+  onRemove,
 }: AddPropertySheetProps) {
   useModalBackButton(onClose);
 
@@ -242,10 +161,71 @@ export function AddPropertySheet({
   const [checkOut, setCheckOut] = useState(initialValues.checkOut ?? "");
   const [checkInTimeOfDay, setCheckInTimeOfDay] = useState(initialValues.checkInTimeOfDay ?? "");
   const [checkOutTimeOfDay, setCheckOutTimeOfDay] = useState(initialValues.checkOutTimeOfDay ?? "");
-  const [imageUrl, setImageUrl] = useState(initialValues.imageUrl ?? "");
+  const [imageUrls, setImageUrls] = useState<string[]>(initialValues.imageUrls ?? []);
 
-  // Manual mode — expand the form without requiring a valid URL
-  const [manualMode, setManualMode] = useState(isEditing && !(initialValues.url ?? ""));
+  // ── Photo upload (3 square slots) ──────────────────────────────────
+  // Uploads the chosen image(s) to the public `lodging-photos` storage
+  // bucket and appends their public URLs to imageUrls (capped at
+  // MAX_PHOTOS). The first entry is the cover the LodgingCard renders.
+  // A user-uploaded photo always wins over the og:image scraped from
+  // the listing.
+  const supabase = useMemo(() => createClient(), []);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadingCount, setUploadingCount] = useState(0);
+  const [uploadError, setUploadError] = useState("");
+
+  const uploadOne = async (file: File): Promise<string | null> => {
+    if (!file.type.startsWith("image/")) {
+      setUploadError("Please choose an image file.");
+      return null;
+    }
+    if (file.size > 8 * 1024 * 1024) {
+      setUploadError("Image must be under 8 MB.");
+      return null;
+    }
+    const ext = (file.name.split(".").pop() || "jpg").toLowerCase();
+    const path = `${crypto.randomUUID()}.${ext}`;
+    const { error } = await supabase.storage
+      .from("lodging-photos")
+      .upload(path, file, { cacheControl: "3600", upsert: false, contentType: file.type });
+    if (error) throw error;
+    const { data } = supabase.storage.from("lodging-photos").getPublicUrl(path);
+    return data.publicUrl;
+  };
+
+  const handlePhotoSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = ""; // allow re-selecting the same file later
+    if (files.length === 0) return;
+
+    // Only take as many as remaining slots allow.
+    const remaining = MAX_PHOTOS - imageUrls.length;
+    if (remaining <= 0) return;
+    const toUpload = files.slice(0, remaining);
+
+    setUploadError("");
+    setUploadingCount(toUpload.length);
+    try {
+      const urls: string[] = [];
+      for (const file of toUpload) {
+        const u = await uploadOne(file);
+        if (u) urls.push(u);
+      }
+      if (urls.length > 0) {
+        setImageUrls((prev) => [...prev, ...urls].slice(0, MAX_PHOTOS));
+        // Stop the listing-meta effect from re-filling the cover photo.
+        setMetaFetchedFor(url.trim());
+      }
+    } catch {
+      setUploadError("Upload failed. Try again.");
+    } finally {
+      setUploadingCount(0);
+    }
+  };
+
+  const removePhoto = (idx: number) => {
+    setImageUrls((prev) => prev.filter((_, i) => i !== idx));
+  };
 
   // ── Listing-metadata fetch (Task 68) ──────────────────────────────
   //
@@ -294,7 +274,7 @@ export function AddPropertySheet({
                 : data.description;
             setNotes(trimmedDesc);
           }
-          if (data.image && !imageUrl) setImageUrl(data.image);
+          if (data.image && imageUrls.length === 0) setImageUrls([data.image]);
         }
         setMetaFetchedFor(trimmed);
       } catch {
@@ -307,7 +287,7 @@ export function AddPropertySheet({
     return () => {
       if (metaTimer.current) clearTimeout(metaTimer.current);
     };
-    // We intentionally don't depend on name/notes/imageUrl — those
+    // We intentionally don't depend on name/notes/imageUrls — those
     // can be set by this very effect, which would re-trigger. The
     // metaFetchedFor guard handles "URL hasn't changed, skip."
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -346,13 +326,27 @@ export function AddPropertySheet({
     }
   };
 
-  // Derived
+  // Derived — a property needs at minimum a title or a valid link.
   const validUrl = isValidUrl(url);
-  const showExpanded = validUrl || manualMode || isEditing;
-  const canSubmit =
-    showExpanded &&
-    (validUrl || manualMode) &&
-    (!manualMode || name.trim().length > 0);
+  const hasContent = name.trim().length > 0 || validUrl;
+
+  // When editing, Save stays disabled until something actually changes —
+  // opening the drawer shouldn't present an active Save. Compared against
+  // the same defaults the state was seeded with.
+  const isDirty =
+    url !== (initialValues.url ?? "") ||
+    name !== (initialValues.name ?? "") ||
+    sleeps !== (initialValues.sleeps ?? "") ||
+    price !== (initialValues.price ?? "") ||
+    notes !== (initialValues.notes ?? "") ||
+    address !== (initialValues.address ?? "") ||
+    checkIn !== (initialValues.checkIn ?? "") ||
+    checkOut !== (initialValues.checkOut ?? "") ||
+    checkInTimeOfDay !== (initialValues.checkInTimeOfDay ?? "") ||
+    checkOutTimeOfDay !== (initialValues.checkOutTimeOfDay ?? "") ||
+    JSON.stringify(imageUrls) !== JSON.stringify(initialValues.imageUrls ?? []);
+
+  const canSubmit = hasContent && (!isEditing || isDirty);
 
   const handleUrlBlur = () => {
     const prefixed = ensureProtocol(url);
@@ -372,7 +366,7 @@ export function AddPropertySheet({
       checkOut,
       checkInTimeOfDay,
       checkOutTimeOfDay,
-      imageUrl,
+      imageUrls,
     });
   };
 
@@ -423,31 +417,170 @@ export function AddPropertySheet({
 
         {/* Header — sticky top */}
         <div
-          className="flex-shrink-0 px-5 pb-3 pt-4"
+          className="flex flex-shrink-0 items-center justify-between gap-3 px-5 pb-3 pt-4"
           style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
         >
-          <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            {isEditing ? "Edit property" : "Add a property"}
-          </h2>
+          {isEditing ? (
+            <div className="min-w-0">
+              <div
+                className="text-[10px] font-bold uppercase tracking-[0.12em]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Lodging
+              </div>
+              <div
+                className="mt-0.5 truncate text-[15px] font-bold"
+                style={{ color: "var(--color-bt-text)" }}
+              >
+                {name || "Untitled property"}
+              </div>
+            </div>
+          ) : (
+            <h2 className="text-lg font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              Add a property
+            </h2>
+          )}
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-80"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+          >
+            <X size={16} />
+          </button>
         </div>
 
-        {/* Body — scrollable */}
-        <div className="flex-1 overflow-y-auto px-5 py-4">
-        {!isEditing && !manualMode && (
-          <p className="mt-0.5 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-            Paste a listing link, or{" "}
-            <button
-              onClick={() => setManualMode(true)}
-              className="underline"
-              style={{ color: "var(--color-bt-accent)" }}
-            >
-              enter manually
-            </button>
-          </p>
-        )}
+        {/* Body — scrollable. Field order: photo, title, link, location,
+            sleeps+cost, check-in/out, notes — then Remove (when editing). */}
+        <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+          {/* Photos — up to 3 square slots. Filled slots show the image
+              with a remove control; the first empty slot is the add
+              button (the others render as quiet placeholders so an empty
+              row reads as "optional" rather than broken). The cover the
+              LodgingCard renders is always the first photo. */}
+          <Field label="Photos" hint="optional">
+            <div className="grid grid-cols-3 gap-2">
+              {Array.from({ length: MAX_PHOTOS }).map((_, i) => {
+                const src = imageUrls[i];
+                const isFirstEmpty = !src && i === imageUrls.length;
+                const isUploadingSlot =
+                  !src && uploadingCount > 0 && i >= imageUrls.length && i < imageUrls.length + uploadingCount;
 
-        {/* URL field */}
-        <div className="mt-4">
+                // Filled slot — image with remove + cover badge.
+                if (src) {
+                  return (
+                    <div
+                      key={i}
+                      className="group relative aspect-square overflow-hidden rounded-xl"
+                      style={{
+                        backgroundImage: `url("${src}")`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                        border: "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      {i === 0 && (
+                        <span
+                          className="absolute left-1.5 top-1.5 rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.06em]"
+                          style={{ background: "rgba(0,0,0,0.55)", color: "#e2e8f0" }}
+                        >
+                          Cover
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => removePhoto(i)}
+                        aria-label="Remove photo"
+                        className="absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold transition-opacity hover:opacity-90"
+                        style={{ background: "rgba(0,0,0,0.6)", color: "#fff" }}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  );
+                }
+
+                // Uploading placeholder.
+                if (isUploadingSlot) {
+                  return (
+                    <div
+                      key={i}
+                      className="flex aspect-square items-center justify-center rounded-xl"
+                      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+                    >
+                      <span
+                        className="inline-block h-3 w-3 animate-pulse rounded-full"
+                        style={{ background: "var(--color-bt-accent)" }}
+                        aria-hidden
+                      />
+                    </div>
+                  );
+                }
+
+                // First empty slot = the add button; the rest are quiet
+                // placeholders so the empty state still looks intentional.
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={isFirstEmpty ? () => fileInputRef.current?.click() : undefined}
+                    disabled={!isFirstEmpty}
+                    aria-label={isFirstEmpty ? "Add photo" : undefined}
+                    className="flex aspect-square items-center justify-center rounded-xl transition-colors disabled:cursor-default"
+                    style={{
+                      background: "var(--color-bt-card)",
+                      border: isFirstEmpty
+                        ? "1.5px dashed var(--color-bt-border)"
+                        : "1px dashed var(--color-bt-subtle-border)",
+                      color: "var(--color-bt-text-dim)",
+                      opacity: isFirstEmpty ? 1 : 0.5,
+                    }}
+                  >
+                    {isFirstEmpty ? (
+                      <ImagePlus size={20} strokeWidth={1.75} />
+                    ) : (
+                      <Hotel size={18} strokeWidth={1.5} style={{ opacity: 0.6 }} />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={handlePhotoSelected}
+            />
+            {metaLoading && imageUrls.length === 0 && (
+              <p className="mt-1.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Fetching listing photo…
+              </p>
+            )}
+            {uploadError && (
+              <p className="mt-1.5 text-[11px]" style={{ color: "var(--color-bt-danger)" }}>
+                {uploadError}
+              </p>
+            )}
+          </Field>
+
+          {/* Title */}
+          <Field label="Title" required>
+            <input
+              type="text"
+              placeholder="e.g. Beach House, The Lodge"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className={inputCls}
+              style={{
+                ...inputStyle,
+                borderColor: name.trim() ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
+              }}
+            />
+          </Field>
+
+          {/* Link */}
           <Field label="Link" hint="opens externally">
             <div className="relative">
               <Link
@@ -461,8 +594,6 @@ export function AddPropertySheet({
                 value={url}
                 onChange={(e) => setUrl(e.target.value.trim())}
                 onBlur={handleUrlBlur}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus={!isEditing && !manualMode}
                 className={`${inputCls} pl-9`}
                 style={{
                   ...inputStyle,
@@ -471,199 +602,164 @@ export function AddPropertySheet({
               />
             </div>
           </Field>
-        </div>
 
-        {/* Link preview */}
-        {validUrl && (
-          <div className="mt-3">
-            <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-              Preview
-            </p>
-            <LinkPreviewCard url={url} name={name} imageUrl={imageUrl} loading={metaLoading} />
-          </div>
-        )}
+          {/* Location — planning only */}
+          {showAddressAndDates && (
+            <Field label="Location" hint="optional">
+              <div className="relative">
+                <MapPin
+                  size={14}
+                  className="absolute left-3 top-3.5"
+                  style={{ color: address ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+                />
+                <input
+                  type="text"
+                  placeholder="Search for an address"
+                  value={address}
+                  onChange={(e) => handleAddressChange(e.target.value)}
+                  className={`${inputCls} pl-9`}
+                  style={{
+                    ...inputStyle,
+                    borderColor: address ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
+                  }}
+                />
+                {addressDropdown.length > 0 && (
+                  <div
+                    className="absolute z-10 mt-1 w-full overflow-hidden rounded-xl shadow-lg"
+                    style={{
+                      background: "var(--color-bt-card-raised)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
+                  >
+                    {addressDropdown.map((p) => (
+                      <button
+                        key={p.placeId}
+                        onClick={() => selectAddress(p)}
+                        className="w-full px-3 py-2 text-left text-sm transition-opacity hover:opacity-70"
+                        style={{ color: "var(--color-bt-text)" }}
+                      >
+                        <span className="font-medium">{p.name}</span>
+                        {p.description && (
+                          <span className="ml-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                            {p.description}
+                          </span>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Field>
+          )}
 
-        {/* Name / Nickname — shown as soon as the form expands, above Optional divider */}
-        {showExpanded && (
-          <div className="mt-3">
-            <Field label={manualMode && !isEditing ? "Title *" : "Title"}>
+          {/* Sleeps + Cost */}
+          <div className="grid grid-cols-2 gap-2">
+            <Field label="Sleeps">
               <input
-                type="text"
-                placeholder="e.g. Beach House, The Lodge"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus={manualMode && !isEditing}
-                className={inputCls}
-                style={{
-                  ...inputStyle,
-                  borderColor: manualMode && !isEditing && name.trim()
-                    ? "var(--color-bt-accent-border)"
-                    : "var(--color-bt-border)",
-                }}
+                type="number"
+                placeholder="e.g. 8"
+                min={1}
+                max={99}
+                value={sleeps}
+                onChange={(e) => setSleeps(e.target.value)}
+                className={`${inputCls} font-mono tabular-nums`}
+                style={inputStyle}
               />
             </Field>
-          </div>
-        )}
-
-        {/* Optional fields — sleeps, price, thoughts, address, dates */}
-        {showExpanded && (
-          <>
-            {/* Divider */}
-            <div className="mt-4 mb-3 flex items-center gap-2">
-              <div className="flex-1 border-t" style={{ borderColor: "var(--color-bt-border)" }} />
-              <span className="text-[11px] font-medium uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-                Optional
-              </span>
-              <div className="flex-1 border-t" style={{ borderColor: "var(--color-bt-border)" }} />
-            </div>
-
-            <div className="space-y-3">
-              {/* Sleeps + Price */}
-              <div className="grid grid-cols-2 gap-2">
-                <Field label="Sleeps">
-                  <input
-                    type="number"
-                    placeholder="e.g. 8"
-                    min={1}
-                    max={99}
-                    value={sleeps}
-                    onChange={(e) => setSleeps(e.target.value)}
-                    className={inputCls}
-                    style={inputStyle}
-                  />
-                </Field>
-                <Field label="Cost">
-                  <div className="relative">
-                    <span
-                      className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 font-mono text-sm"
-                      style={{ color: "var(--color-bt-text-dim)" }}
-                    >
-                      $
-                    </span>
-                    <input
-                      type="text"
-                      inputMode="decimal"
-                      placeholder="2,400"
-                      value={price}
-                      onChange={(e) => setPrice(e.target.value)}
-                      className={`${inputCls} pl-7 text-right font-mono`}
-                      style={inputStyle}
-                    />
-                  </div>
-                </Field>
+            <Field label="Cost">
+              <div className="relative">
+                <span
+                  className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 font-mono text-sm"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  $
+                </span>
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="2,400"
+                  value={price}
+                  onChange={(e) => setPrice(e.target.value)}
+                  className={`${inputCls} pl-7 text-right font-mono tabular-nums`}
+                  style={inputStyle}
+                />
               </div>
+            </Field>
+          </div>
 
-              {/* Notes */}
-              <Field label="Notes" hint="optional">
-                <textarea
-                  placeholder="e.g. great pool, tons of space, perfect grilling deck"
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
-                  rows={2}
-                  className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+          {/* Check-in / Check-out — planning only */}
+          {showAddressAndDates && (
+            <div className="grid grid-cols-2 gap-2">
+              <Field label="Check-in">
+                <input
+                  type="date"
+                  value={checkIn}
+                  onChange={(e) => setCheckIn(e.target.value)}
+                  className={inputCls}
                   style={inputStyle}
                 />
               </Field>
-
-              {/* Address + Dates — planning only */}
-              {showAddressAndDates && (
-                <>
-                  <Field label="Location" hint="optional">
-                    <div className="relative">
-                      <MapPin
-                        size={14}
-                        className="absolute left-3 top-3.5"
-                        style={{ color: address ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
-                      />
-                      <input
-                        type="text"
-                        placeholder="Search for an address"
-                        value={address}
-                        onChange={(e) => handleAddressChange(e.target.value)}
-                        className={`${inputCls} pl-9`}
-                        style={{
-                          ...inputStyle,
-                          borderColor: address ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
-                        }}
-                      />
-                      {addressDropdown.length > 0 && (
-                        <div
-                          className="absolute z-10 mt-1 w-full overflow-hidden rounded-xl shadow-lg"
-                          style={{
-                            background: "var(--color-bt-card-raised)",
-                            border: "1px solid var(--color-bt-border)",
-                          }}
-                        >
-                          {addressDropdown.map((p) => (
-                            <button
-                              key={p.placeId}
-                              onClick={() => selectAddress(p)}
-                              className="w-full px-3 py-2 text-left text-sm transition-opacity hover:opacity-70"
-                              style={{ color: "var(--color-bt-text)" }}
-                            >
-                              <span className="font-medium">{p.name}</span>
-                              {p.description && (
-                                <span className="ml-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                                  {p.description}
-                                </span>
-                              )}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  </Field>
-
-                  <div className="grid grid-cols-2 gap-2">
-                    <Field label="Check-in">
-                      <input
-                        type="date"
-                        value={checkIn}
-                        onChange={(e) => setCheckIn(e.target.value)}
-                        className={inputCls}
-                        style={inputStyle}
-                      />
-                    </Field>
-                    <Field label="Check-out">
-                      <input
-                        type="date"
-                        value={checkOut}
-                        onChange={(e) => setCheckOut(e.target.value)}
-                        className={inputCls}
-                        style={inputStyle}
-                      />
-                    </Field>
-                    <Field label="Check-in time">
-                      <input
-                        type="time"
-                        value={checkInTimeOfDay}
-                        onChange={(e) => setCheckInTimeOfDay(e.target.value)}
-                        className={inputCls}
-                        style={inputStyle}
-                      />
-                    </Field>
-                    <Field label="Check-out time">
-                      <input
-                        type="time"
-                        value={checkOutTimeOfDay}
-                        onChange={(e) => setCheckOutTimeOfDay(e.target.value)}
-                        className={inputCls}
-                        style={inputStyle}
-                      />
-                    </Field>
-                  </div>
-                </>
-              )}
+              <Field label="Check-out">
+                <input
+                  type="date"
+                  value={checkOut}
+                  onChange={(e) => setCheckOut(e.target.value)}
+                  className={inputCls}
+                  style={inputStyle}
+                />
+              </Field>
+              <Field label="Check-in time">
+                <input
+                  type="time"
+                  value={checkInTimeOfDay}
+                  onChange={(e) => setCheckInTimeOfDay(e.target.value)}
+                  onClick={(e) => e.currentTarget.showPicker?.()}
+                  className={`${inputCls} font-mono tabular-nums`}
+                  style={inputStyle}
+                />
+              </Field>
+              <Field label="Check-out time">
+                <input
+                  type="time"
+                  value={checkOutTimeOfDay}
+                  onChange={(e) => setCheckOutTimeOfDay(e.target.value)}
+                  onClick={(e) => e.currentTarget.showPicker?.()}
+                  className={`${inputCls} font-mono tabular-nums`}
+                  style={inputStyle}
+                />
+              </Field>
             </div>
-          </>
-        )}
+          )}
 
+          {/* Notes */}
+          <Field label="Notes" hint="optional">
+            <textarea
+              placeholder="e.g. great pool, tons of space, perfect grilling deck"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+              style={inputStyle}
+            />
+          </Field>
+
+          {/* Remove property — at the end of the body, matching the
+              Receipt/Agenda edit modals (danger action above the footer). */}
+          {isEditing && onRemove && (
+            <div className="pt-1">
+              <ConfirmDeleteButton
+                label="Remove property"
+                confirmLabel="Remove"
+                prompt="Remove this property?"
+                pending={isPending}
+                testId="remove-property-btn"
+                onConfirm={onRemove}
+              />
+            </div>
+          )}
         </div>
 
-        {/* Footer — sticky bottom. Cancel + Save side-by-side, matching
-            the MemberEditor pattern so every drawer's commit point
-            lives in the same spot. */}
+        {/* Footer — sticky bottom */}
         <div
           className="flex flex-shrink-0 gap-2 px-5 py-3"
           style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}

--- a/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
+++ b/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Plus, X, Search, MapPin } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { trpc } from "@/lib/trpc-client";
 
 const GOLF_TYPES = ["golf_course"];
@@ -43,6 +44,10 @@ interface AddScheduleItemSheetProps {
   itemType: "general" | "golf";
   editItem?: ScheduleItemData | null;
   onClose: () => void;
+  /** When editing, wires the footer "Remove from agenda" danger button. */
+  onRemove?: () => void;
+  /** Whether the remove mutation is in flight (disables the button). */
+  removing?: boolean;
 }
 
 // ── Places Autocomplete Hook ─────────────────────────────────────────────
@@ -93,6 +98,8 @@ export function AddScheduleItemSheet({
   itemType,
   editItem,
   onClose,
+  onRemove,
+  removing,
 }: AddScheduleItemSheetProps) {
   useModalBackButton(onClose);
   const utils = trpc.useUtils();
@@ -298,6 +305,7 @@ export function AddScheduleItemSheet({
           // Golf: confirmed as soon as tee times or walk-on are set,
           // regardless of whether the round is on a day yet.
           isConfirmed: golfConfirmed,
+          courseId: course.id,
           courseName: selectedCourse.name,
           courseLocation: selectedCourse.address || null,
           teeTimes: golfTeeTimes,
@@ -352,12 +360,46 @@ export function AddScheduleItemSheet({
     setTeeTimes((prev) => prev.map((t, i) => (i === idx ? val : t)));
 
   const inputStyle = {
-    background: "var(--color-bt-card-raised)",
+    background: "var(--color-bt-card)",
     borderColor: "var(--color-bt-border)",
     color: "var(--color-bt-text)",
   };
 
-  const canSubmit = isGolf ? !!selectedCourse : !!title.trim();
+  // Dirty check — in edit mode the Save button stays disabled until the user
+  // actually changes a field, mirroring the lodging/receipts sheets.
+  const isDirty = (() => {
+    if (!isEditing) return true;
+    if (isGolf) {
+      const initialCourseName = editItem?.course?.name ?? editItem?.course_name ?? "";
+      const initialCourseAddr =
+        editItem?.course?.address ?? editItem?.course_location ?? "";
+      const initialWalkOn =
+        !!editItem &&
+        editItem.item_type === "golf" &&
+        Array.isArray(editItem.tee_times) &&
+        editItem.tee_times.length === 0;
+      const initialTeeTimes = editItem?.tee_times ?? [];
+      const currentTeeTimes = isWalkOn ? [] : teeTimes.filter((t) => t.trim());
+      return (
+        (selectedCourse?.name ?? "") !== initialCourseName ||
+        (selectedCourse?.address ?? "") !== initialCourseAddr ||
+        scheduledDate !== (editItem?.scheduled_date ?? "") ||
+        isWalkOn !== initialWalkOn ||
+        JSON.stringify(currentTeeTimes) !== JSON.stringify(initialTeeTimes)
+      );
+    }
+    return (
+      title !== (editItem?.title ?? "") ||
+      detail !== (editItem?.detail ?? "") ||
+      scheduledDate !== (editItem?.scheduled_date ?? "") ||
+      scheduledTime !== (editItem?.scheduled_time ?? "") ||
+      (selectedLocation?.name ?? "") !== (editItem?.course_name ?? "") ||
+      (selectedLocation?.address ?? "") !== (editItem?.course_location ?? "")
+    );
+  })();
+
+  const canSubmit =
+    (isGolf ? !!selectedCourse : !!title.trim()) && isDirty;
 
   return (
     <>
@@ -398,37 +440,49 @@ export function AddScheduleItemSheet({
       >
         {/* Header — sticky top */}
         <div
-          className="flex-shrink-0 px-5 pb-3 pt-4"
+          className="flex flex-shrink-0 items-center justify-between gap-3 px-5 pb-3 pt-4"
           style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
         >
-          <h2
-            className="text-lg font-semibold"
-            style={{ color: "var(--color-bt-text)" }}
+          {isEditing ? (
+            <div className="min-w-0">
+              <div
+                className="text-[10px] font-bold uppercase tracking-[0.12em]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Agenda
+              </div>
+              <div
+                className="mt-0.5 truncate text-[15px] font-bold"
+                style={{ color: "var(--color-bt-text)" }}
+              >
+                {title || (isGolf ? "Golf round" : "Untitled activity")}
+              </div>
+            </div>
+          ) : (
+            <h2
+              className="text-base font-semibold"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              Add to Agenda
+            </h2>
+          )}
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-80"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
           >
-            {isEditing
-              ? isGolf ? "Edit Golf Round" : "Edit Activity"
-              : "Add to Agenda"}
-          </h2>
+            <X size={16} />
+          </button>
         </div>
 
         {/* Body — scrollable */}
         <div className="flex-1 overflow-y-auto px-5 py-4">
 
-        {/* Helper caption per round-4 item 7 — sets expectations for
-            the type-selector + form below. */}
-        {!isEditing && (
-          <p
-            className="mt-1 text-[12px] leading-snug"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Pick a type, then fill in the basics.
-          </p>
-        )}
-
         {/* ── Type selector (add mode only) ────────────────────────────── */}
         {!isEditing && (
           <div
-            className="mt-3 inline-flex rounded-xl p-1"
+            className="mb-2 inline-flex rounded-xl p-1"
             style={{
               background: "var(--color-bt-card-raised)",
               border: "1px solid var(--color-bt-border)",
@@ -470,10 +524,15 @@ export function AddScheduleItemSheet({
         {/* ── Golf: course search ──────────────────────────────────────── */}
         {isGolf && (
           <>
+            {!manualMode && (
+              <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Golf Course Location<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden />
+              </p>
+            )}
             {selectedCourse && !showSearch ? (
               /* ── Selected course card ── */
               <div
-                className="mt-3 flex items-center gap-3 rounded-xl px-3 py-2.5"
+                className="flex items-center gap-3 rounded-xl px-3 py-2.5"
                 style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-accent-border)" }}
               >
                 <MapPin size={14} style={{ color: "var(--color-bt-accent)" }} />
@@ -503,7 +562,10 @@ export function AddScheduleItemSheet({
               </div>
             ) : manualMode ? (
               /* ── Manual entry fallback ── */
-              <div className="mt-3 space-y-2">
+              <div className="space-y-2">
+                <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  Name<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden />
+                </p>
                 <input
                   type="text"
                   placeholder="Course name"
@@ -521,6 +583,9 @@ export function AddScheduleItemSheet({
                   style={inputStyle}
                   autoFocus
                 />
+                <p className="mb-1.5 mt-3 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  Location <span className="font-medium normal-case tracking-normal">(optional)</span>
+                </p>
                 <input
                   type="text"
                   placeholder="Location (optional)"
@@ -553,7 +618,7 @@ export function AddScheduleItemSheet({
               </div>
             ) : (
               /* ── Places autocomplete search ── */
-              <div className="mt-3 relative">
+              <div className="relative">
                 <div className="relative">
                   <Search
                     size={14}
@@ -634,24 +699,27 @@ export function AddScheduleItemSheet({
                 rounds can be assigned to a day directly from the
                 drawer instead of via On Deck drag. */}
             <p
-              className="mt-3 mb-1.5 text-xs font-medium"
+              className="mt-3 mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]"
               style={{ color: "var(--color-bt-text-dim)" }}
             >
-              Date <span className="font-normal">(optional)</span>
+              Date <span className="font-medium normal-case tracking-normal">(optional)</span>
             </p>
             <input
-              type="date"
+              type={scheduledDate ? "date" : "text"}
               value={scheduledDate}
               min={tripStart}
               max={tripEnd}
+              onFocus={(e) => { e.currentTarget.type = "date"; }}
+              onBlur={(e) => { if (!scheduledDate) e.currentTarget.type = "text"; }}
               onChange={(e) => setScheduledDate(e.target.value)}
+              placeholder="Add a date"
               className="rounded-xl border px-3 py-2.5 text-sm outline-none"
               style={inputStyle}
             />
 
             {/* Tee times */}
             <p
-              className="mt-3 mb-1.5 text-xs font-medium"
+              className="mt-3 mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]"
               style={{ color: "var(--color-bt-text-dim)" }}
             >
               Tee times
@@ -665,7 +733,8 @@ export function AddScheduleItemSheet({
                         type="time"
                         value={t}
                         onChange={(e) => updateTeeTime(idx, e.target.value)}
-                        className="flex-1 rounded-xl border px-3 py-2.5 text-sm outline-none"
+                        onClick={(e) => e.currentTarget.showPicker?.()}
+                        className="flex-1 rounded-xl border px-3 py-2.5 text-sm font-mono tabular-nums outline-none"
                         style={inputStyle}
                       />
                       {teeTimes.length > 1 && (
@@ -690,8 +759,10 @@ export function AddScheduleItemSheet({
                 </button>
               </>
             )}
-            {/* Walk on option — confirmed without a specific tee time */}
-            <label className="mt-2.5 flex cursor-pointer items-center gap-2">
+            {/* Walk on option — confirmed without a specific tee time.
+                Extra top spacing keeps it clear of "Add tee time" so it's
+                not accidentally toggled after entering times. */}
+            <label className="mt-6 flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
                 checked={isWalkOn}
@@ -699,7 +770,7 @@ export function AddScheduleItemSheet({
                   setIsWalkOn(e.target.checked);
                   if (e.target.checked) setTeeTimes([""]);
                 }}
-                className="h-4 w-4 rounded"
+                className="flex-shrink-0 cursor-pointer accent-bt-accent"
               />
               <span className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
                 Walk on — no specific tee time
@@ -711,26 +782,32 @@ export function AddScheduleItemSheet({
         {/* ── General: title + detail ──────────────────────────────────── */}
         {!isGolf && (
           <>
+            <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+              Title<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden />
+            </p>
             <input
               type="text"
               placeholder="Title (e.g. Dinner at The Grill)"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="mt-3 w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+              className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
               style={inputStyle}
             />
+            <p className="mt-3 mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+              Detail <span className="font-medium normal-case tracking-normal">(optional)</span>
+            </p>
             <textarea
               placeholder="Detail (optional)"
               value={detail}
               onChange={(e) => setDetail(e.target.value)}
               rows={2}
-              className="mt-2 w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
+              className="w-full resize-none rounded-xl border px-3 py-2.5 text-sm outline-none"
               style={inputStyle}
             />
 
             {/* Location search (optional) */}
-            <p className="mt-3 mb-1.5 text-xs font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
-              Location <span className="font-normal">(optional)</span>
+            <p className="mt-3 mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+              Location <span className="font-medium normal-case tracking-normal">(optional)</span>
             </p>
             {selectedLocation && !showLocationSearch ? (
               <div
@@ -820,28 +897,32 @@ export function AddScheduleItemSheet({
                 range keeps users from assigning items outside it. */}
             <div className="mt-3 flex gap-3">
               <div>
-                <p className="mb-1.5 text-xs font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
-                  Date <span className="font-normal">(optional)</span>
+                <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  Date <span className="font-medium normal-case tracking-normal">(optional)</span>
                 </p>
                 <input
-                  type="date"
+                  type={scheduledDate ? "date" : "text"}
                   value={scheduledDate}
                   min={tripStart}
                   max={tripEnd}
+                  onFocus={(e) => { e.currentTarget.type = "date"; }}
+                  onBlur={(e) => { if (!scheduledDate) e.currentTarget.type = "text"; }}
                   onChange={(e) => setScheduledDate(e.target.value)}
+                  placeholder="Add a date"
                   className="rounded-xl border px-3 py-2.5 text-sm outline-none"
                   style={inputStyle}
                 />
               </div>
               <div>
-                <p className="mb-1.5 text-xs font-medium" style={{ color: "var(--color-bt-text-dim)" }}>
-                  Time <span className="font-normal">(optional)</span>
+                <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  Time <span className="font-medium normal-case tracking-normal">(optional)</span>
                 </p>
                 <input
                   type="time"
                   value={scheduledTime}
                   onChange={(e) => setScheduledTime(e.target.value)}
-                  className="w-32 rounded-xl border px-3 py-2.5 text-sm outline-none"
+                  onClick={(e) => e.currentTarget.showPicker?.()}
+                  className="w-32 rounded-xl border px-3 py-2.5 text-sm font-mono tabular-nums outline-none"
                   style={inputStyle}
                 />
               </div>
@@ -849,9 +930,25 @@ export function AddScheduleItemSheet({
           </>
         )}
 
+        {/* Destructive "Remove from agenda" sits at the end of the body —
+            above the footer divider and the Cancel/Save row. */}
+        {isEditing && onRemove && (
+          <div className="mt-4">
+            <ConfirmDeleteButton
+              label="Remove from agenda"
+              confirmLabel="Remove"
+              pendingLabel="Removing…"
+              prompt="Remove this from the agenda?"
+              pending={removing}
+              testId="remove-agenda-item-btn"
+              onConfirm={onRemove}
+            />
+          </div>
+        )}
+
         </div>
 
-        {/* Footer — sticky bottom */}
+        {/* Footer — sticky bottom: Cancel + Save row. */}
         <div
           className="flex flex-shrink-0 gap-2 px-5 py-3"
           style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}

--- a/src/app/trips/[tripId]/components/ConfirmDatesModal.tsx
+++ b/src/app/trips/[tripId]/components/ConfirmDatesModal.tsx
@@ -138,7 +138,7 @@ export function ConfirmDatesModal({
         {showClearWarning && (
           <div
             className="mt-3 flex items-start gap-2 rounded-xl px-3 py-2.5"
-            style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
+            style={{ background: "var(--color-bt-warning-faint)" }}
           >
             <span style={{ color: "var(--color-bt-warning)", flexShrink: 0 }}>⚠</span>
             <p className="text-[12px]" style={{ color: "var(--color-bt-warning)" }}>
@@ -167,7 +167,7 @@ export function ConfirmDatesModal({
             className="flex-1 rounded-xl py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
             style={{
               background: "var(--color-bt-accent)",
-              color: "var(--color-bt-base)",
+              color: "var(--color-bt-on-accent)",
             }}
           >
             Set dates

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ExternalLink, MapPin, Trash2, Hotel, Pencil, Clock, Plus, Check, Link2 } from "lucide-react";
+import { ExternalLink, MapPin, Hotel, Clock, Check, Link2, AlertTriangle } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { EmptyState } from "@/components/EmptyState";
 import { SampleHeader, SampleCard, RailComposer } from "@/components/SampleSection";
@@ -66,6 +66,8 @@ interface LodgingItemFull {
    *  When set, surfaces as the LodgingCard photo strip instead of the
    *  placeholder gradient. */
   image_url?: string | null;
+  /** Up to 3 photos; image_url stays synced to the first as the cover. */
+  image_urls?: string[] | null;
 }
 
 // ── LodgingCard ───────────────────────────────────────────────────────────
@@ -74,16 +76,12 @@ function LodgingCard({
   item,
   canEdit,
   onEdit,
-  onRemove,
   onConfirmToggle,
-  removing,
 }: {
   item: LodgingItemFull;
   canEdit: boolean;
   onEdit: () => void;
-  onRemove: () => void;
   onConfirmToggle: () => void;
-  removing: boolean;
 }) {
   const platform = getPlatform(item.transport_type);
   const url = isHttpUrl(item.detail) ? item.detail! : null;
@@ -99,16 +97,55 @@ function LodgingCard({
 
   const confirmed = !!item.is_confirmed;
 
+  // A confirmed property with no check-in *and* no check-out date can't
+  // land on the itinerary — the itinerary keys off dates, so "confirmed
+  // but undated" is a dead end. Flag it so the user knows to add dates.
+  // Dates needn't fall inside the trip range (pre/post-trip stays still
+  // show up); they just have to exist.
+  const needsDates = confirmed && !item.check_in_time && !item.check_out_time;
+
   const price = item.total_price
     ? (/^[$€£¥]/.test(item.total_price) ? item.total_price : `$${item.total_price}`)
     : null;
 
+  // Photos — image_urls is the source of truth; fall back to the legacy
+  // single image_url for rows created before multi-photo. Rendered as up
+  // to three square slots, mirroring AddPropertySheet.
+  const photos = item.image_urls?.length
+    ? item.image_urls
+    : item.image_url
+      ? [item.image_url]
+      : [];
+
   return (
     <div
-      className="flex flex-col gap-2 rounded-xl p-3 transition-all"
+      onClick={canEdit ? onEdit : undefined}
+      role={canEdit ? "button" : undefined}
+      tabIndex={canEdit ? 0 : undefined}
+      onKeyDown={
+        canEdit
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onEdit();
+              }
+            }
+          : undefined
+      }
+      className={`flex flex-col gap-2 rounded-xl p-3 transition-all ${
+        canEdit
+          ? "cursor-pointer hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
+          : ""
+      }`}
       style={{
         background: confirmed ? "var(--color-bt-tag-bg)" : "var(--color-bt-card)",
-        border: `1px solid ${confirmed ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+        border: `1px solid ${
+          needsDates
+            ? "var(--color-bt-warning)"
+            : confirmed
+              ? "var(--color-bt-accent-border)"
+              : "var(--color-bt-border)"
+        }`,
       }}
     >
       {/* Photo strip — real listing photo (og:image) when we have one,
@@ -117,99 +154,99 @@ function LodgingCard({
           Carries the Confirmed pill / Confirm button bottom-right and
           the edit/delete actions top-right when canEdit. Gradient hex
           literals are spec-explicit (HANDOFF rule 4 exception). */}
-      <div
-        className="relative flex items-end justify-end rounded-lg p-2"
-        style={{
-          height: 80,
-          backgroundImage: item.image_url
-            ? `url("${item.image_url}")`
-            : "linear-gradient(135deg, #0d2c3a 0%, #0d3a4f 100%)",
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-        }}
-      >
-        {/* Generic-property placeholder icon — centered, low opacity.
-            Shows only when we don't have a real listing photo, so the
-            tile never reads as a blank panel waiting to load. */}
-        {!item.image_url && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
-            <Hotel size={36} strokeWidth={1.5} style={{ color: "rgba(255,255,255,0.22)" }} />
-          </div>
-        )}
-
-        {/* Edit / delete — top-right overlay on the photo strip */}
-        {canEdit && (
-          <div className="absolute right-1.5 top-1.5 flex items-center gap-1">
-            <button
-              onClick={onEdit}
-              aria-label="Edit property"
-              className="flex h-6 w-6 items-center justify-center rounded transition-colors hover:bg-black/30"
-              style={{ background: "rgba(0,0,0,0.35)", color: "#e2e8f0" }}
-            >
-              <Pencil size={12} strokeWidth={2.25} />
-            </button>
-            <button
-              onClick={onRemove}
-              disabled={removing}
-              aria-label="Remove property"
-              className="flex h-6 w-6 items-center justify-center rounded transition-colors hover:bg-black/30 disabled:opacity-40"
-              style={{ background: "rgba(0,0,0,0.35)", color: "#e2e8f0" }}
-            >
-              <Trash2 size={12} strokeWidth={2.25} />
-            </button>
-          </div>
-        )}
-
-        {/* Confirmed / Confirm — bottom-right matches PropertyExample */}
-        {confirmed ? (
-          <button
-            onClick={onConfirmToggle}
-            disabled={!canEdit}
-            aria-label={canEdit ? "Mark as not confirmed" : undefined}
-            className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em] transition-opacity hover:opacity-85 disabled:cursor-default"
-            style={{
-              background: "var(--color-bt-accent)",
-              color: "var(--color-bt-on-accent)",
-            }}
-          >
-            <Check size={9} strokeWidth={3.5} />
-            Confirmed
-          </button>
-        ) : canEdit ? (
-          <button
-            onClick={onConfirmToggle}
-            className="inline-flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.08em] transition-opacity hover:opacity-85"
-            style={{
-              background: "rgba(0,0,0,0.45)",
-              color: "#e2e8f0",
-              border: "1px solid rgba(255,255,255,0.18)",
-            }}
-          >
-            Confirm
-          </button>
-        ) : null}
+      <div className="relative">
+        {/* Three square photo slots — mirrors AddPropertySheet so the
+            card reads the same as the editor. Filled slots show the
+            photo; empty slots fall back to the placeholder gradient +
+            generic-property icon. Gradient hex literals are
+            spec-explicit (HANDOFF rule 4 exception). */}
+        <div className="grid grid-cols-3 gap-1.5">
+          {Array.from({ length: 3 }).map((_, i) => {
+            const src = photos[i];
+            return (
+              <div
+                key={i}
+                className="relative aspect-square overflow-hidden rounded-lg"
+                style={{
+                  backgroundImage: src
+                    ? `url("${src}")`
+                    : "linear-gradient(135deg, #0d2c3a 0%, #0d3a4f 100%)",
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                }}
+              >
+                {!src && (
+                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center" aria-hidden>
+                    <Hotel size={26} strokeWidth={1.5} style={{ color: "rgba(255,255,255,0.18)" }} />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
-      {/* Name + monospace meta line — same hierarchy as PropertyExample */}
+      {/* Name + monospace meta line — same hierarchy as PropertyExample.
+          The Confirm/Confirmed control sits inline with the title as a
+          pill toggle, matching the Receipts even-split "Customize…"
+          pattern. */}
       <div className="flex flex-col gap-0.5">
-        <div
-          className="truncate text-sm font-semibold"
-          style={{ color: "var(--color-bt-text)" }}
-          title={name}
-        >
-          {name}
+        <div className="flex items-center justify-between gap-2">
+          <div
+            className="min-w-0 flex-1 truncate text-sm font-semibold"
+            style={{ color: "var(--color-bt-text)" }}
+            title={name}
+          >
+            {name}
+          </div>
+          {confirmed ? (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (canEdit) onConfirmToggle();
+              }}
+              disabled={!canEdit}
+              aria-label={canEdit ? "Mark as not confirmed" : undefined}
+              className="inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold transition-opacity hover:opacity-85 disabled:cursor-default disabled:hover:opacity-100"
+              style={{
+                background: "var(--color-bt-accent)",
+                borderColor: "var(--color-bt-accent)",
+                color: "var(--color-bt-on-accent)",
+              }}
+            >
+              <Check size={12} strokeWidth={3} />
+              Confirmed
+            </button>
+          ) : canEdit ? (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfirmToggle();
+              }}
+              className="inline-flex flex-shrink-0 items-center rounded-full border px-2.5 py-1 text-xs font-semibold transition-opacity hover:opacity-80"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                borderColor: "var(--color-bt-accent-border)",
+                color: "var(--color-bt-accent)",
+              }}
+            >
+              Confirm
+            </button>
+          ) : null}
         </div>
-        <div
-          className="font-mono text-[11px]"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          {[
-            price ? price : null,
-            item.property_name ? `sleeps ${item.property_name}` : null,
-          ]
-            .filter(Boolean)
-            .join(" · ") || "—"}
-        </div>
+        {(price || item.property_name) && (
+          <div
+            className="font-mono text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {[
+              price ? price : null,
+              item.property_name ? `sleeps ${item.property_name}` : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </div>
+        )}
       </div>
 
       {/* Notes — italic, smaller */}
@@ -243,8 +280,9 @@ function LodgingCard({
         </div>
       )}
 
-      {/* Date range */}
-      {dateRange && (
+      {/* Date range — or, when confirmed without any dates, a warning
+          chip since the property can't reach the itinerary undated. */}
+      {dateRange ? (
         <div
           className="inline-flex items-center gap-1 text-[11px]"
           style={{ color: "var(--color-bt-text-dim)" }}
@@ -252,7 +290,18 @@ function LodgingCard({
           <Clock size={10} />
           {dateRange}
         </div>
-      )}
+      ) : needsDates ? (
+        <div
+          className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium"
+          style={{
+            background: "var(--color-bt-warning-faint)",
+            color: "var(--color-bt-warning)",
+          }}
+        >
+          <AlertTriangle size={10} />
+          Add dates to show on the itinerary
+        </div>
+      ) : null}
 
       {/* Listing link — anchored to the tile's bottom row */}
       {url && (
@@ -260,6 +309,7 @@ function LodgingCard({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
           className="mt-auto inline-flex items-center gap-0.5 self-start pt-1 no-underline"
           style={{ color: "var(--color-bt-accent)" }}
         >
@@ -479,7 +529,7 @@ export function LodgingPanel({
       checkInTimeOfDay: values.checkInTimeOfDay || undefined,
       checkOutTimeOfDay: values.checkOutTimeOfDay || undefined,
       transportType: platform,
-      imageUrl: values.imageUrl || undefined,
+      imageUrls: values.imageUrls,
     });
   };
 
@@ -501,11 +551,17 @@ export function LodgingPanel({
       checkInTimeOfDay: values.checkInTimeOfDay || null,
       checkOutTimeOfDay: values.checkOutTimeOfDay || null,
       transportType: platform,
-      imageUrl: values.imageUrl || null,
+      imageUrls: values.imageUrls,
     });
   };
 
   const confirmedCount = lodgingItems.filter((i) => i.is_confirmed).length;
+  // A property is "on the itinerary" only when it's confirmed AND dated
+  // (the itinerary keys off dates). Confirmed-but-undated still counts as
+  // an open action item, so it gates the nudge below.
+  const confirmedDatedCount = lodgingItems.filter(
+    (i) => i.is_confirmed && (i.check_in_time || i.check_out_time)
+  ).length;
   const totalCount = lodgingItems.length;
 
   // Lodging items where check-in or check-out date falls outside the trip
@@ -564,17 +620,19 @@ export function LodgingPanel({
             </div>
           </div>
         )}
-        {/* Unconfirmed-properties nudge — only fires when nothing has
-            been confirmed yet (Task 70). Once at least one property is
-            locked in, the rest can sit unconfirmed as "considered but
-            not booked" without nagging. Also suppressed when the
-            warning nudge above is showing so two cards don't stack on
-            the same tab. Pairs with lodgingUnconfirmed in page.tsx,
-            which uses the same `confirmedCount === 0` test for the
-            info dot. */}
+        {/* Lodging action nudge — fires until at least one property is
+            both confirmed AND dated (i.e. actually on the itinerary).
+            Two phases:
+              • Nothing confirmed → "still being considered / tap Confirm."
+              • Confirmed but undated → "add dates so it reaches the
+                itinerary" (warning tier — the property looks decided but
+                won't show up anywhere).
+            Suppressed when the out-of-range warning above is showing so
+            two cards don't stack. Pairs with lodgingUnconfirmed in
+            page.tsx, which uses the same confirmed-AND-dated test. */}
         {canEdit &&
           outOfRangeCount === 0 &&
-          confirmedCount === 0 &&
+          confirmedDatedCount === 0 &&
           totalCount > 0 && (
             <div
               className="mb-4 flex items-center gap-3 rounded-xl px-4 py-3"
@@ -585,30 +643,51 @@ export function LodgingPanel({
             >
               <span
                 className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
-                style={{
-                  background: "var(--color-bt-accent-faint)",
-                  color: "var(--color-bt-accent)",
-                }}
+                style={
+                  confirmedCount > 0
+                    ? { background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }
+                    : { background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }
+                }
               >
                 <Hotel size={14} />
               </span>
-              <div>
-                <p
-                  className="text-[13px] font-semibold leading-tight"
-                  style={{ color: "var(--color-bt-text)" }}
-                >
-                  {totalCount}{" "}
-                  {totalCount === 1 ? "property is" : "properties are"} still
-                  being considered
-                </p>
-                <p
-                  className="mt-0.5 text-[11px] leading-snug"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  Tap Confirm on any once they&apos;re booked so the crew sees the
-                  official lodging.
-                </p>
-              </div>
+              {confirmedCount > 0 ? (
+                <div>
+                  <p
+                    className="text-[13px] font-semibold leading-tight"
+                    style={{ color: "var(--color-bt-text)" }}
+                  >
+                    {confirmedCount === 1
+                      ? "A confirmed property has no dates"
+                      : "Confirmed properties have no dates"}
+                  </p>
+                  <p
+                    className="mt-0.5 text-[11px] leading-snug"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    Add a check-in / check-out so confirmed lodging shows up on
+                    the itinerary.
+                  </p>
+                </div>
+              ) : (
+                <div>
+                  <p
+                    className="text-[13px] font-semibold leading-tight"
+                    style={{ color: "var(--color-bt-text)" }}
+                  >
+                    {totalCount}{" "}
+                    {totalCount === 1 ? "property is" : "properties are"} still
+                    being considered
+                  </p>
+                  <p
+                    className="mt-0.5 text-[11px] leading-snug"
+                    style={{ color: "var(--color-bt-text-dim)" }}
+                  >
+                    Tap Confirm on any once they&apos;re booked so the crew sees the
+                    official lodging.
+                  </p>
+                </div>
+              )}
             </div>
           )}
 
@@ -760,13 +839,11 @@ export function LodgingPanel({
                   item={item}
                   canEdit={canEdit}
                   onEdit={() => setEditingItem(item)}
-                  onRemove={() => removeItem.mutate({ tripId, itemId: item.id })}
                   onConfirmToggle={() =>
                     item.is_confirmed
                       ? unconfirmItem.mutate({ tripId, itemId: item.id })
                       : confirmItem.mutate({ tripId, itemId: item.id })
                   }
-                  removing={removeItem.isPending}
                 />
               ))}
             </div>
@@ -804,11 +881,19 @@ export function LodgingPanel({
               checkOut: editingItem.check_out_time ?? "",
               checkInTimeOfDay: editingItem.check_in_time_of_day ?? "",
               checkOutTimeOfDay: editingItem.check_out_time_of_day ?? "",
-              imageUrl: editingItem.image_url ?? "",
+              imageUrls: editingItem.image_urls?.length
+                ? editingItem.image_urls
+                : editingItem.image_url
+                  ? [editingItem.image_url]
+                  : [],
             }}
             isPending={updateItem.isPending}
             onSubmit={handleUpdate}
             onClose={() => setEditingItem(null)}
+            onRemove={() => {
+              removeItem.mutate({ tripId, itemId: editingItem.id });
+              setEditingItem(null);
+            }}
           />
         )}
       </>
@@ -902,13 +987,11 @@ export function LodgingPanel({
                 item={item}
                 canEdit={canEdit}
                 onEdit={() => setEditingItem(item)}
-                onRemove={() => removeItem.mutate({ tripId, itemId: item.id })}
                 onConfirmToggle={() =>
                   item.is_confirmed
                     ? unconfirmItem.mutate({ tripId, itemId: item.id })
                     : confirmItem.mutate({ tripId, itemId: item.id })
                 }
-                removing={removeItem.isPending}
               />
             ))}
           </div>
@@ -959,11 +1042,19 @@ export function LodgingPanel({
             checkOut: editingItem.check_out_time ?? "",
             checkInTimeOfDay: editingItem.check_in_time_of_day ?? "",
             checkOutTimeOfDay: editingItem.check_out_time_of_day ?? "",
-            imageUrl: editingItem.image_url ?? "",
+            imageUrls: editingItem.image_urls?.length
+              ? editingItem.image_urls
+              : editingItem.image_url
+                ? [editingItem.image_url]
+                : [],
           }}
           isPending={updateItem.isPending}
           onSubmit={handleUpdate}
           onClose={() => setEditingItem(null)}
+          onRemove={() => {
+            removeItem.mutate({ tripId, itemId: editingItem.id });
+            setEditingItem(null);
+          }}
         />
       )}
     </>

--- a/src/app/trips/[tripId]/components/TripInvitationModal.tsx
+++ b/src/app/trips/[tripId]/components/TripInvitationModal.tsx
@@ -136,7 +136,7 @@ export function TripInvitationModal({ tripId, trip, onClose }: TripInvitationMod
             className="flex flex-1 items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
             style={{
               background: "var(--color-bt-accent)",
-              color: "var(--color-bt-base)",
+              color: "var(--color-bt-on-accent)",
               border: "1px solid var(--color-bt-accent)",
             }}
           >

--- a/src/app/trips/[tripId]/components/TripSummaryModal.tsx
+++ b/src/app/trips/[tripId]/components/TripSummaryModal.tsx
@@ -143,7 +143,7 @@ export function TripSummaryModal({ tripId, trip, onClose, onAdvanced }: TripSumm
         {!alreadyGoing && (!hasLockedDate || !hasDestination) && (
           <div
             className="mt-2 flex items-start gap-3 rounded-xl px-4 py-3"
-            style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
+            style={{ background: "var(--color-bt-warning-faint)" }}
           >
             <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-warning)" }} />
             <p className="text-sm" style={{ color: "var(--color-bt-warning)" }}>
@@ -194,7 +194,7 @@ export function TripSummaryModal({ tripId, trip, onClose, onAdvanced }: TripSumm
             disabled={advance.isPending || !hasLockedDate}
             data-testid="trip-summary-send-btn"
             className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-on-accent)" }}
           >
             <Send size={15} />
             {advance.isPending ? "Sending..." : "View Itinerary →"}
@@ -229,7 +229,7 @@ function SummaryRow({
         className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md"
         style={{
           background: needsAttention
-            ? "var(--color-bt-warning-bg, rgba(217,119,6,0.15))"
+            ? "var(--color-bt-warning-faint)"
             : "var(--color-bt-card)",
           color: needsAttention ? "var(--color-bt-warning)" : "var(--color-bt-accent)",
         }}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -277,14 +277,17 @@ export default function TripDetailPage() {
       return (ci && (ci < tripStart || ci > tripEnd)) ||
              (co && (co < tripStart || co > tripEnd));
     });
-  // Task 70: the dot fires only when NOTHING is confirmed yet. Once at
-  // least one property is locked in we consider the lodging decided —
-  // any leftover unconfirmed entries are "considered but not booked"
-  // (parallel options the crew can still browse), not a nag.
+  // Task 70: the dot fires until the lodging is actually "decided." A
+  // property only counts as decided when it's confirmed AND has a date —
+  // confirming without a check-in/out leaves it off the itinerary (the
+  // itinerary keys off dates), so confirmed-but-undated is still an
+  // action item. Dates needn't be in-range (pre/post-trip stays are
+  // fine); they just have to exist. Leftover unconfirmed entries beyond
+  // that are "considered but not booked" and don't nag.
   const lodgingUnconfirmed =
     effectiveCanEdit &&
     lodgingItems.length > 0 &&
-    !lodgingItems.some((i) => i.is_confirmed);
+    !lodgingItems.some((i) => i.is_confirmed && (i.check_in_time || i.check_out_time));
   const scheduleOutOfRange =
     effectiveCanEdit &&
     tripStart && tripEnd &&

--- a/src/app/trips/[tripId]/tabs/AddExpenseModal.tsx
+++ b/src/app/trips/[tripId]/tabs/AddExpenseModal.tsx
@@ -86,17 +86,16 @@ export function AddExpenseModal({
     }
   }
 
-  function switchToEven() {
-    setSplitMode("even");
-    setSplitAmong(members.map((m) => m.user_id));
-    setOverrides({});
+  function handleModeChange(next: "even" | "custom") {
+    if (next === "even") {
+      // Re-include everyone and clear overrides.
+      setSplitAmong(members.map((m) => m.user_id));
+      setOverrides({});
+    }
+    setSplitMode(next);
   }
 
   const amountNum = Number(amount) || 0;
-  const evenPerPerson =
-    amountNum > 0 && members.length > 0
-      ? amountNum / members.length
-      : 0;
 
   function handleCreate() {
     const splitData =
@@ -166,10 +165,11 @@ export function AddExpenseModal({
           </h2>
           <button
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-80"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
           >
-            <X size={18} />
+            <X size={16} />
           </button>
         </div>
 
@@ -178,18 +178,18 @@ export function AddExpenseModal({
           {/* Side-by-side Description + Amount */}
           <div className="flex gap-3">
             <div className="min-w-0 flex-1">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Title</label>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Title<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden /></label>
               <input
                 data-testid="expense-title-input"
                 placeholder="Description (e.g. Dinner)"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
               />
             </div>
             <div className="w-36 flex-shrink-0">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Cost</label>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Cost<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden /></label>
               <CurrencyInput
                 data-testid="expense-amount-input"
                 value={amount}
@@ -202,7 +202,7 @@ export function AddExpenseModal({
           {/* Paid by + Date on same line */}
           <div className="flex gap-3">
             <div className="min-w-0 flex-1">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
                 Paid by
               </label>
               <div className="relative">
@@ -211,7 +211,7 @@ export function AddExpenseModal({
                   value={paidByUserId}
                   onChange={(e) => setPaidByUserId(e.target.value)}
                   className="w-full appearance-none rounded-lg border py-2 pl-3 pr-8 text-sm outline-none"
-                  style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                  style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
                 >
                   {members.map((m) => (
                     <option key={m.user_id} value={m.user_id}>
@@ -225,67 +225,43 @@ export function AddExpenseModal({
               </div>
             </div>
             <div className="w-36 flex-shrink-0">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
                 Date (optional)
               </label>
               <input
-                type="date"
+                type={date ? "date" : "text"}
                 value={date}
+                onFocus={(e) => { e.currentTarget.type = "date"; }}
+                onBlur={(e) => { if (!date) e.currentTarget.type = "text"; }}
                 onChange={(e) => setDate(e.target.value)}
+                placeholder="Add a date"
                 className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
               />
             </div>
           </div>
 
-          {/* Even / Custom toggle */}
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={switchToEven}
-              className="flex-1 rounded-lg border px-3 py-2 text-sm"
-              style={{
-                background: splitMode === "even" ? "var(--color-bt-tag-bg)" : "var(--color-bt-card)",
-                borderColor: splitMode === "even" ? "var(--color-bt-accent)" : "var(--color-bt-border)",
-                color: splitMode === "even" ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-              }}
-            >
-              Even split{evenPerPerson > 0 ? ` · $${evenPerPerson.toFixed(2)}` : ""}
-            </button>
-            <button
-              type="button"
-              onClick={() => setSplitMode("custom")}
-              className="flex-1 rounded-lg border px-3 py-2 text-sm"
-              style={{
-                background: splitMode === "custom" ? "var(--color-bt-tag-bg)" : "var(--color-bt-card)",
-                borderColor: splitMode === "custom" ? "var(--color-bt-accent)" : "var(--color-bt-border)",
-                color: splitMode === "custom" ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-              }}
-            >
-              Custom split
-            </button>
-          </div>
-
-          {/* Custom split panel */}
-          {splitMode === "custom" && (
-            <SplitPanel
-              members={members}
-              totalAmount={amountNum}
-              includedIds={splitAmong}
-              overrides={overrides}
-              onToggle={toggleSplit}
-              onOverrideChange={(uid, val) =>
-                setOverrides((prev) => ({ ...prev, [uid]: val }))
-              }
-              onResetOverride={(uid) =>
-                setOverrides((prev) => {
-                  const next = { ...prev };
-                  delete next[uid];
-                  return next;
-                })
-              }
-            />
-          )}
+          {/* Split panel — dark panel with even (simplified) / custom views */}
+          <SplitPanel
+            members={members}
+            totalAmount={amountNum}
+            includedIds={splitAmong}
+            overrides={overrides}
+            isOwnerEditing
+            mode={splitMode}
+            onModeChange={handleModeChange}
+            onToggle={toggleSplit}
+            onOverrideChange={(uid, val) =>
+              setOverrides((prev) => ({ ...prev, [uid]: val }))
+            }
+            onResetOverride={(uid) =>
+              setOverrides((prev) => {
+                const next = { ...prev };
+                delete next[uid];
+                return next;
+              })
+            }
+          />
 
         </div>
 

--- a/src/app/trips/[tripId]/tabs/EditExpenseModal.tsx
+++ b/src/app/trips/[tripId]/tabs/EditExpenseModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { X } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { trpc } from "@/lib/trpc-client";
 import { SplitPanel } from "./SplitPanel";
 import { CurrencyInput, memberName as getMemberName } from "./ExpensesSection";
@@ -12,11 +13,17 @@ export function EditExpenseModal({
   expense,
   members,
   tripId,
+  isOwner,
+  canDelete,
   onClose,
 }: {
   expense: ExpenseItem;
   members: ExpenseMember[];
   tripId: string;
+  /** Owner — can edit splits/fields (expenses.updateSplits is Owner-only). */
+  isOwner: boolean;
+  /** Owner or Planner — can delete the receipt (expenses.remove is Planner+). */
+  canDelete: boolean;
   onClose: () => void;
 }) {
   const utils = trpc.useUtils();
@@ -46,6 +53,28 @@ export function EditExpenseModal({
   const optedOutIds = expense.splits
     .filter((s) => s.opted_out)
     .map((s) => s.user_id);
+
+  // Split view starts "even" only when every non-opted-out member is
+  // included with no per-person override; any customization → "custom".
+  const [splitMode, setSplitMode] = useState<"even" | "custom">(() => {
+    const allIncluded = members.every(
+      (m) =>
+        optedOutIds.includes(m.user_id) || includedIds.includes(m.user_id)
+    );
+    const noOverrides = Object.keys(overrides).length === 0;
+    return allIncluded && noOverrides && optedOutIds.length === 0
+      ? "even"
+      : "custom";
+  });
+
+  function handleModeChange(next: "even" | "custom") {
+    if (next === "even") {
+      // Re-include everyone and clear overrides (mirrors Add modal).
+      setIncludedIds(members.map((m) => m.user_id));
+      setOverrides({});
+    }
+    setSplitMode(next);
+  }
 
   const updateSplits = trpc.expenses.updateSplits.useMutation({
     async onMutate(vars) {
@@ -84,6 +113,27 @@ export function EditExpenseModal({
     },
   });
 
+  const removeExpense = trpc.expenses.remove.useMutation({
+    async onMutate() {
+      await utils.expenses.list.cancel({ tripId });
+      const prev = utils.expenses.list.getData({ tripId });
+      utils.expenses.list.setData({ tripId }, (old) =>
+        (old ?? []).filter((exp) => exp.id !== expense.id)
+      );
+      return { prev };
+    },
+    onError(_err, _vars, context) {
+      if (context?.prev !== undefined)
+        utils.expenses.list.setData({ tripId }, context.prev);
+    },
+    onSuccess() {
+      onClose();
+    },
+    onSettled() {
+      utils.expenses.list.invalidate({ tripId });
+    },
+  });
+
   const memberName = (uid: string) => getMemberName(members, uid);
 
   function handleToggle(uid: string) {
@@ -100,6 +150,34 @@ export function EditExpenseModal({
   }
 
   const amountNum = Number(amount) || 0;
+
+  // Dirty check — in edit mode Save stays disabled until the user actually
+  // changes a field or the split, mirroring the lodging/agenda sheets.
+  const initialIncludedIds = expense.splits
+    .filter((s) => !s.opted_out)
+    .map((s) => s.user_id);
+  const initialOverrides: Record<string, string> = {};
+  for (const s of expense.splits) {
+    if (!s.opted_out && s.amount !== null)
+      initialOverrides[s.user_id] = String(s.amount);
+  }
+  const normalizeOverrides = (ids: string[], ov: Record<string, string>) => {
+    const out: Record<string, number> = {};
+    for (const id of [...ids].sort()) {
+      const raw = ov[id];
+      if (raw && raw !== "") out[id] = Number(raw);
+    }
+    return JSON.stringify(out);
+  };
+  const isDirty =
+    title.trim() !== expense.title ||
+    amountNum !== expense.amount ||
+    (date || null) !== (expense.date ?? null) ||
+    paidByUserId !== expense.paid_by_user_id ||
+    JSON.stringify([...includedIds].sort()) !==
+      JSON.stringify([...initialIncludedIds].sort()) ||
+    normalizeOverrides(includedIds, overrides) !==
+      normalizeOverrides(initialIncludedIds, initialOverrides);
 
   function handleSave() {
     const splits = includedIds.map((uid) => ({
@@ -174,15 +252,27 @@ export function EditExpenseModal({
           className="flex flex-shrink-0 items-center justify-between px-5 pb-3 pt-4"
           style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
         >
-          <h2 className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            Edit Receipt
-          </h2>
+          <div className="min-w-0">
+            <div
+              className="text-[10px] font-bold uppercase tracking-[0.12em]"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Receipt
+            </div>
+            <div
+              className="mt-0.5 truncate text-[15px] font-bold"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {title || expense.title || "Untitled receipt"}
+            </div>
+          </div>
           <button
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-80"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
           >
-            <X size={18} />
+            <X size={16} />
           </button>
         </div>
 
@@ -190,36 +280,39 @@ export function EditExpenseModal({
         <div className="flex-1 overflow-y-auto px-5 py-4">
 
         {/* Editable expense info */}
-        <div className="mb-4 space-y-2">
+        <div className="mb-4 space-y-3.5">
           <div className="flex gap-3">
             <div className="min-w-0 flex-1">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Title</label>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Title<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden /></label>
               <input
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="Description"
-                className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                disabled={!isOwner}
+                className="w-full rounded-lg border px-3 py-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
               />
             </div>
             <div className="w-36 flex-shrink-0">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Cost</label>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Cost<span className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle" style={{ background: "var(--color-bt-danger)" }} aria-hidden /></label>
               <CurrencyInput
                 value={amount}
                 onChange={setAmount}
                 className="w-full"
+                disabled={!isOwner}
               />
             </div>
           </div>
           <div className="flex items-center gap-3">
             <div className="min-w-0 flex-1">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Paid by</label>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Paid by</label>
               <div className="relative">
                 <select
                   value={paidByUserId}
                   onChange={(e) => setPaidByUserId(e.target.value)}
-                  className="w-full appearance-none rounded-lg border py-2 pl-3 pr-8 text-sm outline-none"
-                  style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                  disabled={!isOwner}
+                  className="w-full appearance-none rounded-lg border py-2 pl-3 pr-8 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                  style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
                 >
                   {members.map((m) => (
                     <option key={m.user_id} value={m.user_id}>
@@ -233,13 +326,17 @@ export function EditExpenseModal({
               </div>
             </div>
             <div className="w-36 flex-shrink-0">
-              <label className="mb-1 block text-xs" style={{ color: "var(--color-bt-text-dim)" }}>Date</label>
+              <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Date <span className="lowercase">(optional)</span></label>
               <input
-                type="date"
+                type={date ? "date" : "text"}
                 value={date}
+                onFocus={(e) => { e.currentTarget.type = "date"; }}
+                onBlur={(e) => { if (!date) e.currentTarget.type = "text"; }}
                 onChange={(e) => setDate(e.target.value)}
-                className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                disabled={!isOwner}
+                placeholder="Add a date"
+                className="w-full rounded-lg border px-3 py-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
               />
             </div>
           </div>
@@ -252,7 +349,9 @@ export function EditExpenseModal({
           includedIds={includedIds}
           overrides={overrides}
           optedOutIds={optedOutIds}
-          isOwnerEditing
+          isOwnerEditing={isOwner}
+          mode={splitMode}
+          onModeChange={handleModeChange}
           onToggle={handleToggle}
           onOverrideChange={(uid, val) =>
             setOverrides((prev) => ({ ...prev, [uid]: val }))
@@ -266,35 +365,56 @@ export function EditExpenseModal({
           }
         />
 
+        {/* Destructive "Delete receipt" sits at the end of the body —
+            above the footer divider and the Cancel/Save row. */}
+        {canDelete && (
+          <div className="mt-4">
+            <ConfirmDeleteButton
+              label="Delete receipt"
+              confirmLabel="Delete"
+              prompt="Delete this receipt?"
+              pending={removeExpense.isPending}
+              testId={`remove-expense-${expense.id}`}
+              onConfirm={() => removeExpense.mutate({ tripId, expenseId: expense.id })}
+            />
+          </div>
+        )}
+
         </div>
 
-        {/* Footer — sticky bottom */}
+        {/* Footer — sticky bottom. Cancel/Save row; the destructive
+            "Delete receipt" action lives at the end of the body in the
+            scrollable body. */}
         <div
-          className="flex flex-shrink-0 gap-2 px-5 py-3"
+          className="flex flex-shrink-0 flex-col gap-2 px-5 py-3"
           style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}
         >
-          <button
-            onClick={onClose}
-            className="rounded-lg border px-4 py-2 text-sm font-medium"
-            style={{
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text-dim)",
-              background: "transparent",
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            disabled={updateSplits.isPending || includedIds.length === 0 || !title.trim() || amountNum <= 0}
-            onClick={handleSave}
-            className="flex-1 rounded-lg py-2 text-sm font-semibold disabled:opacity-40"
-            style={{
-              background: "var(--color-bt-accent)",
-              color: "var(--color-bt-on-accent)",
-            }}
-          >
-            {updateSplits.isPending ? "Saving..." : "Save Changes"}
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className={`rounded-lg border px-4 py-2 text-sm font-medium ${isOwner ? "" : "flex-1"}`}
+              style={{
+                borderColor: "var(--color-bt-border)",
+                color: "var(--color-bt-text-dim)",
+                background: "transparent",
+              }}
+            >
+              {isOwner ? "Cancel" : "Close"}
+            </button>
+            {isOwner && (
+              <button
+                disabled={updateSplits.isPending || includedIds.length === 0 || !title.trim() || amountNum <= 0 || !isDirty}
+                onClick={handleSave}
+                className="flex-1 rounded-lg py-2 text-sm font-semibold disabled:opacity-40"
+                style={{
+                  background: "var(--color-bt-accent)",
+                  color: "var(--color-bt-on-accent)",
+                }}
+              >
+                {updateSplits.isPending ? "Saving..." : "Save Changes"}
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -3,10 +3,6 @@
 import { useState } from "react";
 import {
   DollarSign,
-  Pencil,
-  Plus,
-  Receipt,
-  Trash2,
   UserMinus,
   UserPlus,
 } from "lucide-react";
@@ -73,21 +69,27 @@ export function CurrencyInput({
   onChange,
   placeholder = "0.00",
   className = "",
+  disabled = false,
   "data-testid": testId,
 }: {
   value: string;
   onChange: (val: string) => void;
   placeholder?: string;
   className?: string;
+  disabled?: boolean;
   "data-testid"?: string;
 }) {
   return (
     <div
       className={`relative flex items-center rounded-lg border ${className}`}
-      style={{ background: "var(--color-bt-base)", borderColor: "var(--color-bt-border)" }}
+      style={{
+        background: "var(--color-bt-card)",
+        borderColor: "var(--color-bt-border)",
+        opacity: disabled ? 0.6 : 1,
+      }}
     >
       <span
-        className="pointer-events-none pl-3 text-sm"
+        className="pointer-events-none pl-3 font-mono text-sm"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         $
@@ -100,7 +102,8 @@ export function CurrencyInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="min-w-0 flex-1 bg-transparent py-2 pl-1 pr-3 text-right text-sm outline-none"
+        disabled={disabled}
+        className="min-w-0 flex-1 bg-transparent py-2 pl-1 pr-3 text-right font-mono text-sm outline-none disabled:cursor-not-allowed"
         style={{ color: "var(--color-bt-text)" }}
       />
     </div>
@@ -160,17 +163,12 @@ function ReceiptExample() {
         $480.00
       </span>
 
-      {/* Trailing icon trio — match the populated state's action set
-          so the EXAMPLE faithfully previews what a real row looks like. */}
-      <div className="flex items-center gap-1" style={{ color: "var(--color-bt-text-dim)" }}>
-        <span className="flex h-[26px] w-[26px] items-center justify-center rounded-md">
-          <UserMinus size={14} />
-        </span>
-        <span className="flex h-[26px] w-[26px] items-center justify-center rounded-md">
-          <Pencil size={14} />
-        </span>
-        <span className="flex h-[26px] w-[26px] items-center justify-center rounded-md">
-          <Trash2 size={14} />
+      {/* Trailing action — faithfully previews a real row, which now
+          exposes just the opt-in/out control inline. Edit and delete
+          moved into the tap-to-open editor, so the sample drops them too. */}
+      <div className="flex items-center" style={{ color: "var(--color-bt-text-dim)" }}>
+        <span className="flex h-6 w-6 items-center justify-center rounded-full">
+          <UserMinus size={13} />
         </span>
       </div>
     </div>
@@ -589,13 +587,15 @@ export function ExpensesSection({
   const [editingExpense, setEditingExpense] = useState<ExpenseItem | null>(null);
 
   // ── Queries ──
-  const { data: expenses = [] } = trpc.expenses.list.useQuery({ tripId });
+  // `isLoading` is true only on the very first fetch with no cached data;
+  // revisiting the tab reads from cache and renders instantly. We gate the
+  // empty/populated decision on it so the empty state never flashes before
+  // the receipts arrive (the list isn't prefetched at the page level).
+  const { data: expenses = [], isLoading } = trpc.expenses.list.useQuery({ tripId });
 
   // ── Mutations ──
-  const removeExpense = trpc.expenses.remove.useMutation({
-    onSuccess: () => utils.expenses.list.invalidate({ tripId }),
-  });
-
+  // Deleting a receipt now lives inside EditExpenseModal (tap a row to
+  // open it), so the section itself no longer needs a remove mutation.
   const optOutMutation = trpc.expenses.optOut.useMutation({
     async onMutate(vars) {
       await utils.expenses.list.cancel({ tripId });
@@ -660,6 +660,27 @@ export function ExpensesSection({
     if (a.isGuest !== b.isGuest) return a.isGuest ? 1 : -1;
     return memberName(members, a.user_id).localeCompare(memberName(members, b.user_id));
   });
+
+  // While the first fetch is in flight we can't yet tell empty from
+  // populated, so show a couple of faded placeholder rows instead of
+  // flashing the empty-state composer (which then snaps to the real
+  // list a beat later).
+  if (isLoading) {
+    return (
+      <div className="space-y-2" aria-hidden>
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="h-[58px] animate-pulse rounded-xl"
+            style={{
+              background: "var(--color-bt-card)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <>
@@ -741,7 +762,30 @@ export function ExpensesSection({
                   <div
                     key={expense.id}
                     data-testid={`expense-row-${expense.id}`}
-                    className="flex items-center gap-3 rounded-xl px-3 py-2.5"
+                    // Whole row is the edit affordance (canEdit = Owner or
+                    // Planner). Tap opens the editor where splits/fields are
+                    // changed and the receipt can be deleted — no inline
+                    // pencil/trash clutter. A native drag never fires click,
+                    // and the opt-out button stops propagation, so neither
+                    // collides with the row tap.
+                    onClick={canEdit ? () => setEditingExpense(expense) : undefined}
+                    role={canEdit ? "button" : undefined}
+                    tabIndex={canEdit ? 0 : undefined}
+                    onKeyDown={
+                      canEdit
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              setEditingExpense(expense);
+                            }
+                          }
+                        : undefined
+                    }
+                    className={`flex items-center gap-3 rounded-xl px-3 py-2.5 ${
+                      canEdit
+                        ? "cursor-pointer transition-shadow hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
+                        : ""
+                    }`}
                     style={{
                       background: isOptedOut ? "var(--color-bt-base)" : "var(--color-bt-card)",
                       border: "1px solid var(--color-bt-border)",
@@ -802,13 +846,16 @@ export function ExpensesSection({
                     </div>
                     {userSplit && (
                       <button
-                        onClick={() =>
+                        onClick={(e) => {
+                          // Keep the opt-out tap from bubbling to the row's
+                          // edit handler.
+                          e.stopPropagation();
                           optOutMutation.mutate({
                             tripId,
                             expenseId: expense.id,
                             optOut: !isOptedOut,
-                          })
-                        }
+                          });
+                        }}
                         disabled={optOutMutation.isPending}
                         className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70 disabled:opacity-40"
                         // Opt out (you're in) reads as a quiet gray action;
@@ -818,29 +865,6 @@ export function ExpensesSection({
                         title={isOptedOut ? "Rejoin" : "Opt out"}
                       >
                         {isOptedOut ? <UserPlus size={13} /> : <UserMinus size={13} />}
-                      </button>
-                    )}
-                    {isOwner && (
-                      <button
-                        data-testid={`edit-splits-${expense.id}`}
-                        onClick={() => setEditingExpense(expense)}
-                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-70"
-                        style={{ color: "var(--color-bt-text-dim)" }}
-                      >
-                        <Pencil size={13} />
-                      </button>
-                    )}
-                    {canEdit && (
-                      <button
-                        data-testid={`remove-expense-${expense.id}`}
-                        onClick={() =>
-                          removeExpense.mutate({ tripId, expenseId: expense.id })
-                        }
-                        disabled={removeExpense.isPending}
-                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full disabled:opacity-40"
-                        style={{ color: "var(--color-bt-text-dim)" }}
-                      >
-                        <Trash2 size={13} />
                       </button>
                     )}
                   </div>
@@ -973,6 +997,8 @@ export function ExpensesSection({
           expense={editingExpense}
           members={members}
           tripId={tripId}
+          isOwner={isOwner}
+          canDelete={canEdit}
           onClose={() => setEditingExpense(null)}
         />
       )}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -15,8 +15,6 @@ import {
   GripVertical,
   ChevronUp,
   ChevronDown,
-  Pencil,
-  Trash2,
 } from "lucide-react";
 import { TabHeader } from "@/components/TabHeader";
 import { TabFab } from "@/components/TabFab";
@@ -105,7 +103,6 @@ function ScheduleItemRow({
   item,
   canEdit,
   onEdit,
-  onRemove,
   onMoveUp,
   onMoveDown,
   isFirst,
@@ -124,7 +121,6 @@ function ScheduleItemRow({
   item: ScheduleItem;
   canEdit: boolean;
   onEdit: () => void;
-  onRemove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
   isFirst: boolean;
@@ -184,7 +180,24 @@ function ScheduleItemRow({
           }
           onDrop();
         } : undefined}
-        className="mb-2 flex items-start gap-2 rounded-xl px-4 py-3 transition-all"
+        onClick={canEdit ? onEdit : undefined}
+        role={canEdit ? "button" : undefined}
+        tabIndex={canEdit ? 0 : undefined}
+        onKeyDown={
+          canEdit
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onEdit();
+                }
+              }
+            : undefined
+        }
+        className={`mb-2 flex items-start gap-2 rounded-xl px-4 py-3 transition-all ${
+          canEdit
+            ? "cursor-pointer hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
+            : ""
+        }`}
         style={{
           // Teal highlight = "locked in":
           //   non-golf → has a scheduled date
@@ -376,7 +389,7 @@ function ScheduleItemRow({
         {movable && (
           <div className="flex flex-col lg:hidden">
             <button
-              onClick={onMoveUp}
+              onClick={(e) => { e.stopPropagation(); onMoveUp(); }}
               disabled={isFirst}
               className="flex h-5 w-5 items-center justify-center transition-opacity disabled:opacity-20"
               style={{ color: "var(--color-bt-text-dim)" }}
@@ -385,7 +398,7 @@ function ScheduleItemRow({
               <ChevronUp size={14} />
             </button>
             <button
-              onClick={onMoveDown}
+              onClick={(e) => { e.stopPropagation(); onMoveDown(); }}
               disabled={isLast}
               className="flex h-5 w-5 items-center justify-center transition-opacity disabled:opacity-20"
               style={{ color: "var(--color-bt-text-dim)" }}
@@ -396,41 +409,18 @@ function ScheduleItemRow({
           </div>
         )}
 
-        {canEdit && (
-          <button
-            onClick={onEdit}
-            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            aria-label="Edit item"
-          >
-            <Pencil size={12} />
-          </button>
-        )}
-
+        {/* Send back to On Deck — Day-by-Day rows only. Delete now lives in
+            the edit drawer footer ("Remove from agenda"); the row itself is
+            tappable to open that drawer. */}
         {canEdit && onUnschedule && (
           <button
-            onClick={onUnschedule}
+            onClick={(e) => { e.stopPropagation(); onUnschedule(); }}
             className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80"
             style={{ color: "var(--color-bt-text-dim)" }}
             aria-label="Send back to On Deck"
             title="Send back to On Deck"
           >
             <X size={14} />
-          </button>
-        )}
-        {/* Trash: shown for all On Deck items (onUnschedule absent) regardless of
-            confirmation status. Confirmed golf rounds in On Deck have no X button
-            (they're not on a day) so without this they'd be impossible to remove.
-            Day-by-Day items use the X-to-unschedule flow instead. */}
-        {canEdit && !onUnschedule && (
-          <button
-            onClick={onRemove}
-            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            aria-label="Delete item"
-            title="Delete item"
-          >
-            <Trash2 size={13} />
           </button>
         )}
       </div>
@@ -521,7 +511,6 @@ export function ScheduleTab({
   const utils = trpc.useUtils();
   const [addMode, setAddMode] = useState<AddMode>(null);
   const [editItem, setEditItem] = useState<ScheduleItem | null>(null);
-  const [confirmDelete, setConfirmDelete] = useState<ScheduleItem | null>(null);
   const [dayPickerItem, setDayPickerItem] = useState<ScheduleItem | null>(null);
   const [linkCompEvent, setLinkCompEvent] = useState<EventRow | null>(null);
   const dragState = useRef<{ groupDate: string | null; idx: number; item: ScheduleItem } | null>(null);
@@ -1103,7 +1092,6 @@ export function ScheduleTab({
                           item={item}
                           canEdit={canEdit}
                           onEdit={() => setEditItem(item)}
-                          onRemove={() => setConfirmDelete(item)}
                           onMoveUp={() => handleMove(null, unscheduledItems, idx, "up")}
                           onMoveDown={() => handleMove(null, unscheduledItems, idx, "down")}
                           isFirst={idx === 0}
@@ -1342,7 +1330,6 @@ export function ScheduleTab({
                               item={item}
                               canEdit={canEdit}
                               onEdit={() => setEditItem(item)}
-                              onRemove={() => setConfirmDelete(item)}
                               onMoveUp={() => handleMove(group.date, group.items, idx, "up")}
                               onMoveDown={() => handleMove(group.date, group.items, idx, "down")}
                               isFirst={idx === 0}
@@ -1448,6 +1435,11 @@ export function ScheduleTab({
           itemType={editItem.item_type ?? "general"}
           editItem={editItem}
           onClose={() => setEditItem(null)}
+          onRemove={() => {
+            removeItem.mutate({ tripId, itemId: editItem.id });
+            setEditItem(null);
+          }}
+          removing={removeItem.isPending}
         />
       )}
 
@@ -1600,56 +1592,6 @@ export function ScheduleTab({
       )}
 
       {/* Delete confirmation dialog */}
-      {confirmDelete && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center px-6"
-          style={{ background: "var(--color-bt-overlay)" }}
-          onClick={() => setConfirmDelete(null)}
-        >
-          <div
-            className="w-full max-w-sm rounded-2xl p-5"
-            style={{ background: "var(--color-bt-card)" }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <p
-              className="text-base font-semibold"
-              style={{ color: "var(--color-bt-text)" }}
-            >
-              Remove from agenda?
-            </p>
-            <p className="mt-1 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-              &ldquo;{confirmDelete.title}&rdquo; will be permanently removed.
-            </p>
-            <div className="mt-4 flex gap-3">
-              <button
-                onClick={() => setConfirmDelete(null)}
-                className="flex-1 rounded-xl py-2.5 text-sm font-medium"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text)",
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => {
-                  removeItem.mutate({ tripId, itemId: confirmDelete.id });
-                  setConfirmDelete(null);
-                }}
-                disabled={removeItem.isPending}
-                className="flex-1 rounded-xl py-2.5 text-sm font-semibold transition-opacity disabled:opacity-40"
-                style={{
-                  background: "var(--color-bt-danger)",
-                  color: "#fff",
-                }}
-              >
-                {removeItem.isPending ? "Deleting..." : "Delete"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Mobile-only FAB — mirrors the header's "Add to agenda". canEdit-only
           since members can't author schedule items. */}
       {canEdit && (

--- a/src/app/trips/[tripId]/tabs/SplitPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/SplitPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import type { ExpenseMember } from "./ExpensesSection";
 
 // ── Split computation ─────────────────────────────────────────────────────
@@ -52,6 +53,10 @@ interface SplitPanelProps {
   overrides: Record<string, string>;
   optedOutIds?: string[];
   isOwnerEditing?: boolean;
+  /** "even" → simplified summary + Customize; "custom" → full per-person list. */
+  mode?: "even" | "custom";
+  /** Fired when the user toggles between even/custom views. */
+  onModeChange?: (mode: "even" | "custom") => void;
   onToggle: (userId: string) => void;
   onOverrideChange: (userId: string, value: string) => void;
   onResetOverride: (userId: string) => void;
@@ -64,14 +69,17 @@ export function SplitPanel({
   overrides,
   optedOutIds = [],
   isOwnerEditing = false,
+  mode = "custom",
+  onModeChange,
   onToggle,
   onOverrideChange,
   onResetOverride,
 }: SplitPanelProps) {
+  const currentUser = useCurrentUser();
   const showAmounts = totalAmount > 0;
-  const { perPerson, allOverridden, remaining } = showAmounts
+  const { perPerson, evenShare, allOverridden, remaining } = showAmounts
     ? computeSplitDisplay(totalAmount, includedIds, overrides)
-    : { perPerson: {} as Record<string, number>, allOverridden: false, remaining: 0 };
+    : { perPerson: {} as Record<string, number>, evenShare: 0, allOverridden: false, remaining: 0 };
 
   const memberName = (uid: string) => {
     const m = members.find((x) => x.user_id === uid);
@@ -80,25 +88,89 @@ export function SplitPanel({
     // trip name here, not the stale account name. Was reading
     // m.user.name directly, which surfaced the original users.name
     // even after a rename (e.g. "Tak" lingering after editing to "Taj").
-    return m?.displayName ?? m?.user?.name ?? m?.user?.email ?? uid.slice(0, 6);
+    const name =
+      m?.displayName ?? m?.user?.name ?? m?.user?.email ?? uid.slice(0, 6);
+    return uid === currentUser?.id ? `${name} (you)` : name;
   };
 
+  // Toggle ("Customize…" / "Use even split") shown inline with the
+  // even/custom description line, matching its font size.
+  const modeToggle =
+    isOwnerEditing && onModeChange ? (
+      <button
+        type="button"
+        onClick={() => onModeChange(mode === "even" ? "custom" : "even")}
+        className="flex-shrink-0 rounded-full border px-2.5 py-1 text-xs font-semibold transition-opacity hover:opacity-80"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          borderColor: "var(--color-bt-accent-border)",
+          color: "var(--color-bt-accent)",
+        }}
+      >
+        {mode === "even" ? "Customize…" : "Use even split"}
+      </button>
+    ) : null;
+
   return (
-    <div>
-      {/* Header row */}
+    <div
+      className="rounded-xl p-3"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      {/* Line 1 — "SPLIT" eyebrow */}
       <div
-        className="mb-1 flex items-center gap-2 pr-3 text-xs"
+        className="mb-2 text-[10px] font-bold uppercase tracking-[0.12em]"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
-        <span className="min-w-0 flex-1">Split among</span>
-        {showAmounts && (
-          <>
-            <span className="w-14 flex-shrink-0 text-right">Share</span>
-            <span className="w-16 flex-shrink-0 text-right">Override</span>
-            <div className="w-6 flex-shrink-0" />
-          </>
-        )}
+        Split
       </div>
+
+      {/* Even-split simplified summary */}
+      {mode === "even" ? (
+        /* Line 2 — "Even split · $X each · N crew" + Customize button */
+        <div className="flex items-center justify-between gap-2">
+          <p className="min-w-0 text-sm" style={{ color: "var(--color-bt-text)" }}>
+            <span className="font-semibold" style={{ color: "var(--color-bt-accent)" }}>
+              Even split
+            </span>
+            {showAmounts && includedIds.length > 0 && (
+              <>
+                {" · "}
+                <span className="font-mono">${evenShare.toFixed(2)}</span> each
+              </>
+            )}
+            {" · "}
+            {includedIds.length} {includedIds.length === 1 ? "person" : "crew"}
+          </p>
+          {modeToggle}
+        </div>
+      ) : (
+        <>
+      {/* Line 2 — "Custom split — N of M selected" + Use even split button */}
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <p className="min-w-0 text-sm" style={{ color: "var(--color-bt-text)" }}>
+          <span className="font-semibold" style={{ color: "var(--color-bt-accent)" }}>
+            Custom split
+          </span>{" "}
+          — {includedIds.length} of {members.length} selected
+        </p>
+        {modeToggle}
+      </div>
+
+      {/* Line 3 — SHARE / OVERRIDE column headers (all caps) */}
+      {showAmounts && (
+        <div
+          className="mb-1 mt-2 flex items-center gap-2 pr-3 text-[10px] font-bold uppercase tracking-[0.12em]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <span className="min-w-0 flex-1" />
+          <span className="w-14 flex-shrink-0 text-center">Share</span>
+          <span className="w-20 flex-shrink-0 text-center">Override</span>
+          <div className="w-6 flex-shrink-0" />
+        </div>
+      )}
 
       {/* Member rows */}
       <div>
@@ -118,7 +190,7 @@ export function SplitPanel({
             return (
               <div
                 key={uid}
-                className="flex items-center gap-2 border-b px-3 py-1.5"
+                className="flex min-h-[44px] items-center gap-2 border-b px-3 py-1.5"
                 style={{
                   background: rowBg,
                   borderColor: "var(--color-bt-border)",
@@ -147,7 +219,7 @@ export function SplitPanel({
             return (
               <div
                 key={uid}
-                className="flex items-center gap-2 border-b px-3 py-1.5"
+                className="flex min-h-[44px] items-center gap-2 border-b px-3 py-1.5"
                 style={{
                   background: rowBg,
                   borderColor: "var(--color-bt-border)",
@@ -168,9 +240,9 @@ export function SplitPanel({
                   {memberName(uid)}
                 </label>
                 <span
-                  className="w-14 flex-shrink-0 text-right text-xs tabular-nums"
+                  className="w-14 flex-shrink-0 text-right font-mono text-xs tabular-nums"
                   style={{
-                    color: isNeg ? "var(--color-bt-danger)" : "var(--color-bt-text-dim)",
+                    color: isNeg ? "var(--color-bt-danger)" : "var(--color-bt-text)",
                   }}
                 >
                   {displayAmt !== null ? `$${displayAmt.toFixed(2)}` : ""}
@@ -182,9 +254,9 @@ export function SplitPanel({
                   placeholder="—"
                   value={overrides[uid] ?? ""}
                   onChange={(e) => onOverrideChange(uid, e.target.value)}
-                  className="w-16 flex-shrink-0 rounded-md border px-2 py-1 text-right text-xs outline-none tabular-nums"
+                  className="w-20 flex-shrink-0 rounded-md border px-2 py-1 text-right font-mono text-xs outline-none tabular-nums"
                   style={{
-                    background: "var(--color-bt-base)",
+                    background: "var(--color-bt-card-raised)",
                     borderColor: hasOverride
                       ? "var(--color-bt-accent-border)"
                       : "var(--color-bt-border)",
@@ -211,7 +283,7 @@ export function SplitPanel({
           return (
             <label
               key={uid}
-              className="flex cursor-pointer items-center gap-2 border-b px-3 py-1.5"
+              className="flex min-h-[44px] cursor-pointer items-center gap-2 border-b px-3 py-1.5"
               style={{
                 background: rowBg,
                 borderColor: "var(--color-bt-border)",
@@ -244,6 +316,8 @@ export function SplitPanel({
             ? `Remaining: $${remaining.toFixed(2)} unassigned`
             : `Over by: $${Math.abs(remaining).toFixed(2)}`}
         </p>
+      )}
+        </>
       )}
     </div>
   );

--- a/src/app/trips/[tripId]/tabs/components/MemberEditor.tsx
+++ b/src/app/trips/[tripId]/tabs/components/MemberEditor.tsx
@@ -294,7 +294,7 @@ export function MemberEditor({ tripId, member, canManageRoles, onClose }: Member
           "inset-x-0 bottom-0 max-h-[90vh] rounded-t-2xl",
           // Tablet + desktop (≥640): right-anchored drawer, full height,
           // 440px wide per the canonical edit-drawer spec.
-          "sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-0 sm:h-screen sm:w-[440px] sm:rounded-none",
+          "sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-0 sm:h-screen sm:max-h-screen sm:w-[440px] sm:rounded-none",
         ].join(" ")}
         style={{
           background: "var(--color-bt-card-float)",

--- a/src/app/trips/[tripId]/tabs/components/MemberEditor.tsx
+++ b/src/app/trips/[tripId]/tabs/components/MemberEditor.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ArrowUpCircle, Check, Crown, Loader2, Mail, Send, Trash2, X } from "lucide-react";
+import { ArrowUpCircle, Check, Crown, Loader2, Mail, Send, X } from "lucide-react";
+import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { Avatar } from "@/components/Avatar";
@@ -288,8 +289,9 @@ export function MemberEditor({ tripId, member, canManageRoles, onClose }: Member
         aria-label={`Edit ${member.displayName}`}
         className={[
           "fixed z-50 flex flex-col",
-          // Mobile (<640): bottom-anchored sheet, ~82% height
-          "inset-x-0 bottom-0 h-[82vh] rounded-t-2xl",
+          // Mobile (<640): bottom-anchored sheet that sizes to content
+          // (capped at 90vh), matching the other edit sheets.
+          "inset-x-0 bottom-0 max-h-[90vh] rounded-t-2xl",
           // Tablet + desktop (≥640): right-anchored drawer, full height,
           // 440px wide per the canonical edit-drawer spec.
           "sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-0 sm:h-screen sm:w-[440px] sm:rounded-none",
@@ -515,21 +517,18 @@ export function MemberEditor({ tripId, member, canManageRoles, onClose }: Member
             />
           </div>
 
-          {/* Danger — remove from trip */}
+          {/* Remove from trip — at the end of the body, matching the
+              other edit modals (danger action above the footer). */}
           {!isOwnerRow && (
-            <button
-              onClick={handleRemove}
-              disabled={removeMember.isPending || removeGuest.isPending}
-              className="mt-2 inline-flex items-center justify-center gap-1.5 self-start rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-40"
-              style={{
-                background: "transparent",
-                color: "var(--color-bt-danger)",
-                border: "1px solid var(--color-bt-danger-border)",
-              }}
-            >
-              <Trash2 size={13} />
-              Remove from trip
-            </button>
+            <div className="pt-1">
+              <ConfirmDeleteButton
+                label="Remove from trip"
+                confirmLabel="Remove"
+                prompt="Remove this person from the trip?"
+                pending={removeMember.isPending || removeGuest.isPending}
+                onConfirm={handleRemove}
+              />
+            </div>
           )}
         </div>
 
@@ -577,7 +576,9 @@ export function MemberEditor({ tripId, member, canManageRoles, onClose }: Member
           </div>
         )}
 
-        {/* Footer — Save / Cancel */}
+        {/* Footer — Cancel/Save row. The destructive "Remove from trip"
+            action lives at the end of the scrollable body (danger-above
+            pattern), matching the other edit modals. */}
         <div
           className="flex gap-2 px-4 py-3"
           style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}

--- a/src/components/ConfirmDeleteButton.tsx
+++ b/src/components/ConfirmDeleteButton.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+
+/**
+ * Full-width destructive action for modal/drawer footers (canonical
+ * "danger-above-footer" pattern). On first click it arms into an inline
+ * confirmation — a faint-danger container with a prompt, a ghost "Cancel"
+ * that disarms, and a solid-danger "Delete" that fires `onConfirm`. This
+ * guards against accidental deletes when the button sits next to Save.
+ */
+export function ConfirmDeleteButton({
+  onConfirm,
+  pending = false,
+  label = "Delete",
+  confirmLabel = "Delete",
+  pendingLabel = "Deleting…",
+  prompt = "Are you sure?",
+  testId,
+}: {
+  onConfirm: () => void;
+  pending?: boolean;
+  /** Idle button text, e.g. "Delete receipt", "Remove property". */
+  label?: string;
+  /** Confirm button text once armed. */
+  confirmLabel?: string;
+  pendingLabel?: string;
+  /** Prompt shown in the armed state. */
+  prompt?: string;
+  testId?: string;
+}) {
+  const [armed, setArmed] = useState(false);
+
+  if (armed) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-lg px-3 py-2"
+        style={{
+          background: "var(--color-bt-danger-faint)",
+          border: "1px solid var(--color-bt-danger-border)",
+        }}
+      >
+        <span
+          className="min-w-0 flex-1 truncate text-sm font-medium"
+          style={{ color: "var(--color-bt-danger)" }}
+        >
+          {prompt}
+        </span>
+        <button
+          type="button"
+          onClick={() => setArmed(false)}
+          disabled={pending}
+          className="rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-40"
+          style={{
+            background: "transparent",
+            color: "var(--color-bt-text-dim)",
+            border: "1px solid var(--color-bt-border)",
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={pending}
+          data-testid={testId}
+          className="rounded-md px-3 py-1.5 text-sm font-semibold disabled:opacity-40"
+          style={{ background: "var(--color-bt-danger)", color: "white" }}
+        >
+          {pending ? pendingLabel : confirmLabel}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setArmed(true)}
+      disabled={pending}
+      data-testid={testId ? `${testId}-arm` : undefined}
+      className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+      style={{
+        background: "transparent",
+        color: "var(--color-bt-danger)",
+        border: "1px solid var(--color-bt-danger-border)",
+      }}
+    >
+      <Trash2 size={14} />
+      {label}
+    </button>
+  );
+}

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -17,7 +17,7 @@ const CONFIG: Record<
   idea: { label: "IDEA", bg: "var(--color-bt-blue-bg)", text: "var(--color-bt-planning)" },
   planning: { label: "PLANNING", bg: "var(--color-bt-tag-bg)", text: "var(--color-bt-accent)" },
   going: { label: "GOING", bg: "var(--color-bt-ready-bg, rgba(124,58,237,0.1))", text: "var(--color-bt-ready)" },
-  now: { label: "NOW", bg: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))", text: "var(--color-bt-warning)" },
+  now: { label: "NOW", bg: "var(--color-bt-warning-faint)", text: "var(--color-bt-warning)" },
   past: { label: "PAST", bg: "var(--color-bt-past-bg)", text: "var(--color-bt-text-dim)" },
   saved: { label: "SAVED", bg: "var(--color-bt-past-bg)", text: "var(--color-bt-text-dim)" },
 };

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -256,7 +256,7 @@ export function TripSettingsModal({
                 className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
                 style={{
                   background: "var(--color-bt-accent)",
-                  color: "var(--color-bt-base)",
+                  color: "var(--color-bt-on-accent)",
                 }}
               >
                 {renameMutation.isPending ? "Saving…" : "Rename"}
@@ -338,7 +338,7 @@ export function TripSettingsModal({
                     >
                       <div
                         className="flex items-start gap-2 rounded-lg px-3 py-2"
-                        style={{ background: "var(--color-bt-warning-bg, rgba(217,119,6,0.1))" }}
+                        style={{ background: "var(--color-bt-warning-faint)" }}
                       >
                         <span style={{ color: "var(--color-bt-warning)" }}>⚠</span>
                         <p className="text-xs" style={{ color: "var(--color-bt-warning)" }}>
@@ -369,7 +369,7 @@ export function TripSettingsModal({
                         className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
                         style={{
                           background: "var(--color-bt-accent)",
-                          color: "var(--color-bt-base)",
+                          color: "var(--color-bt-on-accent)",
                         }}
                       >
                         {changeDestinationMutation.isPending ? "Updating…" : "Update destination"}
@@ -492,7 +492,7 @@ export function TripSettingsModal({
                             className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
                             style={{
                               background: "var(--color-bt-accent)",
-                              color: "var(--color-bt-base)",
+                              color: "var(--color-bt-on-accent)",
                             }}
                           >
                             {lockDatesMutation.isPending ? "Updating…" : "Update dates"}
@@ -644,7 +644,7 @@ export function TripSettingsModal({
                     className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
                     style={{
                       background: "var(--color-bt-accent)",
-                      color: "var(--color-bt-base)",
+                      color: "var(--color-bt-on-accent)",
                     }}
                   >
                     {selectedNewOwner

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -772,33 +772,40 @@ export function TripSettingsModal({
 
                 {clearCrewConfirming && (
                   <div
-                    className="mt-2 space-y-2 rounded-xl border p-3"
-                    style={{ borderColor: "var(--color-bt-border)" }}
+                    className="mt-2 flex items-center gap-2 rounded-lg px-3 py-2"
+                    style={{
+                      background: "var(--color-bt-danger-faint)",
+                      border: "1px solid var(--color-bt-danger-border)",
+                    }}
                   >
-                    <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                      Permanently deletes all Crew chat messages for everyone on the
-                      trip. This cannot be undone.
-                    </p>
+                    <span
+                      className="min-w-0 flex-1 truncate text-sm font-medium"
+                      style={{ color: "var(--color-bt-danger)" }}
+                    >
+                      Clear all crew chat? Can&apos;t be undone.
+                    </span>
+                    <button
+                      onClick={() => setClearCrewConfirming(false)}
+                      disabled={clearChatMutation.isPending}
+                      className="rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-40"
+                      style={{
+                        background: "transparent",
+                        color: "var(--color-bt-text-dim)",
+                        border: "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      Cancel
+                    </button>
                     <button
                       data-testid="settings-confirm-clear-crew-btn"
                       disabled={clearChatMutation.isPending}
                       onClick={() =>
                         clearChatMutation.mutate({ tripId, visibility: "crew" })
                       }
-                      className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-40"
-                      style={{ background: "var(--color-bt-danger)", color: "#fff" }}
+                      className="rounded-md px-3 py-1.5 text-sm font-semibold disabled:opacity-40"
+                      style={{ background: "var(--color-bt-danger)", color: "white" }}
                     >
-                      {clearingVisibility === "crew" ? "Clearing…" : "Clear crew chat"}
-                    </button>
-                    <button
-                      onClick={() => setClearCrewConfirming(false)}
-                      className="w-full rounded-xl border py-2 text-sm"
-                      style={{
-                        borderColor: "var(--color-bt-border)",
-                        color: "var(--color-bt-text-dim)",
-                      }}
-                    >
-                      Cancel
+                      {clearingVisibility === "crew" ? "Clearing…" : "Clear"}
                     </button>
                   </div>
                 )}
@@ -836,35 +843,40 @@ export function TripSettingsModal({
 
                 {clearOrgConfirming && (
                   <div
-                    className="mt-2 space-y-2 rounded-xl border p-3"
-                    style={{ borderColor: "var(--color-bt-border)" }}
+                    className="mt-2 flex items-center gap-2 rounded-lg px-3 py-2"
+                    style={{
+                      background: "var(--color-bt-danger-faint)",
+                      border: "1px solid var(--color-bt-danger-border)",
+                    }}
                   >
-                    <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                      Permanently deletes all Organizers chat messages for every owner
-                      and organizer. This cannot be undone.
-                    </p>
+                    <span
+                      className="min-w-0 flex-1 truncate text-sm font-medium"
+                      style={{ color: "var(--color-bt-danger)" }}
+                    >
+                      Clear all organizer chat? Can&apos;t be undone.
+                    </span>
+                    <button
+                      onClick={() => setClearOrgConfirming(false)}
+                      disabled={clearChatMutation.isPending}
+                      className="rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-40"
+                      style={{
+                        background: "transparent",
+                        color: "var(--color-bt-text-dim)",
+                        border: "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      Cancel
+                    </button>
                     <button
                       data-testid="settings-confirm-clear-org-btn"
                       disabled={clearChatMutation.isPending}
                       onClick={() =>
                         clearChatMutation.mutate({ tripId, visibility: "planning" })
                       }
-                      className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-40"
-                      style={{ background: "var(--color-bt-danger)", color: "#fff" }}
+                      className="rounded-md px-3 py-1.5 text-sm font-semibold disabled:opacity-40"
+                      style={{ background: "var(--color-bt-danger)", color: "white" }}
                     >
-                      {clearingVisibility === "planning"
-                        ? "Clearing…"
-                        : "Clear organizer chat"}
-                    </button>
-                    <button
-                      onClick={() => setClearOrgConfirming(false)}
-                      className="w-full rounded-xl border py-2 text-sm"
-                      style={{
-                        borderColor: "var(--color-bt-border)",
-                        color: "var(--color-bt-text-dim)",
-                      }}
-                    >
-                      Cancel
+                      {clearingVisibility === "planning" ? "Clearing…" : "Clear"}
                     </button>
                   </div>
                 )}
@@ -898,32 +910,39 @@ export function TripSettingsModal({
               </button>
 
               {deleteConfirming && (
-                <div className="mt-2 space-y-2 rounded-xl border p-3" style={{ borderColor: "var(--color-bt-border)" }}>
-                  <p className="text-sm" style={{ color: "var(--color-bt-text)" }}>
-                    Delete <strong>{tripName}</strong>?
-                  </p>
-                  <p className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-                    This will permanently delete the trip and remove it for all crew members.
-                    This cannot be undone.
-                  </p>
+                <div
+                  className="mt-2 flex items-center gap-2 rounded-lg px-3 py-2"
+                  style={{
+                    background: "var(--color-bt-danger-faint)",
+                    border: "1px solid var(--color-bt-danger-border)",
+                  }}
+                >
+                  <span
+                    className="min-w-0 flex-1 truncate text-sm font-medium"
+                    style={{ color: "var(--color-bt-danger)" }}
+                  >
+                    Delete {tripName}? Can&apos;t be undone.
+                  </span>
+                  <button
+                    onClick={() => setDeleteConfirming(false)}
+                    disabled={deleteMutation.isPending}
+                    className="rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-40"
+                    style={{
+                      background: "transparent",
+                      color: "var(--color-bt-text-dim)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
+                  >
+                    Cancel
+                  </button>
                   <button
                     data-testid="settings-confirm-delete-btn"
                     disabled={deleteMutation.isPending}
                     onClick={() => deleteMutation.mutate({ tripId })}
-                    className="w-full rounded-xl py-2.5 text-sm font-semibold disabled:opacity-40"
-                    style={{ background: "var(--color-bt-danger)", color: "#fff" }}
+                    className="rounded-md px-3 py-1.5 text-sm font-semibold disabled:opacity-40"
+                    style={{ background: "var(--color-bt-danger)", color: "white" }}
                   >
-                    {deleteMutation.isPending ? "Deleting…" : "Delete trip"}
-                  </button>
-                  <button
-                    onClick={() => setDeleteConfirming(false)}
-                    className="w-full rounded-xl border py-2 text-sm"
-                    style={{
-                      borderColor: "var(--color-bt-border)",
-                      color: "var(--color-bt-text-dim)",
-                    }}
-                  >
-                    Cancel
+                    {deleteMutation.isPending ? "Deleting…" : "Delete"}
                   </button>
                 </div>
               )}

--- a/src/server/routers/logistics.ts
+++ b/src/server/routers/logistics.ts
@@ -55,6 +55,9 @@ export const logisticsRouter = router({
         pickupTime: z.string().max(50).optional(),
         // Lodging photo URL (og:image fetched in AddPropertySheet).
         imageUrl: z.string().url().max(2048).optional(),
+        // Up to 3 lodging photos. image_url is kept in sync with the
+        // first element as the cover the LodgingCard renders.
+        imageUrls: z.array(z.string().url().max(2048)).max(3).optional(),
         // Ordering
         sortOrder: z.number().int().default(0),
       })
@@ -80,7 +83,11 @@ export const logisticsRouter = router({
           transport_type: input.transportType ?? null,
           pickup_location: input.pickupLocation ?? null,
           pickup_time: input.pickupTime ?? null,
-          image_url: input.imageUrl ?? null,
+          // image_urls is the source of truth; image_url stays in sync
+          // with the first element as the cover. Fall back to the
+          // legacy single imageUrl when imageUrls isn't provided.
+          image_urls: input.imageUrls ?? (input.imageUrl ? [input.imageUrl] : []),
+          image_url: input.imageUrls?.[0] ?? input.imageUrl ?? null,
           sort_order: input.sortOrder,
           created_by: ctx.user!.id,
         })
@@ -120,6 +127,7 @@ export const logisticsRouter = router({
         pickupLocation: z.string().max(500).nullable().optional(),
         pickupTime: z.string().max(50).nullable().optional(),
         imageUrl: z.string().url().max(2048).nullable().optional(),
+        imageUrls: z.array(z.string().url().max(2048)).max(3).nullable().optional(),
         sortOrder: z.number().int().optional(),
       })
     )
@@ -140,7 +148,16 @@ export const logisticsRouter = router({
       if (input.transportType !== undefined) update.transport_type = input.transportType;
       if (input.pickupLocation !== undefined) update.pickup_location = input.pickupLocation;
       if (input.pickupTime !== undefined) update.pickup_time = input.pickupTime;
-      if (input.imageUrl !== undefined) update.image_url = input.imageUrl;
+      // imageUrls is the source of truth when provided; keep image_url
+      // synced to the cover (first element). When only the legacy
+      // imageUrl is sent, update image_url alone.
+      if (input.imageUrls !== undefined) {
+        const urls = input.imageUrls ?? [];
+        update.image_urls = urls;
+        update.image_url = urls[0] ?? null;
+      } else if (input.imageUrl !== undefined) {
+        update.image_url = input.imageUrl;
+      }
       if (input.sortOrder !== undefined) update.sort_order = input.sortOrder;
 
       if (Object.keys(update).length === 0) {

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -132,6 +132,7 @@ export const scheduleRouter = router({
         scheduledTime: z.string().nullable().optional(),
         sortOrder: z.number().int().optional(),
         isConfirmed: z.boolean().optional(),
+        courseId: z.string().nullable().optional(),
         courseName: z.string().max(200).nullable().optional(),
         courseLocation: z.string().max(500).nullable().optional(),
         teeTimes: z.array(z.string()).nullable().optional(),
@@ -160,6 +161,7 @@ export const scheduleRouter = router({
           update.confirmed_by = null;
         }
       }
+      if (input.courseId !== undefined) update.course_id = input.courseId;
       if (input.courseName !== undefined) update.course_name = input.courseName;
       if (input.courseLocation !== undefined) update.course_location = input.courseLocation;
       if (input.teeTimes !== undefined) update.tee_times = input.teeTimes;

--- a/supabase/migrations/20260530120000_011_lodging_photos_bucket.sql
+++ b/supabase/migrations/20260530120000_011_lodging_photos_bucket.sql
@@ -1,0 +1,33 @@
+-- Public storage bucket for user-uploaded lodging photos.
+--
+-- Backs the "Replace photo" / "Add photo" action in AddPropertySheet:
+-- the client uploads the chosen image here and stores the resulting
+-- public URL in logistics_items.image_url (a normal https URL, so the
+-- existing z.string().url() validation on the router still holds).
+
+insert into storage.buckets (id, name, public)
+values ('lodging-photos', 'lodging-photos', true)
+on conflict (id) do nothing;
+
+-- Any signed-in user may upload into the bucket.
+drop policy if exists "lodging_photos_insert" on storage.objects;
+create policy "lodging_photos_insert" on storage.objects
+  for insert to authenticated
+  with check (bucket_id = 'lodging-photos');
+
+-- Public read (bucket is public; explicit policy kept for clarity).
+drop policy if exists "lodging_photos_select" on storage.objects;
+create policy "lodging_photos_select" on storage.objects
+  for select to public
+  using (bucket_id = 'lodging-photos');
+
+-- Uploaders can replace/remove the objects they own.
+drop policy if exists "lodging_photos_update" on storage.objects;
+create policy "lodging_photos_update" on storage.objects
+  for update to authenticated
+  using (bucket_id = 'lodging-photos' and owner = auth.uid());
+
+drop policy if exists "lodging_photos_delete" on storage.objects;
+create policy "lodging_photos_delete" on storage.objects
+  for delete to authenticated
+  using (bucket_id = 'lodging-photos' and owner = auth.uid());

--- a/supabase/migrations/20260530130000_012_logistics_image_urls.sql
+++ b/supabase/migrations/20260530130000_012_logistics_image_urls.sql
@@ -1,0 +1,16 @@
+-- Multiple lodging photos.
+--
+-- AddPropertySheet now offers three square photo slots so a property can
+-- carry a couple of images. They live in image_urls (an ordered jsonb
+-- array of public Storage URLs); image_url stays in sync with the first
+-- element as the "cover" the LodgingCard renders, so existing consumers
+-- keep working without change.
+
+alter table public.logistics_items
+  add column if not exists image_urls jsonb not null default '[]'::jsonb;
+
+-- Backfill: existing single image_url becomes the first element.
+update public.logistics_items
+   set image_urls = jsonb_build_array(image_url)
+ where image_url is not null
+   and (image_urls is null or jsonb_array_length(image_urls) = 0);


### PR DESCRIPTION
## Summary
Converges the Lodging / Agenda / Receipts / Crew edit affordances on one consistent set of patterns, and adds multi-photo lodging.

- **Lodging** — properties carry up to 3 photos (`logistics_items.image_urls` ordered jsonb, `image_url` synced as cover); card renders a 3-square grid; Confirm is an inline title-row toggle; confirmed-but-undated properties surface a warning/nudge (no date → never reaches the itinerary); empty meta "—" hidden.
- **Agenda** — rows are tap-to-edit; "Remove from agenda" moves into the editor footer; `schedule.update` accepts `courseId` so edited golf rounds keep their course link.
- **Receipts** — rows tap-to-edit; "Delete receipt" moves into the modal.
- **Crew / Settings** — shared `ConfirmDeleteButton` (idle danger-outline → armed inline confirm); "Remove from trip" moves to end-of-body; crew sheet sizes to content on mobile; Trip Settings danger zone adopts the same inline confirm styling.

### Cross-cutting modal polish
- **Save disabled until dirty** in all edit modals (lodging, agenda, receipts) — no longer enabled on open before any change.
- **Required-field red dot** standardized (replaces ad-hoc `*` asterisks) on the genuinely-required fields. Crew intentionally has none (edit fields optional; add-crew accepts name *or* email).
- Circular ✕ close button + danger-above-footer layout applied consistently.

### Migrations
- `011_lodging_photos_bucket` — public `lodging-photos` Storage bucket + RLS.
- `012_logistics_image_urls` — `image_urls jsonb` column + backfill from `image_url`.
Both idempotent.

## Test plan
- [ ] Lodging: add/edit a property with 1–3 photos; card grid + cover render; confirm w/o dates shows nudge
- [ ] Agenda: tap a row opens editor; remove from editor; edited golf round keeps course
- [ ] Receipts: tap a row opens modal; delete from modal; Save disabled until a field/split changes
- [ ] Crew: remove-from-trip flow; mobile sheet sizes to content
- [ ] Trip Settings danger zone confirm styling
- [ ] `npx tsc --noEmit` clean; Vitest + Playwright green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)