### PR TITLE
Domain-color system (currently all teal)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,6 +82,33 @@
   --color-bt-place-4-bg: rgba(239, 68, 68, 0.16);
   --color-bt-place-4-text: #b91c1c;  /* red-700 */
 
+  /* ── Domain colors — one hue per trip area ──────────────────────────────
+     Each trip area owns ONE color, surfaced in three reinforcing places:
+     the active tab (icon + label + 2px border), the page-header eyebrow,
+     and item accents (content icon-chips, itinerary filter dots).
+     Mode-independent (same value in light & dark) so a domain reads the
+     same wherever it appears. The area→token mapping (single source of
+     truth) lives in src/lib/domainColors.ts — change a token here and the
+     whole area reskins. Shared hues: Travel borrows Crew rose (arrivals
+     are per-person crew data); Events borrows Competition amber (events
+     belong to the competition, not the agenda). */
+  --color-bt-domain-home: #2dd4bf;                       /* teal   */
+  --color-bt-domain-home-faint: rgba(45, 212, 191, 0.13);
+  --color-bt-domain-crew: #fb7185;                       /* rose   */
+  --color-bt-domain-crew-faint: rgba(251, 113, 133, 0.13);
+  --color-bt-domain-lodging: #3b82f6;                    /* blue   */
+  --color-bt-domain-lodging-faint: rgba(59, 130, 246, 0.13);
+  --color-bt-domain-agenda: #f97316;                     /* orange */
+  --color-bt-domain-agenda-faint: rgba(249, 115, 22, 0.13);
+  --color-bt-domain-travel: #fb7185;                     /* rose (= Crew) */
+  --color-bt-domain-travel-faint: rgba(251, 113, 133, 0.13);
+  --color-bt-domain-events: #fbbf24;                     /* amber (= Competition) */
+  --color-bt-domain-events-faint: rgba(251, 191, 36, 0.13);
+  --color-bt-domain-receipts: #22c55e;                   /* green  */
+  --color-bt-domain-receipts-faint: rgba(34, 197, 94, 0.13);
+  --color-bt-domain-competition: #fbbf24;                /* amber  */
+  --color-bt-domain-competition-faint: rgba(251, 191, 36, 0.13);
+
   color-scheme: light;
 }
 

--- a/src/app/trips/[tripId]/components/QuickInfoSection.tsx
+++ b/src/app/trips/[tripId]/components/QuickInfoSection.tsx
@@ -4,6 +4,12 @@ import { useState } from "react";
 import { AlertTriangle, Bell, Building2, Clock, FileText, Flag, Hash, Hotel, KeyRound, Lock, MapPin, Plus, Wifi, X, Zap } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+
