### PR TITLE
Mobile-first UI fixes: Agenda, Lodging, profile & top nav

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -125,7 +125,7 @@ export default function ProfilePage() {
         <DesktopSidebar
           activeTab={activeTab}
           onChangeTab={setActiveTab}
-          onBack={() => router.push("/dashboard")}
+          onBack={() => router.back()}
           onSignOut={() => handleSignOut(router)}
           onDelete={() => setOpenSheet("delete")}
         />
@@ -134,13 +134,13 @@ export default function ProfilePage() {
         <main className="w-full md:flex-1">
           <div className="mx-auto max-w-2xl pb-24 md:pt-8">
             {/* Mobile back button — collapses the desktop sidebar's
-                "Back to dashboard" link into a single arrow in the
-                top-left of the title bar (Supabase-style). */}
+                "Back" link into a single arrow in the top-left of the
+                title bar (Supabase-style). */}
             <div className="px-2 pt-2 md:hidden">
               <button
                 type="button"
-                onClick={() => router.push("/dashboard")}
-                aria-label="Back to dashboard"
+                onClick={() => router.back()}
+                aria-label="Back"
                 className="flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
                 style={{ color: "var(--color-bt-text-dim)" }}
               >
@@ -576,9 +576,10 @@ function DesktopSidebar({
         alignSelf: "flex-start",
       }}
     >
-      {/* Back to dashboard — sits above the section groups, mirroring
-          Supabase's left-column back link. Collapses to a single arrow
-          button in the mobile title bar (rendered in the main area). */}
+      {/* Back — sits above the section groups, mirroring Supabase's
+          left-column back link. Collapses to a single arrow button in
+          the mobile title bar (rendered in the main area). Returns to
+          the previous page rather than a fixed destination. */}
       <button
         type="button"
         onClick={onBack}
@@ -586,7 +587,7 @@ function DesktopSidebar({
         style={{ gap: 10, padding: "9px 16px", color: "var(--color-bt-text-dim)" }}
       >
         <IconArrowLeft size={16} stroke={1.75} />
-        <span style={{ fontSize: 13 }}>Back to dashboard</span>
+        <span style={{ fontSize: 13 }}>Back</span>
       </button>
 
       <SidebarGroup label="Account">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -583,10 +583,10 @@ function DesktopSidebar({
       <button
         type="button"
         onClick={onBack}
-        className="mb-2 flex w-full items-center transition-colors hover:bg-[var(--color-bt-hover)]"
-        style={{ gap: 10, padding: "9px 16px", color: "var(--color-bt-text-dim)" }}
+        className="flex items-center transition-colors hover:text-[var(--color-bt-text)]"
+        style={{ gap: 6, padding: "0 16px 10px", color: "var(--color-bt-text-dim)" }}
       >
-        <IconArrowLeft size={16} stroke={1.75} />
+        <IconArrowLeft size={15} stroke={1.75} />
         <span style={{ fontSize: 13 }}>Back</span>
       </button>
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -11,6 +11,7 @@ import {
   IconArchive,
   IconLogout,
   IconTrash,
+  IconArrowLeft,
 } from "@tabler/icons-react";
 import { trpc } from "@/lib/trpc-client";
 import { createClient } from "@/lib/supabase";
@@ -124,6 +125,7 @@ export default function ProfilePage() {
         <DesktopSidebar
           activeTab={activeTab}
           onChangeTab={setActiveTab}
+          onBack={() => router.push("/dashboard")}
           onSignOut={() => handleSignOut(router)}
           onDelete={() => setOpenSheet("delete")}
         />
@@ -131,6 +133,21 @@ export default function ProfilePage() {
         {/* ── Main scroll container ───────────────────────────────────── */}
         <main className="w-full md:flex-1">
           <div className="mx-auto max-w-2xl pb-24 md:pt-8">
+            {/* Mobile back button — collapses the desktop sidebar's
+                "Back to dashboard" link into a single arrow in the
+                top-left of the title bar (Supabase-style). */}
+            <div className="px-2 pt-2 md:hidden">
+              <button
+                type="button"
+                onClick={() => router.push("/dashboard")}
+                aria-label="Back to dashboard"
+                className="flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                <IconArrowLeft size={20} stroke={1.75} />
+              </button>
+            </div>
+
             {/* Mobile shows everything stacked. Desktop renders only the
                 section matching the active sidebar tab. */}
 
@@ -521,11 +538,13 @@ function AvatarHero({
 function DesktopSidebar({
   activeTab,
   onChangeTab,
+  onBack,
   onSignOut,
   onDelete,
 }: {
   activeTab: SidebarTab;
   onChangeTab: (t: SidebarTab) => void;
+  onBack: () => void;
   onSignOut: () => void;
   onDelete: () => void;
 }) {
@@ -557,6 +576,19 @@ function DesktopSidebar({
         alignSelf: "flex-start",
       }}
     >
+      {/* Back to dashboard — sits above the section groups, mirroring
+          Supabase's left-column back link. Collapses to a single arrow
+          button in the mobile title bar (rendered in the main area). */}
+      <button
+        type="button"
+        onClick={onBack}
+        className="mb-2 flex w-full items-center transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{ gap: 10, padding: "9px 16px", color: "var(--color-bt-text-dim)" }}
+      >
+        <IconArrowLeft size={16} stroke={1.75} />
+        <span style={{ fontSize: 13 }}>Back to dashboard</span>
+      </button>
+
       <SidebarGroup label="Account">
         {account.map((i) => (
           <SidebarItem

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -590,6 +590,13 @@ function DesktopSidebar({
         <span style={{ fontSize: 13 }}>Back</span>
       </button>
 
+      <div
+        style={{
+          borderBottom: "0.5px solid var(--color-bt-border)",
+          marginBottom: 12,
+        }}
+      />
+
       <SidebarGroup label="Account">
         {account.map((i) => (
           <SidebarItem

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -562,7 +562,7 @@ function DesktopSidebar({
       style={{
         background: "var(--color-bt-card)",
         borderRight: "0.5px solid var(--color-bt-border)",
-        padding: "20px 0",
+        padding: "10px 0 20px",
         // Stick to the viewport (below the 56px TopNav) and cap at one
         // viewport height so the bottom block (Sign out / Delete) stays
         // pinned to the bottom of the screen as the main panel scrolls.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -20,7 +20,6 @@ import { Avatar } from "@/components/Avatar";
 import { AvatarIconPicker } from "@/components/AvatarIconPicker";
 import { NotificationsPanel } from "@/components/profile/NotificationsPanel";
 import { ArchivedIdeasPanel } from "@/components/profile/ArchivedIdeasPanel";
-import { useGlobalNotifications } from "@/hooks/useGlobalNotifications";
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -50,7 +49,6 @@ export default function ProfilePage() {
   const authLoaded = useAuthLoaded();
   const authUser = useAuthUser();
   const utils = trpc.useUtils();
-  const { notifications, unreadCount, markAllRead } = useGlobalNotifications();
 
   const { data: me, isLoading } = trpc.users.getMe.useQuery(undefined, {
     enabled: authLoaded && !!authUser,
@@ -101,11 +99,7 @@ export default function ProfilePage() {
   if (!authLoaded || isLoading || !me) {
     return (
       <div className="min-h-screen" style={{ background: "var(--color-bt-base)" }}>
-        <TopNav
-          notifications={notifications}
-          unreadCount={unreadCount}
-          onMarkAllRead={markAllRead}
-        />
+        <TopNav hideTripSwitcher hideNotifications />
         <div className="flex justify-center py-16">
           <div
             className="h-6 w-6 animate-spin rounded-full border-2"
@@ -123,11 +117,7 @@ export default function ProfilePage() {
       className="min-h-screen"
       style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text)" }}
     >
-      <TopNav
-        notifications={notifications}
-        unreadCount={unreadCount}
-        onMarkAllRead={markAllRead}
-      />
+      <TopNav hideTripSwitcher hideNotifications />
 
       <div className="flex">
         {/* ── Desktop sidebar ─────────────────────────────────────────── */}

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -132,7 +132,7 @@ function LodgingCard({
             }
           : undefined
       }
-      className={`flex flex-col gap-2 rounded-xl p-3 transition-all ${
+      className={`@container flex flex-col gap-2 rounded-xl p-3 transition-all ${
         canEdit
           ? "cursor-pointer hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
           : ""
@@ -206,7 +206,7 @@ function LodgingCard({
                 if (canEdit) onConfirmToggle();
               }}
               disabled={!canEdit}
-              aria-label={canEdit ? "Mark as not confirmed" : undefined}
+              aria-label={canEdit ? "Mark as not confirmed" : "Confirmed"}
               className="inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold transition-opacity hover:opacity-85 disabled:cursor-default disabled:hover:opacity-100"
               style={{
                 background: "var(--color-bt-accent)",
@@ -215,7 +215,7 @@ function LodgingCard({
               }}
             >
               <Check size={12} strokeWidth={3} />
-              Confirmed
+              <span className="hidden @[240px]:inline">Confirmed</span>
             </button>
           ) : canEdit ? (
             <button

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -138,7 +138,7 @@ function LodgingCard({
           : ""
       }`}
       style={{
-        background: confirmed ? "var(--color-bt-tag-bg)" : "var(--color-bt-card)",
+        background: confirmed ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)",
         border: `1px solid ${
           needsDates
             ? "var(--color-bt-warning)"

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -206,7 +206,7 @@ function LodgingCard({
                 if (canEdit) onConfirmToggle();
               }}
               disabled={!canEdit}
-              aria-label={canEdit ? "Mark as not confirmed" : "Confirmed"}
+              aria-label={canEdit ? "Mark as not confirmed" : undefined}
               className="inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold transition-opacity hover:opacity-85 disabled:cursor-default disabled:hover:opacity-100"
               style={{
                 background: "var(--color-bt-accent)",
@@ -215,7 +215,7 @@ function LodgingCard({
               }}
             >
               <Check size={12} strokeWidth={3} />
-              <span className="hidden sm:inline">Confirmed</span>
+              Confirmed
             </button>
           ) : canEdit ? (
             <button

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -132,7 +132,7 @@ function LodgingCard({
             }
           : undefined
       }
-      className={`@container flex flex-col gap-2 rounded-xl p-3 transition-all ${
+      className={`flex flex-col gap-2 rounded-xl p-3 transition-all ${
         canEdit
           ? "cursor-pointer hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
           : ""
@@ -215,7 +215,7 @@ function LodgingCard({
               }}
             >
               <Check size={12} strokeWidth={3} />
-              <span className="hidden @[240px]:inline">Confirmed</span>
+              <span className="hidden sm:inline">Confirmed</span>
             </button>
           ) : canEdit ? (
             <button

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -220,10 +220,11 @@ export default function TripDetailPage() {
   // tab via a stale `?tab=comp` URL (from browser-back to a previous
   // owner-side URL state) and see CompTab render even though the tab
   // button itself is hidden in their tab bar.
-  // Comp tab is default-visible for editors (matches TripTabBar). The
-  // invitation card has moved inside the tab, so showing the tab itself
-  // is what gives the owner an entry point. Members still gate on showComp.
-  const canShowCompTab = effectiveCanEdit || showComp;
+  // Competition is an owner/organizer-only authoring surface (matches
+  // TripTabBar). Members never see the tab — they follow a live competition
+  // through the bottom-nav "Live" entry / leaderboard route instead. This
+  // also snaps a member back to "home" if they land on a stale ?tab=comp URL.
+  const canShowCompTab = effectiveCanEdit;
   const canShowLodgingTab =
     stage !== "idea" && effectiveCanEdit;
   const canShowScheduleTab = effectiveCanEdit;
@@ -461,7 +462,6 @@ export default function TripDetailPage() {
               <TripTabBar
                 activeTab={activeTab}
                 onTabChange={(tab) => setActiveTab(tab)}
-                showComp={showComp}
                 canEdit={canEdit}
                 stage={stage}
                 badges={tabBadges}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -259,10 +259,8 @@ export default function TripDetailPage() {
   const scheduleItems = prefetchedSchedule as Array<{
     is_confirmed: boolean;
     scheduled_date?: string | null;
+    item_type?: string | null;
   }>;
-  const scheduleDot =
-    effectiveCanEdit &&
-    scheduleItems.some((item) => !item.scheduled_date || !item.is_confirmed);
   // lodging badge: two tiers.
   //  "warning" — one or more lodging properties have check-in/out dates
   //              that fall outside the trip date range (likely a typo).
@@ -304,6 +302,21 @@ export default function TripDetailPage() {
       const d = item.scheduled_date ?? null;
       return d && (d < tripStart || d > tripEnd);
     });
+  // Agenda info dot — mirror the in-tab nudges so the tab badge never
+  // promises an action item the user can't find. The only actionable
+  // states that surface a nudge in ScheduleTab are:
+  //   1. items exist but trip dates aren't set ("Set dates to schedule"), or
+  //   2. a golf round is on a day but still needs a tee time / walk-on.
+  // On-deck (unscheduled) items are a normal parking state, not an action
+  // item, so they no longer light the dot on their own.
+  const scheduleNeedsDates =
+    effectiveCanEdit && !tripStart && scheduleItems.length > 0;
+  const scheduleUnconfirmedGolf =
+    effectiveCanEdit &&
+    scheduleItems.some(
+      (item) =>
+        item.item_type === "golf" && !item.is_confirmed && !!item.scheduled_date
+    );
   // compDot: warning when any scored GOLF event has no agenda item linked.
   const compDot =
     !!competition &&
@@ -317,7 +330,7 @@ export default function TripDetailPage() {
   // for a softer feel but the dot blended in; amber stands out.
   if (crewDot) tabBadges.crew = "warning";
   if (scheduleOutOfRange) tabBadges.schedule = "warning";
-  else if (scheduleDot) tabBadges.schedule = "info";
+  else if (scheduleNeedsDates || scheduleUnconfirmedGolf) tabBadges.schedule = "info";
   if (lodgingOutOfRange) tabBadges.lodging = "warning";
   else if (lodgingUnconfirmed) tabBadges.lodging = "info";
   if (compDot) tabBadges.comp = "warning";

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -194,7 +194,7 @@ function ScheduleItemRow({
               }
             : undefined
         }
-        className={`mb-2 flex items-start gap-2 rounded-xl px-4 py-3 transition-all ${
+        className={`mb-2 flex ${isOnDeck ? "items-center" : "items-start"} gap-2 rounded-xl px-4 py-3 transition-all ${
           canEdit
             ? "cursor-pointer hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
             : ""
@@ -218,16 +218,16 @@ function ScheduleItemRow({
       {movable && (
         <GripVertical
           size={16}
-          className="mt-0.5 hidden flex-shrink-0 cursor-grab lg:block"
+          className={`${isOnDeck ? "" : "mt-0.5"} hidden flex-shrink-0 cursor-grab lg:block`}
           style={{ color: "var(--color-bt-text-dim)" }}
         />
       )}
 
       {/* Type icon — always present so text aligns across item types */}
       {item.item_type === "golf" ? (
-        <Flag size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
+        <Flag size={14} className={`${isOnDeck ? "" : "mt-0.5"} flex-shrink-0`} style={{ color: "var(--color-bt-accent)" }} />
       ) : (
-        <Calendar size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
+        <Calendar size={14} className={`${isOnDeck ? "" : "mt-0.5"} flex-shrink-0`} style={{ color: "var(--color-bt-text-dim)" }} />
       )}
 
       <div className="min-w-0 flex-1">
@@ -1459,81 +1459,136 @@ export function ScheduleTab({
 
       {/* Day-picker sheet — mobile scheduling for On Deck items */}
       {dayPickerItem && (
-        <div
-          className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
-          style={{ background: "var(--color-bt-overlay)" }}
-          onClick={() => setDayPickerItem(null)}
-        >
+        <>
+          {/* Tiered backdrop tokens — sheet (mobile) vs drawer (desktop),
+              matching AddScheduleItemSheet. */}
           <div
-            className="w-full max-w-sm rounded-t-2xl sm:rounded-2xl"
-            style={{ background: "var(--color-bt-card)" }}
+            className="fixed inset-0 z-40 sm:hidden"
+            style={{ background: "var(--color-bt-overlay-sheet)" }}
+            onClick={() => setDayPickerItem(null)}
+            aria-hidden
+          />
+          <div
+            className="fixed inset-0 z-40 hidden sm:block"
+            style={{ background: "var(--color-bt-overlay-drawer)" }}
+            onClick={() => setDayPickerItem(null)}
+            aria-hidden
+          />
+
+          {/* Panel — bottom-sheet (mobile) / right-anchored 440px drawer
+              (sm+), mirroring the canonical edit-drawer spec. */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            className={[
+              "fixed z-50 flex flex-col",
+              "inset-x-0 bottom-0 max-h-[85vh] rounded-t-2xl",
+              "sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-0 sm:h-screen sm:max-h-screen sm:w-[440px] sm:rounded-none",
+            ].join(" ")}
+            style={{
+              background: "var(--color-bt-card-float)",
+              boxShadow: "var(--shadow-floating)",
+              borderLeft: "1px solid var(--color-bt-border)",
+            }}
             onClick={(e) => e.stopPropagation()}
           >
-            {/* Header */}
-            <div className="px-5 pb-3 pt-5">
-              <p className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                Add to a day
-              </p>
-              <p className="mt-0.5 truncate text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                {dayPickerItem.title}
-              </p>
-            </div>
-
-            {/* Day list */}
-            <div className="max-h-72 overflow-y-auto px-3 pb-3">
-              {trip.start_date && trip.end_date
-                ? generateTripDays(trip.start_date, trip.end_date).map((date) => {
-                    const num = dayNumber(date, trip.start_date ?? null);
-                    const count = allItems.filter((i) => i.scheduled_date === date).length;
-                    return (
-                      <button
-                        key={date}
-                        onClick={() => {
-                          updateItem.mutate({
-                            tripId,
-                            itemId: dayPickerItem.id,
-                            scheduledDate: date,
-                            // Non-golf: confirmed by being on a day.
-                            ...(dayPickerItem.item_type !== "golf" && { isConfirmed: true }),
-                          });
-                          setDayPickerItem(null);
-                        }}
-                        className="mb-1.5 flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-opacity hover:opacity-80"
-                        style={{
-                          background: "var(--color-bt-card-raised)",
-                          border: "1px solid var(--color-bt-border)",
-                        }}
-                      >
-                        <span className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
-                          {num !== null ? `Day ${num} — ` : ""}{fmtDayHeader(date)}
-                        </span>
-                        {count > 0 && (
-                          <span className="ml-3 flex-shrink-0 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                            {count} item{count !== 1 ? "s" : ""}
-                          </span>
-                        )}
-                      </button>
-                    );
-                  })
-                : null}
-            </div>
-
-            {/* Cancel */}
-            <div className="px-5 pb-5">
+            {/* Header — sticky top: Agenda eyebrow + item title + close. */}
+            <div
+              className="flex flex-shrink-0 items-center justify-between gap-3 px-5 pb-3 pt-4"
+              style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+            >
+              <div className="min-w-0">
+                <div
+                  className="text-[10px] font-bold uppercase tracking-[0.12em]"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                >
+                  Add to a day
+                </div>
+                <div
+                  className="mt-0.5 truncate text-[15px] font-bold"
+                  style={{ color: "var(--color-bt-text)" }}
+                >
+                  {dayPickerItem.title}
+                </div>
+              </div>
               <button
                 onClick={() => setDayPickerItem(null)}
-                className="w-full rounded-xl py-2.5 text-sm font-medium"
+                aria-label="Close"
+                className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-80"
+                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            {/* Body — scrollable day list. */}
+            <div className="flex-1 overflow-y-auto px-5 py-4">
+              <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Choose a day
+              </p>
+              <div className="space-y-1.5">
+                {trip.start_date && trip.end_date
+                  ? generateTripDays(trip.start_date, trip.end_date).map((date) => {
+                      const num = dayNumber(date, trip.start_date ?? null);
+                      const count = allItems.filter((i) => i.scheduled_date === date).length;
+                      const isCurrent = dayPickerItem.scheduled_date === date;
+                      return (
+                        <button
+                          key={date}
+                          onClick={() => {
+                            updateItem.mutate({
+                              tripId,
+                              itemId: dayPickerItem.id,
+                              scheduledDate: date,
+                              // Non-golf: confirmed by being on a day.
+                              ...(dayPickerItem.item_type !== "golf" && { isConfirmed: true }),
+                            });
+                            setDayPickerItem(null);
+                          }}
+                          className="flex w-full items-center justify-between gap-3 rounded-xl px-4 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+                          style={{
+                            background: isCurrent ? "var(--color-bt-tag-bg)" : "var(--color-bt-card)",
+                            border: `1px solid ${isCurrent ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+                          }}
+                        >
+                          <span className="min-w-0 flex-1 truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
+                            {num !== null ? `Day ${num} — ` : ""}{fmtDayHeader(date)}
+                          </span>
+                          {isCurrent ? (
+                            <span className="flex flex-shrink-0 items-center gap-1 text-[11px] font-semibold" style={{ color: "var(--color-bt-accent)" }}>
+                              <Check size={12} strokeWidth={3} /> Current
+                            </span>
+                          ) : count > 0 ? (
+                            <span className="flex-shrink-0 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                              {count} item{count !== 1 ? "s" : ""}
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })
+                  : null}
+              </div>
+            </div>
+
+            {/* Footer — sticky bottom: Cancel. */}
+            <div
+              className="flex flex-shrink-0 gap-2 px-5 py-3"
+              style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}
+            >
+              <button
+                onClick={() => setDayPickerItem(null)}
+                className="flex-1 rounded-lg border px-4 py-2 text-sm font-medium"
                 style={{
-                  background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text)",
-                  border: "1px solid var(--color-bt-border)",
+                  borderColor: "var(--color-bt-border)",
+                  color: "var(--color-bt-text-dim)",
+                  background: "transparent",
                 }}
               >
                 Cancel
               </button>
             </div>
           </div>
-        </div>
+        </>
       )}
 
       {/* Competition event linker — mobile picker to link a comp event to an agenda item */}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -450,10 +450,12 @@ function CompEventChip({
           onClick={(e) => { e.stopPropagation(); onLinkToItem(); }}
           className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full transition-opacity hover:opacity-80 lg:hidden"
           style={{ color: "var(--color-bt-accent)" }}
-          aria-label="Add to an agenda item"
-          title="Add to an agenda item"
+          aria-label={isGolf ? "Add to a golf round" : "Add to an agenda item"}
+          title={isGolf ? "Add to a golf round" : "Add to an agenda item"}
         >
-          <CalendarDays size={14} />
+          {/* Golf events only attach to a golf round → flag icon; everything
+              else attaches to any agenda item → agenda (calendar) icon. */}
+          {isGolf ? <Flag size={14} /> : <CalendarDays size={14} />}
         </button>
       )}
     </div>

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -224,11 +224,12 @@ function ScheduleItemRow({
         />
       )}
 
-      {/* Type icon — always present so text aligns across item types */}
+      {/* Type icon — always present so text aligns across item types.
+          Agenda-item icons are teal (vs gray competition-event icons). */}
       {item.item_type === "golf" ? (
         <Flag size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
       ) : (
-        <Calendar size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
+        <Calendar size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
       )}
 
       <div className="min-w-0 flex-1">
@@ -421,7 +422,7 @@ function CompEventChip({
         onDragStarted?.(event.type);
       } : undefined}
       onDragEnd={canEdit ? () => onDragEnded?.() : undefined}
-      className={`flex items-center gap-2 rounded-lg px-2.5 py-2 ${canEdit ? "cursor-grab active:cursor-grabbing" : ""}`}
+      className={`flex items-center gap-2 rounded-xl px-4 py-3 ${canEdit ? "cursor-grab active:cursor-grabbing" : ""}`}
       style={{
         background: "var(--color-bt-card-raised)",
         border: "1px solid var(--color-bt-border)",
@@ -434,10 +435,11 @@ function CompEventChip({
           style={{ color: "var(--color-bt-text-dim)" }}
         />
       )}
-      <span style={{ color: isGolf ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>
+      {/* Competition-event icons are gray (vs teal agenda-item icons). */}
+      <span style={{ color: "var(--color-bt-text-dim)" }}>
         {isGolf ? <Flag size={12} /> : <Star size={12} />}
       </span>
-      <p className="min-w-0 flex-1 truncate text-[12px] font-medium" style={{ color: "var(--color-bt-text)" }}>
+      <p className="min-w-0 flex-1 truncate text-[12px] font-medium leading-5" style={{ color: "var(--color-bt-text)" }}>
         {event.title}
       </p>
       {event.scoring_format && (
@@ -1013,9 +1015,7 @@ export function ScheduleTab({
                     className="mt-1 text-[11px] italic leading-snug"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    {unscheduledItems.length === 0
-                      ? "Unscheduled items live here. Drag onto a day when ready."
-                      : "Drag these to a day to add it to the agenda"}
+                    Drag these to a day...
                   </p>
                 )}
               </div>
@@ -1231,7 +1231,7 @@ export function ScheduleTab({
                     </h4>
                   </div>
                   <p className="mb-2 text-[10px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
-                    {canEdit ? "Drag onto an agenda item to add it to the schedule, or keep it unscheduled and complete it at any time" : "Competition events for this trip"}
+                    {canEdit ? "Drag these onto an item" : "Competition events for this trip"}
                   </p>
                   <div className="space-y-1.5">
                     {unlinkedCompEvents.map((event) => (

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -112,6 +112,7 @@ function ScheduleItemRow({
   isDragging,
   showDropIndicator,
   onDragStart,
+  onDragEnd,
   onDragOver,
   onDrop,
   onCompEventDrop,
@@ -130,6 +131,9 @@ function ScheduleItemRow({
   isDragging: boolean;
   showDropIndicator: boolean;
   onDragStart: () => void;
+  /** Fires when the drag gesture ends, including when the item is released
+   *  outside any drop target. Clears drag state so the row returns to normal. */
+  onDragEnd?: () => void;
   onDragOver: (e: React.DragEvent) => void;
   onDrop: () => void;
   onCompEventDrop?: (eventId: string, itemType: string) => void;
@@ -171,6 +175,7 @@ function ScheduleItemRow({
       <div
         draggable={movable}
         onDragStart={movable ? onDragStart : undefined}
+        onDragEnd={movable ? onDragEnd : undefined}
         onDragOver={canEdit ? onDragOver : undefined}
         onDrop={canEdit ? (e) => {
           const compEventId = e.dataTransfer.getData(DND_EVENT_KEY);
@@ -784,6 +789,15 @@ export function ScheduleTab({
     reorderInGroup(groupDate, newItems);
   };
 
+  // Resets drag state when a gesture ends without a successful drop (e.g. the
+  // user releases outside any target). Without this the source row stays at
+  // the dimmed "dragging" opacity because isDragging reads from dragState.
+  const handleDragEnd = () => {
+    dragState.current = null;
+    setDragOverGroup(false);
+    setDragOverIdx(null);
+  };
+
   const handleDragDrop = (targetGroupDate: string | null, targetItems: ScheduleItem[], toIdx: number) => {
     if (!dragState.current) return;
     const { groupDate: sourceDate, idx: fromIdx, item: draggedItem } = dragState.current;
@@ -1108,6 +1122,7 @@ export function ScheduleTab({
                           onDragStart={() => {
                             dragState.current = { groupDate: null, idx, item };
                           }}
+                          onDragEnd={handleDragEnd}
                           onDragOver={(e) => {
                             // The panel only accepts reordering of items already
                             // here — scheduled items leave the agenda via the X,
@@ -1361,6 +1376,7 @@ export function ScheduleTab({
                                 dragState.current?.idx !== idx
                               }
                               onDragStart={() => { dragState.current = { groupDate: group.date, idx, item }; }}
+                              onDragEnd={handleDragEnd}
                               onDragOver={(e) => {
                                 e.preventDefault();
                                 setDragOverIdx({ groupDate: group.date, idx });

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -301,7 +301,7 @@ function ScheduleItemRow({
             ) : (
               <Star size={12} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
             )}
-            <p className="min-w-0 flex-1 truncate text-[12px] font-medium" style={{ color: "var(--color-bt-text)" }}>
+            <p className="min-w-0 flex-1 truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
               {ce.title}
             </p>
             {canEdit && onUnlinkCompEvent && (
@@ -445,7 +445,7 @@ function CompEventChip({
       <span style={{ color: "var(--color-bt-text-dim)" }}>
         {isGolf ? <Flag size={12} /> : <Star size={12} />}
       </span>
-      <p className="min-w-0 flex-1 truncate text-[12px] font-medium leading-5" style={{ color: "var(--color-bt-text)" }}>
+      <p className="min-w-0 flex-1 truncate text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>
         {event.title}
       </p>
       {event.scoring_format && (
@@ -1193,7 +1193,7 @@ export function ScheduleTab({
                   <div className="flex items-center gap-2">
                     <Trophy size={12} style={{ color: "var(--color-bt-text-dim)" }} />
                     <h4
-                      className="text-[11px] font-semibold uppercase tracking-wider"
+                      className="text-[11px] font-bold uppercase tracking-[0.12em]"
                       style={{ color: "var(--color-bt-text-dim)" }}
                     >
                       Competition Events
@@ -1232,11 +1232,11 @@ export function ScheduleTab({
                 <div>
                   <div className="mb-2 flex items-center gap-2">
                     <Trophy size={12} style={{ color: "var(--color-bt-text-dim)" }} />
-                    <h4 className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                    <h4 className="text-[11px] font-bold uppercase tracking-[0.12em]" style={{ color: "var(--color-bt-text-dim)" }}>
                       Competition Events
                     </h4>
                   </div>
-                  <p className="mb-2 text-[10px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
+                  <p className="mb-2 text-[11px] italic leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
                     {canEdit ? "Drag these onto an item" : "Competition events for this trip"}
                   </p>
                   <div className="space-y-1.5">
@@ -1272,7 +1272,7 @@ export function ScheduleTab({
                     className="text-[11px] font-bold uppercase tracking-[0.12em]"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    Day-by-Day
+                    Day-by-Day Agenda
                   </h4>
                 </div>
                 {canEdit && (

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -8,6 +8,7 @@ import {
   Check,
   Clock,
   Flag,
+  Inbox,
   MapPin,
   Plus,
   Star,
@@ -351,12 +352,12 @@ function ScheduleItemRow({
       <div className="flex flex-shrink-0 items-center gap-1 self-center">
 
         {/* Schedule via the day picker — opens a modal to pick a day (and,
-            for already-scheduled items, return to On Deck). Replaces drag on
-            touch and is the single move/unschedule affordance on every tile. */}
+            for already-scheduled items, return to On Deck). Touch-only: on
+            desktop (lg+) drag-and-drop is the move/unschedule affordance. */}
         {canEdit && onAddToDay && (
           <button
             onClick={(e) => { e.stopPropagation(); onAddToDay(); }}
-            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80"
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80 lg:hidden"
             style={{ color: "var(--color-bt-accent)" }}
             aria-label={isOnDeck ? "Add to a day" : "Move to another day"}
             title={isOnDeck ? "Add to a day" : "Move to another day"}
@@ -983,7 +984,9 @@ export function ScheduleTab({
                   the same y-coordinate. */}
               <div className="mb-3">
                 <div className="flex items-center gap-2">
-                  <span className="h-3 w-3 flex-shrink-0" aria-hidden />
+                  <span className="flex h-3 w-3 flex-shrink-0 items-center justify-center" style={{ color: "var(--color-bt-text-dim)" }}>
+                    <Inbox size={12} />
+                  </span>
                   <h4
                     className="text-[11px] font-bold uppercase tracking-[0.12em]"
                     style={{ color: "var(--color-bt-text-dim)" }}
@@ -1056,7 +1059,41 @@ export function ScheduleTab({
                     All items have been scheduled.
                   </p>
                 ) : (
-                  <div className="space-y-1.5">
+                  <div
+                    className="space-y-1.5 rounded-xl transition-colors"
+                    // Landing area for items dragged off a day. The list itself
+                    // is the drop target (no permanent dashed chrome) — it only
+                    // lights up while a scheduled item is dragged over it. Rows
+                    // handle their own drops first; this catches releases in the
+                    // gaps, and the bubbled second drop no-ops (handleDragDrop
+                    // clears dragState on its first call).
+                    onDragOver={canEdit ? (e) => {
+                      if (dragState.current && dragState.current.groupDate !== null) {
+                        e.preventDefault();
+                        e.dataTransfer.dropEffect = "move";
+                        setUnscheduledDragOver(true);
+                      }
+                    } : undefined}
+                    onDragLeave={canEdit ? (e) => {
+                      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                        setUnscheduledDragOver(false);
+                      }
+                    } : undefined}
+                    onDrop={canEdit ? (e) => {
+                      if (dragState.current && dragState.current.groupDate !== null) {
+                        e.preventDefault();
+                        setUnscheduledDragOver(false);
+                        handleDragDrop(null, unscheduledItems, unscheduledItems.length);
+                      }
+                    } : undefined}
+                    style={{
+                      outline: unscheduledDragOver ? "1.5px dashed var(--color-bt-accent)" : "none",
+                      outlineOffset: "4px",
+                      background: unscheduledDragOver
+                        ? "var(--color-bt-accent-faint, rgba(13,148,136,0.06))"
+                        : "transparent",
+                    }}
+                  >
                       {/* eslint-disable react-hooks/refs */}
                       {unscheduledItems.map((item, idx) => (
                         <ScheduleItemRow

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -974,6 +974,18 @@ export function ScheduleTab({
 
             {/* ── Column 1: Unscheduled Items ──────────────────────── */}
             <section style={{ alignSelf: "start" }}>
+              {/* When the main layout collapses to a single column (below lg),
+                  On Deck and Competition Events sit side-by-side as two columns
+                  so the rail's vertical content doesn't stack into a tall strip.
+                  At lg+ they restack inside the narrow 320px rail. The 2-col
+                  split only kicks in when there's a competition cell to show. */}
+              <div
+                className={`grid grid-cols-1 gap-6 lg:grid-cols-1 ${
+                  !competition || unlinkedCompEvents.length > 0 ? "sm:grid-cols-2" : ""
+                }`}
+              >
+              {/* ── On Deck cell ── */}
+              <div>
               {/* Eyebrow + caption — text-only per HANDOFF round 2 A1
                   (no icon prefix). Wrapped with mb-3 so there's
                   breathing room between the caption and the content
@@ -1155,12 +1167,16 @@ export function ScheduleTab({
                   </div>
                 )
               )}
+              </div>
+              {/* ── Competition cell — sits beside On Deck below lg, beneath it
+                  at lg+. The grid gap handles spacing, so no top margins here. ── */}
+              <div>
               {/* Competition-off nudge — replaces the live competition-events
                   list when there's no competition for this trip yet. Per
                   HANDOFF-gaps-agenda-empty.md §2b. */}
               {!competition && (
                 <div
-                  className="mt-6 rounded-xl p-3.5"
+                  className="rounded-xl p-3.5"
                   style={{
                     background: "var(--color-bt-card)",
                     border: "1px dashed var(--color-bt-border)",
@@ -1205,7 +1221,7 @@ export function ScheduleTab({
                   Drag a competition event onto a Day-by-Day agenda item to link it.
                   Linked events disappear from here (they belong to the agenda item). */}
               {competition && unlinkedCompEvents.length > 0 && (
-                <div className="mt-8">
+                <div>
                   <div className="mb-2 flex items-center gap-2">
                     <Trophy size={12} style={{ color: "var(--color-bt-text-dim)" }} />
                     <h4 className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -1229,6 +1245,8 @@ export function ScheduleTab({
                   </div>
                 </div>
               )}
+              </div>
+              </div>
             </section>
 
             {/* ── Column 2: Schedule (day groups only) ─────────────── */}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -461,6 +461,13 @@ function CompEventChip({
         border: "1px solid var(--color-bt-border)",
       }}
     >
+      {canEdit && (
+        <GripVertical
+          size={14}
+          className="hidden flex-shrink-0 cursor-grab lg:block"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        />
+      )}
       <span style={{ color: isGolf ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>
         {isGolf ? <Flag size={12} /> : <Star size={12} />}
       </span>
@@ -1206,13 +1213,7 @@ export function ScheduleTab({
                   <p className="mb-2 text-[10px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
                     {canEdit ? "Drag onto an agenda item to add it to the schedule, or keep it unscheduled and complete it at any time" : "Competition events for this trip"}
                   </p>
-                  <div
-                    className="rounded-xl p-3 transition-colors space-y-1.5"
-                    style={{
-                      border: "1px dashed var(--color-bt-border)",
-                      background: "transparent",
-                    }}
-                  >
+                  <div className="space-y-1.5">
                     {unlinkedCompEvents.map((event) => (
                       <CompEventChip
                         key={event.id}
@@ -1305,14 +1306,25 @@ export function ScheduleTab({
                             handleDragDrop(group.date, group.items, group.items.length);
                           }
                         } : undefined}
-                        className="rounded-xl px-3 pt-3 pb-1 transition-colors"
+                        className="rounded-xl transition-colors"
                         style={{
+                          // Once a day has items it reads as content, not a
+                          // drop target — drop the dashed panel chrome and
+                          // its padding. The panel only returns when the day
+                          // is empty (a teaching hint) or is being dragged
+                          // over (an active drop affordance).
+                          padding:
+                            group.items.length === 0 || dragOverGroup === group.date
+                              ? "12px 12px 4px"
+                              : "0",
                           background: dragOverGroup === group.date
                             ? "var(--color-bt-accent-faint, rgba(13,148,136,0.06))"
                             : "transparent",
                           border: dragOverGroup === group.date
                             ? "1.5px dashed var(--color-bt-accent)"
-                            : "1px dashed var(--color-bt-border)",
+                            : group.items.length === 0
+                            ? "1px dashed var(--color-bt-border)"
+                            : "none",
                         }}
                       >
                       {group.items.length === 0 ? (

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -442,19 +442,24 @@ function CompEventChip({
   onLinkToItem?: () => void;
 }) {
   const isGolf = event.type === "GOLF";
+  // Local drag feedback so the chip dims while in flight and restores when the
+  // gesture ends — including when released outside any drop target.
+  const [isDragging, setIsDragging] = useState(false);
   return (
     <div
       draggable={canEdit}
       onDragStart={canEdit ? (e) => {
         e.dataTransfer.setData(DND_EVENT_KEY, event.id);
         e.dataTransfer.effectAllowed = "move";
+        setIsDragging(true);
         onDragStarted?.(event.type);
       } : undefined}
-      onDragEnd={canEdit ? () => onDragEnded?.() : undefined}
-      className={`flex items-center gap-2 rounded-xl px-4 py-3 ${canEdit ? "cursor-grab active:cursor-grabbing" : ""}`}
+      onDragEnd={canEdit ? () => { setIsDragging(false); onDragEnded?.(); } : undefined}
+      className={`flex items-center gap-2 rounded-xl px-4 py-3 transition-all ${canEdit ? "cursor-grab active:cursor-grabbing" : ""}`}
       style={{
         background: "var(--color-bt-card-raised)",
         border: "1px solid var(--color-bt-border)",
+        opacity: isDragging ? 0.4 : 1,
       }}
     >
       {canEdit && (

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -294,7 +294,13 @@ function ScheduleItemRow({
               border: "1px solid var(--color-bt-border)",
             }}
           >
-            <Trophy size={12} className="flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
+            {/* Competition-event icons are gray; golf events use a flag,
+                everything else uses a star (matching the events panel). */}
+            {ce.type === "GOLF" ? (
+              <Flag size={12} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
+            ) : (
+              <Star size={12} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
+            )}
             <p className="min-w-0 flex-1 truncate text-[12px] font-medium" style={{ color: "var(--color-bt-text)" }}>
               {ce.title}
             </p>
@@ -1007,7 +1013,7 @@ export function ScheduleTab({
                     className="text-[11px] font-bold uppercase tracking-[0.12em]"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    On Deck
+                    Not scheduled yet
                   </h4>
                 </div>
                 {canEdit && (
@@ -1285,7 +1291,7 @@ export function ScheduleTab({
                   style={{ color: "var(--color-bt-text-dim)" }}
                 >
                   {trip.start_date
-                    ? "Nothing on the schedule yet — drag from On Deck onto a day."
+                    ? "Nothing on the schedule yet — drag an item onto a day."
                     : "Set trip dates to see the day-by-day schedule."}
                 </p>
               ) : (
@@ -1605,7 +1611,7 @@ export function ScheduleTab({
                     background: "transparent",
                   }}
                 >
-                  Return to On Deck
+                  Return to Not Scheduled Yet
                 </button>
               )}
               <button

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -397,7 +397,7 @@ function ScheduleItemRow({
           </button>
         )}
 
-        {movable && (
+        {movable && !(isFirst && isLast) && (
           <div className="flex flex-col lg:hidden">
             <button
               onClick={(e) => { e.stopPropagation(); onMoveUp(); }}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -1021,7 +1021,7 @@ export function ScheduleTab({
                     className="mt-1 text-[11px] italic leading-snug"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    Drag these to a day...
+                    Drag these onto a day
                   </p>
                 )}
               </div>
@@ -1280,7 +1280,9 @@ export function ScheduleTab({
                     className="mt-1 text-[11px] italic leading-snug"
                     style={{ color: "var(--color-bt-text-dim)" }}
                   >
-                    Drop an item onto a day to schedule it
+                    {competition
+                      ? "Drop an item onto a day to schedule it, drop an event onto an item to give it a place and time"
+                      : "Drop an item onto a day to schedule it"}
                   </p>
                 )}
               </div>

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -352,7 +352,7 @@ function ScheduleItemRow({
           round-7 item 4) since they're inherently unconfirmed. */}
       {!isOnDeck && (
         <span
-          className="mt-0.5 inline-flex flex-shrink-0 items-center gap-1 self-start rounded-full px-2.5 py-1 text-xs font-semibold"
+          className="inline-flex flex-shrink-0 items-center gap-1 self-center rounded-full px-2.5 py-1 text-xs font-semibold"
           style={
             item.is_confirmed
               ? {
@@ -376,7 +376,7 @@ function ScheduleItemRow({
         </span>
       )}
 
-      <div className="flex flex-shrink-0 items-center gap-1">
+      <div className="flex flex-shrink-0 items-center gap-1 self-center">
 
         {/* Mobile-only: schedule to a day via picker (replaces drag on touch).
             Shown as an icon button in the action column, before reorder arrows. */}

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -115,7 +115,6 @@ function ScheduleItemRow({
   onDrop,
   onCompEventDrop,
   onUnlinkCompEvent,
-  onUnschedule,
   compDragType,
   onAddToDay,
 }: {
@@ -133,14 +132,11 @@ function ScheduleItemRow({
   onDrop: () => void;
   onCompEventDrop?: (eventId: string, itemType: string) => void;
   onUnlinkCompEvent?: (eventId: string) => void;
-  /** Day-by-Day rows pass this — the trailing button becomes an X that
-   *  sends the item back to On Deck (clears its date). When omitted, the
-   *  trailing button is a trash can wired to onRemove (delete). */
-  onUnschedule?: () => void;
   /** When non-null, a competition event is being dragged. The row computes
    *  whether it's a valid target and highlights itself accordingly. */
   compDragType?: "GOLF" | "GENERIC" | null;
-  /** Mobile-only: open day-picker sheet to schedule this On Deck item. */
+  /** Opens the day-picker sheet to (re)schedule this item — pick a day, or
+   *  return a scheduled item to On Deck. Replaces drag on touch. */
   onAddToDay?: () => void;
 }) {
   const movable = canEdit;
@@ -207,7 +203,7 @@ function ScheduleItemRow({
           background: isValidCompTarget
             ? "var(--color-bt-accent-faint)"
             : (!!item.scheduled_date && (item.item_type !== "golf" || item.is_confirmed))
-            ? "var(--color-bt-tag-bg)"
+            ? "var(--color-bt-accent-faint)"
             : "var(--color-bt-card)",
           border: isValidCompTarget
             ? "1.5px solid var(--color-bt-accent)"
@@ -352,46 +348,18 @@ function ScheduleItemRow({
       </div>
       </div>
 
-      {/* DRAFT / CONFIRMED status pill — only meaningful for items that
-          are actually on a day. On Deck rows hide it entirely (per
-          round-7 item 4) since they're inherently unconfirmed. */}
-      {!isOnDeck && (
-        <span
-          className="inline-flex flex-shrink-0 items-center gap-1 self-center rounded-full px-2.5 py-1 text-xs font-semibold"
-          style={
-            item.is_confirmed
-              ? {
-                  background: "var(--color-bt-accent)",
-                  border: "1px solid var(--color-bt-accent)",
-                  color: "var(--color-bt-on-accent)",
-                }
-              : {
-                  background: "var(--color-bt-card-raised)",
-                  border: "1px solid var(--color-bt-accent-border)",
-                  color: "var(--color-bt-accent)",
-                }
-          }
-        >
-          {item.is_confirmed && <Check size={12} strokeWidth={3} />}
-          {item.is_confirmed ? (
-            <span className="hidden sm:inline">Confirmed</span>
-          ) : (
-            "Draft"
-          )}
-        </span>
-      )}
-
       <div className="flex flex-shrink-0 items-center gap-1 self-center">
 
-        {/* Mobile-only: schedule to a day via picker (replaces drag on touch).
-            Shown as an icon button in the action column, before reorder arrows. */}
+        {/* Schedule via the day picker — opens a modal to pick a day (and,
+            for already-scheduled items, return to On Deck). Replaces drag on
+            touch and is the single move/unschedule affordance on every tile. */}
         {canEdit && onAddToDay && (
           <button
             onClick={(e) => { e.stopPropagation(); onAddToDay(); }}
-            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80 lg:hidden"
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80"
             style={{ color: "var(--color-bt-accent)" }}
-            aria-label="Add to a day"
-            title="Add to a day"
+            aria-label={isOnDeck ? "Add to a day" : "Move to another day"}
+            title={isOnDeck ? "Add to a day" : "Move to another day"}
           >
             <CalendarDays size={14} />
           </button>
@@ -420,20 +388,6 @@ function ScheduleItemRow({
           </div>
         )}
 
-        {/* Send back to On Deck — Day-by-Day rows only. Delete now lives in
-            the edit drawer footer ("Remove from agenda"); the row itself is
-            tappable to open that drawer. */}
-        {canEdit && onUnschedule && (
-          <button
-            onClick={(e) => { e.stopPropagation(); onUnschedule(); }}
-            className="flex h-6 w-6 items-center justify-center rounded-full transition-opacity hover:opacity-80"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            aria-label="Send back to On Deck"
-            title="Send back to On Deck"
-          >
-            <X size={14} />
-          </button>
-        )}
       </div>
     </div>
     </>
@@ -1389,16 +1343,7 @@ export function ScheduleTab({
                                 linkToAgendaItem.mutate({ tripId, eventId, agendaItemId: null });
                               } : undefined}
                               compDragType={compDragType}
-                              onUnschedule={() => {
-                                updateItem.mutate({
-                                  tripId,
-                                  itemId: item.id,
-                                  scheduledDate: null,
-                                  // Non-golf: unconfirmed when sent back to On Deck.
-                                  // Golf: keeps its confirmed status (tee times / walk-on drive it).
-                                  ...(item.item_type !== "golf" && { isConfirmed: false }),
-                                });
-                              }}
+                              onAddToDay={trip.start_date && trip.end_date ? () => setDayPickerItem(item) : undefined}
                             />
                           ))}
                           {/* Bottom drop zone — append to end of day */}
@@ -1579,14 +1524,36 @@ export function ScheduleTab({
               </div>
             </div>
 
-            {/* Footer — sticky bottom: Cancel. */}
+            {/* Footer — sticky bottom: return-to-On-Deck (scheduled items only) + Cancel. */}
             <div
-              className="flex flex-shrink-0 gap-2 px-5 py-3"
+              className="flex flex-shrink-0 flex-col gap-2 px-5 py-3"
               style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}
             >
+              {dayPickerItem.scheduled_date && (
+                <button
+                  onClick={() => {
+                    updateItem.mutate({
+                      tripId,
+                      itemId: dayPickerItem.id,
+                      scheduledDate: null,
+                      // Non-golf: leaving the agenda clears confirmation.
+                      ...(dayPickerItem.item_type !== "golf" && { isConfirmed: false }),
+                    });
+                    setDayPickerItem(null);
+                  }}
+                  className="w-full rounded-lg border px-4 py-2 text-sm font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+                  style={{
+                    borderColor: "var(--color-bt-border)",
+                    color: "var(--color-bt-text)",
+                    background: "transparent",
+                  }}
+                >
+                  Return to On Deck
+                </button>
+              )}
               <button
                 onClick={() => setDayPickerItem(null)}
-                className="flex-1 rounded-lg border px-4 py-2 text-sm font-medium"
+                className="w-full rounded-lg border px-4 py-2 text-sm font-medium"
                 style={{
                   borderColor: "var(--color-bt-border)",
                   color: "var(--color-bt-text-dim)",

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -194,7 +194,7 @@ function ScheduleItemRow({
               }
             : undefined
         }
-        className={`mb-2 flex ${isOnDeck ? "items-center" : "items-start"} gap-2 rounded-xl px-4 py-3 transition-all ${
+        className={`mb-2 flex items-center gap-2 rounded-xl px-4 py-3 transition-all ${
           canEdit
             ? "cursor-pointer hover:shadow-[0_0_0_1px_var(--color-bt-accent-border)]"
             : ""
@@ -218,16 +218,16 @@ function ScheduleItemRow({
       {movable && (
         <GripVertical
           size={16}
-          className={`${isOnDeck ? "" : "mt-0.5"} hidden flex-shrink-0 cursor-grab lg:block`}
+          className="hidden flex-shrink-0 cursor-grab lg:block"
           style={{ color: "var(--color-bt-text-dim)" }}
         />
       )}
 
       {/* Type icon — always present so text aligns across item types */}
       {item.item_type === "golf" ? (
-        <Flag size={14} className={`${isOnDeck ? "" : "mt-0.5"} flex-shrink-0`} style={{ color: "var(--color-bt-accent)" }} />
+        <Flag size={14} className="flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
       ) : (
-        <Calendar size={14} className={`${isOnDeck ? "" : "mt-0.5"} flex-shrink-0`} style={{ color: "var(--color-bt-text-dim)" }} />
+        <Calendar size={14} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
       )}
 
       <div className="min-w-0 flex-1">

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -118,6 +118,7 @@ function ScheduleItemRow({
   onUnlinkCompEvent,
   compDragType,
   onAddToDay,
+  onUnschedule,
 }: {
   item: ScheduleItem;
   canEdit: boolean;
@@ -136,9 +137,12 @@ function ScheduleItemRow({
   /** When non-null, a competition event is being dragged. The row computes
    *  whether it's a valid target and highlights itself accordingly. */
   compDragType?: "GOLF" | "GENERIC" | null;
-  /** Opens the day-picker sheet to (re)schedule this item — pick a day, or
-   *  return a scheduled item to On Deck. Replaces drag on touch. */
+  /** Opens the day-picker sheet to (re)schedule this item — pick a day to
+   *  move it to. Replaces drag on touch. */
   onAddToDay?: () => void;
+  /** Removes a scheduled item from the agenda (back to "Not scheduled yet").
+   *  Rendered as the X on the title line of a scheduled row. */
+  onUnschedule?: () => void;
 }) {
   const movable = canEdit;
   // GOLF events can only land on golf items; non-GOLF events land on anything.
@@ -397,6 +401,20 @@ function ScheduleItemRow({
         )}
 
       </div>
+
+      {/* Remove from agenda — scheduled items only. Sits on the title line at
+          the far right (self-start), matching the linked competition-event X. */}
+      {!isOnDeck && canEdit && onUnschedule && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onUnschedule(); }}
+          className="flex h-5 w-5 flex-shrink-0 items-center justify-center self-start rounded-full transition-opacity hover:opacity-70"
+          style={{ color: "var(--color-bt-text-dim)" }}
+          title="Remove from agenda"
+          aria-label="Remove from agenda"
+        >
+          <X size={12} />
+        </button>
+      )}
     </div>
     </>
   );
@@ -499,7 +517,6 @@ export function ScheduleTab({
   const dragState = useRef<{ groupDate: string | null; idx: number; item: ScheduleItem } | null>(null);
   const [dragOverGroup, setDragOverGroup] = useState<string | null | false>(false);
   const [dragOverIdx, setDragOverIdx] = useState<{ groupDate: string | null; idx: number } | null>(null);
-  const [unscheduledDragOver, setUnscheduledDragOver] = useState(false);
   // Type of competition event currently being dragged (null when no comp drag).
   // Drives per-item highlighting on Day-by-Day rows.
   const [compDragType, setCompDragType] = useState<"GOLF" | "GENERIC" | null>(null);
@@ -774,6 +791,10 @@ export function ScheduleTab({
     setDragOverGroup(false);
     setDragOverIdx(null);
 
+    // Removal from the agenda is X-only — a scheduled item can never be
+    // unscheduled by dragging it back into "Not scheduled yet".
+    if (targetGroupDate === null && sourceDate !== null) return;
+
     // Same group — simple reorder
     if (sourceDate === targetGroupDate) {
       if (fromIdx === toIdx) return;
@@ -1016,7 +1037,7 @@ export function ScheduleTab({
                     Not scheduled yet
                   </h4>
                 </div>
-                {canEdit && (
+                {canEdit && unscheduledItems.length > 0 && (
                   <p
                     className="mt-1 text-[11px] italic leading-snug"
                     style={{ color: "var(--color-bt-text-dim)" }}
@@ -1032,33 +1053,15 @@ export function ScheduleTab({
 
               {unscheduledItems.length === 0 && canEdit ? (
                 /* Round 2 A3: thin one-line dashed teal button replaces
-                   the old 100px invitation block. Doubles as the drop
-                   target so items dragged back from Day-by-Day still
-                   have somewhere to land. */
+                   the old 100px invitation block. Items leave the agenda
+                   via the X on a scheduled row, not by dragging back here. */
                 <button
                   type="button"
                   onClick={() => setAddMode("general")}
-                  onDragOver={(e) => {
-                    e.preventDefault();
-                    e.dataTransfer.dropEffect = "move";
-                    setUnscheduledDragOver(true);
-                  }}
-                  onDragLeave={(e) => {
-                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                      setUnscheduledDragOver(false);
-                    }
-                  }}
-                  onDrop={(e) => {
-                    e.preventDefault();
-                    setUnscheduledDragOver(false);
-                    if (dragState.current && dragState.current.groupDate !== null) {
-                      handleDragDrop(null, unscheduledItems, unscheduledItems.length);
-                    }
-                  }}
                   className="mt-3 flex w-full items-center justify-center gap-1 rounded-[10px] py-3 text-xs font-semibold transition-colors"
                   style={{
                     background: "var(--color-bt-accent-faint)",
-                    border: `1px dashed ${unscheduledDragOver ? "var(--color-bt-accent)" : "var(--color-bt-accent)"}`,
+                    border: "1px dashed var(--color-bt-accent)",
                     color: "var(--color-bt-accent)",
                   }}
                 >
@@ -1079,41 +1082,7 @@ export function ScheduleTab({
                     All items have been scheduled.
                   </p>
                 ) : (
-                  <div
-                    className="space-y-1.5 rounded-xl transition-colors"
-                    // Landing area for items dragged off a day. The list itself
-                    // is the drop target (no permanent dashed chrome) — it only
-                    // lights up while a scheduled item is dragged over it. Rows
-                    // handle their own drops first; this catches releases in the
-                    // gaps, and the bubbled second drop no-ops (handleDragDrop
-                    // clears dragState on its first call).
-                    onDragOver={canEdit ? (e) => {
-                      if (dragState.current && dragState.current.groupDate !== null) {
-                        e.preventDefault();
-                        e.dataTransfer.dropEffect = "move";
-                        setUnscheduledDragOver(true);
-                      }
-                    } : undefined}
-                    onDragLeave={canEdit ? (e) => {
-                      if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                        setUnscheduledDragOver(false);
-                      }
-                    } : undefined}
-                    onDrop={canEdit ? (e) => {
-                      if (dragState.current && dragState.current.groupDate !== null) {
-                        e.preventDefault();
-                        setUnscheduledDragOver(false);
-                        handleDragDrop(null, unscheduledItems, unscheduledItems.length);
-                      }
-                    } : undefined}
-                    style={{
-                      outline: unscheduledDragOver ? "1.5px dashed var(--color-bt-accent)" : "none",
-                      outlineOffset: "4px",
-                      background: unscheduledDragOver
-                        ? "var(--color-bt-accent-faint, rgba(13,148,136,0.06))"
-                        : "transparent",
-                    }}
-                  >
+                  <div className="space-y-1.5">
                       {/* eslint-disable react-hooks/refs */}
                       {unscheduledItems.map((item, idx) => (
                         <ScheduleItemRow
@@ -1140,6 +1109,10 @@ export function ScheduleTab({
                             dragState.current = { groupDate: null, idx, item };
                           }}
                           onDragOver={(e) => {
+                            // The panel only accepts reordering of items already
+                            // here — scheduled items leave the agenda via the X,
+                            // not by dragging back. Reject day-sourced drags.
+                            if (dragState.current?.groupDate !== null) return;
                             e.preventDefault();
                             setDragOverIdx({ groupDate: null, idx });
                           }}
@@ -1409,6 +1382,14 @@ export function ScheduleTab({
                               } : undefined}
                               compDragType={compDragType}
                               onAddToDay={trip.start_date && trip.end_date ? () => setDayPickerItem(item) : undefined}
+                              onUnschedule={() => {
+                                updateItem.mutate({
+                                  tripId,
+                                  itemId: item.id,
+                                  scheduledDate: null,
+                                  ...(item.item_type !== "golf" && { isConfirmed: false }),
+                                });
+                              }}
                             />
                           ))}
                           {/* Bottom drop zone — append to end of day */}
@@ -1594,28 +1575,6 @@ export function ScheduleTab({
               className="flex flex-shrink-0 flex-col gap-2 px-5 py-3"
               style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}
             >
-              {dayPickerItem.scheduled_date && (
-                <button
-                  onClick={() => {
-                    updateItem.mutate({
-                      tripId,
-                      itemId: dayPickerItem.id,
-                      scheduledDate: null,
-                      // Non-golf: leaving the agenda clears confirmation.
-                      ...(dayPickerItem.item_type !== "golf" && { isConfirmed: false }),
-                    });
-                    setDayPickerItem(null);
-                  }}
-                  className="w-full rounded-lg border px-4 py-2 text-sm font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
-                  style={{
-                    borderColor: "var(--color-bt-border)",
-                    color: "var(--color-bt-text)",
-                    background: "transparent",
-                  }}
-                >
-                  Return to Not Scheduled Yet
-                </button>
-              )}
               <button
                 onClick={() => setDayPickerItem(null)}
                 className="w-full rounded-lg border px-4 py-2 text-sm font-medium"

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -368,7 +368,11 @@ function ScheduleItemRow({
           }
         >
           {item.is_confirmed && <Check size={12} strokeWidth={3} />}
-          {item.is_confirmed ? "Confirmed" : "Draft"}
+          {item.is_confirmed ? (
+            <span className="hidden sm:inline">Confirmed</span>
+          ) : (
+            "Draft"
+          )}
         </span>
       )}
 

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -215,19 +215,23 @@ function ScheduleItemRow({
           opacity: isDragging ? 0.4 : 1,
         }}
       >
+      {/* Left group — icon stays on the title's line (items-start) while the
+          whole group is centered within the row (row is items-center) so a
+          title-only item has no empty space beneath it. */}
+      <div className="flex min-w-0 flex-1 items-start gap-2">
       {movable && (
         <GripVertical
           size={16}
-          className="hidden flex-shrink-0 cursor-grab lg:block"
+          className="mt-0.5 hidden flex-shrink-0 cursor-grab lg:block"
           style={{ color: "var(--color-bt-text-dim)" }}
         />
       )}
 
       {/* Type icon — always present so text aligns across item types */}
       {item.item_type === "golf" ? (
-        <Flag size={14} className="flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
+        <Flag size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-accent)" }} />
       ) : (
-        <Calendar size={14} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
+        <Calendar size={14} className="mt-0.5 flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
       )}
 
       <div className="min-w-0 flex-1">
@@ -345,6 +349,7 @@ function ScheduleItemRow({
             Add tee time(s) or walk on
           </button>
         )}
+      </div>
       </div>
 
       {/* DRAFT / CONFIRMED status pill — only meaningful for items that

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -525,6 +525,11 @@ export function ScheduleTab({
   const [dayPickerItem, setDayPickerItem] = useState<ScheduleItem | null>(null);
   const [linkCompEvent, setLinkCompEvent] = useState<EventRow | null>(null);
   const dragState = useRef<{ groupDate: string | null; idx: number; item: ScheduleItem } | null>(null);
+  // Mirrors "a row is being dragged" as real state. dragState is a ref (so the
+  // drop handlers can read it synchronously), but isDragging must re-render
+  // reliably on drag end — even when the dragOver states are already at their
+  // defaults (e.g. released in empty space after a dragLeave reset them).
+  const [draggingActive, setDraggingActive] = useState(false);
   const [dragOverGroup, setDragOverGroup] = useState<string | null | false>(false);
   const [dragOverIdx, setDragOverIdx] = useState<{ groupDate: string | null; idx: number } | null>(null);
   // Type of competition event currently being dragged (null when no comp drag).
@@ -799,6 +804,7 @@ export function ScheduleTab({
   // the dimmed "dragging" opacity because isDragging reads from dragState.
   const handleDragEnd = () => {
     dragState.current = null;
+    setDraggingActive(false);
     setDragOverGroup(false);
     setDragOverIdx(null);
   };
@@ -807,6 +813,7 @@ export function ScheduleTab({
     if (!dragState.current) return;
     const { groupDate: sourceDate, idx: fromIdx, item: draggedItem } = dragState.current;
     dragState.current = null;
+    setDraggingActive(false);
     setDragOverGroup(false);
     setDragOverIdx(null);
 
@@ -1114,6 +1121,7 @@ export function ScheduleTab({
                           isFirst={idx === 0}
                           isLast={idx === unscheduledItems.length - 1}
                           isDragging={
+                            draggingActive &&
                             !!dragState.current &&
                             dragState.current.groupDate === null &&
                             dragState.current.idx === idx
@@ -1126,6 +1134,7 @@ export function ScheduleTab({
                           }
                           onDragStart={() => {
                             dragState.current = { groupDate: null, idx, item };
+                            setDraggingActive(true);
                           }}
                           onDragEnd={handleDragEnd}
                           onDragOver={(e) => {
@@ -1370,6 +1379,7 @@ export function ScheduleTab({
                               isFirst={idx === 0}
                               isLast={idx === group.items.length - 1}
                               isDragging={
+                                draggingActive &&
                                 !!dragState.current &&
                                 dragState.current.groupDate === group.date &&
                                 dragState.current.idx === idx
@@ -1380,7 +1390,7 @@ export function ScheduleTab({
                                 dragOverIdx.idx === idx &&
                                 dragState.current?.idx !== idx
                               }
-                              onDragStart={() => { dragState.current = { groupDate: group.date, idx, item }; }}
+                              onDragStart={() => { dragState.current = { groupDate: group.date, idx, item }; setDraggingActive(true); }}
                               onDragEnd={handleDragEnd}
                               onDragOver={(e) => {
                                 e.preventDefault();

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -331,7 +331,7 @@ function ScheduleItemRow({
         {!isOnDeck && item.item_type !== "golf" && item.scheduled_time && (
           <div className="mt-1 flex items-center gap-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
             <Clock size={10} />
-            {item.scheduled_time}
+            {fmtTime12(item.scheduled_time)}
           </div>
         )}
         {/* Golf: prompt to add tee time when unconfirmed — placed in the content

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -5,6 +5,7 @@ import {
   Calendar,
   CalendarDays,
   CalendarPlus,
+  Check,
   Clock,
   Flag,
   MapPin,
@@ -351,21 +352,22 @@ function ScheduleItemRow({
           round-7 item 4) since they're inherently unconfirmed. */}
       {!isOnDeck && (
         <span
-          className="mt-0.5 flex-shrink-0 self-start rounded-[4px] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.08em]"
+          className="mt-0.5 inline-flex flex-shrink-0 items-center gap-1 self-start rounded-full px-2.5 py-1 text-xs font-semibold"
           style={
             item.is_confirmed
               ? {
-                  background: "var(--color-bt-accent-faint)",
-                  color: "var(--color-bt-accent)",
-                  border: "0.5px solid var(--color-bt-accent-border)",
+                  background: "var(--color-bt-accent)",
+                  border: "1px solid var(--color-bt-accent)",
+                  color: "var(--color-bt-on-accent)",
                 }
               : {
                   background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text-dim)",
-                  border: "0.5px dashed var(--color-bt-border)",
+                  border: "1px solid var(--color-bt-accent-border)",
+                  color: "var(--color-bt-accent)",
                 }
           }
         >
+          {item.is_confirmed && <Check size={12} strokeWidth={3} />}
           {item.is_confirmed ? "Confirmed" : "Draft"}
         </span>
       )}

--- a/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
+++ b/src/app/trips/[tripId]/tabs/components/GettingThereSection.tsx
@@ -223,7 +223,12 @@ export function GettingThereSection({ tripId, isOwner, onCancel }: GettingThereS
         </div>
       )}
 
-      {showEmptyState && <EmptyArrivalsState onCancel={onCancel} />}
+      {showEmptyState && (
+        <EmptyArrivalsState
+          onCancel={onCancel}
+          onAdd={() => setExpanded(true)}
+        />
+      )}
 
       {showFilterPills && (
         <div className="flex flex-wrap items-center gap-2">
@@ -536,7 +541,15 @@ function OtherMemberTravelRow({
 // + centered icon/heading/description + faded skeleton preview of what
 // populated arrival rows will look like.
 
-function EmptyArrivalsState({ onCancel }: { onCancel?: () => void }) {
+function EmptyArrivalsState({
+  onCancel,
+  onAdd,
+}: {
+  onCancel?: () => void;
+  /** Opens the inline travel form so the viewer can share their plans —
+      without this the empty state is a dead end with no add affordance. */
+  onAdd: () => void;
+}) {
   return (
     // flex-1 = grow to fill the section's h-full container so the dashed
     // box matches the height of the Itinerary panel's empty state when
@@ -581,6 +594,14 @@ function EmptyArrivalsState({ onCancel }: { onCancel?: () => void }) {
           Share your travel and the crew can coordinate pickups, dinner
           times, and tee slots around real arrival times.
         </p>
+        <button
+          type="button"
+          onClick={onAdd}
+          className="mt-4 flex items-center justify-center gap-1.5 rounded-xl px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90"
+          style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+        >
+          <Plus size={15} /> Add your travel
+        </button>
       </div>
 
       {/* Skeleton arrivals — three faded rows mirroring the intro modal */}

--- a/src/components/FloatingChatPanel.tsx
+++ b/src/components/FloatingChatPanel.tsx
@@ -977,6 +977,12 @@ function ChatBody({
             background: "var(--color-bt-base)",
             borderColor: "var(--color-bt-border)",
             color: "var(--color-bt-text)",
+            // One-line floor. The auto-grow effect sets an inline height from
+            // scrollHeight; on a responsive layout switch the textarea can be
+            // measured with no layout (scrollHeight ≈ 0), leaving a stale ~few-px
+            // inline height. min-height wins over height, so the field can never
+            // collapse below a single row regardless of a bad measurement.
+            minHeight: "2.25rem", // leading-5 (20px) + py-1.5 (12px) + border (2px)
             maxHeight: "4.5rem", // ~3 lines (leading-5 = 20px × 3 + py-1.5), then scrolls
             overflowY: "auto",
           }}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -45,6 +45,11 @@ interface TopNavProps {
   /** Reflects whether the FloatingChatPanel is currently open — used to
    *  render the chat button in its active state. */
   chatOpen?: boolean;
+  /** Hide the trip-switcher grid button (e.g. on the profile page, which
+   *  isn't trip-scoped and doesn't need trip navigation). */
+  hideTripSwitcher?: boolean;
+  /** Hide the notifications bell (e.g. on the profile page). */
+  hideNotifications?: boolean;
 }
 
 const NOTIFICATION_ICONS: Record<string, typeof Bell> = {
@@ -68,6 +73,8 @@ export const TopNav: FC<TopNavProps> = ({
   tripId,
   onOpenChat,
   chatOpen = false,
+  hideTripSwitcher = false,
+  hideNotifications = false,
 }) => {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -78,8 +85,10 @@ export const TopNav: FC<TopNavProps> = ({
   // empty-state hero already exposes "New trip" as the primary CTA, so
   // an extra switcher button just opens an empty panel. TanStack Query
   // dedupes against the same query the page may already be running.
-  const { data: tripsForSwitcher } = trpc.trips.list.useQuery();
-  const showSwitcher = (tripsForSwitcher?.length ?? 0) > 0;
+  const { data: tripsForSwitcher } = trpc.trips.list.useQuery(undefined, {
+    enabled: !hideTripSwitcher,
+  });
+  const showSwitcher = !hideTripSwitcher && (tripsForSwitcher?.length ?? 0) > 0;
 
   // Close on outside click
   useEffect(() => {
@@ -168,6 +177,7 @@ export const TopNav: FC<TopNavProps> = ({
           </>
         )}
 
+        {!hideNotifications && (
         <div ref={ref} className="relative">
           <button
             aria-label="Notifications"
@@ -310,6 +320,7 @@ export const TopNav: FC<TopNavProps> = ({
             </>
           )}
         </div>
+        )}
 
         {tripId && onOpenChat && (
           <ChatButton tripId={tripId} onClick={onOpenChat} isOpen={chatOpen} />

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -155,35 +155,26 @@ export const TopNav: FC<TopNavProps> = ({
               data-testid="trip-switcher-trigger"
               data-trip-switcher-trigger="true"
               onClick={() => setSwitcherOpen((p) => !p)}
-              className="flex h-7 w-7 items-center justify-center rounded-md transition-colors md:h-8 md:w-8 md:rounded-lg"
-              style={
-                switcherOpen
-                  ? {
-                      background: "rgba(45, 212, 191, 0.12)",
-                      color: "var(--color-bt-accent)",
-                    }
-                  : {
-                      background: "transparent",
-                      color: "var(--color-bt-text-dim)",
-                    }
-              }
+              className="relative flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{
+                color: switcherOpen
+                  ? "var(--color-bt-accent)"
+                  : "var(--color-bt-text-dim)",
+              }}
             >
-              <IconLayoutGrid size={18} stroke={1.75} />
+              <IconLayoutGrid size={20} stroke={1.5} />
             </button>
             <TripSwitcher open={switcherOpen} onClose={() => setSwitcherOpen(false)} />
           </>
         )}
 
-        {tripId && onOpenChat && (
-          <ChatButton tripId={tripId} onClick={onOpenChat} isOpen={chatOpen} />
-        )}
         <div ref={ref} className="relative">
           <button
             aria-label="Notifications"
             data-testid="notification-bell"
             onClick={handleBellClick}
             className="relative flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            style={{ color: open ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
           >
             <Bell size={20} strokeWidth={1.5} />
             {unreadCount > 0 && (
@@ -319,6 +310,10 @@ export const TopNav: FC<TopNavProps> = ({
             </>
           )}
         </div>
+
+        {tripId && onOpenChat && (
+          <ChatButton tripId={tripId} onClick={onOpenChat} isOpen={chatOpen} />
+        )}
 
         <UserMenu />
       </div>

--- a/src/components/TripSwitcher.tsx
+++ b/src/components/TripSwitcher.tsx
@@ -103,7 +103,6 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
       currentTripId={currentTripId}
       onSelectTrip={(id) => handleNavigate(`/trips/${id}`)}
       onNewTrip={() => handleNavigate("/trips/new")}
-      onViewAll={() => handleNavigate("/dashboard")}
     />
   );
 
@@ -138,7 +137,7 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
         }}
       >
         <div
-          className="px-4 py-3"
+          className="flex items-center justify-between px-4 py-3"
           style={{ borderBottom: "0.5px solid var(--color-bt-border)" }}
         >
           <span
@@ -147,6 +146,14 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
           >
             My trips
           </span>
+          <button
+            type="button"
+            onClick={() => handleNavigate("/dashboard")}
+            className="text-xs transition-colors hover:opacity-80"
+            style={{ color: "var(--color-bt-accent)" }}
+          >
+            View all
+          </button>
         </div>
         <div style={{ maxHeight: "min(480px, calc(100vh - 80px))", overflowY: "auto" }}>
           {body}
@@ -164,14 +171,12 @@ function TripSwitcherBody({
   currentTripId,
   onSelectTrip,
   onNewTrip,
-  onViewAll,
 }: {
   activeTrips: SwitcherTrip[];
   pastTrips: SwitcherTrip[];
   currentTripId: string | null;
   onSelectTrip: (tripId: string) => void;
   onNewTrip: () => void;
-  onViewAll: () => void;
 }) {
   const showDividers = activeTrips.length > 0 && pastTrips.length > 0;
   const noTrips = activeTrips.length === 0 && pastTrips.length === 0;
@@ -242,20 +247,6 @@ function TripSwitcherBody({
         >
           New trip
         </span>
-      </button>
-
-      {/* View all trips */}
-      <button
-        type="button"
-        onClick={onViewAll}
-        className="block w-full text-center transition-opacity hover:opacity-80"
-        style={{
-          padding: "10px 16px",
-          fontSize: 12,
-          color: "var(--color-bt-text-dim)",
-        }}
-      >
-        View all trips →
       </button>
     </div>
   );

--- a/src/components/TripTabBar.test.tsx
+++ b/src/components/TripTabBar.test.tsx
@@ -106,29 +106,30 @@ describe("Stage-gated bottom nav visibility", () => {
 describe("Stage-gated tab bar — tab filtering", () => {
   const ALL_TAB_IDS = ["home", "crew", "schedule", "expenses", "comp"];
 
-  function getVisibleTabs(stage: string, canEdit: boolean, showComp: boolean) {
+  // Competition is an owner/organizer-only authoring surface: the tab shows
+  // iff the viewer can edit (Owner or Planner), independent of stage or
+  // whether a competition row exists. Members reach a live competition via
+  // the bottom-nav "Live" entry instead.
+  function getVisibleTabs(canEdit: boolean) {
     return ALL_TAB_IDS.filter((id) => {
-      if (id === "comp") {
-        if (stage === "planning") return false;
-        return canEdit && showComp;
-      }
+      if (id === "comp") return canEdit;
       return true;
     });
   }
 
-  it("PLANNING stage hides Competition tab even when comp exists", () => {
-    const tabs = getVisibleTabs("planning", true, true);
+  it("hides Competition tab from members (non-editors)", () => {
+    const tabs = getVisibleTabs(false);
     expect(tabs).not.toContain("comp");
     expect(tabs).toEqual(["home", "crew", "schedule", "expenses"]);
   });
 
-  it("READY stage shows Competition tab when comp exists", () => {
-    const tabs = getVisibleTabs("going", true, true);
+  it("shows Competition tab for owners/organizers (editors)", () => {
+    const tabs = getVisibleTabs(true);
     expect(tabs).toContain("comp");
   });
 
   it("Expenses tab is always present in tab list (disabled state handled at click level)", () => {
-    const tabs = getVisibleTabs("planning", true, false);
+    const tabs = getVisibleTabs(true);
     expect(tabs).toContain("expenses");
   });
 });

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -22,7 +22,6 @@ const ALL_TABS: TabDef[] = [
 interface TripTabBarProps {
   activeTab: TabId;
   onTabChange: (tab: TabId) => void;
-  showComp?: boolean;
   canEdit?: boolean;
   /** Trip stage — used to disable Expenses in PLANNING and hide Competition */
   stage?: string;
@@ -40,7 +39,6 @@ interface TripTabBarProps {
 export const TripTabBar: FC<TripTabBarProps> = ({
   activeTab,
   onTabChange,
-  showComp = false,
   canEdit = false,
   stage,
   badges,
@@ -50,13 +48,10 @@ export const TripTabBar: FC<TripTabBarProps> = ({
 
   const tabs = ALL_TABS.filter((t) => {
     if (t.id === "comp") {
-      // Comp tab is now an editor surface by default — owners/planners see
-      // the tab from PLANNING onwards and the invitation-card lives inside
-      // the tab itself. Members continue to access competition via the
-      // bottom nav once the comp is active (showComp is still consulted
-      // for the member-facing path, but it doesn't gate the editor tab).
-      if (canEdit) return true;
-      return showComp;
+      // Competition is an owner/organizer-only authoring surface. Members
+      // never see the tab — they follow a *live* competition through the
+      // bottom nav's "Live" entry (the leaderboard route) instead.
+      return canEdit;
     }
     // Lodging and Expenses are only meaningful once a destination is locked in —
     // keep them out of the IDEA stage. PLANNING and GOING both show all five

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -15,18 +15,28 @@ import { Avatar } from "@/components/Avatar";
 export function UserMenu() {
   const { data: me } = trpc.users.getMe.useQuery();
 
+  const displayName = me?.name ?? me?.email ?? null;
+
   return (
     <Link
       href="/profile"
       aria-label="Open profile"
       data-testid="user-menu-btn"
-      className="transition-opacity hover:opacity-80"
+      className="flex items-center gap-2 transition-opacity hover:opacity-80"
     >
       <Avatar
         name={me?.name ?? me?.email ?? "?"}
         avatarIcon={me?.avatar_icon ?? null}
         size="sm"
       />
+      {displayName && (
+        <span
+          className="hidden max-w-[120px] truncate text-sm font-medium sm:inline"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {displayName}
+        </span>
+      )}
     </Link>
   );
 }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,42 +1,169 @@
 "use client";
 
-import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { IconSettings, IconLogout } from "@tabler/icons-react";
 import { trpc } from "@/lib/trpc-client";
+import { createClient } from "@/lib/supabase";
 import { Avatar } from "@/components/Avatar";
 
 /**
- * Top-right user affordance — a plain Avatar link to /profile.
+ * Top-right user affordance — the avatar opens a dropdown menu:
  *
- * Previously this rendered a dropdown with Profile + Sign out, but
- * the redesigned /profile page now hosts both (sign out lives in the
- * sidebar on desktop / in a card on mobile), so the dropdown became
- * a redundant extra tap. Keeping the click target small and quiet.
+ *   ┌──────────────────────────┐
+ *   │  Name                    │   ← account header
+ *   │  email@example.com       │
+ *   ├──────────────────────────┤
+ *   │  ⚙  Account preferences  │   → /profile
+ *   ├──────────────────────────┤
+ *   │  ⎋  Log out              │   ← separate section
+ *   └──────────────────────────┘
+ *
+ * Dismiss + positioning mirror the notifications bell / trip switcher
+ * panels in TopNav (mousedown-outside + Escape; fixed below the nav on
+ * mobile, absolute-anchored on desktop).
  */
 export function UserMenu() {
   const { data: me } = trpc.users.getMe.useQuery();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
-  const displayName = me?.name ?? me?.email ?? null;
+  // Outside-click + Escape to close. Listeners are only attached while
+  // open, so they're registered AFTER the click that opened the menu —
+  // the opening tap's mousedown has already fired and won't self-close.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onMouseDown);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onMouseDown);
+    };
+  }, [open]);
+
+  const name = me?.name ?? null;
+  const email = me?.email ?? null;
+
+  const handleSignOut = async () => {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/");
+    router.refresh();
+  };
 
   return (
-    <Link
-      href="/profile"
-      aria-label="Open profile"
-      data-testid="user-menu-btn"
-      className="flex items-center gap-2 transition-opacity hover:opacity-80"
-    >
-      <Avatar
-        name={me?.name ?? me?.email ?? "?"}
-        avatarIcon={me?.avatar_icon ?? null}
-        size="sm"
-      />
-      {displayName && (
-        <span
-          className="hidden max-w-[120px] truncate text-sm font-medium sm:inline"
-          style={{ color: "var(--color-bt-text)" }}
-        >
-          {displayName}
-        </span>
+    <div ref={ref} className="relative flex items-center">
+      <button
+        type="button"
+        aria-label="Open profile menu"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="user-menu-btn"
+        onClick={() => setOpen((p) => !p)}
+        className="flex items-center rounded-full transition-opacity hover:opacity-80"
+      >
+        <Avatar
+          name={me?.name ?? me?.email ?? "?"}
+          avatarIcon={me?.avatar_icon ?? null}
+          size="sm"
+        />
+      </button>
+
+      {open && (
+        <>
+          {/* Mobile dim backdrop — sm:hidden so it disappears once the
+              panel switches to absolute positioning on larger screens. */}
+          <div
+            className="fixed inset-0 z-40 sm:hidden"
+            style={{ background: "var(--color-bt-overlay)" }}
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+
+          <div
+            role="menu"
+            aria-label="Account menu"
+            data-testid="user-menu-dropdown"
+            className="fixed right-4 top-14 z-50 w-[calc(100vw-32px)] max-w-[260px] overflow-hidden rounded-xl shadow-2xl sm:absolute sm:right-0 sm:top-full sm:mt-1 sm:w-[240px] sm:rounded-[14px] sm:shadow-none"
+            style={{
+              background: "var(--color-bt-card)",
+              border: "0.5px solid var(--color-bt-border)",
+              boxShadow: "var(--shadow-floating)",
+            }}
+          >
+            {/* Account header — name + email */}
+            <div
+              className="px-4 py-3"
+              style={{ borderBottom: "0.5px solid var(--color-bt-border)" }}
+            >
+              <div
+                className="truncate text-sm font-semibold"
+                style={{ color: "var(--color-bt-text)" }}
+              >
+                {name ?? "Your account"}
+              </div>
+              {email && (
+                <div
+                  className="truncate text-xs"
+                  style={{ color: "var(--color-bt-text-dim)", marginTop: 1 }}
+                >
+                  {email}
+                </div>
+              )}
+            </div>
+
+            {/* Account preferences → loads the profile page */}
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                router.push("/profile");
+              }}
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-[13px] transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              <IconSettings
+                size={16}
+                stroke={1.75}
+                style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+                aria-hidden="true"
+              />
+              Account preferences
+            </button>
+
+            {/* Log out — separate section */}
+            <button
+              type="button"
+              role="menuitem"
+              data-testid="user-menu-signout"
+              onClick={handleSignOut}
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-[13px] transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{
+                color: "var(--color-bt-text)",
+                borderTop: "0.5px solid var(--color-bt-border)",
+              }}
+            >
+              <IconLogout
+                size={16}
+                stroke={1.75}
+                style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+                aria-hidden="true"
+              />
+              Log out
+            </button>
+          </div>
+        </>
       )}
-    </Link>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

A round of mobile-first UI bug fixes, concentrated on the **Agenda (Schedule)** tab with supporting fixes in Lodging, the profile page, and the top nav.

### Agenda / Schedule
- Reworked the scheduled-item UI: add-to-day icon on tiles, removed the standalone X, and made the inline X (on the title line) the single way to remove an item from the agenda
- Removed drag-and-drop onto "Not scheduled yet" — items leave the agenda only via the X
- Removed the redundant "Return to Not Scheduled Yet" button from the day-picker modal
- Hid the "Drag these onto a day" caption when nothing is unscheduled
- Renamed "On Deck" → "Not scheduled yet"; "Day-by-Day" → "Day-by-Day Agenda"
- Competition-aware captions; golf-only events use a flag icon, others the calendar/star icon
- Teal item icons, gray competition-event icons, matched row heights, standardized typography
- On Deck + Competition Events go two-up when the rail unstacks
- Confirmed agenda/lodging items now use dimmed teal (`--color-bt-accent-faint`) instead of full teal
- **Drag-state fixes:** rows and competition chips now reliably return to normal when a drag ends without a successful drop (driven by real state so the re-render always fires)

### Lodging
- Confirmed cards use the dimmed-teal surface to match the Agenda

### Profile & top nav
- Back-to-dashboard affordance + spacing/separator polish on the profile page
- Hide trip switcher/notifications on the profile page
- Account dropdown on the avatar; show the user's name next to the avatar
- Reordered/normalized top-nav icon buttons
- Hide the Competition tab from non-owner/non-organizer members
- Prevent the chat composer collapsing on layout switch

## Test plan
- [ ] Drag a scheduled item and drop it on another day — moves correctly
- [ ] Drag a scheduled item and release in empty space — row returns to normal opacity
- [ ] Drag an On Deck item / competition chip and release in empty space — returns to normal
- [ ] Remove a scheduled item via the inline X — returns to Not Scheduled Yet
- [ ] Confirmed agenda + lodging items render in dimmed teal
- [ ] Profile page: Back link returns to previous page; nav chrome hidden
- [ ] Verify across mobile / tablet / desktop breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)