### PR TITLE
Reusable DatePicker for all date inputs

### DIFF
--- a/e2e/trip-settings.spec.ts
+++ b/e2e/trip-settings.spec.ts
@@ -191,6 +191,31 @@ test.describe("TripSettings — owner flows", () => {
     await expect(page.getByText("Danger zone")).toBeVisible();
   });
 
+  test("owner picks a trip-date range with the DatePicker", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    await page.getByTestId("trip-settings-btn").click();
+
+    // Expand the "Change dates" section, which now hosts the shared DatePicker.
+    await page.getByTestId("settings-change-dates-btn").click();
+
+    // Open the popover calendar.
+    const trigger = page.getByTestId("settings-dates-picker");
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Use a quick preset to fill a valid range, then commit with Apply.
+    await dialog.getByText("This weekend").click();
+    await dialog.getByRole("button", { name: "Apply" }).click();
+
+    // The trigger now reflects the chosen range with a nights tag.
+    await expect(trigger).toContainText("night");
+  });
+
   test("owner can expand transfer ownership and see crew members", async ({ page }) => {
     await setupMocks(page);
     await page.goto(`/trips/${TRIP_ID}`);

--- a/src/app/trips/[tripId]/components/AddPropertySheet.tsx
+++ b/src/app/trips/[tripId]/components/AddPropertySheet.tsx
@@ -5,6 +5,9 @@ import { Hotel, Link, MapPin, ImagePlus, X } from "lucide-react";
 import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { createClient } from "@/lib/supabase";
+import { DatePicker } from "@/components/DatePicker";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { parseLocalDate, toISODate } from "@/lib/dates";
 
 // ── Platform detection (exported so parents can use it) ───────────────────
 
@@ -689,25 +692,23 @@ export function AddPropertySheet({
 
           {/* Check-in / Check-out — planning only */}
           {showAddressAndDates && (
-            <div className="grid grid-cols-2 gap-2">
-              <Field label="Check-in">
-                <input
-                  type="date"
-                  value={checkIn}
-                  onChange={(e) => setCheckIn(e.target.value)}
-                  className={inputCls}
-                  style={inputStyle}
-                />
-              </Field>
-              <Field label="Check-out">
-                <input
-                  type="date"
-                  value={checkOut}
-                  onChange={(e) => setCheckOut(e.target.value)}
-                  className={inputCls}
-                  style={inputStyle}
-                />
-              </Field>
+            <div className="space-y-2">
+              <DatePicker
+                mode="range"
+                label="Check-in → check-out"
+                icon={<Hotel size={15} />}
+                accent={DOMAIN_COLORS.lodging.color}
+                accentFaint={DOMAIN_COLORS.lodging.faint}
+                value={{
+                  start: checkIn ? parseLocalDate(checkIn) : null,
+                  end: checkOut ? parseLocalDate(checkOut) : null,
+                }}
+                onChange={(r) => {
+                  setCheckIn(r.start ? toISODate(r.start) : "");
+                  setCheckOut(r.end ? toISODate(r.end) : "");
+                }}
+              />
+              <div className="grid grid-cols-2 gap-2">
               <Field label="Check-in time">
                 <input
                   type="time"
@@ -728,6 +729,7 @@ export function AddPropertySheet({
                   style={inputStyle}
                 />
               </Field>
+              </div>
             </div>
           )}
 

--- a/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
+++ b/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
@@ -5,6 +5,9 @@ import { Plus, X, Search, MapPin } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { trpc } from "@/lib/trpc-client";
+import { DatePicker } from "@/components/DatePicker";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { parseLocalDate, toISODate } from "@/lib/dates";
 
 const GOLF_TYPES = ["golf_course"];
 
@@ -704,17 +707,14 @@ export function AddScheduleItemSheet({
             >
               Date <span className="font-medium normal-case tracking-normal">(optional)</span>
             </p>
-            <input
-              type={scheduledDate ? "date" : "text"}
-              value={scheduledDate}
-              min={tripStart}
-              max={tripEnd}
-              onFocus={(e) => { e.currentTarget.type = "date"; }}
-              onBlur={(e) => { if (!scheduledDate) e.currentTarget.type = "text"; }}
-              onChange={(e) => setScheduledDate(e.target.value)}
-              placeholder="Add a date"
-              className="rounded-xl border px-3 py-2.5 text-sm outline-none"
-              style={inputStyle}
+            <DatePicker
+              mode="single"
+              accent={DOMAIN_COLORS.agenda.color}
+              accentFaint={DOMAIN_COLORS.agenda.faint}
+              min={tripStart ? parseLocalDate(tripStart) : null}
+              max={tripEnd ? parseLocalDate(tripEnd) : null}
+              value={scheduledDate ? parseLocalDate(scheduledDate) : null}
+              onChange={(d) => setScheduledDate(d ? toISODate(d) : "")}
             />
 
             {/* Tee times */}
@@ -896,21 +896,18 @@ export function AddScheduleItemSheet({
                 Native date input with min/max bound to the trip's date
                 range keeps users from assigning items outside it. */}
             <div className="mt-3 flex gap-3">
-              <div>
+              <div className="flex-1">
                 <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
                   Date <span className="font-medium normal-case tracking-normal">(optional)</span>
                 </p>
-                <input
-                  type={scheduledDate ? "date" : "text"}
-                  value={scheduledDate}
-                  min={tripStart}
-                  max={tripEnd}
-                  onFocus={(e) => { e.currentTarget.type = "date"; }}
-                  onBlur={(e) => { if (!scheduledDate) e.currentTarget.type = "text"; }}
-                  onChange={(e) => setScheduledDate(e.target.value)}
-                  placeholder="Add a date"
-                  className="rounded-xl border px-3 py-2.5 text-sm outline-none"
-                  style={inputStyle}
+                <DatePicker
+                  mode="single"
+                  accent={DOMAIN_COLORS.agenda.color}
+                  accentFaint={DOMAIN_COLORS.agenda.faint}
+                  min={tripStart ? parseLocalDate(tripStart) : null}
+                  max={tripEnd ? parseLocalDate(tripEnd) : null}
+                  value={scheduledDate ? parseLocalDate(scheduledDate) : null}
+                  onChange={(d) => setScheduledDate(d ? toISODate(d) : "")}
                 />
               </div>
               <div>

--- a/src/app/trips/[tripId]/tabs/AddExpenseModal.tsx
+++ b/src/app/trips/[tripId]/tabs/AddExpenseModal.tsx
@@ -7,6 +7,9 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { trpc } from "@/lib/trpc-client";
 import { SplitPanel } from "./SplitPanel";
 import { CurrencyInput, memberName } from "./ExpensesSection";
+import { DatePicker } from "@/components/DatePicker";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { parseLocalDate, toISODate } from "@/lib/dates";
 import type { ExpenseMember } from "./ExpensesSection";
 
 export function AddExpenseModal({
@@ -228,15 +231,12 @@ export function AddExpenseModal({
               <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
                 Date (optional)
               </label>
-              <input
-                type={date ? "date" : "text"}
-                value={date}
-                onFocus={(e) => { e.currentTarget.type = "date"; }}
-                onBlur={(e) => { if (!date) e.currentTarget.type = "text"; }}
-                onChange={(e) => setDate(e.target.value)}
-                placeholder="Add a date"
-                className="w-full rounded-lg border px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+              <DatePicker
+                mode="single"
+                accent={DOMAIN_COLORS.receipts.color}
+                accentFaint={DOMAIN_COLORS.receipts.faint}
+                value={date ? parseLocalDate(date) : null}
+                onChange={(d) => setDate(d ? toISODate(d) : "")}
               />
             </div>
           </div>

--- a/src/app/trips/[tripId]/tabs/EditExpenseModal.tsx
+++ b/src/app/trips/[tripId]/tabs/EditExpenseModal.tsx
@@ -8,6 +8,9 @@ import { trpc } from "@/lib/trpc-client";
 import { SplitPanel } from "./SplitPanel";
 import { CurrencyInput, memberName as getMemberName } from "./ExpensesSection";
 import type { ExpenseItem, ExpenseMember } from "./ExpensesSection";
+import { DatePicker } from "@/components/DatePicker";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { parseLocalDate, toISODate } from "@/lib/dates";
 
 export function EditExpenseModal({
   expense,
@@ -327,16 +330,13 @@ export function EditExpenseModal({
             </div>
             <div className="w-36 flex-shrink-0">
               <label className="mb-1 block text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>Date <span className="lowercase">(optional)</span></label>
-              <input
-                type={date ? "date" : "text"}
-                value={date}
-                onFocus={(e) => { e.currentTarget.type = "date"; }}
-                onBlur={(e) => { if (!date) e.currentTarget.type = "text"; }}
-                onChange={(e) => setDate(e.target.value)}
+              <DatePicker
+                mode="single"
                 disabled={!isOwner}
-                placeholder="Add a date"
-                className="w-full rounded-lg border px-3 py-2 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)", color: "var(--color-bt-text)" }}
+                accent={DOMAIN_COLORS.receipts.color}
+                accentFaint={DOMAIN_COLORS.receipts.faint}
+                value={date ? parseLocalDate(date) : null}
+                onChange={(d) => setDate(d ? toISODate(d) : "")}
               />
             </div>
           </div>

--- a/src/app/trips/[tripId]/tabs/components/TravelControls.tsx
+++ b/src/app/trips/[tripId]/tabs/components/TravelControls.tsx
@@ -282,6 +282,11 @@ export function TravelFields({
   const inputBg =
     surface === "recessed" ? "var(--color-bt-base)" : "var(--color-bt-card-raised)";
 
+  // Everything below the mode picker depends on a chosen mode — travel won't
+  // persist without one. Keep the detail/arrival fields disabled until the
+  // user selects Flying / Driving / Other so the form can't be half-filled.
+  const modeSelected = !!value.mode;
+
   return (
     <div className="space-y-3">
       {arrivalBeforeTrip && (
@@ -355,12 +360,13 @@ export function TravelFields({
           type="text"
           value={value.detail}
           onChange={(e) => onChange({ ...value, detail: e.target.value })}
+          disabled={!modeSelected}
           placeholder={
             value.mode
               ? TRAVEL_MODE_META[value.mode].placeholder
               : "Pick how you're getting there above"
           }
-          className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+          className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
           style={{
             background: inputBg,
             borderColor: "var(--color-bt-border)",
@@ -381,6 +387,7 @@ export function TravelFields({
           <DatePicker
             mode="single"
             icon={<Plane size={15} />}
+            disabled={!modeSelected}
             accent={DOMAIN_COLORS.travel.color}
             accentFaint={DOMAIN_COLORS.travel.faint}
             value={value.arrivalDate ? parseLocalDate(value.arrivalDate) : null}
@@ -400,7 +407,8 @@ export function TravelFields({
             type="time"
             value={value.arrivalTime}
             onChange={(e) => onChange({ ...value, arrivalTime: e.target.value })}
-            className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
+            disabled={!modeSelected}
+            className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
             style={{
               background: inputBg,
               borderColor: "var(--color-bt-border)",

--- a/src/app/trips/[tripId]/tabs/components/TravelControls.tsx
+++ b/src/app/trips/[tripId]/tabs/components/TravelControls.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { AlertTriangle, Car, HelpCircle, Plane } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { DatePicker } from "@/components/DatePicker";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { parseLocalDate, toISODate } from "@/lib/dates";
 
 /**
  * Shared travel controls for the Crew tab.
@@ -375,16 +378,15 @@ export function TravelFields({
           >
             Arriving
           </label>
-          <input
-            type="date"
-            value={value.arrivalDate}
-            onChange={(e) => onChange({ ...value, arrivalDate: e.target.value })}
-            className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none"
-            style={{
-              background: inputBg,
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
+          <DatePicker
+            mode="single"
+            icon={<Plane size={15} />}
+            accent={DOMAIN_COLORS.travel.color}
+            accentFaint={DOMAIN_COLORS.travel.faint}
+            value={value.arrivalDate ? parseLocalDate(value.arrivalDate) : null}
+            onChange={(d) =>
+              onChange({ ...value, arrivalDate: d ? toISODate(d) : "" })
+            }
           />
         </div>
         <div style={{ flex: "1 1 100px" }}>

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -2,11 +2,13 @@
 
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { Calendar as CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
 import {
   addMonths,
@@ -85,6 +87,10 @@ const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
 // (per the design spec). Dark ink reads on every domain hue.
 const CAP_TEXT = "#0d1f1a";
 
+// Popover geometry — kept in sync with the dialog's Tailwind width (w-[300px]).
+const POPOVER_W = 300;
+const POPOVER_GAP = 8;
+
 // ── Component ────────────────────────────────────────────────────────────────
 
 /**
@@ -114,6 +120,10 @@ export function DatePicker(props: DatePickerProps) {
   const [open, setOpen] = useState(false);
   const [hovered, setHovered] = useState<Date | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  // Fixed-position coords for the portaled popover (null until measured).
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
 
   // Draft selection lives only while the popover is open; Apply commits it.
   const [draftRange, setDraftRange] = useState<DateRange>({ start: null, end: null });
@@ -134,13 +144,15 @@ export function DatePicker(props: DatePickerProps) {
     setOpen(true);
   }
 
-  // Close on outside click / Escape.
+  // Close on outside click / Escape. The popover is portaled to <body>, so a
+  // click inside it is outside rootRef — check both refs before closing.
   useEffect(() => {
     if (!open) return;
     function onDown(e: MouseEvent) {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const target = e.target as Node;
+      const inTrigger = rootRef.current?.contains(target);
+      const inPopover = popoverRef.current?.contains(target);
+      if (!inTrigger && !inPopover) setOpen(false);
     }
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") setOpen(false);
@@ -152,6 +164,38 @@ export function DatePicker(props: DatePickerProps) {
       document.removeEventListener("keydown", onKey);
     };
   }, [open]);
+
+  // Position the portaled popover relative to the trigger, flipping above when
+  // there isn't room below. Recomputed on open and on scroll/resize.
+  useLayoutEffect(() => {
+    if (!open) return;
+    function reposition() {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const r = trigger.getBoundingClientRect();
+      const popH = popoverRef.current?.offsetHeight ?? 360;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let left = r.left;
+      if (left + POPOVER_W > vw - POPOVER_GAP) left = vw - POPOVER_W - POPOVER_GAP;
+      if (left < POPOVER_GAP) left = POPOVER_GAP;
+
+      let top = r.bottom + POPOVER_GAP;
+      const fitsBelow = top + popH <= vh - POPOVER_GAP;
+      const fitsAbove = r.top - POPOVER_GAP - popH >= POPOVER_GAP;
+      if (!fitsBelow && fitsAbove) top = r.top - POPOVER_GAP - popH;
+
+      setCoords({ top, left });
+    }
+    reposition();
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open, mode]);
 
   // ── Trigger display ────────────────────────────────────────────────────
   const triggerText =
@@ -225,6 +269,7 @@ export function DatePicker(props: DatePickerProps) {
 
       {/* ── Trigger pill ──────────────────────────────────────────────── */}
       <button
+        ref={triggerRef}
         type="button"
         data-testid={testId}
         onClick={() => (open ? setOpen(false) : handleOpen())}
@@ -260,12 +305,17 @@ export function DatePicker(props: DatePickerProps) {
         />
       </button>
 
-      {/* ── Popover calendar ──────────────────────────────────────────── */}
-      {open && (
+      {/* ── Popover calendar (portaled to <body> so it escapes any clipping
+            ancestor and floats above the surrounding panel) ─────────────── */}
+      {open && typeof document !== "undefined" && createPortal(
         <div
+          ref={popoverRef}
           role="dialog"
-          className="absolute left-0 top-full z-50 mt-2 w-[300px] rounded-2xl p-3"
+          className="fixed z-[100] w-[300px] rounded-2xl p-3"
           style={{
+            top: coords?.top ?? -9999,
+            left: coords?.left ?? -9999,
+            visibility: coords ? "visible" : "hidden",
             background: "var(--color-bt-card-float)",
             border: "1px solid var(--color-bt-border)",
             boxShadow: "var(--shadow-floating)",
@@ -444,7 +494,8 @@ export function DatePicker(props: DatePickerProps) {
               Apply
             </button>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  addMonths,
+  applyRangeClick,
+  atNoon,
+  isOutOfBounds,
+  isSameDay,
+  isWithinRange,
+  monthMatrix,
+  nightsBetween,
+  rangePresets,
+  startOfMonth,
+  type DateRange,
+} from "@/lib/calendar";
+
+// ── Props ──────────────────────────────────────────────────────────────────
+
+interface BaseProps {
+  /** Domain tint for caps, today dot, focus ring, icon. Default teal. */
+  accent?: string;
+  /** ~0.16-alpha of accent — fills the range body. Default accent-faint. */
+  accentFaint?: string;
+  /** Label above the trigger field. */
+  label?: string;
+  /** Leading glyph in the trigger field (domain-colored). */
+  icon?: ReactNode;
+  /** Show quick presets above the grid. Default true. */
+  presets?: boolean;
+  /** Earliest selectable day (inclusive). Days before are disabled. */
+  min?: Date | null;
+  /** Latest selectable day (inclusive). Days after are disabled. */
+  max?: Date | null;
+  /** data-testid for the trigger field (E2E). */
+  testId?: string;
+  disabled?: boolean;
+}
+
+interface RangeProps extends BaseProps {
+  mode: "range";
+  value: DateRange | null;
+  onChange: (value: DateRange) => void;
+}
+
+interface SingleProps extends BaseProps {
+  mode: "single";
+  value: Date | null;
+  onChange: (value: Date | null) => void;
+}
+
+export type DatePickerProps = RangeProps | SingleProps;
+
+// ── Formatting ──────────────────────────────────────────────────────────────
+
+const fmtMonthDay = (d: Date) =>
+  d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+
+function fmtRange(start: Date | null, end: Date | null): string {
+  if (start && end) {
+    const sameMonth =
+      start.getMonth() === end.getMonth() &&
+      start.getFullYear() === end.getFullYear();
+    return sameMonth
+      ? `${fmtMonthDay(start)} – ${end.getDate()}`
+      : `${fmtMonthDay(start)} – ${fmtMonthDay(end)}`;
+  }
+  if (start) return fmtMonthDay(start);
+  if (end) return fmtMonthDay(end);
+  return "";
+}
+
+const nightsLabel = (n: number) => `${n} ${n === 1 ? "night" : "nights"}`;
+
+const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
+
+// Cap text on the accent fill — the only hard-coded color in this component
+// (per the design spec). Dark ink reads on every domain hue.
+const CAP_TEXT = "#0d1f1a";
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Shared calendar date-picker. One component, two modes:
+ *   - range  → start→end selection in a single calendar (value {start,end})
+ *   - single → one day (value Date)
+ *
+ * A trigger pill replaces the old native <input type="date">; clicking it
+ * opens a popover calendar that holds a *draft* selection and commits via
+ * Apply. The tint is fully prop-driven so each screen passes its domain hue.
+ */
+export function DatePicker(props: DatePickerProps) {
+  const {
+    mode,
+    accent = "var(--color-bt-accent)",
+    accentFaint = "var(--color-bt-accent-faint)",
+    label,
+    icon,
+    presets = true,
+    min,
+    max,
+    testId,
+    disabled = false,
+  } = props;
+
+  const today = useMemo(() => atNoon(new Date()), []);
+  const [open, setOpen] = useState(false);
+  const [hovered, setHovered] = useState<Date | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Draft selection lives only while the popover is open; Apply commits it.
+  const [draftRange, setDraftRange] = useState<DateRange>({ start: null, end: null });
+  const [draftSingle, setDraftSingle] = useState<Date | null>(null);
+  const [viewDate, setViewDate] = useState<Date>(today);
+
+  // Seed the draft + view from the committed value each time we open.
+  function handleOpen() {
+    if (disabled) return;
+    if (mode === "range") {
+      const v = props.value ?? { start: null, end: null };
+      setDraftRange({ start: v.start, end: v.end });
+      setViewDate(startOfMonth(v.start ?? v.end ?? today));
+    } else {
+      setDraftSingle(props.value ?? null);
+      setViewDate(startOfMonth(props.value ?? today));
+    }
+    setOpen(true);
+  }
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // ── Trigger display ────────────────────────────────────────────────────
+  const triggerText =
+    mode === "range"
+      ? props.value && (props.value.start || props.value.end)
+        ? fmtRange(props.value.start, props.value.end)
+        : ""
+      : props.value
+        ? fmtMonthDay(props.value)
+        : "";
+  const placeholder = mode === "range" ? "Select dates" : "Select date";
+  const triggerNights =
+    mode === "range" && props.value?.start && props.value?.end
+      ? nightsBetween(props.value.start, props.value.end)
+      : null;
+
+  // ── Draft validity + footer summary ──────────────────────────────────────
+  const valid =
+    mode === "range" ? !!(draftRange.start && draftRange.end) : !!draftSingle;
+
+  let summary: string;
+  if (mode === "range") {
+    if (draftRange.start && draftRange.end) {
+      summary = `${fmtMonthDay(draftRange.start)} – ${fmtMonthDay(
+        draftRange.end
+      )} · ${nightsLabel(nightsBetween(draftRange.start, draftRange.end))}`;
+    } else if (draftRange.start) {
+      summary = "Pick an end date";
+    } else {
+      summary = "Pick a start date";
+    }
+  } else {
+    summary = draftSingle ? fmtMonthDay(draftSingle) : "Pick a date";
+  }
+
+  function commit() {
+    if (!valid) return;
+    if (mode === "range") {
+      props.onChange({ start: draftRange.start, end: draftRange.end });
+    } else {
+      props.onChange(draftSingle);
+    }
+    setOpen(false);
+  }
+
+  function handleDayClick(day: Date) {
+    if (isOutOfBounds(day, min, max)) return;
+    if (mode === "range") {
+      setDraftRange((cur) => applyRangeClick(cur, day));
+    } else {
+      setDraftSingle(atNoon(day));
+    }
+  }
+
+  const weeks = useMemo(() => monthMatrix(viewDate), [viewDate]);
+  const monthLabel = viewDate.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div className="relative" ref={rootRef}>
+      {label && (
+        <label
+          className="mb-1 block text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {label}
+        </label>
+      )}
+
+      {/* ── Trigger pill ──────────────────────────────────────────────── */}
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={() => (open ? setOpen(false) : handleOpen())}
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 rounded-xl border px-3 py-2.5 text-left text-sm outline-none transition-shadow disabled:opacity-50"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          borderColor: open ? accent : "var(--color-bt-border)",
+          color: triggerText ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+          boxShadow: open ? `0 0 0 3px ${accentFaint}` : "none",
+        }}
+      >
+        <span className="flex flex-shrink-0 items-center" style={{ color: accent }}>
+          {icon ?? <CalendarIcon size={15} />}
+        </span>
+        <span className="min-w-0 flex-1 truncate">
+          {triggerText || placeholder}
+        </span>
+        {triggerNights !== null && (
+          <span
+            className="flex-shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px]"
+            style={{ background: accentFaint, color: accent }}
+          >
+            {nightsLabel(triggerNights)}
+          </span>
+        )}
+        <CalendarIcon
+          size={15}
+          className="flex-shrink-0"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        />
+      </button>
+
+      {/* ── Popover calendar ──────────────────────────────────────────── */}
+      {open && (
+        <div
+          role="dialog"
+          className="absolute left-0 top-full z-50 mt-2 w-[300px] rounded-2xl p-3"
+          style={{
+            background: "var(--color-bt-card-float)",
+            border: "1px solid var(--color-bt-border)",
+            boxShadow: "var(--shadow-floating)",
+          }}
+        >
+          {/* Presets */}
+          {presets && (
+            <div className="mb-3 flex flex-wrap gap-1.5">
+              {mode === "range"
+                ? rangePresets(today).map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => {
+                        setDraftRange(p.range);
+                        if (p.range.start) setViewDate(startOfMonth(p.range.start));
+                      }}
+                      className="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                      style={{
+                        background: "var(--color-bt-card-raised)",
+                        color: "var(--color-bt-text-dim)",
+                        border: "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      {p.label}
+                    </button>
+                  ))
+                : (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDraftSingle(today);
+                        setViewDate(startOfMonth(today));
+                      }}
+                      className="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                      style={{
+                        background: "var(--color-bt-card-raised)",
+                        color: "var(--color-bt-text-dim)",
+                        border: "1px solid var(--color-bt-border)",
+                      }}
+                    >
+                      Today
+                    </button>
+                  )}
+            </div>
+          )}
+
+          {/* Month nav */}
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() => setViewDate((d) => addMonths(d, -1))}
+              className="flex h-7 w-7 items-center justify-center rounded-lg"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <span
+              className="text-sm font-semibold"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {monthLabel}
+            </span>
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() => setViewDate((d) => addMonths(d, 1))}
+              className="flex h-7 w-7 items-center justify-center rounded-lg"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <ChevronRight size={16} />
+            </button>
+          </div>
+
+          {/* Weekday header */}
+          <div className="grid grid-cols-7">
+            {WEEKDAYS.map((d, i) => (
+              <div
+                key={i}
+                className="flex h-7 items-center justify-center text-[10px] font-semibold uppercase"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {d}
+              </div>
+            ))}
+          </div>
+
+          {/* Day grid */}
+          <div className="grid grid-cols-7">
+            {weeks.flat().map((day) => {
+              const inMonth = day.getMonth() === viewDate.getMonth();
+              const outOfBounds = isOutOfBounds(day, min, max);
+              const isToday = isSameDay(day, today);
+
+              const range =
+                mode === "range" ? draftRange : { start: draftSingle, end: null };
+              const isStart = isSameDay(day, range.start);
+              const isEnd = mode === "range" && isSameDay(day, range.end);
+              const isCap = isStart || isEnd;
+              const between =
+                mode === "range" && isWithinRange(day, draftRange);
+              const hasEnd = mode === "range" && !!draftRange.end;
+              const isHovered = isSameDay(day, hovered);
+
+              // Continuous range fill: a half/full bar behind the caps.
+              const showFill = between || (isStart && hasEnd) || isEnd;
+
+              return (
+                <div key={day.getTime()} className="relative h-9">
+                  {showFill && (
+                    <div
+                      className="absolute inset-y-1"
+                      style={{
+                        left: isStart ? "50%" : 0,
+                        right: isEnd ? "50%" : 0,
+                        background: accentFaint,
+                      }}
+                    />
+                  )}
+                  <button
+                    type="button"
+                    disabled={outOfBounds}
+                    onClick={() => handleDayClick(day)}
+                    onMouseEnter={() => setHovered(day)}
+                    onMouseLeave={() => setHovered(null)}
+                    className="relative mx-auto flex h-9 w-9 items-center justify-center rounded-full text-[13px] disabled:cursor-not-allowed"
+                    style={{
+                      background: isCap ? accent : "transparent",
+                      color: isCap
+                        ? CAP_TEXT
+                        : outOfBounds
+                          ? "var(--color-bt-text-dim)"
+                          : inMonth
+                            ? "var(--color-bt-text)"
+                            : "var(--color-bt-text-dim)",
+                      opacity: outOfBounds ? 0.35 : inMonth ? 1 : 0.45,
+                      fontWeight: isCap ? 700 : 400,
+                      boxShadow:
+                        isHovered && !isCap && !outOfBounds
+                          ? `inset 0 0 0 1px ${accent}`
+                          : "none",
+                    }}
+                  >
+                    {day.getDate()}
+                    {isToday && !isCap && (
+                      <span
+                        className="absolute bottom-1 h-1 w-1 rounded-full"
+                        style={{ background: accent }}
+                        aria-hidden
+                      />
+                    )}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Footer: live summary + Apply */}
+          <div className="mt-2 flex items-center justify-between gap-2 border-t pt-2.5"
+            style={{ borderColor: "var(--color-bt-border)" }}
+          >
+            <span
+              className="min-w-0 truncate text-xs"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              {summary}
+            </span>
+            <button
+              type="button"
+              onClick={commit}
+              disabled={!valid}
+              className="flex-shrink-0 rounded-lg px-3.5 py-1.5 text-xs font-semibold transition-opacity disabled:opacity-40"
+              style={{ background: accent, color: CAP_TEXT }}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -16,7 +16,9 @@ import {
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { RoleBadge } from "@/components/RoleBadge";
-import { formatDateRangeCompact } from "@/lib/dates";
+import { formatDateRangeCompact, parseLocalDate, toISODate } from "@/lib/dates";
+import { DatePicker } from "@/components/DatePicker";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
 import type { TripRole } from "@/server/middleware";
 import type { TripData } from "@/app/trips/[tripId]/tabs/types";
 
@@ -437,48 +439,21 @@ export function TripSettingsModal({
                       style={{ borderColor: "var(--color-bt-border)" }}
                     >
                       <>
-                          <div className="grid grid-cols-2 gap-2">
-                            <div className="space-y-1">
-                              <label
-                                className="text-[11px] font-semibold uppercase tracking-wider"
-                                style={{ color: "var(--color-bt-text-dim)" }}
-                              >
-                                Start date
-                              </label>
-                              <input
-                                type="date"
-                                data-testid="settings-start-date-input"
-                                value={startDraft}
-                                onChange={(e) => setStartDraft(e.target.value)}
-                                className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
-                                style={{
-                                  background: "var(--color-bt-card-raised)",
-                                  borderColor: "var(--color-bt-border)",
-                                  color: "var(--color-bt-text)",
-                                }}
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <label
-                                className="text-[11px] font-semibold uppercase tracking-wider"
-                                style={{ color: "var(--color-bt-text-dim)" }}
-                              >
-                                End date
-                              </label>
-                              <input
-                                type="date"
-                                data-testid="settings-end-date-input"
-                                value={endDraft}
-                                onChange={(e) => setEndDraft(e.target.value)}
-                                className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
-                                style={{
-                                  background: "var(--color-bt-card-raised)",
-                                  borderColor: "var(--color-bt-border)",
-                                  color: "var(--color-bt-text)",
-                                }}
-                              />
-                            </div>
-                          </div>
+                          <DatePicker
+                            mode="range"
+                            label="Trip dates"
+                            testId="settings-dates-picker"
+                            accent={DOMAIN_COLORS.home.color}
+                            accentFaint={DOMAIN_COLORS.home.faint}
+                            value={{
+                              start: startDraft ? parseLocalDate(startDraft) : null,
+                              end: endDraft ? parseLocalDate(endDraft) : null,
+                            }}
+                            onChange={(r) => {
+                              setStartDraft(r.start ? toISODate(r.start) : "");
+                              setEndDraft(r.end ? toISODate(r.end) : "");
+                            }}
+                          />
                           <button
                             data-testid="settings-save-dates-btn"
                             disabled={!canSaveDates}

--- a/src/lib/calendar.test.ts
+++ b/src/lib/calendar.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import {
+  atNoon,
+  isSameDay,
+  isBeforeDay,
+  isAfterDay,
+  addDays,
+  addMonths,
+  nightsBetween,
+  startOfMonth,
+  monthMatrix,
+  applyRangeClick,
+  isWithinRange,
+  isOutOfBounds,
+  nextFriday,
+  rangePresets,
+  type DateRange,
+} from "./calendar";
+
+/** Helper: build a local-noon day from y/m/d (month is 1-based here for readability). */
+const d = (y: number, m: number, day: number) => new Date(y, m - 1, day, 12, 0, 0, 0);
+
+describe("atNoon", () => {
+  it("strips time-of-day to local noon", () => {
+    const result = atNoon(new Date(2026, 5, 15, 23, 45, 30, 500));
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it("preserves the calendar day for early-morning times", () => {
+    const result = atNoon(new Date(2026, 5, 15, 0, 5, 0, 0));
+    expect(result.getDate()).toBe(15);
+  });
+});
+
+describe("isSameDay", () => {
+  it("ignores time-of-day", () => {
+    expect(isSameDay(new Date(2026, 5, 15, 1, 0), new Date(2026, 5, 15, 23, 0))).toBe(true);
+  });
+  it("distinguishes different days", () => {
+    expect(isSameDay(d(2026, 6, 15), d(2026, 6, 16))).toBe(false);
+  });
+  it("returns false when either side is null", () => {
+    expect(isSameDay(null, d(2026, 6, 15))).toBe(false);
+    expect(isSameDay(d(2026, 6, 15), null)).toBe(false);
+    expect(isSameDay(null, null)).toBe(false);
+  });
+});
+
+describe("isBeforeDay / isAfterDay", () => {
+  it("compares at day granularity", () => {
+    expect(isBeforeDay(d(2026, 6, 14), d(2026, 6, 15))).toBe(true);
+    expect(isAfterDay(d(2026, 6, 16), d(2026, 6, 15))).toBe(true);
+  });
+  it("same day is neither before nor after", () => {
+    expect(isBeforeDay(d(2026, 6, 15), d(2026, 6, 15))).toBe(false);
+    expect(isAfterDay(d(2026, 6, 15), d(2026, 6, 15))).toBe(false);
+  });
+});
+
+describe("addDays", () => {
+  it("adds positive days", () => {
+    expect(isSameDay(addDays(d(2026, 6, 15), 3), d(2026, 6, 18))).toBe(true);
+  });
+  it("adds negative days across a month boundary", () => {
+    expect(isSameDay(addDays(d(2026, 6, 1), -1), d(2026, 5, 31))).toBe(true);
+  });
+});
+
+describe("addMonths", () => {
+  it("advances by whole months", () => {
+    expect(isSameDay(addMonths(d(2026, 1, 15), 2), d(2026, 3, 15))).toBe(true);
+  });
+  it("clamps the day to the target month's length", () => {
+    // Jan 31 + 1 month → Feb 28 (2026 is not a leap year)
+    expect(isSameDay(addMonths(d(2026, 1, 31), 1), d(2026, 2, 28))).toBe(true);
+  });
+  it("handles negative months across a year boundary", () => {
+    expect(isSameDay(addMonths(d(2026, 1, 15), -1), d(2025, 12, 15))).toBe(true);
+  });
+});
+
+describe("nightsBetween", () => {
+  it("counts whole nights", () => {
+    expect(nightsBetween(d(2026, 6, 15), d(2026, 6, 18))).toBe(3);
+  });
+  it("is zero for the same day", () => {
+    expect(nightsBetween(d(2026, 6, 15), d(2026, 6, 15))).toBe(0);
+  });
+  it("counts across a month boundary", () => {
+    expect(nightsBetween(d(2026, 6, 28), d(2026, 7, 2))).toBe(4);
+  });
+});
+
+describe("startOfMonth", () => {
+  it("returns the first day at noon", () => {
+    const result = startOfMonth(d(2026, 6, 15));
+    expect(result.getDate()).toBe(1);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getHours()).toBe(12);
+  });
+});
+
+describe("monthMatrix", () => {
+  it("returns a 6x7 grid", () => {
+    const grid = monthMatrix(d(2026, 6, 15));
+    expect(grid).toHaveLength(6);
+    grid.forEach((week) => expect(week).toHaveLength(7));
+  });
+  it("starts each row on Sunday", () => {
+    const grid = monthMatrix(d(2026, 6, 15));
+    grid.forEach((week) => expect(week[0].getDay()).toBe(0));
+  });
+  it("includes leading days from the previous month", () => {
+    // June 2026: the 1st is a Monday, so the grid starts on Sun May 31.
+    const grid = monthMatrix(d(2026, 6, 15));
+    expect(isSameDay(grid[0][0], d(2026, 5, 31))).toBe(true);
+  });
+  it("contains the first of the target month", () => {
+    const grid = monthMatrix(d(2026, 6, 15));
+    const flat = grid.flat();
+    expect(flat.some((day) => isSameDay(day, d(2026, 6, 1)))).toBe(true);
+  });
+});
+
+describe("applyRangeClick", () => {
+  it("begins a new range when nothing is selected", () => {
+    const result = applyRangeClick({ start: null, end: null }, d(2026, 6, 15));
+    expect(isSameDay(result.start, d(2026, 6, 15))).toBe(true);
+    expect(result.end).toBeNull();
+  });
+
+  it("sets the end when clicking a later day after a start", () => {
+    const result = applyRangeClick({ start: d(2026, 6, 15), end: null }, d(2026, 6, 18));
+    expect(isSameDay(result.start, d(2026, 6, 15))).toBe(true);
+    expect(isSameDay(result.end, d(2026, 6, 18))).toBe(true);
+  });
+
+  it("allows end == start (same-day click)", () => {
+    const result = applyRangeClick({ start: d(2026, 6, 15), end: null }, d(2026, 6, 15));
+    expect(isSameDay(result.start, d(2026, 6, 15))).toBe(true);
+    expect(isSameDay(result.end, d(2026, 6, 15))).toBe(true);
+  });
+
+  it("resets the start when clicking before the current start", () => {
+    const result = applyRangeClick({ start: d(2026, 6, 15), end: null }, d(2026, 6, 10));
+    expect(isSameDay(result.start, d(2026, 6, 10))).toBe(true);
+    expect(result.end).toBeNull();
+  });
+
+  it("begins a fresh range when a complete range already exists", () => {
+    const complete: DateRange = { start: d(2026, 6, 15), end: d(2026, 6, 18) };
+    const result = applyRangeClick(complete, d(2026, 6, 20));
+    expect(isSameDay(result.start, d(2026, 6, 20))).toBe(true);
+    expect(result.end).toBeNull();
+  });
+});
+
+describe("isWithinRange", () => {
+  const range: DateRange = { start: d(2026, 6, 15), end: d(2026, 6, 18) };
+  it("is true for an interior day", () => {
+    expect(isWithinRange(d(2026, 6, 16), range)).toBe(true);
+  });
+  it("excludes the caps", () => {
+    expect(isWithinRange(d(2026, 6, 15), range)).toBe(false);
+    expect(isWithinRange(d(2026, 6, 18), range)).toBe(false);
+  });
+  it("is false for an incomplete range", () => {
+    expect(isWithinRange(d(2026, 6, 16), { start: d(2026, 6, 15), end: null })).toBe(false);
+  });
+});
+
+describe("isOutOfBounds", () => {
+  const min = d(2026, 6, 10);
+  const max = d(2026, 6, 20);
+  it("flags days before min", () => {
+    expect(isOutOfBounds(d(2026, 6, 9), min, max)).toBe(true);
+  });
+  it("flags days after max", () => {
+    expect(isOutOfBounds(d(2026, 6, 21), min, max)).toBe(true);
+  });
+  it("allows the boundary days", () => {
+    expect(isOutOfBounds(min, min, max)).toBe(false);
+    expect(isOutOfBounds(max, min, max)).toBe(false);
+  });
+  it("is never out of bounds without limits", () => {
+    expect(isOutOfBounds(d(2026, 6, 15))).toBe(false);
+  });
+});
+
+describe("nextFriday", () => {
+  it("returns the same day when already Friday", () => {
+    // June 5, 2026 is a Friday.
+    expect(isSameDay(nextFriday(d(2026, 6, 5)), d(2026, 6, 5))).toBe(true);
+  });
+  it("returns the upcoming Friday otherwise", () => {
+    // June 1, 2026 is a Monday → next Friday is June 5.
+    expect(isSameDay(nextFriday(d(2026, 6, 1)), d(2026, 6, 5))).toBe(true);
+  });
+});
+
+describe("rangePresets", () => {
+  // today = Monday June 1, 2026 → next Friday = June 5.
+  const presets = rangePresets(d(2026, 6, 1));
+
+  it("returns weekend, long-weekend and week presets", () => {
+    expect(presets.map((p) => p.id)).toEqual(["weekend", "long-weekend", "week"]);
+  });
+  it("This weekend spans Fri → Sun", () => {
+    const weekend = presets.find((p) => p.id === "weekend")!;
+    expect(isSameDay(weekend.range.start, d(2026, 6, 5))).toBe(true);
+    expect(isSameDay(weekend.range.end, d(2026, 6, 7))).toBe(true);
+  });
+  it("Long weekend spans Fri → Mon", () => {
+    const long = presets.find((p) => p.id === "long-weekend")!;
+    expect(isSameDay(long.range.start, d(2026, 6, 5))).toBe(true);
+    expect(isSameDay(long.range.end, d(2026, 6, 8))).toBe(true);
+  });
+  it("A week spans Fri → following Fri", () => {
+    const week = presets.find((p) => p.id === "week")!;
+    expect(isSameDay(week.range.start, d(2026, 6, 5))).toBe(true);
+    expect(isSameDay(week.range.end, d(2026, 6, 12))).toBe(true);
+  });
+});

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure calendar helpers for the shared <DatePicker>. Kept free of React so
+ * the selection logic (the tricky part) is unit-testable in isolation.
+ *
+ * All Date values are treated as "local noon" days — callers build them via
+ * parseLocalDate / atNoon so timezone offsets never flip the calendar day.
+ */
+
+/** Normalize any Date to local noon, dropping the time-of-day. */
+export function atNoon(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 12, 0, 0, 0);
+}
+
+/** True when two dates fall on the same local calendar day. */
+export function isSameDay(a: Date | null, b: Date | null): boolean {
+  if (!a || !b) return false;
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/** a < b at day granularity. */
+export function isBeforeDay(a: Date, b: Date): boolean {
+  return atNoon(a).getTime() < atNoon(b).getTime();
+}
+
+/** a > b at day granularity. */
+export function isAfterDay(a: Date, b: Date): boolean {
+  return atNoon(a).getTime() > atNoon(b).getTime();
+}
+
+/** Add `n` calendar days (n may be negative). */
+export function addDays(date: Date, n: number): Date {
+  const d = atNoon(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}
+
+/** Add `n` months, clamping the day to the target month's length. */
+export function addMonths(date: Date, n: number): Date {
+  const d = atNoon(date);
+  const targetMonth = d.getMonth() + n;
+  const target = new Date(d.getFullYear(), targetMonth, 1, 12, 0, 0, 0);
+  const lastDay = new Date(target.getFullYear(), target.getMonth() + 1, 0).getDate();
+  target.setDate(Math.min(d.getDate(), lastDay));
+  return target;
+}
+
+/** Whole nights between two days: (end − start) in days. */
+export function nightsBetween(start: Date, end: Date): number {
+  const ms = atNoon(end).getTime() - atNoon(start).getTime();
+  return Math.round(ms / 86_400_000);
+}
+
+/** First day of the month containing `date`, at local noon. */
+export function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1, 12, 0, 0, 0);
+}
+
+/**
+ * 6×7 grid of days covering the month of `viewDate`, padded with the
+ * trailing days of the previous month and leading days of the next so every
+ * row is full. Weeks start on Sunday. Always 42 cells (6 rows) for a stable
+ * popover height.
+ */
+export function monthMatrix(viewDate: Date): Date[][] {
+  const first = startOfMonth(viewDate);
+  const gridStart = addDays(first, -first.getDay()); // back up to Sunday
+  const weeks: Date[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const row: Date[] = [];
+    for (let d = 0; d < 7; d++) {
+      row.push(addDays(gridStart, w * 7 + d));
+    }
+    weeks.push(row);
+  }
+  return weeks;
+}
+
+export interface DateRange {
+  start: Date | null;
+  end: Date | null;
+}
+
+/**
+ * Range-mode click reducer — the key selection behavior:
+ *   - No start yet, or a complete range already set → begin a new range
+ *     (start = clicked, end cleared).
+ *   - Start set, no end:
+ *       · clicked ≥ start → set end (range complete)
+ *       · clicked < start → reset start to clicked (can't build backwards)
+ */
+export function applyRangeClick(current: DateRange, clicked: Date): DateRange {
+  const day = atNoon(clicked);
+  if (!current.start || current.end) {
+    return { start: day, end: null };
+  }
+  if (isBeforeDay(day, current.start)) {
+    return { start: day, end: null };
+  }
+  return { start: current.start, end: day };
+}
+
+/** True when `day` is between range start/end (exclusive of the caps). */
+export function isWithinRange(day: Date, range: DateRange): boolean {
+  if (!range.start || !range.end) return false;
+  return isAfterDay(day, range.start) && isBeforeDay(day, range.end);
+}
+
+/** True when `day` falls outside an optional [min, max] window (disabled). */
+export function isOutOfBounds(day: Date, min?: Date | null, max?: Date | null): boolean {
+  if (min && isBeforeDay(day, min)) return true;
+  if (max && isAfterDay(day, max)) return true;
+  return false;
+}
+
+/** The upcoming Friday on or after `from` (today by default). */
+export function nextFriday(from: Date): Date {
+  const d = atNoon(from);
+  const delta = (5 - d.getDay() + 7) % 7; // 5 = Friday
+  return addDays(d, delta);
+}
+
+export interface RangePreset {
+  id: string;
+  label: string;
+  range: DateRange;
+}
+
+/**
+ * Quick range presets relative to `today`:
+ *   - This weekend: next Fri → Sun
+ *   - Long weekend: next Fri → Mon
+ *   - A week:       next Fri → following Fri
+ */
+export function rangePresets(today: Date): RangePreset[] {
+  const fri = nextFriday(today);
+  return [
+    { id: "weekend", label: "This weekend", range: { start: fri, end: addDays(fri, 2) } },
+    { id: "long-weekend", label: "Long weekend", range: { start: fri, end: addDays(fri, 3) } },
+    { id: "week", label: "A week", range: { start: fri, end: addDays(fri, 7) } },
+  ];
+}

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -25,6 +25,20 @@ export function parseLocalDate(dateStr: string): Date {
 }
 
 /**
+ * Format a Date back into a YYYY-MM-DD string using its LOCAL calendar
+ * fields (not UTC), the inverse of parseLocalDate. Using toISOString()
+ * here would shift the day backward in western timezones — the same
+ * off-by-one bug parseLocalDate guards against — so we assemble the
+ * string from local getFullYear/getMonth/getDate instead.
+ */
+export function toISODate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
  * Format a YYYY-MM-DD date string for display (e.g. "Jun 15, 2026").
  */
 export function formatDate(


### PR DESCRIPTION
## Summary
- Adds one shared `<DatePicker>` (trigger pill + portaled popover calendar) with **range** and **single** modes, replacing every paired/native `<input type="date">`.
- Pure selection logic lives in `src/lib/calendar.ts` (unit-testable); `toISODate()` is added to `src/lib/dates.ts` as the inverse of `parseLocalDate` so call sites convert between ISO strings and `Date`.
- Tint is fully prop-driven from the DOMAIN lookup (all teal for now), so finalizing colors later reskins every picker.

## Where it's used
| Context | Mode | Domain |
|---|---|---|
| Trip dates (settings) | range | home |
| Lodging stay (check-in → check-out) | range | lodging |
| Agenda day (golf + general) | single | agenda |
| Receipt date — add **and edit** | single | receipts |
| Travel arrival | single | travel |

## Notable details
- **Portaled popover:** the calendar renders through a portal to `<body>` with fixed positioning anchored to the trigger, so it floats above panels with `overflow` (e.g. the Crew YOU card) instead of being clipped. Flips above when there's no room below; repositions on scroll/resize.
- **Travel mode gating:** travel won't persist without a mode, so a date-only entry silently failed to save. The Details / Arriving / Time fields are now disabled until Flying / Driving / Other is selected.
- **Bounding:** Agenda days are bound to the trip window (`min`/`max`). Travel arrival is intentionally left **unbounded** — an arrival before the trip start is a warned-but-allowed case.
- **Only hardcoded color** is `#0d1f1a` for cap text on the accent fill (per spec).

## Not converted (flagging for your call)
`DatePollCard.tsx` (poll date-window) and `DatePickerPanel.tsx` (direct trip-date set) are separate date surfaces outside the five — left as-is pending your decision.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Vitest: 396 passed (incl. 38 new `calendar.test.ts` cases — range reducer, backwards reset, nights, month matrix, out-of-bounds, presets)
- [x] Added a `trip-settings` Playwright spec for the range flow (the file's specs fail locally at the auth-session mock — pre-existing, runs against CI auth setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)