+// Quick Info is a Home-tab content surface, so its (non-alert) item
+// icon-chips take the Home domain hue. Alert tiles keep their warning
+// amber identity. Pulled from the shared map so a Home reskin reaches here.
+const HOME = DOMAIN_COLORS.home;
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -434,8 +440,8 @@ export function QuickInfoSection({
                 <span
                   className={`flex flex-shrink-0 items-center justify-center rounded-xl ${TILE_CHIP_CLASS}`}
                   style={{
-                    background: alert ? "var(--color-bt-warning-faint)" : "var(--color-bt-accent-faint)",
-                    color: alert ? "var(--color-bt-warning)" : "var(--color-bt-accent)",
+                    background: alert ? "var(--color-bt-warning-faint)" : HOME.faint,
+                    color: alert ? "var(--color-bt-warning)" : HOME.color,
                   }}
                 >
                   {alert ? <Bell className={TILE_ICON_CLASS} /> : tileIconFor(tile, TILE_ICON_CLASS)}

--- a/src/app/trips/[tripId]/tabs/CrewTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CrewTab.tsx
@@ -603,6 +603,7 @@ export function CrewTab({ trip, embedded }: TabProps & { embedded?: boolean }) {
           // member-facing framing.
           eyebrow={`Crew · ${totalCount}`}
           eyebrowTone="accent"
+          domain="crew"
           headline="Everyone on the trip"
           body="Tag the Owner with planning questions. Roles, emails, and the roster itself are managed by the Owner."
         />
@@ -673,6 +674,7 @@ export function CrewTab({ trip, embedded }: TabProps & { embedded?: boolean }) {
         // breakdown.
         eyebrow={`Crew · ${totalCount}`}
         eyebrowTone="accent"
+        domain="crew"
         headline="Who's on the trip"
         // Populated copy per round-3 C3-2: surfaces the **placeholder**
         // defined term and pins ownership/permissions correctly.

--- a/src/app/trips/[tripId]/tabs/ExpensesTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesTab.tsx
@@ -39,6 +39,7 @@ export function ExpensesTab({ trip, canEdit, isOwner }: TabProps) {
     <div className="px-4">
       <TabHeader
         eyebrow="Receipts"
+        domain="receipts"
         headline="Track who paid for what"
         body="Log anything the crew pays for — group dinners, lodging, green fees, rentals. Pick who paid and who's splitting it and we'll keep balances straight so nobody chases anyone for money at the end."
         desktopAction={

--- a/src/app/trips/[tripId]/tabs/LodgingTab.tsx
+++ b/src/app/trips/[tripId]/tabs/LodgingTab.tsx
@@ -32,6 +32,7 @@ export function LodgingTab({ trip, canEdit, embedded }: TabProps & { embedded?: 
     <div className={embedded ? undefined : "px-4"}>
       <TabHeader
         eyebrow="Lodging"
+        domain="lodging"
         headline="Where everyone's staying"
         body="Drop in the places you're considering so the crew can compare — links, prices, sleep counts. Confirm the one(s) you book, and they're locked in as official trip details. Multi-property and multi-leg trips are fine — confirm as many as you need."
         desktopAction={

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -886,6 +886,7 @@ export function ScheduleTab({
           rounds / out-of-range) sit between the header and the grid. */}
       <TabHeader
         eyebrow="Agenda"
+        domain="agenda"
         headline="What you're actually doing"
         body="Tee times, dinners, side games, anything else on the calendar. Treat it like a rough draft — once an item is ready for the crew, confirm it and it'll appear on their itinerary."
         desktopAction={

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -25,6 +25,7 @@ import {
   type ItineraryTripMember,
 } from "../../components/itinerary";
 import type { TripData } from "../types";
+import { DOMAIN_COLORS, type Domain } from "@/lib/domainColors";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -377,27 +378,14 @@ function SkeletonRow({
 
 type PillTone = "all" | "lodging" | "travel" | "events";
 
-const PILL_TONES: Record<PillTone, { bg: string; color: string; border: string }> = {
-  all: {
-    bg: "var(--color-bt-accent-faint)",
-    color: "var(--color-bt-accent)",
-    border: "var(--color-bt-accent-border)",
-  },
-  lodging: {
-    bg: "var(--color-bt-blue-bg)",
-    color: "var(--color-bt-planning)",
-    border: "var(--color-bt-planning-border)",
-  },
-  travel: {
-    bg: "var(--color-bt-accent-faint)",
-    color: "var(--color-bt-accent)",
-    border: "var(--color-bt-accent-border)",
-  },
-  events: {
-    bg: "var(--color-bt-ready-bg)",
-    color: "var(--color-bt-ready)",
-    border: "var(--color-bt-ready-border)",
-  },
+// Each filter pill borrows its content area's domain color (item accents),
+// so the itinerary filters read in the same hues as their source tabs.
+// "All" uses Home teal — the itinerary lives on the Home tab.
+const PILL_DOMAIN: Record<PillTone, Domain> = {
+  all: "home",
+  lodging: "lodging",
+  travel: "travel",
+  events: "events",
 };
 
 function FilterPill({
@@ -411,19 +399,19 @@ function FilterPill({
   active: boolean;
   onClick: () => void;
 }) {
-  const cfg = PILL_TONES[tone];
+  const { color, faint } = DOMAIN_COLORS[PILL_DOMAIN[tone]];
   return (
     <button
       type="button"
       onClick={onClick}
       data-active={active}
-      className="rounded-full px-3 py-1.5 text-xs font-semibold"
+      className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold"
       style={
         active
           ? {
-              background: cfg.bg,
-              color: cfg.color,
-              border: `1px solid ${cfg.border}`,
+              background: faint,
+              color,
+              border: `1px solid ${color}`,
             }
           : {
               background: "var(--color-bt-card-raised)",
@@ -432,6 +420,13 @@ function FilterPill({
             }
       }
     >
+      {/* Domain dot — always tinted to the area's hue so the color reads
+          even on inactive pills (where the label itself stays neutral). */}
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full"
+        style={{ background: color }}
+        aria-hidden
+      />
       {label}
     </button>
   );

--- a/src/components/TabHeader.tsx
+++ b/src/components/TabHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { DOMAIN_COLORS, type Domain } from "@/lib/domainColors";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -12,13 +13,20 @@ interface TabHeaderProps {
    */
   eyebrow?: string;
   /**
-   * Eyebrow color. "accent" (default) uses the brand teal — the
-   * standard tab eyebrow treatment. "dim" uses bt-text-dim and is
-   * reserved for empty-state pages where the eyebrow conveys
-   * neutral context (trip name · location) rather than the tab
+   * Eyebrow color. "accent" (default) takes the domain hue when `domain`
+   * is supplied (the standard tab eyebrow treatment — it matches the
+   * active tab), falling back to the brand teal otherwise. "dim" uses
+   * bt-text-dim and is reserved for empty-state pages where the eyebrow
+   * conveys neutral context (trip name · location) rather than the tab
    * identity itself.
    */
   eyebrowTone?: "accent" | "dim";
+  /**
+   * Trip area this header belongs to. When set (and tone is "accent"),
+   * the eyebrow is painted in that area's domain color so it reinforces
+   * the active tab. Omit on neutral/empty-state headers.
+   */
+  domain?: Domain;
   /** Bold display headline. */
   headline: string;
   /** Short paragraph of dim body copy below the headline. Accepts a
@@ -66,12 +74,22 @@ interface TabHeaderProps {
 export function TabHeader({
   eyebrow,
   eyebrowTone = "accent",
+  domain,
   headline,
   body,
   desktopAction,
   actionAlwaysVisible = false,
   testId,
 }: TabHeaderProps) {
+  // Eyebrow color: "dim" stays neutral; otherwise pull the domain hue so
+  // the eyebrow matches the active tab, falling back to accent teal when
+  // no domain is supplied.
+  const eyebrowColor =
+    eyebrowTone === "dim"
+      ? "var(--color-bt-text-dim)"
+      : domain
+        ? DOMAIN_COLORS[domain].color
+        : "var(--color-bt-accent)";
   return (
     <div className="mb-6" data-testid={testId}>
       {/* Eyebrow row — only renders when an eyebrow is supplied. The
@@ -82,13 +100,7 @@ export function TabHeader({
         <div className="mb-3 flex items-center justify-between gap-3">
           <span
             className="text-[11px] font-semibold uppercase"
-            style={{
-              color:
-                eyebrowTone === "dim"
-                  ? "var(--color-bt-text-dim)"
-                  : "var(--color-bt-accent)",
-              letterSpacing: "0.1em",
-            }}
+            style={{ color: eyebrowColor, letterSpacing: "0.1em" }}
           >
             {eyebrow}
           </span>

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState, useEffect, type FC } from "react";
 import { House, Users, Hotel, Calendar, DollarSign, Trophy, type LucideIcon } from "lucide-react";
 import type { TabId } from "./BottomNav";
+import { DOMAIN_COLORS, TAB_DOMAIN } from "@/lib/domainColors";
 
 interface TabDef {
   id: TabId;
@@ -85,6 +86,10 @@ export const TripTabBar: FC<TripTabBarProps> = ({
       {tabs.map(({ id, label, Icon }) => {
         const active = activeTab === id;
         const badgeTier = badges?.[id];
+        // Each area owns one hue — the active tab paints its icon, label,
+        // and 2px underline in that domain color. Inactive tabs stay
+        // neutral gray (color marks, never floods).
+        const domainColor = DOMAIN_COLORS[TAB_DOMAIN[id]].color;
         return (
           <button
             key={id}
@@ -92,9 +97,9 @@ export const TripTabBar: FC<TripTabBarProps> = ({
             onClick={() => onTabChange(id)}
             className="flex flex-1 flex-col items-center justify-center gap-1 py-2.5 transition-colors"
             style={{
-              color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+              color: active ? domainColor : "var(--color-bt-text-dim)",
               borderBottom: active
-                ? "2px solid var(--color-bt-accent)"
+                ? `2px solid ${domainColor}`
                 : "2px solid transparent",
             }}
           >

--- a/src/lib/domainColors.ts
+++ b/src/lib/domainColors.ts
@@ -1,0 +1,88 @@
+import type { TabId } from "@/components/BottomNav";
+
+/**
+ * Domain-color system — single source of truth.
+ *
+ * Each trip area owns ONE color, surfaced in three reinforcing places:
+ *   1. the active tab (icon + label + 2px bottom border),
+ *   2. the page-header eyebrow (the small ALL-CAPS label above the H1), and
+ *   3. item accents (content icon-chips, itinerary filter dots).
+ *
+ * Color marks, never floods: inactive tabs and all H1 titles stay neutral.
+ *
+ * The hex/rgba values live as `--color-bt-domain-*` tokens in globals.css;
+ * this module maps each area to those tokens. Changing one entry (here or
+ * the token it points at) reskins that area everywhere it appears.
+ *
+ * Shared hues point at where the data actually lives:
+ *   - Travel borrows Crew rose — arrivals are per-person crew data.
+ *   - Events borrows Competition amber — events belong to the competition.
+ *
+ * NOTE: per-person team-member avatar colors are a SEPARATE system
+ * (team hues) and are intentionally not part of this map.
+ */
+export type Domain =
+  | "home"
+  | "crew"
+  | "lodging"
+  | "agenda"
+  | "travel"
+  | "events"
+  | "receipts"
+  | "competition";
+
+export interface DomainColor {
+  /** Solid hue — active tab icon/label/border, eyebrow text, item glyph. */
+  color: string;
+  /** Faint fill — icon-chip background, active filter-pill background. */
+  faint: string;
+}
+
+export const DOMAIN_COLORS: Record<Domain, DomainColor> = {
+  home: {
+    color: "var(--color-bt-domain-home)",
+    faint: "var(--color-bt-domain-home-faint)",
+  },
+  crew: {
+    color: "var(--color-bt-domain-crew)",
+    faint: "var(--color-bt-domain-crew-faint)",
+  },
+  lodging: {
+    color: "var(--color-bt-domain-lodging)",
+    faint: "var(--color-bt-domain-lodging-faint)",
+  },
+  agenda: {
+    color: "var(--color-bt-domain-agenda)",
+    faint: "var(--color-bt-domain-agenda-faint)",
+  },
+  travel: {
+    color: "var(--color-bt-domain-travel)",
+    faint: "var(--color-bt-domain-travel-faint)",
+  },
+  events: {
+    color: "var(--color-bt-domain-events)",
+    faint: "var(--color-bt-domain-events-faint)",
+  },
+  receipts: {
+    color: "var(--color-bt-domain-receipts)",
+    faint: "var(--color-bt-domain-receipts-faint)",
+  },
+  competition: {
+    color: "var(--color-bt-domain-competition)",
+    faint: "var(--color-bt-domain-competition-faint)",
+  },
+};
+
+/**
+ * Maps a TripTabBar / BottomNav TabId to its domain. Tab ids diverge from
+ * domain names for historical reasons (schedule→agenda, expenses→receipts,
+ * comp→competition).
+ */
+export const TAB_DOMAIN: Record<TabId, Domain> = {
+  home: "home",
+  crew: "crew",
+  lodging: "lodging",
+  schedule: "agenda",
+  expenses: "receipts",
+  comp: "competition",
+};

--- a/src/lib/domainColors.ts
+++ b/src/lib/domainColors.ts
@@ -38,39 +38,25 @@ export interface DomainColor {
   faint: string;
 }
 
+// TEMPORARY: every area is mapped to teal (Home's hue) for now. The real
+// per-area hues still live in the `--color-bt-domain-*` tokens in
+// globals.css — to re-enable the full palette, point each entry back at
+// its own `var(--color-bt-domain-<area>)` / `-faint` token (see the
+// commented-out values beside each line).
+const TEAL: DomainColor = {
+  color: "var(--color-bt-domain-home)",
+  faint: "var(--color-bt-domain-home-faint)",
+};
+
 export const DOMAIN_COLORS: Record<Domain, DomainColor> = {
-  home: {
-    color: "var(--color-bt-domain-home)",
-    faint: "var(--color-bt-domain-home-faint)",
-  },
-  crew: {
-    color: "var(--color-bt-domain-crew)",
-    faint: "var(--color-bt-domain-crew-faint)",
-  },
-  lodging: {
-    color: "var(--color-bt-domain-lodging)",
-    faint: "var(--color-bt-domain-lodging-faint)",
-  },
-  agenda: {
-    color: "var(--color-bt-domain-agenda)",
-    faint: "var(--color-bt-domain-agenda-faint)",
-  },
-  travel: {
-    color: "var(--color-bt-domain-travel)",
-    faint: "var(--color-bt-domain-travel-faint)",
-  },
-  events: {
-    color: "var(--color-bt-domain-events)",
-    faint: "var(--color-bt-domain-events-faint)",
-  },
-  receipts: {
-    color: "var(--color-bt-domain-receipts)",
-    faint: "var(--color-bt-domain-receipts-faint)",
-  },
-  competition: {
-    color: "var(--color-bt-domain-competition)",
-    faint: "var(--color-bt-domain-competition-faint)",
-  },
+  home: TEAL, // { color: "var(--color-bt-domain-home)",        faint: "var(--color-bt-domain-home-faint)" }
+  crew: TEAL, // { color: "var(--color-bt-domain-crew)",        faint: "var(--color-bt-domain-crew-faint)" }
+  lodging: TEAL, // { color: "var(--color-bt-domain-lodging)",     faint: "var(--color-bt-domain-lodging-faint)" }
+  agenda: TEAL, // { color: "var(--color-bt-domain-agenda)",      faint: "var(--color-bt-domain-agenda-faint)" }
+  travel: TEAL, // { color: "var(--color-bt-domain-travel)",      faint: "var(--color-bt-domain-travel-faint)" }
+  events: TEAL, // { color: "var(--color-bt-domain-events)",      faint: "var(--color-bt-domain-events-faint)" }
+  receipts: TEAL, // { color: "var(--color-bt-domain-receipts)",    faint: "var(--color-bt-domain-receipts-faint)" }
+  competition: TEAL, // { color: "var(--color-bt-domain-competition)", faint: "var(--color-bt-domain-competition-faint)" }
 };
 
 /**


### PR DESCRIPTION
## Summary
Introduces a centralized **domain-color system**: each trip area owns one hue, surfaced in three reinforcing places — the active tab (icon + label + 2px underline), the page-header eyebrow, and item accents (itinerary filter dots, Quick Info chips). Inactive tabs and all H1 titles stay neutral.

- **Single source of truth**: `--color-bt-domain-*` tokens in `globals.css` (color + faint per area) + `src/lib/domainColors.ts` (`DOMAIN_COLORS` lookup + `TAB_DOMAIN` tab-id map). Travel borrows Crew rose; Events borrows Competition amber.
- **Active tab** (`TripTabBar`): selected tab takes its domain hue; inactive stays neutral; notification dots unchanged.
- **Eyebrow** (`TabHeader`): new `domain` prop pulls the eyebrow color from the map (was hardcoded teal). Crew/Lodging/Agenda/Receipts pass their domain. H1 stays neutral; "dim" empty-state tone untouched.
- **Item accents**: itinerary filter pills get a domain-colored dot + active hue; Quick Info non-alert chips take Home teal (alert tiles keep warning amber).
- **Crew domain** is rose `#fb7185` (replacing old purple) — per-person team-member avatar hues are a **separate** system and are not touched.

**Currently every domain is mapped to teal** (last commit) per request — the real per-area hues remain defined in the tokens, and re-enabling the full palette is a one-edit revert in `domainColors.ts` (original values inlined as comments).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Vitest `trips.test.ts` 45/45
- [ ] Visual pass in light + dark: active tab, eyebrow, filter dots, Quick Info chips all read teal
- [ ] Flip a lookup entry back to its own token and confirm that area reskins everywhere it appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)