### PR TITLE
Reusable TimePicker component + swap all native time inputs

### DIFF
--- a/e2e/trip-detail.spec.ts
+++ b/e2e/trip-detail.spec.ts
@@ -273,6 +273,31 @@ test.describe("TripDetail — SPEC 2 structure", () => {
     await expect(page.getByTestId("rsvp-out")).toBeVisible();
   });
 
+  test("sets an arrival time with the TimePicker in the YOU-tile travel editor", async ({
+    page,
+  }) => {
+    await setupMocks(page);
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    await page.getByTestId("tab-crew").click();
+
+    // Open the YOU-tile inline travel editor (current user has no travel yet).
+    await page.getByRole("button", { name: "Add your travel" }).click();
+
+    // Time field is gated on a chosen mode — pick Flying to enable it.
+    await page.getByRole("button", { name: "Flying" }).click();
+
+    // Open the TimePicker popover and use a daypart preset.
+    await page.getByText("Select time").click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByText("Evening").click();
+    await dialog.getByRole("button", { name: "Set time" }).click();
+
+    // The trigger now reflects the chosen 6:00 PM evening preset.
+    await expect(page.getByText("6:00 PM")).toBeVisible();
+  });
+
   test("switches to Schedule tab and shows date poll + expenses", async ({
     page,
   }) => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -236,3 +236,12 @@ summary,
 .animate-fade-in {
   animation: fade-in 0.25s ease-out both;
 }
+
+/* Hide scrollbars while keeping scroll behaviour (TimePicker wheels). */
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE/Edge */
+  scrollbar-width: none; /* Firefox */
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none; /* WebKit */
+}

--- a/src/app/trips/[tripId]/components/AddPropertySheet.tsx
+++ b/src/app/trips/[tripId]/components/AddPropertySheet.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
-import { Hotel, Link, MapPin, ImagePlus, X } from "lucide-react";
+import { Hotel, Link, MapPin, ImagePlus, X, Clock } from "lucide-react";
 import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { createClient } from "@/lib/supabase";
 import { DatePicker } from "@/components/DatePicker";
+import { TimePicker } from "@/components/TimePicker";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
 import { parseLocalDate, toISODate } from "@/lib/dates";
+import { parseTime, toTime24 } from "@/lib/time";
 
 // ── Platform detection (exported so parents can use it) ───────────────────
 
