### PR TITLE
Redesign app title bar: two-zone layout + News tool

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -104,7 +104,7 @@ export default function ProfilePage() {
   if (!authLoaded || isLoading || !me) {
     return (
       <div className="min-h-screen" style={{ background: "var(--color-bt-base)" }}>
-        <TopNav hideTripSwitcher hideBoard />
+        <TopNav hideTripSwitcher hideNews />
         <div className="flex justify-center py-16">
           <div
             className="h-6 w-6 animate-spin rounded-full border-2"
@@ -122,7 +122,7 @@ export default function ProfilePage() {
       className="min-h-screen"
       style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text)" }}
     >
-      <TopNav hideTripSwitcher hideBoard />
+      <TopNav hideTripSwitcher hideNews />
 
       <div className="flex">
         {/* ── Desktop sidebar ─────────────────────────────────────────── */}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -104,7 +104,7 @@ export default function ProfilePage() {
   if (!authLoaded || isLoading || !me) {
     return (
       <div className="min-h-screen" style={{ background: "var(--color-bt-base)" }}>
-        <TopNav hideTripSwitcher />
+        <TopNav hideTripSwitcher hideBoard />
         <div className="flex justify-center py-16">
           <div
             className="h-6 w-6 animate-spin rounded-full border-2"
@@ -122,7 +122,7 @@ export default function ProfilePage() {
       className="min-h-screen"
       style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text)" }}
     >
-      <TopNav hideTripSwitcher />
+      <TopNav hideTripSwitcher hideBoard />
 
       <div className="flex">
         {/* ── Desktop sidebar ─────────────────────────────────────────── */}

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -55,22 +55,22 @@ interface AvatarProps {
  * classes below instead of these numbers.
  */
 const SIZE_MAP = {
-  sm: { circle: 30, icon: 14, initials: 11 }, // mobile values (used only as a hint for the Tabler `size` prop ceiling)
-  md: { circle: 36, icon: 18, initials: 13 },
-  lg: { circle: 72, icon: 28, initials: 24 },
+  sm: { circle: 30, icon: 20, initials: 11 }, // mobile values (used only as a hint for the Tabler `size` prop ceiling)
+  md: { circle: 36, icon: 23, initials: 13 },
+  lg: { circle: 72, icon: 44, initials: 24 },
 } as const;
 
 /**
  * Responsive Tailwind classes for `size="sm"` only. Spec calls for
  *   container: 30px mobile / 34px desktop
- *   icon:      14px mobile / 16px desktop
+ *   icon:      20px mobile / 22px desktop (filled — icons read clearly small)
  *   initials:  11px mobile / 12px desktop
  * The icon-size class targets the SVG that Tabler renders inside the
  * circle (Tailwind v4 arbitrary descendant selectors).
  */
 const SM_RESPONSIVE_CLASSES =
   "h-[30px] w-[30px] md:h-[34px] md:w-[34px] " +
-  "[&_svg]:h-[14px] [&_svg]:w-[14px] md:[&_svg]:h-[16px] md:[&_svg]:w-[16px] " +
+  "[&_svg]:h-[20px] [&_svg]:w-[20px] md:[&_svg]:h-[22px] md:[&_svg]:w-[22px] " +
   "[&_span]:text-[11px] md:[&_span]:text-[12px]";
 
 /** "Zach Grether" → "ZG"; "Llama" → "L"; "" → "?" */
@@ -100,7 +100,9 @@ export function Avatar({
   const { circle, icon: iconSize, initials: initialsSize } = fixedPx
     ? {
         circle: fixedPx,
-        icon: Math.round(fixedPx * 0.5),
+        // Icons fill ~62% of the circle so they stay legible at small
+        // sizes; initials stay smaller (text needs more breathing room).
+        icon: Math.round(fixedPx * 0.62),
         initials: Math.max(9, Math.round(fixedPx * 0.4)),
       }
     : SIZE_MAP[size];
@@ -154,7 +156,7 @@ export function Avatar({
         // SVG has enough resolution; Tailwind classes scale the SVG down
         // to 14px on mobile via the [&_svg]:h-[14px] selector above.
         <IconComponent
-          size={isResponsive ? 16 : iconSize}
+          size={isResponsive ? 22 : iconSize}
           stroke={1.75}
           aria-hidden="true"
         />

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -39,6 +39,13 @@ interface AvatarProps {
    * foreground stays reserved for "real"/actionable members.
    */
   muted?: boolean;
+  /**
+   * Inverted "filled" treatment: solid accent (teal) circle with a dark
+   * foreground, instead of the default teal-on-raised. Used for the
+   * top-nav account avatar so it reads as a distinct identity affordance.
+   * Ignored in competition mode (teamColor wins).
+   */
+  accent?: boolean;
   className?: string;
 }
 
@@ -84,6 +91,7 @@ export function Avatar({
   size = "md",
   sizePx,
   muted = false,
+  accent = false,
   className,
 }: AvatarProps) {
   // An explicit sizePx wins over the named preset and disables the
@@ -98,15 +106,24 @@ export function Avatar({
     : SIZE_MAP[size];
   const isResponsive = size === "sm" && fixedPx === null;
 
-  // Competition context (team color set) → white foreground on team-color bg
+  // Competition context (team color set) → white foreground on team-color bg.
+  // Accent ("filled") → dark foreground on a solid teal circle.
+  // Default → teal (or muted grey) foreground on a neutral raised surface.
   const competitionMode = !!teamColor;
-  const background = competitionMode ? (teamColor as string) : "var(--color-bt-card-raised)";
+  const background = competitionMode
+    ? (teamColor as string)
+    : accent
+      ? "var(--color-bt-accent)"
+      : "var(--color-bt-card-raised)";
   const foreground = competitionMode
     ? "#ffffff"
-    : muted
-      ? "var(--color-bt-text-dim)"
-      : "var(--color-bt-accent)";
-  const border = competitionMode ? "none" : "1.5px solid var(--color-bt-border)";
+    : accent
+      ? "#0d1f1a"
+      : muted
+        ? "var(--color-bt-text-dim)"
+        : "var(--color-bt-accent)";
+  const border =
+    competitionMode || accent ? "none" : "1.5px solid var(--color-bt-border)";
 
   // Look up the icon component. If avatarIcon is set but unknown (e.g. an
   // old value from before we curated the list), fall back to initials.

--- a/src/components/AvatarIconPicker.tsx
+++ b/src/components/AvatarIconPicker.tsx
@@ -86,7 +86,7 @@ export function AvatarIconPicker({ value, onChange, showSaved }: AvatarIconPicke
               aria-label={icon.label}
               aria-pressed={isSelected}
               onClick={() => onChange(isSelected ? null : icon.id)}
-              className="flex aspect-square items-center justify-center rounded-[9px] transition-colors"
+              className="flex aspect-square items-center justify-center rounded-[9px] transition-colors [&_svg]:h-[34px] [&_svg]:w-[34px] sm:[&_svg]:h-[28px] sm:[&_svg]:w-[28px]"
               style={
                 isSelected
                   ? {

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -45,6 +45,9 @@ interface TopNavProps {
   /** Hide the trip-breadcrumb switcher (e.g. on the profile page, which
    *  isn't trip-scoped). */
   hideTripSwitcher?: boolean;
+  /** Hide the Board tool (e.g. on the profile page, where the global
+   *  broadcast surface isn't relevant). */
+  hideBoard?: boolean;
 }
 
 // Minimal shape we read off trips.list for the breadcrumb.
@@ -60,6 +63,7 @@ export const TopNav: FC<TopNavProps> = ({
   onOpenChat,
   chatOpen = false,
   hideTripSwitcher = false,
+  hideBoard = false,
 }) => {
   const router = useRouter();
   const params = useParams<{ tripId?: string }>();
@@ -189,14 +193,16 @@ export const TopNav: FC<TopNavProps> = ({
       {/* ── RIGHT: global tools + me ───────────────────────────────────── */}
       <div className="flex flex-shrink-0 items-center gap-1">
         {/* Board — inert placeholder; persistent broadcast surface (TBD). */}
-        <ToolButton
-          icon={Megaphone}
-          label="Board"
-          count={BOARD_PLACEHOLDER_COUNT}
-          badgeBg="var(--color-bt-accent)"
-          ariaLabel="Board"
-          testId="board-button"
-        />
+        {!hideBoard && (
+          <ToolButton
+            icon={Megaphone}
+            label="Board"
+            count={BOARD_PLACEHOLDER_COUNT}
+            badgeBg="var(--color-bt-accent)"
+            ariaLabel="Board"
+            testId="board-button"
+          />
+        )}
 
         {tripId && onOpenChat && (
           <ChatToolButton

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -2,28 +2,56 @@
 
 import type { FC } from "react";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { MessageCircle } from "lucide-react";
-import { IconLayoutGrid } from "@tabler/icons-react";
+import { useRouter, useParams } from "next/navigation";
+import { Megaphone, MessageCircle, ChevronDown } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { UserMenu } from "./UserMenu";
 import { TripSwitcher } from "./TripSwitcher";
 import { trpc } from "@/lib/trpc-client";
 import { useChatUnreadCount } from "./FloatingChatPanel";
 
+/**
+ * App title bar — two zones:
+ *   LEFT  = identity / scope  → flag-home anchor + trip-breadcrumb switcher
+ *   RIGHT = global tools + me → Board, Chat, and the account avatar
+ *
+ * The host is a container-query context (`@container`), so the responsive
+ * collapse below 600px keys off the bar's OWN width — not the viewport —
+ * which keeps it correct inside any future split/columned layout.
+ *
+ * Notifications were removed entirely; "Board" occupies that slot
+ * conceptually but is a persistent broadcast surface, not a notification
+ * stream.
+ */
+
+// Board has no backing feature yet (no board/broadcast surface exists). The
+// button is rendered to spec but inert, and its unread badge is driven by this
+// placeholder count — 0 keeps the badge hidden until the feature ships. Flip
+// this to a real selector once Board exists.
+const BOARD_PLACEHOLDER_COUNT = 0;
+
 interface TopNavProps {
+  /** Wordmark next to the flag. Always "BuddyTrip" per the design; kept as a
+   *  prop only so existing call sites compile unchanged. */
   title?: string;
-  /** When present, renders the crew-chat button with an unread badge driven
+  /** When present, renders the crew-chat tool with an unread badge driven
    *  by useChatUnreadCount(tripId). */
   tripId?: string;
-  /** Opens the FloatingChatPanel. Required alongside tripId to show the chat
-   *  button. */
+  /** Opens the FloatingChatPanel. Required alongside tripId to show Chat. */
   onOpenChat?: () => void;
-  /** Reflects whether the FloatingChatPanel is currently open — used to
-   *  render the chat button in its active state. */
+  /** Reflects whether the FloatingChatPanel is currently open — paints the
+   *  Chat tool in its active state. */
   chatOpen?: boolean;
-  /** Hide the trip-switcher grid button (e.g. on the profile page, which
-   *  isn't trip-scoped and doesn't need trip navigation). */
+  /** Hide the trip-breadcrumb switcher (e.g. on the profile page, which
+   *  isn't trip-scoped). */
   hideTripSwitcher?: boolean;
+}
+
+// Minimal shape we read off trips.list for the breadcrumb.
+interface SwitcherTripRow {
+  id: string;
+  title: string;
+  myRole?: string | null;
 }
 
 export const TopNav: FC<TopNavProps> = ({
@@ -34,70 +62,180 @@ export const TopNav: FC<TopNavProps> = ({
   hideTripSwitcher = false,
 }) => {
   const router = useRouter();
+  const params = useParams<{ tripId?: string }>();
+  const currentTripId = params?.tripId ?? null;
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
-  // Hide the trip switcher entirely when the user has no trips — the
-  // empty-state hero already exposes "New trip" as the primary CTA, so
-  // an extra switcher button just opens an empty panel. TanStack Query
-  // dedupes against the same query the page may already be running.
+  // Drives the breadcrumb label + Owner pill. TanStack dedupes against the
+  // same query the page may already be running.
   const { data: tripsForSwitcher } = trpc.trips.list.useQuery(undefined, {
     enabled: !hideTripSwitcher,
   });
-  const showSwitcher = !hideTripSwitcher && (tripsForSwitcher?.length ?? 0) > 0;
+
+  // The breadcrumb switcher only makes sense when a specific trip is in
+  // scope. On the dashboard / profile the LEFT zone is just the flag +
+  // wordmark (global scope).
+  const currentTrip =
+    (tripsForSwitcher as SwitcherTripRow[] | undefined)?.find(
+      (t) => t.id === currentTripId
+    ) ?? null;
+  const showSwitcher = !hideTripSwitcher && currentTrip != null;
+  const isOwner = currentTrip?.myRole === "Owner";
 
   return (
     <header
-      className="sticky top-0 z-40 flex h-14 items-center justify-between px-6"
+      className="@container sticky top-0 z-40 flex h-14 items-center justify-between"
       style={{
         background: "var(--color-bt-nav-bg)",
         backdropFilter: "blur(14px)",
         WebkitBackdropFilter: "blur(14px)",
         borderBottom: "1px solid var(--color-bt-subtle-border)",
+        padding: "0 16px",
       }}
     >
-      <button
-        onClick={() => router.push("/")}
-        className="flex items-center gap-[7px] text-[18px] font-semibold transition-opacity hover:opacity-80"
-        style={{ color: "var(--color-bt-text)", letterSpacing: "0.06em" }}
-        aria-label="Go to dashboard"
-      >
-        <svg width="18" height="18" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}>
-          <path d="M 28 8 L 38 8 L 76 26 L 38 44 L 38 75 L 33 92 L 28 75 Z" fill="currentColor"/>
-        </svg>
-        {title}
-      </button>
+      {/* ── LEFT: identity / scope ─────────────────────────────────────── */}
+      <div className="flex min-w-0 items-center">
+        {/* Home anchor — flag + wordmark navigate to the dashboard. */}
+        <button
+          type="button"
+          onClick={() => router.push("/")}
+          aria-label="Go to dashboard"
+          className="flex items-center gap-[7px] rounded-[9px] px-2 py-1.5 transition-colors hover:bg-[var(--color-bt-hover)]"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 100 100"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            style={{ flexShrink: 0, color: "var(--color-bt-accent)" }}
+          >
+            <path
+              d="M 28 8 L 38 8 L 76 26 L 38 44 L 38 75 L 33 92 L 28 75 Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            className="@max-[600px]:hidden"
+            style={{
+              fontSize: 16,
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              color: "var(--color-bt-text)",
+            }}
+          >
+            {title}
+          </span>
+        </button>
 
-      <div className="relative flex items-center gap-2">
-        {/* Trip switcher trigger + panel — rendered only when the user
-            has at least one trip. With no trips the panel would just
-            show "New trip" / "View all trips" links which are already
-            exposed elsewhere (the empty-state hero CTA + Dashboard). */}
-        {showSwitcher && (
-          <>
+        {showSwitcher && currentTrip && (
+          <div className="relative flex min-w-0 items-center">
+            {/* Hairline divider — hidden on collapse along with the wordmark. */}
+            <span
+              aria-hidden="true"
+              className="@max-[600px]:hidden"
+              style={{
+                width: 1,
+                height: 22,
+                background: "var(--color-bt-border)",
+                margin: "0 10px",
+                flexShrink: 0,
+              }}
+            />
+
+            {/* Breadcrumb switcher — keeps a resting surface (it's a dropdown
+                control, not a plain action). */}
             <button
               type="button"
-              aria-label="My trips"
+              aria-label="Switch trip"
               aria-haspopup="dialog"
               aria-expanded={switcherOpen}
               data-testid="trip-switcher-trigger"
               data-trip-switcher-trigger="true"
               onClick={() => setSwitcherOpen((p) => !p)}
-              className="relative flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+              className="flex min-w-0 items-center gap-1.5 transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{
-                color: switcherOpen
-                  ? "var(--color-bt-accent)"
-                  : "var(--color-bt-text-dim)",
+                background: "var(--color-bt-card-raised)",
+                border: "1px solid var(--color-bt-border)",
+                borderRadius: 9,
+                padding: "5px 9px 5px 7px",
               }}
             >
-              <IconLayoutGrid size={20} stroke={1.5} />
+              {isOwner && (
+                <span
+                  className="flex-shrink-0"
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                    lineHeight: 1,
+                    color: "var(--color-bt-owner)",
+                    border: "1px solid var(--color-bt-owner)",
+                    borderRadius: 4,
+                    padding: "2px 4px",
+                  }}
+                >
+                  Owner
+                </span>
+              )}
+              <span
+                className="truncate max-w-[240px] @max-[600px]:max-w-[140px]"
+                style={{
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: "var(--color-bt-text)",
+                }}
+              >
+                {currentTrip.title}
+              </span>
+              <ChevronDown
+                size={14}
+                strokeWidth={2}
+                style={{ flexShrink: 0, color: "var(--color-bt-text-dim)" }}
+                aria-hidden="true"
+              />
             </button>
-            <TripSwitcher open={switcherOpen} onClose={() => setSwitcherOpen(false)} />
-          </>
+
+            <TripSwitcher
+              open={switcherOpen}
+              onClose={() => setSwitcherOpen(false)}
+            />
+          </div>
         )}
+      </div>
+
+      {/* ── RIGHT: global tools + me ───────────────────────────────────── */}
+      <div className="flex flex-shrink-0 items-center gap-1">
+        {/* Board — inert placeholder; persistent broadcast surface (TBD). */}
+        <ToolButton
+          icon={Megaphone}
+          label="Board"
+          count={BOARD_PLACEHOLDER_COUNT}
+          badgeBg="var(--color-bt-accent)"
+          ariaLabel="Board"
+          testId="board-button"
+        />
 
         {tripId && onOpenChat && (
-          <ChatButton tripId={tripId} onClick={onOpenChat} isOpen={chatOpen} />
+          <ChatToolButton
+            tripId={tripId}
+            onClick={onOpenChat}
+            active={chatOpen}
+          />
         )}
+
+        {/* Divider between tools and identity. */}
+        <span
+          aria-hidden="true"
+          className="mx-1.5"
+          style={{
+            width: 1,
+            height: 24,
+            background: "var(--color-bt-border)",
+            flexShrink: 0,
+          }}
+        />
 
         <UserMenu />
       </div>
@@ -105,34 +243,121 @@ export const TopNav: FC<TopNavProps> = ({
   );
 };
 
-// ── ChatButton ───────────────────────────────────────────────────────────────
-// Isolated sub-component so the useChatUnreadCount hook only mounts on trip
-// pages where a tripId is present. Mirrors the notification bell's shape,
-// hover, and badge treatment.
-
-function ChatButton({ tripId, onClick, isOpen }: { tripId: string; onClick: () => void; isOpen: boolean }) {
+// ── ChatToolButton ──────────────────────────────────────────────────────────
+// Thin wrapper so useChatUnreadCount only mounts on trip pages (tripId present).
+function ChatToolButton({
+  tripId,
+  onClick,
+  active,
+}: {
+  tripId: string;
+  onClick: () => void;
+  active: boolean;
+}) {
   const unread = useChatUnreadCount(tripId);
   return (
-    <button
-      aria-label="Open crew chat"
-      data-testid="chat-button"
+    <ToolButton
+      icon={MessageCircle}
+      label="Chat"
+      count={unread}
+      badgeBg="var(--color-bt-owner)"
+      active={active}
       onClick={onClick}
-      className={`relative flex h-8 w-8 items-center justify-center transition-colors ${isOpen ? "rounded-lg" : "rounded-full hover:bg-[var(--color-bt-hover)]"}`}
-      style={
-        isOpen
-          ? { color: "var(--color-bt-accent)", background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }
-          : { color: "var(--color-bt-text-dim)" }
-      }
+      ariaLabel="Open crew chat"
+      testId="chat-button"
+    />
+  );
+}
+
+// ── ToolButton ────────────────────────────────────────────────────────────────
+// Backgroundless labeled tool — hover wash only, no resting fill or border so
+// the bar reads light. Below 600px (container width) it collapses to an icon-
+// only square with the count as a ringed corner badge. The badge is the only
+// color in the right cluster.
+function ToolButton({
+  icon: Icon,
+  label,
+  count,
+  badgeBg,
+  active = false,
+  onClick,
+  ariaLabel,
+  testId,
+}: {
+  icon: LucideIcon;
+  label: string;
+  count: number;
+  badgeBg: string;
+  active?: boolean;
+  onClick?: () => void;
+  ariaLabel: string;
+  testId: string;
+}) {
+  const showBadge = count > 0;
+  const badgeLabel = count > 99 ? "99+" : String(count);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-testid={testId}
+      className="relative inline-flex h-9 items-center gap-[7px] rounded-[9px] px-2.5 transition-colors hover:bg-[var(--color-bt-hover)] @max-[600px]:w-9 @max-[600px]:justify-center @max-[600px]:gap-0 @max-[600px]:px-0"
+      style={{
+        background: active ? "var(--color-bt-hover)" : "none",
+        border: "none",
+        color: "var(--color-bt-text)",
+        fontSize: 13,
+        fontWeight: 600,
+        cursor: "pointer",
+      }}
     >
-      <MessageCircle size={20} strokeWidth={1.5} />
-      {unread > 0 && (
-        <span
-          data-testid="chat-unread-badge"
-          className="absolute right-1 top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-0.5 text-[10px] font-bold"
-          style={{ background: "var(--color-bt-warning)", color: "var(--color-bt-base-alt)" }}
-        >
-          {unread > 9 ? "9+" : unread}
-        </span>
+      <Icon size={16} strokeWidth={2} aria-hidden="true" />
+      <span className="@max-[600px]:hidden">{label}</span>
+
+      {showBadge && (
+        <>
+          {/* Inline badge — expanded layout. */}
+          <span
+            data-testid={`${testId}-badge`}
+            className="@max-[600px]:hidden"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              borderRadius: 9999,
+              padding: "0 5px",
+              lineHeight: "15px",
+              minWidth: 15,
+              textAlign: "center",
+              background: badgeBg,
+              color: "#0d1f1a",
+            }}
+          >
+            {badgeLabel}
+          </span>
+
+          {/* Corner badge — collapsed (icon-only) layout. A ring in the bar
+              color separates it from the icon. */}
+          <span
+            aria-hidden="true"
+            className="absolute hidden items-center justify-center @max-[600px]:flex"
+            style={{
+              top: -3,
+              right: -3,
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              borderRadius: 9999,
+              padding: "0 4px",
+              lineHeight: "14px",
+              minWidth: 14,
+              textAlign: "center",
+              background: badgeBg,
+              color: "#0d1f1a",
+              border: "1.5px solid var(--color-bt-nav-bg)",
+            }}
+          >
+            {badgeLabel}
+          </span>
+        </>
       )}
     </button>
   );

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -80,7 +80,6 @@ export const TopNav: FC<TopNavProps> = ({
       (t) => t.id === currentTripId
     ) ?? null;
   const showSwitcher = !hideTripSwitcher && currentTrip != null;
-  const isOwner = currentTrip?.myRole === "Owner";
 
   return (
     <header
@@ -161,24 +160,6 @@ export const TopNav: FC<TopNavProps> = ({
                 padding: "5px 9px 5px 7px",
               }}
             >
-              {isOwner && (
-                <span
-                  className="flex-shrink-0"
-                  style={{
-                    fontSize: 9,
-                    fontWeight: 700,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.06em",
-                    lineHeight: 1,
-                    color: "var(--color-bt-owner)",
-                    border: "1px solid var(--color-bt-owner)",
-                    borderRadius: 4,
-                    padding: "2px 4px",
-                  }}
-                >
-                  Owner
-                </span>
-              )}
               <span
                 className="truncate max-w-[240px] @max-[600px]:max-w-[140px]"
                 style={{

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,7 +3,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { Megaphone, MessageCircle, ChevronDown } from "lucide-react";
+import { Pin, MessageCircle, ChevronDown } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { UserMenu } from "./UserMenu";
 import { TripSwitcher } from "./TripSwitcher";
@@ -19,16 +19,16 @@ import { useChatUnreadCount } from "./FloatingChatPanel";
  * collapse below 600px keys off the bar's OWN width — not the viewport —
  * which keeps it correct inside any future split/columned layout.
  *
- * Notifications were removed entirely; "Board" occupies that slot
+ * Notifications were removed entirely; "News" occupies that slot
  * conceptually but is a persistent broadcast surface, not a notification
  * stream.
  */
 
-// Board has no backing feature yet (no board/broadcast surface exists). The
+// News has no backing feature yet (no news/broadcast surface exists). The
 // button is rendered to spec but inert, and its unread badge is driven by this
 // placeholder count — 0 keeps the badge hidden until the feature ships. Flip
-// this to a real selector once Board exists.
-const BOARD_PLACEHOLDER_COUNT = 0;
+// this to a real selector once News exists.
+const NEWS_PLACEHOLDER_COUNT = 0;
 
 interface TopNavProps {
   /** Wordmark next to the flag. Always "BuddyTrip" per the design; kept as a
@@ -45,9 +45,9 @@ interface TopNavProps {
   /** Hide the trip-breadcrumb switcher (e.g. on the profile page, which
    *  isn't trip-scoped). */
   hideTripSwitcher?: boolean;
-  /** Hide the Board tool (e.g. on the profile page, where the global
+  /** Hide the News tool (e.g. on the profile page, where the global
    *  broadcast surface isn't relevant). */
-  hideBoard?: boolean;
+  hideNews?: boolean;
 }
 
 // Minimal shape we read off trips.list for the breadcrumb.
@@ -63,7 +63,7 @@ export const TopNav: FC<TopNavProps> = ({
   onOpenChat,
   chatOpen = false,
   hideTripSwitcher = false,
-  hideBoard = false,
+  hideNews = false,
 }) => {
   const router = useRouter();
   const params = useParams<{ tripId?: string }>();
@@ -192,15 +192,15 @@ export const TopNav: FC<TopNavProps> = ({
 
       {/* ── RIGHT: global tools + me ───────────────────────────────────── */}
       <div className="flex flex-shrink-0 items-center gap-1">
-        {/* Board — inert placeholder; persistent broadcast surface (TBD). */}
-        {!hideBoard && (
+        {/* News — inert placeholder; persistent broadcast surface (TBD). */}
+        {!hideNews && (
           <ToolButton
-            icon={Megaphone}
-            label="Board"
-            count={BOARD_PLACEHOLDER_COUNT}
+            icon={Pin}
+            label="News"
+            count={NEWS_PLACEHOLDER_COUNT}
             badgeBg="var(--color-bt-accent)"
-            ariaLabel="Board"
-            testId="board-button"
+            ariaLabel="News"
+            testId="news-button"
           />
         )}
 

--- a/src/components/TripSwitcher.tsx
+++ b/src/components/TripSwitcher.tsx
@@ -39,9 +39,36 @@ type SwitcherTrip = TripStatusFields & {
   end_date: string | null;
   locked_destination_title: string | null;
   locked_destination_location: string | null;
+  updated_at?: string | null;
+  created_at?: string | null;
 };
 
-const ACTIVE_STATUSES: TripDisplayStatus[] = ["idea", "planning", "going", "now"];
+// Order within the Active group: most imminent/committed first, so a trip
+// that's happening Now floats to the top and idea-stage trips sink to the
+// bottom. Mirrors the dashboard's section order.
+const ACTIVE_PRIORITY: Record<TripDisplayStatus, number> = {
+  now: 0,
+  going: 1,
+  planning: 2,
+  idea: 3,
+  past: 4,
+  saved: 5,
+};
+
+// Tiebreak within a single phase: dated phases by their relevant date,
+// undated phases (planning/idea) by most-recently-touched.
+function phaseTiebreak(
+  a: SwitcherTrip,
+  b: SwitcherTrip,
+  status: TripDisplayStatus
+): number {
+  if (status === "now") return (a.end_date ?? "").localeCompare(b.end_date ?? "");
+  if (status === "going")
+    return (a.start_date ?? "").localeCompare(b.start_date ?? "");
+  const ak = a.updated_at ?? a.created_at ?? "";
+  const bk = b.updated_at ?? b.created_at ?? "";
+  return bk.localeCompare(ak);
+}
 
 export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
   const router = useRouter();
@@ -58,11 +85,21 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
     const past: SwitcherTrip[] = [];
     for (const t of trips as SwitcherTrip[]) {
       const status = getEffectiveStatus(t);
-      if (status === "past") past.push(t);
-      else if (ACTIVE_STATUSES.includes(status)) active.push(t);
-      // 'saved' falls through — we treat it as past for the switcher
-      else past.push(t);
+      // 'saved' is treated as past for the switcher.
+      if (status === "past" || status === "saved") past.push(t);
+      else active.push(t);
     }
+    // Active: Now → Going → Planning → Idea (then within-phase tiebreak).
+    active.sort((a, b) => {
+      const sa = getEffectiveStatus(a);
+      const sb = getEffectiveStatus(b);
+      const pa = ACTIVE_PRIORITY[sa];
+      const pb = ACTIVE_PRIORITY[sb];
+      if (pa !== pb) return pa - pb;
+      return phaseTiebreak(a, b, sa);
+    });
+    // Past: most-recently-ended first.
+    past.sort((a, b) => (b.end_date ?? "").localeCompare(a.end_date ?? ""));
     return { activeTrips: active, pastTrips: past };
   }, [trips]);
 

--- a/src/components/TripSwitcher.tsx
+++ b/src/components/TripSwitcher.tsx
@@ -129,7 +129,7 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
         ref={dropdownRef}
         role="dialog"
         aria-label="My trips"
-        className="fixed right-4 top-14 z-50 w-[calc(100vw-32px)] max-w-[320px] overflow-hidden rounded-xl shadow-2xl sm:absolute sm:right-0 sm:top-full sm:mt-1 sm:w-[280px] sm:rounded-[14px] sm:shadow-none"
+        className="fixed left-4 top-14 z-50 w-[calc(100vw-32px)] max-w-[320px] overflow-hidden rounded-xl shadow-2xl sm:absolute sm:left-0 sm:top-full sm:mt-1 sm:w-[280px] sm:rounded-[14px] sm:shadow-none"
         style={{
           background: "var(--color-bt-card)",
           border: "0.5px solid var(--color-bt-border)",

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -74,7 +74,7 @@ export function UserMenu() {
         <Avatar
           name={me?.name ?? me?.email ?? "?"}
           avatarIcon={me?.avatar_icon ?? null}
-          size="sm"
+          sizePx={32}
         />
       </button>
 

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -75,6 +75,7 @@ export function UserMenu() {
           name={me?.name ?? me?.email ?? "?"}
           avatarIcon={me?.avatar_icon ?? null}
           sizePx={32}
+          accent
         />
       </button>
 


### PR DESCRIPTION
## Summary
Rebuilds the app title bar into two zones and refreshes the surrounding avatar / switcher affordances. Stacks on the now-merged notifications removal (#278).

- **Two-zone bar** — LEFT = identity/scope (flag + "BuddyTrip" wordmark home anchor, hairline divider, trip breadcrumb switcher), RIGHT = global tools + me (News, Chat, avatar account menu). Collapses below 600px via a container query (wordmark + divider hide; tool labels drop to icon-only with corner badges).
- **News tool** — backgroundless ghost button with a pin icon and a mono count badge. Inert placeholder (count 0) until the broadcast surface ships; hidden on the profile page.
- **Trip switcher** — Owner pill removed (it duplicated the trip header below). The "My trips" dropdown now sorts the Active group by phase (Now → Going → Planning → Idea) instead of raw recency, matching the dashboard's priority.
- **Avatars** — nav avatar inverted to a filled teal circle with dark foreground (opt-in `accent` prop on the shared `Avatar`, so other call sites are unchanged). Tabler icon-to-circle ratio bumped (~0.5 → ~0.62) so icons read clearly at small sizes, including the profile avatar picker.

## Test plan
- [ ] Title bar renders correctly on dashboard, trip pages, and profile
- [ ] Below 600px the bar collapses (wordmark hides, tools go icon-only, badges move to corners)
- [ ] "My trips" switcher lists Now/Going trips above Planning/Idea
- [ ] Profile page shows no News tool and no trip switcher
- [ ] Avatar icons fill the circle and remain legible at all sizes
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)