### PR TITLE
perf(receipts): prefetch expenses.list so the tab opens instantly

### DIFF
--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -92,6 +92,10 @@ export default function TripDetailPage() {
   // Not added to dataLoading — loads in parallel, dot appears when ready.
   const { data: prefetchedSchedule = [] } = trpc.schedule.list.useQuery({ tripId });
   const { data: prefetchedLogistics = [] } = trpc.logistics.list.useQuery({ tripId });
+  // Background prefetch for receipts so the Expenses tab reads from cache
+  // instead of flashing its loading skeleton for 1–2s on first open. Same
+  // queryKey as ExpensesSection's own useQuery, so it hydrates instantly.
+  trpc.expenses.list.useQuery({ tripId });
   // Background prefetch for competition events — drives the comp tab warning badge.
   const { data: prefetchedCompEvents = [] } = trpc.events.list.useQuery(
     { tripId, competitionId: competition?.id ?? "" },


### PR DESCRIPTION
## Summary
The Receipts tab flashed its loading skeleton for ~1–2s on first open while every other tab rendered instantly. Cause: the page background-prefetches `schedule.list` (Agenda), `logistics.list` (Lodging), and `tripMembers.list` (Crew), but **not** `expenses.list` — so Receipts fired its query fresh on mount.

This adds the matching background prefetch (same queryKey as `ExpensesSection`'s own `useQuery`), so the tab hydrates from cache. It's intentionally left out of the blocking `dataLoading` gate, matching the existing `teams.list`/`teamAssignments.list` bare-prefetch pattern, so it doesn't delay initial page render.

Follow-up to #273 — this one 4-line change landed on the branch just after the squash-merge cutoff.

## Test plan
- [ ] Load a trip, switch to Receipts → no skeleton flash; list renders immediately
- [ ] Initial trip page load isn't visibly slower (prefetch is non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)