@@ -710,23 +712,23 @@ export function AddPropertySheet({
               />
               <div className="grid grid-cols-2 gap-2">
               <Field label="Check-in time">
-                <input
-                  type="time"
-                  value={checkInTimeOfDay}
-                  onChange={(e) => setCheckInTimeOfDay(e.target.value)}
-                  onClick={(e) => e.currentTarget.showPicker?.()}
-                  className={`${inputCls} font-mono tabular-nums`}
-                  style={inputStyle}
+                <TimePicker
+                  icon={<Clock size={15} />}
+                  presets="daypart"
+                  accent={DOMAIN_COLORS.lodging.color}
+                  accentFaint={DOMAIN_COLORS.lodging.faint}
+                  value={parseTime(checkInTimeOfDay)}
+                  onChange={(t) => setCheckInTimeOfDay(toTime24(t))}
                 />
               </Field>
               <Field label="Check-out time">
-                <input
-                  type="time"
-                  value={checkOutTimeOfDay}
-                  onChange={(e) => setCheckOutTimeOfDay(e.target.value)}
-                  onClick={(e) => e.currentTarget.showPicker?.()}
-                  className={`${inputCls} font-mono tabular-nums`}
-                  style={inputStyle}
+                <TimePicker
+                  icon={<Clock size={15} />}
+                  presets="daypart"
+                  accent={DOMAIN_COLORS.lodging.color}
+                  accentFaint={DOMAIN_COLORS.lodging.faint}
+                  value={parseTime(checkOutTimeOfDay)}
+                  onChange={(t) => setCheckOutTimeOfDay(toTime24(t))}
                 />
               </Field>
               </div>

--- a/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
+++ b/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Plus, X, Search, MapPin } from "lucide-react";
+import { Plus, X, Search, MapPin, Flag, Clock } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { ConfirmDeleteButton } from "@/components/ConfirmDeleteButton";
 import { trpc } from "@/lib/trpc-client";
 import { DatePicker } from "@/components/DatePicker";
+import { TimePicker } from "@/components/TimePicker";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
 import { parseLocalDate, toISODate } from "@/lib/dates";
+import { parseTime, toTime24 } from "@/lib/time";
 
 const GOLF_TYPES = ["golf_course"];
 
@@ -729,14 +731,16 @@ export function AddScheduleItemSheet({
                 <div className="space-y-1.5">
                   {teeTimes.map((t, idx) => (
                     <div key={idx} className="flex items-center gap-2">
-                      <input
-                        type="time"
-                        value={t}
-                        onChange={(e) => updateTeeTime(idx, e.target.value)}
-                        onClick={(e) => e.currentTarget.showPicker?.()}
-                        className="flex-1 rounded-xl border px-3 py-2.5 text-sm font-mono tabular-nums outline-none"
-                        style={inputStyle}
-                      />
+                      <div className="flex-1">
+                        <TimePicker
+                          icon={<Flag size={15} />}
+                          presets="tee"
+                          accent={DOMAIN_COLORS.agenda.color}
+                          accentFaint={DOMAIN_COLORS.agenda.faint}
+                          value={parseTime(t)}
+                          onChange={(time) => updateTeeTime(idx, toTime24(time))}
+                        />
+                      </div>
                       {teeTimes.length > 1 && (
                         <button
                           onClick={() => removeTeeTime(idx)}
@@ -910,17 +914,17 @@ export function AddScheduleItemSheet({
                   onChange={(d) => setScheduledDate(d ? toISODate(d) : "")}
                 />
               </div>
-              <div>
+              <div className="w-40">
                 <p className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: "var(--color-bt-text-dim)" }}>
                   Time <span className="font-medium normal-case tracking-normal">(optional)</span>
                 </p>
-                <input
-                  type="time"
-                  value={scheduledTime}
-                  onChange={(e) => setScheduledTime(e.target.value)}
-                  onClick={(e) => e.currentTarget.showPicker?.()}
-                  className="w-32 rounded-xl border px-3 py-2.5 text-sm font-mono tabular-nums outline-none"
-                  style={inputStyle}
+                <TimePicker
+                  icon={<Clock size={15} />}
+                  presets="daypart"
+                  accent={DOMAIN_COLORS.agenda.color}
+                  accentFaint={DOMAIN_COLORS.agenda.faint}
+                  value={parseTime(scheduledTime)}
+                  onChange={(t) => setScheduledTime(toTime24(t))}
                 />
               </div>
             </div>

--- a/src/app/trips/[tripId]/tabs/components/TravelControls.tsx
+++ b/src/app/trips/[tripId]/tabs/components/TravelControls.tsx
@@ -5,8 +5,10 @@ import { AlertTriangle, Car, HelpCircle, Plane } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { DatePicker } from "@/components/DatePicker";
+import { TimePicker } from "@/components/TimePicker";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
 import { parseLocalDate, toISODate } from "@/lib/dates";
+import { parseTime, toTime24 } from "@/lib/time";
 
 /**
  * Shared travel controls for the Crew tab.
@@ -397,23 +399,15 @@ export function TravelFields({
           />
         </div>
         <div style={{ flex: "1 1 100px" }}>
-          <label
-            className="mb-1 block text-[10px] font-bold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Time
-          </label>
-          <input
-            type="time"
-            value={value.arrivalTime}
-            onChange={(e) => onChange({ ...value, arrivalTime: e.target.value })}
+          <TimePicker
+            label="Time"
+            icon={<Plane size={15} />}
+            presets="daypart"
             disabled={!modeSelected}
-            className="w-full rounded-lg border px-2.5 py-1.5 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            style={{
-              background: inputBg,
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
+            accent={DOMAIN_COLORS.travel.color}
+            accentFaint={DOMAIN_COLORS.travel.faint}
+            value={parseTime(value.arrivalTime)}
+            onChange={(t) => onChange({ ...value, arrivalTime: toTime24(t) })}
           />
         </div>
       </div>

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { Clock } from "lucide-react";
+import {
+  formatTime12,
+  DAYPART_PRESETS,
+  TEE_PRESETS,
+  type Period,
+  type TimePreset,
+  type TimeValue,
+} from "@/lib/time";
+
+// ── Props ──────────────────────────────────────────────────────────────────
+
+export type TimePresetKind = "daypart" | "tee" | false;
+
+interface TimePickerProps {
+  /** 12-hour value. null shows the placeholder. */
+  value: TimeValue | null;
+  onChange: (value: TimeValue) => void;
+  /** Domain tint for icon, selected items, center band, focus ring. Default teal. */
+  accent?: string;
+  /** ~0.16-alpha of accent — center band + focus ring. Default accent-faint. */
+  accentFaint?: string;
+  /** Label above the trigger field. */
+  label?: string;
+  /** Leading glyph in the trigger field (domain-colored). */
+  icon?: ReactNode;
+  /** Preset row above the wheels. "daypart" | "tee" | false. Default "daypart". */
+  presets?: TimePresetKind;
+  /** data-testid for the trigger field (E2E). */
+  testId?: string;
+  disabled?: boolean;
+}
+
+// Cap text on the accent fill — the only hard-coded color in this component
+// (per the design spec). Dark ink reads on every domain hue.
+const CAP_TEXT = "#0d1f1a";
+
+// Popover geometry — kept in sync with the dialog's Tailwind width.
+const POPOVER_W = 280;
+const POPOVER_GAP = 8;
+
+// Wheel geometry. The center selection band is BAND_H tall; each item is
+// ITEM_H tall; spacers above/below = (BAND_H − ITEM_H)/2 so the first/last
+// items can scroll to the band's center.
+const ITEM_H = 36;
+const BAND_H = 38;
+const WHEEL_VISIBLE = 5; // odd → one row dead-center
+const WHEEL_H = ITEM_H * WHEEL_VISIBLE;
+const SPACER = (WHEEL_H - ITEM_H) / 2;
+
+const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1–12
+const MINUTES = Array.from({ length: 60 }, (_, i) => i); // 0–59
+const PERIODS: Period[] = ["AM", "PM"];
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Shared time-picker. A trigger pill (matching DatePicker) opens a popover
+ * with three tap-or-scroll wheels (hour · minute · AM/PM). Selection lives in
+ * a draft while open and commits on "Set time". Emits a 12-hour TimeValue —
+ * callers convert to "HH:MM" at the data layer (see lib/time.ts).
+ */
+export function TimePicker({
+  value,
+  onChange,
+  accent = "var(--color-bt-accent)",
+  accentFaint = "var(--color-bt-accent-faint)",
+  label,
+  icon,
+  presets = "daypart",
+  testId,
+  disabled = false,
+}: TimePickerProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+
+  // Draft selection — defaults to noon when opening with no value.
+  const [draft, setDraft] = useState<TimeValue>({ h: 12, m: 0, period: "PM" });
+
+  const presetList: TimePreset[] | null = useMemo(() => {
+    if (presets === "daypart") return DAYPART_PRESETS;
+    if (presets === "tee") return TEE_PRESETS;
+    return null;
+  }, [presets]);
+
+  function handleOpen() {
+    if (disabled) return;
+    setDraft(value ?? { h: 12, m: 0, period: "PM" });
+    setOpen(true);
+  }
+
+  // Close on outside click / Escape. Popover is portaled, so check both refs.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      const target = e.target as Node;
+      const inTrigger = rootRef.current?.contains(target);
+      const inPopover = popoverRef.current?.contains(target);
+      if (!inTrigger && !inPopover) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Position the portaled popover relative to the trigger, flipping above when
+  // there isn't room below. Recomputed on open and on scroll/resize.
+  useLayoutEffect(() => {
+    if (!open) return;
+    function reposition() {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const r = trigger.getBoundingClientRect();
+      const popH = popoverRef.current?.offsetHeight ?? 360;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let left = r.left;
+      if (left + POPOVER_W > vw - POPOVER_GAP) left = vw - POPOVER_W - POPOVER_GAP;
+      if (left < POPOVER_GAP) left = POPOVER_GAP;
+
+      let top = r.bottom + POPOVER_GAP;
+      const fitsBelow = top + popH <= vh - POPOVER_GAP;
+      const fitsAbove = r.top - POPOVER_GAP - popH >= POPOVER_GAP;
+      if (!fitsBelow && fitsAbove) top = r.top - POPOVER_GAP - popH;
+
+      setCoords({ top, left });
+    }
+    reposition();
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open]);
+
+  const triggerText = value ? formatTime12(value) : "";
+
+  function commit() {
+    onChange(draft);
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative" ref={rootRef}>
+      {label && (
+        <label
+          className="mb-1 block text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {label}
+        </label>
+      )}
+
+      {/* ── Trigger pill ──────────────────────────────────────────────── */}
+      <button
+        ref={triggerRef}
+        type="button"
+        data-testid={testId}
+        onClick={() => (open ? setOpen(false) : handleOpen())}
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 rounded-xl border px-3 py-2.5 text-left text-sm outline-none transition-shadow disabled:opacity-50"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          borderColor: open ? accent : "var(--color-bt-border)",
+          color: triggerText ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+          boxShadow: open ? `0 0 0 3px ${accentFaint}` : "none",
+        }}
+      >
+        <span className="flex flex-shrink-0 items-center" style={{ color: accent }}>
+          {icon ?? <Clock size={15} />}
+        </span>
+        <span className="min-w-0 flex-1 truncate tabular-nums">
+          {triggerText || "Select time"}
+        </span>
+        <Clock
+          size={15}
+          className="flex-shrink-0"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        />
+      </button>
+
+      {/* ── Popover wheels (portaled to <body>) ───────────────────────── */}
+      {open && typeof document !== "undefined" && createPortal(
+        <div
+          ref={popoverRef}
+          role="dialog"
+          className="fixed z-[100] w-[280px] rounded-2xl p-3"
+          style={{
+            top: coords?.top ?? -9999,
+            left: coords?.left ?? -9999,
+            visibility: coords ? "visible" : "hidden",
+            background: "var(--color-bt-card-float)",
+            border: "1px solid var(--color-bt-border)",
+            boxShadow: "var(--shadow-floating)",
+          }}
+        >
+          {/* Presets */}
+          {presetList && (
+            <div
+              className={
+                presets === "tee"
+                  ? "mb-3 grid grid-cols-4 gap-1.5"
+                  : "mb-3 flex flex-wrap gap-1.5"
+              }
+            >
+              {presetList.map((p) => (
+                <button
+                  key={p.label}
+                  type="button"
+                  onClick={() => setDraft(p.value)}
+                  className={
+                    presets === "tee"
+                      ? "rounded-lg px-1.5 py-1 text-center font-mono text-[11px] font-semibold"
+                      : "rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                  }
+                  style={{
+                    background: "var(--color-bt-card-raised)",
+                    color: "var(--color-bt-text-dim)",
+                    border: "1px solid var(--color-bt-border)",
+                  }}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Three wheels with a shared center band behind them */}
+          <div className="relative" style={{ height: WHEEL_H }}>
+            {/* Center selection band */}
+            <div
+              className="pointer-events-none absolute inset-x-0 rounded-lg"
+              style={{
+                top: (WHEEL_H - BAND_H) / 2,
+                height: BAND_H,
+                background: accentFaint,
+              }}
+              aria-hidden
+            />
+            <div className="relative grid grid-cols-3">
+              <Wheel
+                items={HOURS}
+                render={(h) => String(h)}
+                selectedIndex={HOURS.indexOf(draft.h)}
+                onSelect={(i) => setDraft((d) => ({ ...d, h: HOURS[i] }))}
+                accent={accent}
+                open={open}
+              />
+              <Wheel
+                items={MINUTES}
+                render={(m) => String(m).padStart(2, "0")}
+                selectedIndex={MINUTES.indexOf(draft.m)}
+                onSelect={(i) => setDraft((d) => ({ ...d, m: MINUTES[i] }))}
+                accent={accent}
+                open={open}
+                mono
+              />
+              <Wheel
+                items={PERIODS}
+                render={(p) => p}
+                selectedIndex={PERIODS.indexOf(draft.period)}
+                onSelect={(i) => setDraft((d) => ({ ...d, period: PERIODS[i] }))}
+                accent={accent}
+                open={open}
+              />
+            </div>
+          </div>
+
+          {/* Footer: live summary + Set time */}
+          <div
+            className="mt-2 flex items-center justify-between gap-2 border-t pt-2.5"
+            style={{ borderColor: "var(--color-bt-border)" }}
+          >
+            <span
+              className="min-w-0 truncate text-xs tabular-nums"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              {formatTime12(draft)}
+            </span>
+            <button
+              type="button"
+              onClick={commit}
+              className="flex-shrink-0 rounded-lg px-3.5 py-1.5 text-xs font-semibold"
+              style={{ background: accent, color: CAP_TEXT }}
+            >
+              Set time
+            </button>
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}
+
+// ── Wheel ────────────────────────────────────────────────────────────────────
+
+interface WheelProps<T> {
+  items: T[];
+  render: (item: T) => string;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  accent: string;
+  open: boolean;
+  mono?: boolean;
+}
+
+/**
+ * One scroll-snap column. Tap an item or scroll/snap it into the center band.
+ * On open and whenever the selected index changes externally (e.g. a preset),
+ * scrollTop is set directly to selectedIndex × ITEM_H (not scrollIntoView, so
+ * sibling wheels and the page don't get dragged around).
+ */
+function Wheel<T>({
+  items,
+  render,
+  selectedIndex,
+  onSelect,
+  accent,
+  open,
+  mono = false,
+}: WheelProps<T>) {
+  const ref = useRef<HTMLDivElement>(null);
+  const scrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync scroll position to the selected index (open + external changes).
+  useLayoutEffect(() => {
+    if (!open) return;
+    const el = ref.current;
+    if (!el || selectedIndex < 0) return;
+    el.scrollTop = selectedIndex * ITEM_H;
+  }, [open, selectedIndex]);
+
+  // After the user stops scrolling, snap-commit the nearest item.
+  function onScroll() {
+    const el = ref.current;
+    if (!el) return;
+    if (scrollTimer.current) clearTimeout(scrollTimer.current);
+    scrollTimer.current = setTimeout(() => {
+      const idx = Math.round(el.scrollTop / ITEM_H);
+      const clamped = Math.max(0, Math.min(items.length - 1, idx));
+      if (clamped !== selectedIndex) onSelect(clamped);
+    }, 90);
+  }
+
+  return (
+    <div
+      ref={ref}
+      onScroll={onScroll}
+      className="no-scrollbar overflow-y-auto overscroll-contain"
+      style={{
+        height: WHEEL_H,
+        scrollSnapType: "y mandatory",
+      }}
+    >
+      <div style={{ height: SPACER }} aria-hidden />
+      {items.map((item, i) => {
+        const selected = i === selectedIndex;
+        return (
+          <button
+            key={i}
+            type="button"
+            onClick={() => onSelect(i)}
+            className={`flex w-full items-center justify-center ${mono ? "font-mono" : ""}`}
+            style={{
+              height: ITEM_H,
+              scrollSnapAlign: "center",
+              color: selected ? accent : "var(--color-bt-text-dim)",
+              fontWeight: selected ? 700 : 400,
+              fontSize: selected ? 15 : 14,
+              opacity: selected ? 1 : 0.55,
+            }}
+          >
+            {render(item)}
+          </button>
+        );
+      })}
+      <div style={{ height: SPACER }} aria-hidden />
+    </div>
+  );
+}

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseTime,
+  toTime24,
+  formatTime12,
+  DAYPART_PRESETS,
+  TEE_PRESETS,
+  type TimeValue,
+} from "./time";
+
+describe("parseTime", () => {
+  it("parses a morning time", () => {
+    expect(parseTime("08:05")).toEqual({ h: 8, m: 5, period: "AM" });
+  });
+
+  it("parses an afternoon time", () => {
+    expect(parseTime("15:42")).toEqual({ h: 3, m: 42, period: "PM" });
+  });
+
+  it("maps midnight to 12 AM", () => {
+    expect(parseTime("00:00")).toEqual({ h: 12, m: 0, period: "AM" });
+  });
+
+  it("maps noon to 12 PM", () => {
+    expect(parseTime("12:00")).toEqual({ h: 12, m: 0, period: "PM" });
+  });
+
+  it("maps 12:30 to 12:30 PM", () => {
+    expect(parseTime("12:30")).toEqual({ h: 12, m: 30, period: "PM" });
+  });
+
+  it("maps 23:59 to 11:59 PM", () => {
+    expect(parseTime("23:59")).toEqual({ h: 11, m: 59, period: "PM" });
+  });
+
+  it("returns null for empty / nullish input", () => {
+    expect(parseTime("")).toBeNull();
+    expect(parseTime(null)).toBeNull();
+    expect(parseTime(undefined)).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseTime("not-a-time")).toBeNull();
+    expect(parseTime("12")).toBeNull();
+    expect(parseTime("24:00")).toBeNull();
+    expect(parseTime("12:60")).toBeNull();
+  });
+});
+
+describe("toTime24", () => {
+  it("converts an AM time", () => {
+    expect(toTime24({ h: 8, m: 5, period: "AM" })).toBe("08:05");
+  });
+
+  it("converts a PM time", () => {
+    expect(toTime24({ h: 3, m: 42, period: "PM" })).toBe("15:42");
+  });
+
+  it("converts 12 AM to midnight", () => {
+    expect(toTime24({ h: 12, m: 0, period: "AM" })).toBe("00:00");
+  });
+
+  it("converts 12 PM to noon", () => {
+    expect(toTime24({ h: 12, m: 0, period: "PM" })).toBe("12:00");
+  });
+
+  it("converts 11:59 PM", () => {
+    expect(toTime24({ h: 11, m: 59, period: "PM" })).toBe("23:59");
+  });
+});
+
+describe("round-trip parseTime ↔ toTime24", () => {
+  const samples = ["00:00", "00:30", "06:15", "11:59", "12:00", "12:45", "15:42", "23:59"];
+  for (const s of samples) {
+    it(`is stable for ${s}`, () => {
+      const v = parseTime(s) as TimeValue;
+      expect(v).not.toBeNull();
+      expect(toTime24(v)).toBe(s);
+    });
+  }
+});
+
+describe("formatTime12", () => {
+  it("formats with zero-padded minutes and un-padded hour", () => {
+    expect(formatTime12({ h: 3, m: 42, period: "PM" })).toBe("3:42 PM");
+    expect(formatTime12({ h: 8, m: 0, period: "AM" })).toBe("8:00 AM");
+    expect(formatTime12({ h: 12, m: 5, period: "AM" })).toBe("12:05 AM");
+  });
+});
+
+describe("presets", () => {
+  it("daypart presets convert to expected 24h strings", () => {
+    expect(DAYPART_PRESETS.map((p) => toTime24(p.value))).toEqual([
+      "08:00",
+      "12:00",
+      "18:00",
+    ]);
+  });
+
+  it("tee presets are all valid times", () => {
+    for (const p of TEE_PRESETS) {
+      expect(parseTime(toTime24(p.value))).toEqual(p.value);
+    }
+  });
+});

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,78 @@
+/**
+ * Time utilities for BuddyTrip.
+ *
+ * The app stores times as "HH:MM" 24-hour strings (e.g. "15:42"). The
+ * TimePicker UI works in a friendlier 12-hour shape — `{ h, m, period }`
+ * with h: 1–12, m: 0–59, period: 'AM' | 'PM'. These helpers convert at the
+ * data-layer boundary so the picker never has to think in 24-hour math.
+ */
+
+export type Period = "AM" | "PM";
+
+export interface TimeValue {
+  /** 1–12 */
+  h: number;
+  /** 0–59 */
+  m: number;
+  period: Period;
+}
+
+/**
+ * Parse an "HH:MM" 24-hour string into a 12-hour TimeValue.
+ * Returns null for empty / malformed input so callers can show a placeholder.
+ */
+export function parseTime(str: string | null | undefined): TimeValue | null {
+  if (!str) return null;
+  const parts = str.split(":");
+  if (parts.length < 2) return null;
+  const h24 = Number(parts[0]);
+  const m = Number(parts[1]);
+  if (!Number.isInteger(h24) || !Number.isInteger(m)) return null;
+  if (h24 < 0 || h24 > 23 || m < 0 || m > 59) return null;
+  const period: Period = h24 >= 12 ? "PM" : "AM";
+  const h = h24 % 12 === 0 ? 12 : h24 % 12;
+  return { h, m, period };
+}
+
+/**
+ * Convert a 12-hour TimeValue into an "HH:MM" 24-hour string for storage.
+ */
+export function toTime24({ h, m, period }: TimeValue): string {
+  let h24 = h % 12; // 12 → 0
+  if (period === "PM") h24 += 12; // 12 PM → 12, 1 PM → 13
+  return `${String(h24).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+/**
+ * Format a 12-hour TimeValue for display (e.g. "3:42 PM"). Minutes are
+ * always zero-padded; the hour is not.
+ */
+export function formatTime12(v: TimeValue): string {
+  return `${v.h}:${String(v.m).padStart(2, "0")} ${v.period}`;
+}
+
+// ── Presets ──────────────────────────────────────────────────────────────
+
+export interface TimePreset {
+  label: string;
+  value: TimeValue;
+}
+
+/** Daypart presets — quick anchors for arrival / agenda start times. */
+export const DAYPART_PRESETS: TimePreset[] = [
+  { label: "Morning", value: { h: 8, m: 0, period: "AM" } },
+  { label: "Noon", value: { h: 12, m: 0, period: "PM" } },
+  { label: "Evening", value: { h: 6, m: 0, period: "PM" } },
+];
+
+/** Common golf tee-time slots (mono grid). */
+export const TEE_PRESETS: TimePreset[] = [
+  { label: "7:00", value: { h: 7, m: 0, period: "AM" } },
+  { label: "7:10", value: { h: 7, m: 10, period: "AM" } },
+  { label: "7:20", value: { h: 7, m: 20, period: "AM" } },
+  { label: "7:30", value: { h: 7, m: 30, period: "AM" } },
+  { label: "8:00", value: { h: 8, m: 0, period: "AM" } },
+  { label: "8:30", value: { h: 8, m: 30, period: "AM" } },
+  { label: "1:00", value: { h: 1, m: 0, period: "PM" } },
+  { label: "1:30", value: { h: 1, m: 30, period: "PM" } },
+];


### PR DESCRIPTION
## Summary
- Adds a shared `<TimePicker>` mirroring the `<DatePicker>` trigger-field + portaled-popover convention: three tap-or-scroll wheels (hour · minute · AM/PM) with a center selection band, daypart/tee presets, and a prop-driven domain tint. Only hardcoded color is `#0d1f1a` for text on accent.
- Adds `lib/time.ts` (`parseTime` / `toTime24` / `formatTime12` + daypart/tee presets) with 24 Vitest cases, keeping 24h↔12h conversion at the data layer — the UI emits a 12-hour `{ h, m, period }` value.
- Swaps **every** `<input type="time">` to `<TimePicker>`, varying only by props per context:
  - **Travel arrival** → plane icon, daypart presets, travel tint (already gated on a chosen mode)
  - **Agenda tee times** → flag icon, tee presets
  - **Agenda start time** → clock icon, daypart presets
  - **Lodging check-in / check-out** → clock icon, daypart presets
- Adds a `no-scrollbar` utility (globals.css) for the wheels.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Vitest: 420 passing (24 new in `time.test.ts`)
- [x] Lint clean on all changed files
- [ ] CI Playwright: new E2E drives the TimePicker through the Crew → YOU-tile travel editor (Evening preset → 6:00 PM). Runs against CI auth setup — local run blocked by the same pre-existing auth-mock limitation that affects the sibling Crew tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)