### PR TITLE
Date poll redesign — stacked cards + single picker surface

### DIFF
--- a/src/app/trips/[tripId]/components/DatesSheet.tsx
+++ b/src/app/trips/[tripId]/components/DatesSheet.tsx
@@ -1,12 +1,27 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { X, CalendarCheck, Users } from "lucide-react";
+import {
+  X,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { DatePickerPanel } from "../tabs/components/DatePickerPanel";
-import { DatePollCard } from "../tabs/components/DatePollCard";
-import { ConfirmDatesModal } from "./ConfirmDatesModal";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
+import {
+  addMonths,
+  applyRangeClick,
+  atNoon,
+  isOutOfBounds,
+  isSameDay,
+  isWithinRange,
+  monthMatrix,
+  nightsBetween,
+  rangePresets,
+  startOfMonth,
+  type DateRange,
+} from "@/lib/calendar";
 import type { TripData } from "../tabs/types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -17,33 +32,22 @@ interface DatesSheetProps {
   tripId: string;
   trip: TripData;
   isOwner: boolean;
-  /**
-   * When provided and the user taps "Manage crew" inside the poll grid,
-   * we hand them off to the Crew tab. Optional — owner-only context.
-   */
-  onTabChange?: (tab: string) => void;
 }
-
-type Mode = "set" | "poll";
 
 // ── Component ────────────────────────────────────────────────────────────
 
 /**
- * DatesSheet — single surface for setting / polling / clearing trip dates.
+ * DatesSheet — explicit "pick dates" surface.
  *
- * Opens from the "Set dates →" / "Polling crew →" / locked-range link in the
- * trip header. Replaces the home-tab DatesPanel (which has been retired with
- * the basic planning stage).
+ * Opens from the "Set dates →" / locked-range link in the trip header.
  *
- *   Mode 1 — Pick dates (default)
- *     Lock dates directly. Pre-filled when dates already locked; offers a
- *     "Clear dates" link in that case. Drops into ConfirmDatesModal when a
- *     date poll exists so the owner can choose to preserve or clear votes.
- *
- *   Mode 2 — Poll the crew
- *     Embeds the existing DatePollCard. Locking a window from the grid
- *     closes the sheet via the same effect that detects dates appearing
- *     in the cache.
+ * Single mode: lock dates directly via the inline FullRangeCalendar.
+ * Pre-filled when dates already locked; offers a "Clear dates" link in
+ * that case. Polling lives entirely on the home tab now (inside
+ * FreshTripGuide → SetDatesFlipCard → DatePollCard) — committing dates
+ * here is an explicit override that kills any active poll (windows,
+ * votes, and the flag), since the owner has consciously chosen to skip
+ * the crew's input.
  *
  * Renders as a centred modal — same fixed-inset overlay treatment used by
  * DatesModal across the rest of the trip detail page (the trip header lives
@@ -56,47 +60,36 @@ export function DatesSheet({
   tripId,
   trip,
   isOwner,
-  onTabChange,
 }: DatesSheetProps) {
   const utils = trpc.useUtils();
 
   const datesLocked = !!(trip.start_date && trip.end_date);
-  const pollMode = !!trip.poll_mode;
+  const pollActiveServer = !!trip.poll_mode;
 
-  // Default mode: poll if a poll is already in flight, otherwise pick.
-  const [mode, setMode] = useState<Mode>(pollMode && !datesLocked ? "poll" : "set");
-  const [pendingStart, setPendingStart] = useState("");
-  const [pendingEnd, setPendingEnd] = useState("");
-  const [showConfirm, setShowConfirm] = useState(false);
+  // Range lives at the sheet level so the calendar can stay a pure
+  // controlled component and the footer Cancel/Save/Clear buttons can
+  // act on the same state. Seed from the trip's saved dates when the
+  // sheet opens.
+  const [range, setRange] = useState<DateRange>(() => ({
+    start: trip.start_date ? atNoon(new Date(trip.start_date)) : null,
+    end: trip.end_date ? atNoon(new Date(trip.end_date)) : null,
+  }));
 
-  // Reset mode whenever the sheet re-opens so the default reflects the
-  // *current* server state (e.g. user opened it, started a poll, closed,
-  // re-opened — the poll mode should be the default now).
+  // Reset the local range each time the sheet opens, so a previous edit
+  // session doesn't persist into the next open. (Mounting once and
+  // toggling visibility is cheaper than remounting; this useEffect runs
+  // exactly when isOpen flips true.)
   useEffect(() => {
     if (isOpen) {
-      setMode(pollMode && !datesLocked ? "poll" : "set");
+      setRange({
+        start: trip.start_date ? atNoon(new Date(trip.start_date)) : null,
+        end: trip.end_date ? atNoon(new Date(trip.end_date)) : null,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   useModalBackButton(isOpen ? onClose : () => {});
-
-  // Fetch the active poll only when needed for the ConfirmDatesModal's
-  // "preserve poll votes" check. tRPC dedupes against the DatePollCard's
-  // identical query in poll mode, so this is free.
-  const { data: poll } = trpc.datePoll.get.useQuery(
-    { tripId },
-    { enabled: isOpen && isOwner && !datesLocked }
-  );
-  const pollWindows = useMemo(
-    () =>
-      (poll?.windows ?? []) as Array<{
-        id: string;
-        start_date: string;
-        end_date: string;
-      }>,
-    [poll?.windows]
-  );
 
   // ── Mutations ──────────────────────────────────────────────────────────
 
@@ -121,9 +114,6 @@ export function DatesSheet({
         utils.trips.getById.setData({ tripId }, ctx.prev);
     },
     onSuccess() {
-      setShowConfirm(false);
-      setPendingStart("");
-      setPendingEnd("");
       onClose();
     },
     onSettled() {
@@ -133,6 +123,10 @@ export function DatesSheet({
     },
   });
 
+  // datePoll.unlock clears trip.start_date / trip.end_date AND removes the
+  // associated date_window if it has no votes — same procedure used by
+  // SetDatesFlipCard's Clear button. Leaves the poll itself untouched so
+  // a re-poll is possible.
   const clearDatesMutation = trpc.datePoll.unlock.useMutation({
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
@@ -141,12 +135,16 @@ export function DatesSheet({
     },
   });
 
-  const setPollActive = trpc.datePoll.setPollMode.useMutation({
-    async onMutate(vars) {
+  // setPollMode({pollMode: false}) is a full wipe — deletes every window,
+  // every vote, closes the poll row, and flips trip.poll_mode = false.
+  // We fire this *before* lockDates whenever the trip has an active poll
+  // so the explicit pick takes precedence over the in-flight crew vote.
+  const endPoll = trpc.datePoll.setPollMode.useMutation({
+    async onMutate() {
       await utils.trips.getById.cancel({ tripId });
       const prev = utils.trips.getById.getData({ tripId });
       utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
-        old ? { ...old, poll_mode: vars.pollMode } : old
+        old ? { ...old, poll_mode: false } : old
       );
       return { prev };
     },
@@ -160,37 +158,86 @@ export function DatesSheet({
     },
   });
 
+  // ── Derived state ──────────────────────────────────────────────────────
+
+  // YYYY-MM-DD using local parts so a UTC-shifted toISOString() doesn't
+  // slip the saved string back a day in non-UTC zones.
+  const localYMD = (d: Date): string => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  };
+
+  const rangeYMD: { start: string | null; end: string | null } = {
+    start: range.start ? localYMD(range.start) : null,
+    end: range.end ? localYMD(range.end) : null,
+  };
+  const rangeValid = !!(range.start && range.end);
+  const rangeEmpty = !range.start && !range.end;
+  const sameAsInitial =
+    rangeYMD.start === (trip.start_date ?? null) &&
+    rangeYMD.end === (trip.end_date ?? null);
+
+  // Save enabled in two cases:
+  //   1. The user picked a complete new (or different) range — we'll
+  //      lockDates.
+  //   2. The user cleared a previously-locked range — we'll unlock so
+  //      the trip drops back to a date-less state. (Empty selection on
+  //      a trip that already had no dates is a no-op, so disabled.)
+  const canSave =
+    !sameAsInitial &&
+    ((rangeValid) || (rangeEmpty && datesLocked));
+
+  const pendingMutation =
+    lockDates.isPending ||
+    endPoll.isPending ||
+    clearDatesMutation.isPending;
+
   // ── Actions ────────────────────────────────────────────────────────────
 
-  /** Called by DatePickerPanel with valid inputs. */
-  const handleDatePickerSave = (start: string, end: string) => {
-    if (pollMode) {
-      // Need ConfirmDatesModal to handle the preserve-or-clear choice.
-      setPendingStart(start);
-      setPendingEnd(end);
-      setShowConfirm(true);
-    } else {
-      // No poll → straight lock.
-      lockDates.mutate({ tripId, startDate: start, endDate: end });
+  const handleSave = async () => {
+    if (!canSave || pendingMutation) return;
+    // Clear path: user emptied a previously-locked range.
+    if (rangeEmpty && datesLocked) {
+      clearDatesMutation.mutate({ tripId }, { onSuccess: onClose });
+      return;
+    }
+    // Lock path: full valid range. End any active poll first — the
+    // explicit pick takes precedence over the in-flight crew vote
+    // (server wipes windows + votes; lockDates pins the dates and
+    // sets trip.poll_mode = false in one row update).
+    //
+    // Sequenced (not concurrent) so endPoll's DELETE of date_windows
+    // can't race with lockDates' INSERT of the new window — a
+    // concurrent run could leave a dangling locked date with no
+    // backing window, and on some races caused lockDates to error
+    // (which kept the modal open because the lockDates.onSuccess
+    // close handler never fired).
+    if (!range.start || !range.end) return;
+    try {
+      if (pollActiveServer) {
+        await endPoll.mutateAsync({ tripId, pollMode: false });
+      }
+      await lockDates.mutateAsync({
+        tripId,
+        startDate: localYMD(range.start),
+        endDate: localYMD(range.end),
+      });
+      onClose();
+    } catch {
+      // Either mutation's onError already rolled back the optimistic
+      // cache write; nothing else to do here except keep the modal
+      // open so the user can retry.
     }
   };
 
-  /** Called by ConfirmDatesModal. */
-  const handleConfirmDates = (preservePoll: boolean) => {
-    if (!pendingStart || !pendingEnd) return;
-    if (pollMode && !preservePoll) {
-      setPollActive.mutate({ tripId, pollMode: false });
-    }
-    lockDates.mutate({
-      tripId,
-      startDate: pendingStart,
-      endDate: pendingEnd,
-    });
-  };
-
-  const handleClearDates = () => {
-    clearDatesMutation.mutate({ tripId });
-    onClose();
+  /** Clear only wipes the local working selection now — committing the
+   *  empty selection via Save is what actually clears the dates on the
+   *  trip row. This keeps Clear and Save in the same explicit "review →
+   *  commit" model as InfoTileModal. */
+  const handleClearSelection = () => {
+    setRange({ start: null, end: null });
   };
 
   if (!isOpen) return null;
@@ -209,193 +256,136 @@ export function DatesSheet({
         <div
           className="w-full max-w-[480px] overflow-hidden rounded-t-2xl sm:rounded-2xl"
           style={{
-            background: "var(--color-bt-card)",
+            // Matches InfoTileModal: card-float surface + the shared
+            // floating shadow token so every "decision" modal in the
+            // app sits on the same raised plane.
+            background: "var(--color-bt-card-float)",
             border: "1px solid var(--color-bt-border)",
-            boxShadow: "0 24px 60px rgba(0,0,0,0.5)",
+            boxShadow: "var(--shadow-floating)",
             maxHeight: "min(85dvh, 720px)",
           }}
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Header */}
-          <div className="flex items-center justify-between px-5 pb-3 pt-5">
-            <p
-              className="text-base font-bold"
-              style={{ color: "var(--color-bt-text)" }}
-            >
-              Trip dates
-            </p>
+          {/* Header — h3 + dim subtitle + 8x8 close button, mirroring
+              the InfoTileModal cadence. */}
+          <div className="flex items-start justify-between gap-3 px-5 pt-4 pb-3">
+            <div className="min-w-0">
+              <h3
+                className="text-base font-semibold"
+                style={{ color: "var(--color-bt-text)" }}
+              >
+                Trip dates
+              </h3>
+              <p
+                className="mt-0.5 text-[12px] leading-snug"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                Lock in when the trip starts and ends. Everything else
+                hangs off these bookends.
+              </p>
+            </div>
             <button
+              type="button"
               onClick={onClose}
-              className="flex h-8 w-8 items-center justify-center rounded-full"
+              aria-label="Close"
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{
                 background: "var(--color-bt-card-raised)",
                 color: "var(--color-bt-text-dim)",
-                border: "none",
-                cursor: "pointer",
               }}
-              aria-label="Close"
             >
-              <X size={14} />
+              <X size={16} />
             </button>
           </div>
 
-          {/* Body — scrollable when content overflows */}
+          {/* Body — scrolls when content overflows. Single mode: pick
+              dates. Polling lives entirely on the home tab now
+              (FreshTripGuide → DatePollCard); committing dates here is
+              an explicit override that ends any in-flight crew vote. */}
           <div
-            className="overflow-y-auto px-5 pb-5"
-            style={{ maxHeight: "calc(85dvh - 70px)" }}
+            className="overflow-y-auto px-5 pb-4"
+            style={{ maxHeight: "calc(85dvh - 180px)" }}
           >
-            {/* Mode toggle. Hidden for non-owners — they only ever see the
-                poll (DatePollCard) since they can't lock dates anyway. */}
-            {isOwner && !datesLocked && (
-              <div
-                className="mb-4 flex overflow-hidden rounded-xl"
-                style={{ border: "1px solid var(--color-bt-border)" }}
-              >
-                <ModeButton
-                  active={mode === "set"}
-                  onClick={() => setMode("set")}
-                  icon={<CalendarCheck size={15} />}
-                  label="Pick dates"
-                />
-                <div
-                  className="w-px self-stretch"
-                  style={{ background: "var(--color-bt-border)" }}
-                />
-                <ModeButton
-                  active={mode === "poll"}
-                  onClick={() => setMode("poll")}
-                  icon={<Users size={15} />}
-                  label="Poll the crew"
-                  badge={pollMode ? "Active" : undefined}
-                />
-              </div>
-            )}
-
-            {/* Pick dates mode */}
-            {mode === "set" && (
-              <PickDatesMode
-                tripId={tripId}
-                datesLocked={datesLocked}
-                startDate={trip.start_date ?? null}
-                endDate={trip.end_date ?? null}
-                isOwner={isOwner}
-                isSaving={lockDates.isPending}
-                isClearing={clearDatesMutation.isPending}
-                onSave={handleDatePickerSave}
-                onSwitchToPoll={() => setMode("poll")}
-                onClear={handleClearDates}
-              />
-            )}
-
-            {/* Poll mode */}
-            {mode === "poll" && (
-              <DatePollCard
-                trip={trip}
-                isOwner={isOwner}
-                onManageCrew={
-                  onTabChange
-                    ? () => {
-                        onClose();
-                        onTabChange("crew");
-                      }
-                    : undefined
-                }
-              />
-            )}
+            <PickDatesMode
+              datesLocked={datesLocked}
+              pollActive={pollActiveServer}
+              isOwner={isOwner}
+              range={range}
+              onRangeChange={setRange}
+            />
           </div>
+
+          {/* Footer — bordered top, Cancel + Save on the right, Clear on
+              the left (only when there's a selection to wipe). Same
+              shape as InfoTileModal. Clear is local-only now: it wipes
+              the working selection. Committing that empty selection via
+              Save is what actually clears the dates on the trip row,
+              keeping intent explicit and reviewable. */}
+          {isOwner && (
+            <div
+              className="flex items-center gap-2 px-5 py-3"
+              style={{ borderTop: "1px solid var(--color-bt-border)" }}
+            >
+              {(range.start || range.end) ? (
+                <button
+                  type="button"
+                  onClick={handleClearSelection}
+                  className="text-[13px] font-medium transition-opacity hover:opacity-80"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                  data-testid="dates-sheet-clear"
+                >
+                  Clear
+                </button>
+              ) : null}
+              <div className="flex-1" />
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg px-3 py-1.5 text-sm transition-colors hover:bg-[var(--color-bt-hover)]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+                data-testid="dates-sheet-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSave || pendingMutation}
+                className="flex items-center gap-2 rounded-lg px-3.5 py-1.5 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+                style={{
+                  background: "var(--color-bt-accent)",
+                  color: "var(--color-bt-on-accent, #0d1f1a)",
+                }}
+                data-testid="dates-sheet-save"
+              >
+                {pendingMutation && <Loader2 size={13} className="animate-spin" />}
+                Save
+              </button>
+            </div>
+          )}
         </div>
       </div>
-
-      {/* Confirmation modal — handles poll-window preserve/clear choice.
-          Rendered as a sibling so it stacks above the sheet. */}
-      {showConfirm && pendingStart && pendingEnd && (
-        <ConfirmDatesModal
-          startDate={pendingStart}
-          endDate={pendingEnd}
-          hasPoll={pollMode}
-          pollWindows={pollWindows}
-          isPending={lockDates.isPending}
-          onConfirm={handleConfirmDates}
-          onCancel={() => setShowConfirm(false)}
-        />
-      )}
     </>
-  );
-}
-
-// ── Mode toggle button ──────────────────────────────────────────────────
-
-function ModeButton({
-  active,
-  onClick,
-  icon,
-  label,
-  badge,
-}: {
-  active: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
-  badge?: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex flex-1 items-center justify-center gap-1.5 py-2.5 text-sm font-medium transition-colors"
-      style={
-        active
-          ? {
-              background: "var(--color-bt-card-float)",
-              color: "var(--color-bt-text)",
-            }
-          : {
-              background: "transparent",
-              color: "var(--color-bt-text-dim)",
-            }
-      }
-    >
-      {icon}
-      {label}
-      {badge && (
-        <span
-          className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide"
-          style={{
-            background: "var(--color-bt-accent)",
-            color: "var(--color-bt-base)",
-          }}
-        >
-          {badge}
-        </span>
-      )}
-    </button>
   );
 }
 
 // ── Pick-dates mode ─────────────────────────────────────────────────────
 
 function PickDatesMode({
-  tripId,
   datesLocked,
-  startDate,
-  endDate,
+  pollActive,
   isOwner,
-  isSaving,
-  isClearing,
-  onSave,
-  onSwitchToPoll,
-  onClear,
+  range,
+  onRangeChange,
 }: {
-  tripId: string;
   datesLocked: boolean;
-  startDate: string | null;
-  endDate: string | null;
+  /** True when trip.poll_mode is set. Surfaces a small warning above the
+   *  picker so the owner knows committing dates here will end the crew's
+   *  in-flight vote. */
+  pollActive: boolean;
   isOwner: boolean;
-  isSaving: boolean;
-  isClearing: boolean;
-  onSave: (start: string, end: string) => void;
-  onSwitchToPoll: () => void;
-  onClear: () => void;
+  range: DateRange;
+  onRangeChange: (r: DateRange) => void;
 }) {
   // Members can't lock dates; show them the locked range read-only.
   if (!isOwner) {
@@ -421,51 +411,233 @@ function PickDatesMode({
 
   return (
     <div className="space-y-3">
-      <DatePickerPanel
-        tripId={tripId}
-        initialStartDate={startDate}
-        initialEndDate={endDate}
-        onSave={onSave}
-        isSaving={isSaving}
-        showDescription={!datesLocked}
-      />
-
-      {/* "Poll the crew instead →" — only when dates aren't locked yet. */}
-      {!datesLocked && (
-        <button
-          type="button"
-          onClick={onSwitchToPoll}
-          className="text-xs font-medium"
+      {/* Poll-active warning — the owner has a crew vote in flight; let
+          them know that committing dates here will end the poll (windows
+          + votes wiped). Polling lives on the home tab (FreshTripGuide
+          → DatePollCard); this modal is the explicit override route. */}
+      {!datesLocked && pollActive && (
+        <div
+          className="rounded-lg px-3 py-2 text-[12px] leading-snug"
           style={{
-            color: "var(--color-bt-accent)",
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-            padding: 0,
+            background: "var(--color-bt-accent-faint)",
+            border: "1px solid var(--color-bt-accent-border)",
+            color: "var(--color-bt-text-dim)",
           }}
         >
-          Poll the crew instead &rarr;
-        </button>
+          <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
+            A date poll is open.
+          </span>{" "}
+          Picking dates here will end the poll and clear the crew&apos;s
+          votes.
+        </div>
       )}
 
-      {/* "Clear dates" — danger-styled link when dates are locked. */}
-      {datesLocked && (
+      {/* Full-size inline calendar — controlled component. State lives at
+          the DatesSheet level so the footer's Cancel/Clear/Save buttons
+          act on the same range. Same round-cap / fill-bar / pill-preset
+          design as the lodging DatePicker. */}
+      <FullRangeCalendar range={range} onRangeChange={onRangeChange} />
+    </div>
+  );
+}
+
+// ── FullRangeCalendar ─────────────────────────────────────────────────────
+//
+// Full-size inline range picker for the DatesSheet's Pick mode. Same
+// design vocabulary as src/components/DatePicker.tsx (round caps with a
+// continuous in-range fill bar behind them, round-pill quick presets,
+// SMTWTFS weekday header, today dot) but rendered inline rather than as
+// a popover. The flip card's compact picker (SetDatesFlipCard's
+// InlineRangeCalendar) uses the same vocabulary at smaller cell sizes;
+// this one runs at DatePicker's ROW_H/CAP_PX so the modal's calendar
+// reads like the lodging picker at native scale.
+
+const FULL_ROW_H = 36;
+const FULL_CAP_PX = 32;
+const FULL_CAP_TEXT = "var(--color-bt-on-accent, #0d1f1a)";
+
+function FullRangeCalendar({
+  range,
+  onRangeChange,
+}: {
+  range: DateRange;
+  onRangeChange: (r: DateRange) => void;
+}) {
+  const today = useMemo(() => atNoon(new Date()), []);
+  const accent = "var(--color-bt-accent)";
+  const accentFaint = "var(--color-bt-accent-faint)";
+
+  // View (the focused month) is local — it's purely presentational state.
+  // Seed from the current selection's start, falling back to today.
+  const [view, setView] = useState<Date>(() =>
+    range.start ? startOfMonth(range.start) : startOfMonth(today),
+  );
+
+  // Hover state for the day cells. Matches src/components/DatePicker.tsx
+  // (the lodging popover) — non-cap, in-bounds days draw a 1px inset
+  // accent ring on hover so the pointer always reads as a primed target.
+  const [hovered, setHovered] = useState<Date | null>(null);
+
+  const matrix = useMemo(() => monthMatrix(view), [view]);
+  const presets = useMemo(() => rangePresets(today), [today]);
+  const nights = range.start && range.end ? nightsBetween(range.start, range.end) : null;
+
+  const monthLabel = view.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const handleDayClick = (day: Date) => {
+    if (isOutOfBounds(day, null, null)) return;
+    onRangeChange(applyRangeClick(range, day));
+  };
+
+  return (
+    <div className="flex flex-col">
+      {/* Presets — round-pill quick selections, matching the lodging
+          DatePicker popover's preset row. */}
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        {presets.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => {
+              onRangeChange(p.range);
+              if (p.range.start) setView(startOfMonth(p.range.start));
+            }}
+            className="rounded-full px-2.5 py-1 text-[11px] font-semibold transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Month nav */}
+      <div className="mb-2 flex items-center justify-between">
         <button
           type="button"
-          onClick={onClear}
-          disabled={isClearing}
-          className="text-xs font-medium disabled:opacity-50"
-          style={{
-            color: "var(--color-bt-danger)",
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-            padding: 0,
-          }}
+          aria-label="Previous month"
+          onClick={() => setView((v) => addMonths(v, -1))}
+          className="flex h-7 w-7 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
         >
-          {isClearing ? "Clearing…" : "Clear dates"}
+          <ChevronLeft size={16} />
         </button>
-      )}
+        <span
+          className="text-sm font-semibold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {monthLabel}
+        </span>
+        <button
+          type="button"
+          aria-label="Next month"
+          onClick={() => setView((v) => addMonths(v, 1))}
+          className="flex h-7 w-7 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      {/* Weekday header */}
+      <div className="grid grid-cols-7">
+        {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
+          <div
+            key={`${d}-${i}`}
+            className="flex h-7 items-center justify-center text-[10px] font-semibold uppercase"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid — round caps with the continuous fill bar behind them.
+          Bar peeks out from under the cap on the side that faces its
+          partner, giving the range a single continuous strip. */}
+      <div className="grid grid-cols-7">
+        {matrix.flat().map((day, idx) => {
+          const inMonth = day.getMonth() === view.getMonth();
+          const isStart = isSameDay(day, range.start);
+          const isEnd = isSameDay(day, range.end);
+          const isCap = isStart || isEnd;
+          const between = isWithinRange(day, range);
+          const hasEnd = !!range.end;
+          const isToday = isSameDay(day, today);
+          const showFill = between || (isStart && hasEnd) || isEnd;
+          return (
+            <div key={idx} className="relative" style={{ height: FULL_ROW_H }}>
+              {showFill && (
+                <div
+                  className="absolute inset-y-1"
+                  style={{
+                    left: isStart ? "50%" : 0,
+                    right: isEnd ? "50%" : 0,
+                    background: accentFaint,
+                  }}
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => handleDayClick(day)}
+                onMouseEnter={() => setHovered(day)}
+                onMouseLeave={() => setHovered(null)}
+                className="relative mx-auto flex items-center justify-center rounded-full text-[13px] transition-colors"
+                style={{
+                  width: FULL_CAP_PX,
+                  height: FULL_CAP_PX,
+                  background: isCap ? accent : "transparent",
+                  color: isCap
+                    ? FULL_CAP_TEXT
+                    : inMonth
+                      ? "var(--color-bt-text)"
+                      : "var(--color-bt-text-dim)",
+                  fontWeight: isCap ? 700 : 400,
+                  opacity: inMonth ? 1 : 0.45,
+                  // Teal 1px inset ring on hover, but only for non-cap
+                  // days (caps already carry the accent fill). Matches
+                  // DatePicker's hover treatment.
+                  boxShadow:
+                    isSameDay(day, hovered) && !isCap
+                      ? `inset 0 0 0 1px ${accent}`
+                      : "none",
+                }}
+                data-testid={`full-day-${day.toISOString().slice(0, 10)}`}
+              >
+                {day.getDate()}
+                {isToday && !isCap && (
+                  <span
+                    className="absolute bottom-1 h-1 w-1 rounded-full"
+                    style={{ background: accent }}
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Status line — quietly echoes the working selection so the user
+          can scan "how many nights am I about to lock in." Commit
+          happens in the modal footer's Save button. */}
+      <p
+        className="mt-2 text-center text-[11px]"
+        style={{ color: "var(--color-bt-text-dim)" }}
+        data-testid="dates-sheet-status"
+      >
+        {nights != null
+          ? `${nights} night${nights === 1 ? "" : "s"}`
+          : range.start
+            ? "Pick an end date"
+            : "Pick a range"}
+      </p>
     </div>
   );
 }

--- a/src/app/trips/[tripId]/components/setup-guide/DismissedEmptyState.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/DismissedEmptyState.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Calendar } from "lucide-react";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+
+// ── DismissedEmptyState ──────────────────────────────────────────────────
+//
+// Shown when the owner has dismissed the FreshTripGuide AND no dates are
+// set. A single clean dashed empty card with one clear path: Set dates.
+// The "Show setup guide" link lets the owner bring the guide back.
+//
+// When dates ARE set we don't render this — the real itinerary bookends
+// from ItineraryView take over, with the "Show setup guide" link sitting
+// above them (ItineraryPanel handles that case).
+
+export function DismissedEmptyState({
+  onSetDates,
+  onRestoreGuide,
+}: {
+  onSetDates: () => void;
+  onRestoreGuide: () => void;
+}) {
+  const tint = DOMAIN_COLORS.home;
+  return (
+    <div className="flex flex-col items-stretch gap-2">
+      <div
+        className="relative flex flex-1 flex-col items-center rounded-xl p-6 text-center"
+        style={{
+          background: "var(--color-bt-base)",
+          border: "1.5px dashed var(--color-bt-border)",
+        }}
+        data-testid="guide-dismissed-empty"
+      >
+        <span
+          className="mb-3 flex h-12 w-12 items-center justify-center rounded-2xl"
+          style={{
+            background: tint.faint,
+            color: tint.color,
+          }}
+          aria-hidden="true"
+        >
+          <Calendar size={22} />
+        </span>
+        <p
+          className="text-sm font-bold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          Your trip, day by day
+        </p>
+        <p
+          className="mt-1 max-w-[300px] text-xs leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Pick or poll a date range and the timeline starts to build itself
+          — lodging check-ins, travel arrivals, and confirmed agenda items
+          weave in automatically.
+        </p>
+        <button
+          type="button"
+          onClick={onSetDates}
+          className="mt-4 rounded-lg px-4 py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+          style={{
+            background: tint.color,
+            color: "var(--color-bt-on-accent, #0d1f1a)",
+          }}
+          data-testid="guide-dismissed-set-dates"
+        >
+          Set dates
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onRestoreGuide}
+        className="self-center text-[11px] transition-opacity hover:opacity-80"
+        style={{ color: "var(--color-bt-text-dim)" }}
+        data-testid="guide-dismissed-restore"
+      >
+        Show setup guide
+      </button>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -25,9 +25,9 @@ import type { TripData } from "../../tabs/types";
 //     eyebrow + "Add what you've got" + the in-progress copy.
 //
 // Below the header, a 4-up responsive grid of step cards (set dates /
-// invite the crew / add lodging / plan the agenda). Every card is the
-// same fixed height as the flipped Set-dates card so nothing jumps when
-// the picker opens.
+// invite the crew / add lodging / plan the agenda). Each card sizes to
+// its own content; the Set Dates card grows in place when the user
+// flips it open to reveal the calendar.
 
 export interface FreshTripGuideProps {
   tripId: string;
@@ -40,11 +40,6 @@ export interface FreshTripGuideProps {
   /** Owner dismissed the guide. */
   onDismiss: () => void;
 }
-
-// Match the flipped Set-dates card height so every step card holds the
-// same shape before AND after the picker opens. Tuned to fit calendar +
-// presets + Save row at the picker's tightest layout.
-const CARD_MIN_H = 420;
 
 export function FreshTripGuide({
   tripId,
@@ -147,7 +142,6 @@ export function FreshTripGuide({
             trip={trip}
             onOpenDatesSheet={onOpenDatesSheet}
             onTabChange={onTabChange}
-            minHeight={CARD_MIN_H}
             pollMode={pollMode}
             onPollExpand={() => setPollMode(true)}
             onPollCancel={() => setPollMode(false)}
@@ -169,7 +163,6 @@ export function FreshTripGuide({
               ctaIcon={<UserPlus size={14} strokeWidth={2} />}
               ctaVariant="ghost"
               onCta={() => onTabChange?.("crew")}
-              minHeight={CARD_MIN_H}
               testId="guide-step-crew"
             />
             <StepCard
@@ -182,7 +175,6 @@ export function FreshTripGuide({
               ctaIcon={<Building2 size={14} strokeWidth={2} />}
               ctaVariant="ghost"
               onCta={() => onTabChange?.("lodging")}
-              minHeight={CARD_MIN_H}
               testId="guide-step-lodging"
             />
             <StepCard
@@ -195,7 +187,6 @@ export function FreshTripGuide({
               ctaIcon={<Flag size={14} strokeWidth={2} />}
               ctaVariant="ghost"
               onCta={() => onTabChange?.("schedule")}
-              minHeight={CARD_MIN_H}
               testId="guide-step-agenda"
             />
           </>

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Building2, Flag, UserPlus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { StepCard } from "./StepCard";
@@ -57,34 +57,15 @@ export function FreshTripGuide({
   const datesSet = !!(trip.start_date && trip.end_date);
   const accent = DOMAIN_COLORS.home.color;
 
-  // Poll-builder takeover: when the user taps "Set up date poll →" on
-  // the dates flip card with ≥2 crew, the Set Dates card expands across
-  // the whole grid and the other three steps hide until the poll is
-  // committed or cancelled.
-  //
-  // The takeover is driven by two signals OR'd together:
-  //   1. trip.poll_mode (server state) — set true by DatePollCard once the
-  //      owner adds their first window, cleared when they lock a window
-  //      or end the poll. Surviving the local state means a poll-in-flight
-  //      stays present after navigation / reload, on the home tab, for
-  //      both the owner and the crew.
-  //   2. localPollMode (UI state) — flips true the moment the owner taps
-  //      "Set up date poll" so the takeover happens immediately, before
-  //      the first window is added. Cleared on cancel.
-  const [localPollMode, setLocalPollMode] = useState(false);
-  const pollMode = !!trip.poll_mode || localPollMode;
-
-  // When the server-side poll flag flips off (poll committed via Lock, or
-  // dates picked from DatesSheet which ends the poll), drop the local
-  // latch too. Without this, an owner who started the poll in this
-  // session would stay on the poll surface forever — localPollMode
-  // remains true even though trip.poll_mode is false, and the OR keeps
-  // pollMode true.
-  useEffect(() => {
-    if (!trip.poll_mode && localPollMode) {
-      setLocalPollMode(false);
-    }
-  }, [trip.poll_mode, localPollMode]);
+  // Poll-builder takeover: derived purely from trip.poll_mode. The
+  // server flag flips true the moment the owner taps "Set up date poll"
+  // — activatePoll's tRPC mutation does an optimistic cache write that
+  // sets trip.poll_mode = true synchronously, so the takeover feels
+  // instant without needing a separate local latch. Clearing follows
+  // the same path: locking a window / cancelling the poll / picking
+  // dates via DatesSheet all set poll_mode = false and the surface
+  // collapses back to the normal grid.
+  const pollMode = !!trip.poll_mode;
 
   // Destination string for the eyebrow + location graphic. Prefer the
   // explicit locked-destination location (semantic geographic string),
@@ -232,13 +213,19 @@ export function FreshTripGuide({
       ) : (
         <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {/* Step 1 — Set dates (flip card; primary CTA) */}
+          {/* SetDatesFlipCard's onPollExpand / onPollCancel are no-ops
+              now — the takeover is purely server-state-driven via
+              activatePoll's optimistic write to trip.poll_mode, which
+              FreshTripGuide reads as `pollMode` and branches on
+              upstream. The callbacks remain on the interface for
+              future "local optimism" flows. */}
           <SetDatesFlipCard
             tripId={tripId}
             trip={trip}
             onTabChange={onTabChange}
             pollMode={false}
-            onPollExpand={() => setLocalPollMode(true)}
-            onPollCancel={() => setLocalPollMode(false)}
+            onPollExpand={() => {}}
+            onPollCancel={() => {}}
           />
           <StepCard
             number={2}

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -69,24 +69,37 @@ export function FreshTripGuide({
         className="relative flex items-start gap-4 pr-10 sm:gap-5"
       >
         <LocationGraphic location={destination} />
-        <div className="min-w-0 flex-1 pt-1">
+        {/* Text block — same typography cadence as the shared TabHeader
+            (see src/components/TabHeader.tsx): 11px accent eyebrow,
+            clamp-scaled semibold headline with -0.015em tracking, 15px
+            body at 1.65 line-height, mb-3 rhythm between each row. */}
+        <div className="min-w-0 flex-1">
           <p
-            className="text-[11px] font-semibold uppercase tracking-[0.10em]"
-            style={{ color: accent }}
+            className="mb-3 text-[11px] font-semibold uppercase"
+            style={{ color: accent, letterSpacing: "0.1em" }}
           >
             {datesSet ? "Get set up" : `New trip · ${destinationUpper}`}
           </p>
           <h2
-            className="mt-1 text-[22px] font-bold leading-tight sm:text-[24px]"
-            style={{ color: "var(--color-bt-text)" }}
+            className="mb-3 font-semibold"
+            style={{
+              color: "var(--color-bt-text)",
+              fontSize: "clamp(20px, 2.8vw, 26px)",
+              lineHeight: 1.15,
+              letterSpacing: "-0.015em",
+            }}
           >
             {datesSet
               ? "Add what you've got"
               : `${destination} — nice pick.`}
           </h2>
           <p
-            className="mt-2 max-w-prose text-[13px] leading-snug"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            className="max-w-prose"
+            style={{
+              color: "var(--color-bt-text-dim)",
+              fontSize: 15,
+              lineHeight: 1.65,
+            }}
           >
             {datesSet
               ? "Add any of these in any order and they weave into one timeline. Dates frame it best — start there if you can — but nothing's blocked until you do."

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -8,38 +8,42 @@ import {
   CrewThumbnail,
   AgendaThumbnail,
 } from "./thumbnails";
+import { LocationGraphic } from "./LocationGraphic";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
 import type { TripData } from "../../tabs/types";
 
 // ── FreshTripGuide ───────────────────────────────────────────────────────
 //
-// The empty-itinerary teaching surface for a fresh trip. Renders an
-// "Itinerary" header (eyebrow + title + dismiss ×) and a 4-up responsive
-// grid of step cards: dates / lodging / crew / agenda. The dates card
-// flips in place to reveal an inline date picker; the other three are
-// launchers to their tab. Steps 2–4 are independent — nothing is gated on
-// dates being set yet, so the owner can add things in any order.
+// Owner's empty-itinerary teaching surface. Two states:
 //
-// Once trip.start_date is locked, the eyebrow flips from "New trip" to
-// "Get set up", the title flips to "Add what you've got", and the dates
-// step renders its done state ("May 26 – Jun 14") — but every step
-// remains as an add-launcher so the guide stays useful through the rest
-// of setup.
+//   No dates yet → welcome header: location graphic on the left,
+//     "NEW TRIP · DESTINATION" eyebrow + "Destination — nice pick." +
+//     a one-sentence welcome on the right.
+//
+//   Dates set    → planning header: same location graphic, "GET SET UP"
+//     eyebrow + "Add what you've got" + the in-progress copy.
+//
+// Below the header, a 4-up responsive grid of step cards (set dates /
+// invite the crew / add lodging / plan the agenda). Every card is the
+// same fixed height as the flipped Set-dates card so nothing jumps when
+// the picker opens.
 
 export interface FreshTripGuideProps {
   tripId: string;
   trip: TripData;
-  /** Opens the existing DatesSheet (used by the dates flip-card's Poll
-   *  branch when ≥2 crew, since the full poll builder lives there). */
+  /** Opens the existing DatesSheet — used by the Poll branch (≥2 crew). */
   onOpenDatesSheet?: () => void;
-  /** Navigate to a tab — drives the Lodging / Crew / Agenda step CTAs and
-   *  the "Add the crew first" redirect in the Poll branch. */
+  /** Navigate to a tab — drives the Lodging / Crew / Agenda CTAs and
+   *  the Poll-branch "Add the crew first" redirect. */
   onTabChange?: (tab: string) => void;
-  /** Owner dismissed the guide. The ItineraryPanel handles what to render
-   *  next (DismissedEmptyState if no dates, real bookends + restore link
-   *  if dates set), so the guide just calls this. */
+  /** Owner dismissed the guide. */
   onDismiss: () => void;
 }
+
+// Match the flipped Set-dates card height so every step card holds the
+// same shape before AND after the picker opens. Tuned to fit calendar +
+// presets + Save row at the picker's tightest layout.
+const CARD_MIN_H = 420;
 
 export function FreshTripGuide({
   tripId,
@@ -49,78 +53,76 @@ export function FreshTripGuide({
   onDismiss,
 }: FreshTripGuideProps) {
   const datesSet = !!(trip.start_date && trip.end_date);
-  const eyebrow = datesSet ? "Get set up" : "New trip";
-  const headline = datesSet
-    ? "Add what you've got"
-    : "Your itinerary builds itself";
+  const accent = DOMAIN_COLORS.home.color;
+
+  // Destination string for the eyebrow + location graphic. Prefer the
+  // explicit locked-destination location (semantic geographic string),
+  // falling back to whatever the trip exposes.
+  const destination =
+    trip.locked_destination_location ?? trip.location ?? trip.title;
+  const destinationUpper = destination?.toUpperCase() ?? "";
 
   return (
-    // Flush — no outer panel. The mock renders the guide directly under the
-    // Itinerary header with full container width so the four step cards
-    // breathe; an extra bordered box just shrinks them.
     <section data-testid="fresh-trip-guide">
-      {/* Header — eyebrow + title + dismiss */}
-      <header className="relative pr-10">
-        <p
-          className="text-[10px] font-semibold uppercase tracking-[0.08em]"
-          style={{ color: DOMAIN_COLORS.home.color }}
-        >
-          {eyebrow}
-        </p>
-        <h2
-          className="mt-1 text-lg font-bold leading-tight"
-          style={{ color: "var(--color-bt-text)" }}
-        >
-          {headline}
-        </h2>
-        <p
-          className="mt-1 text-[12px] leading-snug"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Add any of these in any order and they weave into one timeline.
-          Dates frame it best — start there if you can — but nothing's
-          blocked until you do.
-        </p>
+      {/* ── Welcome / planning header ─────────────────────────────────── */}
+      <header
+        className="relative flex items-start gap-4 pr-10 sm:gap-5"
+      >
+        <LocationGraphic location={destination} />
+        <div className="min-w-0 flex-1 pt-1">
+          <p
+            className="text-[11px] font-semibold uppercase tracking-[0.10em]"
+            style={{ color: accent }}
+          >
+            {datesSet ? "Get set up" : `New trip · ${destinationUpper}`}
+          </p>
+          <h2
+            className="mt-1 text-[22px] font-bold leading-tight sm:text-[24px]"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            {datesSet
+              ? "Add what you've got"
+              : `${destination} — nice pick.`}
+          </h2>
+          <p
+            className="mt-2 text-[13px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {datesSet
+              ? "Add any of these in any order and they weave into one timeline. Dates frame it best — start there if you can — but nothing's blocked until you do."
+              : "That's the hard part done. Now let's build it out — set your dates, add lodging, pull in the crew. Each piece weaves into one day-by-day timeline, in whatever order you like."}
+          </p>
+        </div>
         <button
           type="button"
           onClick={onDismiss}
           aria-label="Dismiss setup guide"
           className="absolute right-0 top-0 inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-          style={{ color: "var(--color-bt-text-dim)" }}
+          style={{
+            color: "var(--color-bt-text-dim)",
+            background: "var(--color-bt-card-raised)",
+            border: "1px solid var(--color-bt-border)",
+          }}
           data-testid="fresh-trip-guide-dismiss"
         >
           <X size={16} />
         </button>
       </header>
 
-      {/* Step grid — 1 col mobile, 2 col tablet, 4 col desktop */}
+      {/* ── Step grid — 1 col mobile, 2 col tablet, 4 col desktop ─────── */}
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {/* Step 1 — Set dates (flip card; owns its own done state) */}
+        {/* Step 1 — Set dates (flip card; primary CTA) */}
         <SetDatesFlipCard
           tripId={tripId}
           trip={trip}
           onOpenDatesSheet={onOpenDatesSheet}
           onTabChange={onTabChange}
+          minHeight={CARD_MIN_H}
         />
 
-        {/* Step 2 — Add lodging (ghost CTA — only step 1 is the
-            attention-grabber) */}
+        {/* Step 2 — Invite the crew (ghost) */}
         <StepCard
           number={2}
-          domain="lodging"
-          title="Add lodging"
-          body="Properties and rooms. Set nightly dates now or once your trip dates land."
-          thumbnail={<LodgingThumbnail />}
-          cta="Add lodging"
-          ctaIcon={<Building2 size={14} strokeWidth={2} />}
-          ctaVariant="ghost"
-          onCta={() => onTabChange?.("lodging")}
-          testId="guide-step-lodging"
-        />
-
-        {/* Step 3 — Invite the crew (ghost) */}
-        <StepCard
-          number={3}
           domain="crew"
           title="Invite the crew"
           body="Add everyone — they join, share travel, and split costs from their phone."
@@ -129,7 +131,23 @@ export function FreshTripGuide({
           ctaIcon={<UserPlus size={14} strokeWidth={2} />}
           ctaVariant="ghost"
           onCta={() => onTabChange?.("crew")}
+          minHeight={CARD_MIN_H}
           testId="guide-step-crew"
+        />
+
+        {/* Step 3 — Add lodging (ghost) */}
+        <StepCard
+          number={3}
+          domain="lodging"
+          title="Add lodging"
+          body="Properties and rooms. Set nightly dates now or once your trip dates land."
+          thumbnail={<LodgingThumbnail />}
+          cta="Add lodging"
+          ctaIcon={<Building2 size={14} strokeWidth={2} />}
+          ctaVariant="ghost"
+          onCta={() => onTabChange?.("lodging")}
+          minHeight={CARD_MIN_H}
+          testId="guide-step-lodging"
         />
 
         {/* Step 4 — Plan the agenda (ghost) */}
@@ -143,6 +161,7 @@ export function FreshTripGuide({
           ctaIcon={<Flag size={14} strokeWidth={2} />}
           ctaVariant="ghost"
           onCta={() => onTabChange?.("schedule")}
+          minHeight={CARD_MIN_H}
           testId="guide-step-agenda"
         />
       </div>

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Building2, Flag, UserPlus, X } from "lucide-react";
+import { Building2, Flag, UserPlus } from "lucide-react";
 import { StepCard } from "./StepCard";
 import { SetDatesFlipCard } from "./SetDatesFlipCard";
 import {
@@ -109,19 +109,17 @@ export function FreshTripGuide({
               : "That's the hard part done. Now let's build it out — set your dates, add lodging, pull in the crew. Each piece weaves into one day-by-day timeline, in whatever order you like."}
           </p>
         </div>
+        {/* Toggle to the itinerary view. Sits in the top-right of the
+            guide; pairs with the "← Setup guide" link rendered by
+            ItineraryView's header when the guide is dismissed. */}
         <button
           type="button"
           onClick={onDismiss}
-          aria-label="Dismiss setup guide"
-          className="absolute right-0 top-0 inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-          style={{
-            color: "var(--color-bt-text-dim)",
-            background: "var(--color-bt-card-raised)",
-            border: "1px solid var(--color-bt-border)",
-          }}
+          className="absolute right-0 top-0 inline-flex items-center gap-1 text-[12px] font-semibold transition-opacity hover:opacity-80"
+          style={{ color: "var(--color-bt-accent)" }}
           data-testid="fresh-trip-guide-dismiss"
         >
-          <X size={16} />
+          View itinerary →
         </button>
       </header>
 

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -87,8 +87,8 @@ export function FreshTripGuide({
   const firstLodging = useMemo(() => {
     const lodgings = (logistics as Array<{
       type?: string | null;
-      property_name?: string | null;
       label?: string | null;
+      property_name?: string | null;
       check_in_time?: string | null;
     }>).filter((l) => l.type === "lodging");
     lodgings.sort((a, b) => {
@@ -102,8 +102,13 @@ export function FreshTripGuide({
     return lodgings[0];
   }, [logistics]);
   const lodgingDone = !!firstLodging;
+  // Read from `label` — AddPropertySheet stores the user-typed title in
+  // the `label` column. `property_name` is misnamed: LodgingPanel writes
+  // the "sleeps" capacity number into it (see LodgingPanel.handleCreate).
+  // Worth a follow-up rename in the schema, but for now `label` is the
+  // right field for "the property's title."
   const lodgingDoneCta =
-    firstLodging?.property_name ?? firstLodging?.label ?? "Lodging added";
+    firstLodging?.label ?? firstLodging?.property_name ?? "Lodging added";
 
   return (
     <section data-testid="fresh-trip-guide">

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -111,16 +111,21 @@ export function FreshTripGuide({
         </div>
         {/* Toggle to the itinerary view. Sits in the top-right of the
             guide; pairs with the "← Setup guide" link rendered by
-            ItineraryView's header when the guide is dismissed. */}
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="absolute right-0 top-0 inline-flex items-center gap-1 text-[12px] font-semibold transition-opacity hover:opacity-80"
-          style={{ color: "var(--color-bt-accent)" }}
-          data-testid="fresh-trip-guide-dismiss"
-        >
-          View itinerary →
-        </button>
+            ItineraryView's header when the guide is dismissed. Only
+            shown once dates are locked — before that there's no
+            itinerary to view, so the link would just lead to an empty
+            state. */}
+        {datesSet && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="absolute right-0 top-0 inline-flex items-center gap-1 text-[12px] font-semibold transition-opacity hover:opacity-80"
+            style={{ color: "var(--color-bt-accent)" }}
+            data-testid="fresh-trip-guide-dismiss"
+          >
+            View itinerary →
+          </button>
+        )}
       </header>
 
       {/* ── Step grid — 1 col mobile, 2 col tablet, 4 col desktop.

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -85,7 +85,7 @@ export function FreshTripGuide({
               : `${destination} — nice pick.`}
           </h2>
           <p
-            className="mt-2 text-[13px] leading-snug"
+            className="mt-2 max-w-prose text-[13px] leading-snug"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             {datesSet

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Building2, Flag, UserPlus, X } from "lucide-react";
 import { StepCard } from "./StepCard";
 import { SetDatesFlipCard } from "./SetDatesFlipCard";
@@ -54,6 +55,13 @@ export function FreshTripGuide({
 }: FreshTripGuideProps) {
   const datesSet = !!(trip.start_date && trip.end_date);
   const accent = DOMAIN_COLORS.home.color;
+
+  // Poll-builder takeover: when the user taps "Set up date poll →" on
+  // the dates flip card with ≥2 crew, the Set Dates card expands across
+  // the whole grid and the other three steps hide until the poll is
+  // committed or cancelled. Starting a poll is a "finish it" task —
+  // splitting attention with the rest of the guide isn't useful.
+  const [pollMode, setPollMode] = useState(false);
 
   // Destination string for the eyebrow + location graphic. Prefer the
   // explicit locked-destination location (semantic geographic string),
@@ -122,61 +130,76 @@ export function FreshTripGuide({
         </button>
       </header>
 
-      {/* ── Step grid — 1 col mobile, 2 col tablet, 4 col desktop ─────── */}
+      {/* ── Step grid — 1 col mobile, 2 col tablet, 4 col desktop.
+              In pollMode the Set Dates card spans the full grid width
+              and the other three steps drop out of the DOM. ─────────── */}
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {/* Step 1 — Set dates (flip card; primary CTA) */}
-        <SetDatesFlipCard
-          tripId={tripId}
-          trip={trip}
-          onOpenDatesSheet={onOpenDatesSheet}
-          onTabChange={onTabChange}
-          minHeight={CARD_MIN_H}
-        />
+        <div
+          className={
+            pollMode
+              ? "sm:col-span-2 lg:col-span-4"
+              : "sm:col-span-1 lg:col-span-1"
+          }
+        >
+          <SetDatesFlipCard
+            tripId={tripId}
+            trip={trip}
+            onOpenDatesSheet={onOpenDatesSheet}
+            onTabChange={onTabChange}
+            minHeight={CARD_MIN_H}
+            pollMode={pollMode}
+            onPollExpand={() => setPollMode(true)}
+            onPollCancel={() => setPollMode(false)}
+          />
+        </div>
 
-        {/* Step 2 — Invite the crew (ghost) */}
-        <StepCard
-          number={2}
-          domain="crew"
-          title="Invite the crew"
-          body="Add everyone — they join, share travel, and split costs from their phone."
-          thumbnail={<CrewThumbnail />}
-          cta="Invite crew"
-          ctaIcon={<UserPlus size={14} strokeWidth={2} />}
-          ctaVariant="ghost"
-          onCta={() => onTabChange?.("crew")}
-          minHeight={CARD_MIN_H}
-          testId="guide-step-crew"
-        />
-
-        {/* Step 3 — Add lodging (ghost) */}
-        <StepCard
-          number={3}
-          domain="lodging"
-          title="Add lodging"
-          body="Properties and rooms. Set nightly dates now or once your trip dates land."
-          thumbnail={<LodgingThumbnail />}
-          cta="Add lodging"
-          ctaIcon={<Building2 size={14} strokeWidth={2} />}
-          ctaVariant="ghost"
-          onCta={() => onTabChange?.("lodging")}
-          minHeight={CARD_MIN_H}
-          testId="guide-step-lodging"
-        />
-
-        {/* Step 4 — Plan the agenda (ghost) */}
-        <StepCard
-          number={4}
-          domain="agenda"
-          title="Plan the agenda"
-          body="Tee times, dinners, side games. Slot them onto days whenever you like."
-          thumbnail={<AgendaThumbnail />}
-          cta="Plan agenda"
-          ctaIcon={<Flag size={14} strokeWidth={2} />}
-          ctaVariant="ghost"
-          onCta={() => onTabChange?.("schedule")}
-          minHeight={CARD_MIN_H}
-          testId="guide-step-agenda"
-        />
+        {/* Steps 2-4 hide while a poll is being built — starting a
+            poll is a "finish it" task; the other steps just split
+            attention. They return on cancel/launch. */}
+        {!pollMode && (
+          <>
+            <StepCard
+              number={2}
+              domain="crew"
+              title="Invite the crew"
+              body="Add everyone — they join, share travel, and split costs from their phone."
+              thumbnail={<CrewThumbnail />}
+              cta="Invite crew"
+              ctaIcon={<UserPlus size={14} strokeWidth={2} />}
+              ctaVariant="ghost"
+              onCta={() => onTabChange?.("crew")}
+              minHeight={CARD_MIN_H}
+              testId="guide-step-crew"
+            />
+            <StepCard
+              number={3}
+              domain="lodging"
+              title="Add lodging"
+              body="Properties and rooms. Set nightly dates now or once your trip dates land."
+              thumbnail={<LodgingThumbnail />}
+              cta="Add lodging"
+              ctaIcon={<Building2 size={14} strokeWidth={2} />}
+              ctaVariant="ghost"
+              onCta={() => onTabChange?.("lodging")}
+              minHeight={CARD_MIN_H}
+              testId="guide-step-lodging"
+            />
+            <StepCard
+              number={4}
+              domain="agenda"
+              title="Plan the agenda"
+              body="Tee times, dinners, side games. Slot them onto days whenever you like."
+              thumbnail={<AgendaThumbnail />}
+              cta="Plan agenda"
+              ctaIcon={<Flag size={14} strokeWidth={2} />}
+              ctaVariant="ghost"
+              onCta={() => onTabChange?.("schedule")}
+              minHeight={CARD_MIN_H}
+              testId="guide-step-agenda"
+            />
+          </>
+        )}
       </div>
     </section>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -9,6 +9,7 @@ import {
   AgendaThumbnail,
 } from "./thumbnails";
 import { formatDateRangeCompact } from "@/lib/dates";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
 import type { TripData } from "../../tabs/types";
 
 // ── FreshTripGuide ───────────────────────────────────────────────────────
@@ -58,19 +59,15 @@ export function FreshTripGuide({
     : undefined;
 
   return (
-    <section
-      className="rounded-2xl p-5"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-      data-testid="fresh-trip-guide"
-    >
+    // Flush — no outer panel. The mock renders the guide directly under the
+    // Itinerary header with full container width so the four step cards
+    // breathe; an extra bordered box just shrinks them.
+    <section data-testid="fresh-trip-guide">
       {/* Header — eyebrow + title + dismiss */}
       <header className="relative pr-10">
         <p
           className="text-[10px] font-semibold uppercase tracking-[0.08em]"
-          style={{ color: "var(--color-bt-accent)" }}
+          style={{ color: DOMAIN_COLORS.home.color }}
         >
           {eyebrow}
         </p>
@@ -84,9 +81,9 @@ export function FreshTripGuide({
           className="mt-1 text-[12px] leading-snug"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
-          {datesSet
-            ? "Lodging, crew, and agenda items feed straight into the timeline below. Tap any step to keep going."
-            : "Tap a step to start. Anything you add — lodging, crew, agenda — weaves into the day-by-day timeline once dates are set."}
+          Add any of these in any order and they weave into one timeline.
+          Dates frame it best — start there if you can — but nothing's
+          blocked until you do.
         </p>
         <button
           type="button"
@@ -117,7 +114,7 @@ export function FreshTripGuide({
           number={2}
           domain="lodging"
           title="Add lodging"
-          body="The houses, rooms, and check-in details. Each property becomes a card in the timeline."
+          body="Houses, rooms, and check-in details. Each property becomes a card in the timeline."
           thumbnail={<LodgingThumbnail />}
           cta="Add a property"
           onCta={() => onTabChange?.("lodging")}

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { X } from "lucide-react";
+import { StepCard } from "./StepCard";
+import { SetDatesFlipCard } from "./SetDatesFlipCard";
+import {
+  LodgingThumbnail,
+  CrewThumbnail,
+  AgendaThumbnail,
+} from "./thumbnails";
+import { formatDateRangeCompact } from "@/lib/dates";
+import type { TripData } from "../../tabs/types";
+
+// ── FreshTripGuide ───────────────────────────────────────────────────────
+//
+// The empty-itinerary teaching surface for a fresh trip. Renders an
+// "Itinerary" header (eyebrow + title + dismiss ×) and a 4-up responsive
+// grid of step cards: dates / lodging / crew / agenda. The dates card
+// flips in place to reveal an inline date picker; the other three are
+// launchers to their tab. Steps 2–4 are independent — nothing is gated on
+// dates being set yet, so the owner can add things in any order.
+//
+// Once trip.start_date is locked, the eyebrow flips from "New trip" to
+// "Get set up", the title flips to "Add what you've got", and the dates
+// step renders its done state ("May 26 – Jun 14") — but every step
+// remains as an add-launcher so the guide stays useful through the rest
+// of setup.
+
+export interface FreshTripGuideProps {
+  tripId: string;
+  trip: TripData;
+  /** Opens the existing DatesSheet (used by the dates flip-card's Poll
+   *  branch when ≥2 crew, since the full poll builder lives there). */
+  onOpenDatesSheet?: () => void;
+  /** Navigate to a tab — drives the Lodging / Crew / Agenda step CTAs and
+   *  the "Add the crew first" redirect in the Poll branch. */
+  onTabChange?: (tab: string) => void;
+  /** Owner dismissed the guide. The ItineraryPanel handles what to render
+   *  next (DismissedEmptyState if no dates, real bookends + restore link
+   *  if dates set), so the guide just calls this. */
+  onDismiss: () => void;
+}
+
+export function FreshTripGuide({
+  tripId,
+  trip,
+  onOpenDatesSheet,
+  onTabChange,
+  onDismiss,
+}: FreshTripGuideProps) {
+  const datesSet = !!(trip.start_date && trip.end_date);
+  const eyebrow = datesSet ? "Get set up" : "New trip";
+  const headline = datesSet
+    ? "Add what you've got"
+    : "Your itinerary builds itself";
+  const datesSummary = datesSet
+    ? formatDateRangeCompact(trip.start_date, trip.end_date)
+    : undefined;
+
+  return (
+    <section
+      className="rounded-2xl p-5"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      data-testid="fresh-trip-guide"
+    >
+      {/* Header — eyebrow + title + dismiss */}
+      <header className="relative pr-10">
+        <p
+          className="text-[10px] font-semibold uppercase tracking-[0.08em]"
+          style={{ color: "var(--color-bt-accent)" }}
+        >
+          {eyebrow}
+        </p>
+        <h2
+          className="mt-1 text-lg font-bold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {headline}
+        </h2>
+        <p
+          className="mt-1 text-[12px] leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {datesSet
+            ? "Lodging, crew, and agenda items feed straight into the timeline below. Tap any step to keep going."
+            : "Tap a step to start. Anything you add — lodging, crew, agenda — weaves into the day-by-day timeline once dates are set."}
+        </p>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss setup guide"
+          className="absolute right-0 top-0 inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+          data-testid="fresh-trip-guide-dismiss"
+        >
+          <X size={16} />
+        </button>
+      </header>
+
+      {/* Step grid — 1 col mobile, 2 col tablet, 4 col desktop */}
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Step 1 — Set dates (flip card) */}
+        <SetDatesFlipCard
+          tripId={tripId}
+          trip={trip}
+          onOpenDatesSheet={onOpenDatesSheet}
+          onTabChange={onTabChange}
+          done={datesSet}
+          doneSummary={datesSummary}
+        />
+
+        {/* Step 2 — Add lodging */}
+        <StepCard
+          number={2}
+          domain="lodging"
+          title="Add lodging"
+          body="The houses, rooms, and check-in details. Each property becomes a card in the timeline."
+          thumbnail={<LodgingThumbnail />}
+          cta="Add a property"
+          onCta={() => onTabChange?.("lodging")}
+          testId="guide-step-lodging"
+        />
+
+        {/* Step 3 — Invite the crew */}
+        <StepCard
+          number={3}
+          domain="crew"
+          title="Invite the crew"
+          body="Add everyone joining. Crew members sign up, RSVP, and share their travel."
+          thumbnail={<CrewThumbnail />}
+          cta="Invite crew"
+          onCta={() => onTabChange?.("crew")}
+          testId="guide-step-crew"
+        />
+
+        {/* Step 4 — Plan the agenda */}
+        <StepCard
+          number={4}
+          domain="agenda"
+          title="Plan the agenda"
+          body="Activities, tee times, dinners. Confirmed items appear on the timeline."
+          thumbnail={<AgendaThumbnail />}
+          cta="Plan something"
+          onCta={() => onTabChange?.("schedule")}
+          testId="guide-step-agenda"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X } from "lucide-react";
+import { Building2, Flag, UserPlus, X } from "lucide-react";
 import { StepCard } from "./StepCard";
 import { SetDatesFlipCard } from "./SetDatesFlipCard";
 import {
@@ -8,7 +8,6 @@ import {
   CrewThumbnail,
   AgendaThumbnail,
 } from "./thumbnails";
-import { formatDateRangeCompact } from "@/lib/dates";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
 import type { TripData } from "../../tabs/types";
 
@@ -54,9 +53,6 @@ export function FreshTripGuide({
   const headline = datesSet
     ? "Add what you've got"
     : "Your itinerary builds itself";
-  const datesSummary = datesSet
-    ? formatDateRangeCompact(trip.start_date, trip.end_date)
-    : undefined;
 
   return (
     // Flush — no outer panel. The mock renders the guide directly under the
@@ -99,48 +95,53 @@ export function FreshTripGuide({
 
       {/* Step grid — 1 col mobile, 2 col tablet, 4 col desktop */}
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {/* Step 1 — Set dates (flip card) */}
+        {/* Step 1 — Set dates (flip card; owns its own done state) */}
         <SetDatesFlipCard
           tripId={tripId}
           trip={trip}
           onOpenDatesSheet={onOpenDatesSheet}
           onTabChange={onTabChange}
-          done={datesSet}
-          doneSummary={datesSummary}
         />
 
-        {/* Step 2 — Add lodging */}
+        {/* Step 2 — Add lodging (ghost CTA — only step 1 is the
+            attention-grabber) */}
         <StepCard
           number={2}
           domain="lodging"
           title="Add lodging"
-          body="Houses, rooms, and check-in details. Each property becomes a card in the timeline."
+          body="Properties and rooms. Set nightly dates now or once your trip dates land."
           thumbnail={<LodgingThumbnail />}
-          cta="Add a property"
+          cta="Add lodging"
+          ctaIcon={<Building2 size={14} strokeWidth={2} />}
+          ctaVariant="ghost"
           onCta={() => onTabChange?.("lodging")}
           testId="guide-step-lodging"
         />
 
-        {/* Step 3 — Invite the crew */}
+        {/* Step 3 — Invite the crew (ghost) */}
         <StepCard
           number={3}
           domain="crew"
           title="Invite the crew"
-          body="Add everyone joining. Crew members sign up, RSVP, and share their travel."
+          body="Add everyone — they join, share travel, and split costs from their phone."
           thumbnail={<CrewThumbnail />}
           cta="Invite crew"
+          ctaIcon={<UserPlus size={14} strokeWidth={2} />}
+          ctaVariant="ghost"
           onCta={() => onTabChange?.("crew")}
           testId="guide-step-crew"
         />
 
-        {/* Step 4 — Plan the agenda */}
+        {/* Step 4 — Plan the agenda (ghost) */}
         <StepCard
           number={4}
           domain="agenda"
           title="Plan the agenda"
-          body="Activities, tee times, dinners. Confirmed items appear on the timeline."
+          body="Tee times, dinners, side games. Slot them onto days whenever you like."
           thumbnail={<AgendaThumbnail />}
-          cta="Plan something"
+          cta="Plan agenda"
+          ctaIcon={<Flag size={14} strokeWidth={2} />}
+          ctaVariant="ghost"
           onCta={() => onTabChange?.("schedule")}
           testId="guide-step-agenda"
         />

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Building2, Flag, UserPlus } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
 import { StepCard } from "./StepCard";
 import { SetDatesFlipCard } from "./SetDatesFlipCard";
 import {
@@ -64,6 +65,45 @@ export function FreshTripGuide({
   const destination =
     trip.locked_destination_location ?? trip.location ?? trip.title;
   const destinationUpper = destination?.toUpperCase() ?? "";
+
+  // ── Done-state derivations for the Crew + Lodging steps ───────────
+  //
+  // Crew:    counts non-owner members. "3 added" type label.
+  // Lodging: first lodging entry sorted by check-in date; CTA shows
+  //          its property_name. Trips can have multiple properties
+  //          (lake house → resort), so we surface the earliest one
+  //          since that's the trip's opening lodging.
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+  const { data: logistics = [] } = trpc.logistics.list.useQuery({ tripId });
+
+  const crewAdded = useMemo(() => {
+    return (members as Array<{ role?: string | null }>).filter(
+      (m) => m.role !== "Owner",
+    ).length;
+  }, [members]);
+  const crewDone = crewAdded > 0;
+  const crewDoneCta = `${crewAdded} added`;
+
+  const firstLodging = useMemo(() => {
+    const lodgings = (logistics as Array<{
+      type?: string | null;
+      property_name?: string | null;
+      label?: string | null;
+      check_in_time?: string | null;
+    }>).filter((l) => l.type === "lodging");
+    lodgings.sort((a, b) => {
+      const ax = a.check_in_time ?? "";
+      const bx = b.check_in_time ?? "";
+      if (!ax && !bx) return 0;
+      if (!ax) return 1;
+      if (!bx) return -1;
+      return ax.localeCompare(bx);
+    });
+    return lodgings[0];
+  }, [logistics]);
+  const lodgingDone = !!firstLodging;
+  const lodgingDoneCta =
+    firstLodging?.property_name ?? firstLodging?.label ?? "Lodging added";
 
   return (
     <section data-testid="fresh-trip-guide">
@@ -166,6 +206,8 @@ export function FreshTripGuide({
               ctaIcon={<UserPlus size={14} strokeWidth={2} />}
               ctaVariant="ghost"
               onCta={() => onTabChange?.("crew")}
+              done={crewDone}
+              doneCta={crewDone ? crewDoneCta : undefined}
               testId="guide-step-crew"
             />
             <StepCard
@@ -178,6 +220,8 @@ export function FreshTripGuide({
               ctaIcon={<Building2 size={14} strokeWidth={2} />}
               ctaVariant="ghost"
               onCta={() => onTabChange?.("lodging")}
+              done={lodgingDone}
+              doneCta={lodgingDone ? lodgingDoneCta : undefined}
               testId="guide-step-lodging"
             />
             <StepCard

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Building2, Flag, UserPlus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { StepCard } from "./StepCard";
 import { SetDatesFlipCard } from "./SetDatesFlipCard";
+import { DatePollCard } from "../../tabs/components/DatePollCard";
 import {
   LodgingThumbnail,
   CrewThumbnail,
@@ -33,7 +34,11 @@ import type { TripData } from "../../tabs/types";
 export interface FreshTripGuideProps {
   tripId: string;
   trip: TripData;
-  /** Opens the existing DatesSheet — used by the Poll branch (≥2 crew). */
+  /** Opens the existing DatesSheet. Kept on the interface for the parent
+   *  (ItineraryPanel) to keep wiring — there's no in-guide consumer
+   *  anymore since the inline poll surface (DatePollCard) replaced the
+   *  hand-off-to-DatesSheet placeholder, but the prop is harmless and
+   *  reserved for future "open the full picker" affordances. */
   onOpenDatesSheet?: () => void;
   /** Navigate to a tab — drives the Lodging / Crew / Agenda CTAs and
    *  the Poll-branch "Add the crew first" redirect. */
@@ -45,7 +50,7 @@ export interface FreshTripGuideProps {
 export function FreshTripGuide({
   tripId,
   trip,
-  onOpenDatesSheet,
+  onOpenDatesSheet: _onOpenDatesSheet,
   onTabChange,
   onDismiss,
 }: FreshTripGuideProps) {
@@ -55,9 +60,31 @@ export function FreshTripGuide({
   // Poll-builder takeover: when the user taps "Set up date poll →" on
   // the dates flip card with ≥2 crew, the Set Dates card expands across
   // the whole grid and the other three steps hide until the poll is
-  // committed or cancelled. Starting a poll is a "finish it" task —
-  // splitting attention with the rest of the guide isn't useful.
-  const [pollMode, setPollMode] = useState(false);
+  // committed or cancelled.
+  //
+  // The takeover is driven by two signals OR'd together:
+  //   1. trip.poll_mode (server state) — set true by DatePollCard once the
+  //      owner adds their first window, cleared when they lock a window
+  //      or end the poll. Surviving the local state means a poll-in-flight
+  //      stays present after navigation / reload, on the home tab, for
+  //      both the owner and the crew.
+  //   2. localPollMode (UI state) — flips true the moment the owner taps
+  //      "Set up date poll" so the takeover happens immediately, before
+  //      the first window is added. Cleared on cancel.
+  const [localPollMode, setLocalPollMode] = useState(false);
+  const pollMode = !!trip.poll_mode || localPollMode;
+
+  // When the server-side poll flag flips off (poll committed via Lock, or
+  // dates picked from DatesSheet which ends the poll), drop the local
+  // latch too. Without this, an owner who started the poll in this
+  // session would stay on the poll surface forever — localPollMode
+  // remains true even though trip.poll_mode is false, and the OR keeps
+  // pollMode true.
+  useEffect(() => {
+    if (!trip.poll_mode && localPollMode) {
+      setLocalPollMode(false);
+    }
+  }, [trip.poll_mode, localPollMode]);
 
   // Destination string for the eyebrow + location graphic. Prefer the
   // explicit locked-destination location (semantic geographic string),
@@ -122,11 +149,22 @@ export function FreshTripGuide({
             clamp-scaled semibold headline with -0.015em tracking, 15px
             body at 1.65 line-height, mb-3 rhythm between each row. */}
         <div className="min-w-0 flex-1">
+          {/* Three-stage header copy. Priority order:
+                pollMode → poll-in-flight ("Now let's lock the dates")
+                datesSet → bookends locked ("Add what you've got")
+                otherwise → fresh trip ("Destination — nice pick.")
+              pollMode wins over datesSet because the only way to be in
+              both states is a race; the poll surface is what's actually
+              showing under the header, so the copy should match it. */}
           <p
             className="mb-3 text-[11px] font-semibold uppercase"
             style={{ color: accent, letterSpacing: "0.1em" }}
           >
-            {datesSet ? "Get set up" : `New trip · ${destinationUpper}`}
+            {pollMode
+              ? "Date poll"
+              : datesSet
+                ? "Get set up"
+                : `New trip · ${destinationUpper}`}
           </p>
           <h2
             className="mb-3 font-semibold"
@@ -137,9 +175,11 @@ export function FreshTripGuide({
               letterSpacing: "-0.015em",
             }}
           >
-            {datesSet
-              ? "Add what you've got"
-              : `${destination} — nice pick.`}
+            {pollMode
+              ? "Now let's lock the dates"
+              : datesSet
+                ? "Add what you've got"
+                : `${destination} — nice pick.`}
           </h2>
           <p
             className="max-w-prose"
@@ -149,9 +189,11 @@ export function FreshTripGuide({
               lineHeight: 1.65,
             }}
           >
-            {datesSet
-              ? "Add any of these in any order and they weave into one timeline. Dates frame it best — start there if you can — but nothing's blocked until you do."
-              : "That's the hard part done. Now let's build it out — set your dates, add lodging, pull in the crew. Each piece weaves into one day-by-day timeline, in whatever order you like."}
+            {pollMode
+              ? "The crew's weighing in on which window works — pick the winner once it's clear. Everything else can fill in around it."
+              : datesSet
+                ? "Add any of these in any order and they weave into one timeline. Dates frame it best — start there if you can — but nothing's blocked until you do."
+                : "That's the hard part done. Now let's build it out — set your dates, add lodging, pull in the crew. Each piece weaves into one day-by-day timeline, in whatever order you like."}
           </p>
         </div>
         {/* Toggle to the itinerary view. Sits in the top-right of the
@@ -173,77 +215,73 @@ export function FreshTripGuide({
         )}
       </header>
 
-      {/* ── Step grid — 1 col mobile, 2 col tablet, 4 col desktop.
-              In pollMode the Set Dates card spans the full grid width
-              and the other three steps drop out of the DOM. ─────────── */}
-      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {/* Step 1 — Set dates (flip card; primary CTA) */}
-        <div
-          className={
-            pollMode
-              ? "sm:col-span-2 lg:col-span-4"
-              : "sm:col-span-1 lg:col-span-1"
-          }
-        >
+      {/* Body — split on pollMode:
+            • Poll active → DatePollCard rendered flush, no outer card
+              chrome, no "Set your dates" header. The FreshTripGuide
+              header up top already announces the poll context ("Now
+              let's lock the dates").
+            • Otherwise → the four-up step grid. */}
+      {pollMode ? (
+        <div className="mt-4">
+          <DatePollCard
+            trip={trip}
+            isOwner
+            onManageCrew={onTabChange ? () => onTabChange("crew") : undefined}
+          />
+        </div>
+      ) : (
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {/* Step 1 — Set dates (flip card; primary CTA) */}
           <SetDatesFlipCard
             tripId={tripId}
             trip={trip}
-            onOpenDatesSheet={onOpenDatesSheet}
             onTabChange={onTabChange}
-            pollMode={pollMode}
-            onPollExpand={() => setPollMode(true)}
-            onPollCancel={() => setPollMode(false)}
+            pollMode={false}
+            onPollExpand={() => setLocalPollMode(true)}
+            onPollCancel={() => setLocalPollMode(false)}
+          />
+          <StepCard
+            number={2}
+            domain="crew"
+            title="Invite the crew"
+            body="Add everyone — they join, share travel, and split costs from their phone."
+            thumbnail={<CrewThumbnail />}
+            cta="Invite crew"
+            ctaIcon={<UserPlus size={14} strokeWidth={2} />}
+            ctaVariant="ghost"
+            onCta={() => onTabChange?.("crew")}
+            done={crewDone}
+            doneCta={crewDone ? crewDoneCta : undefined}
+            testId="guide-step-crew"
+          />
+          <StepCard
+            number={3}
+            domain="lodging"
+            title="Add lodging"
+            body="Properties and rooms. Set nightly dates now or once your trip dates land."
+            thumbnail={<LodgingThumbnail />}
+            cta="Add lodging"
+            ctaIcon={<Building2 size={14} strokeWidth={2} />}
+            ctaVariant="ghost"
+            onCta={() => onTabChange?.("lodging")}
+            done={lodgingDone}
+            doneCta={lodgingDone ? lodgingDoneCta : undefined}
+            testId="guide-step-lodging"
+          />
+          <StepCard
+            number={4}
+            domain="agenda"
+            title="Plan the agenda"
+            body="Tee times, dinners, side games. Slot them onto days whenever you like."
+            thumbnail={<AgendaThumbnail />}
+            cta="Plan agenda"
+            ctaIcon={<Flag size={14} strokeWidth={2} />}
+            ctaVariant="ghost"
+            onCta={() => onTabChange?.("schedule")}
+            testId="guide-step-agenda"
           />
         </div>
-
-        {/* Steps 2-4 hide while a poll is being built — starting a
-            poll is a "finish it" task; the other steps just split
-            attention. They return on cancel/launch. */}
-        {!pollMode && (
-          <>
-            <StepCard
-              number={2}
-              domain="crew"
-              title="Invite the crew"
-              body="Add everyone — they join, share travel, and split costs from their phone."
-              thumbnail={<CrewThumbnail />}
-              cta="Invite crew"
-              ctaIcon={<UserPlus size={14} strokeWidth={2} />}
-              ctaVariant="ghost"
-              onCta={() => onTabChange?.("crew")}
-              done={crewDone}
-              doneCta={crewDone ? crewDoneCta : undefined}
-              testId="guide-step-crew"
-            />
-            <StepCard
-              number={3}
-              domain="lodging"
-              title="Add lodging"
-              body="Properties and rooms. Set nightly dates now or once your trip dates land."
-              thumbnail={<LodgingThumbnail />}
-              cta="Add lodging"
-              ctaIcon={<Building2 size={14} strokeWidth={2} />}
-              ctaVariant="ghost"
-              onCta={() => onTabChange?.("lodging")}
-              done={lodgingDone}
-              doneCta={lodgingDone ? lodgingDoneCta : undefined}
-              testId="guide-step-lodging"
-            />
-            <StepCard
-              number={4}
-              domain="agenda"
-              title="Plan the agenda"
-              body="Tee times, dinners, side games. Slot them onto days whenever you like."
-              thumbnail={<AgendaThumbnail />}
-              cta="Plan agenda"
-              ctaIcon={<Flag size={14} strokeWidth={2} />}
-              ctaVariant="ghost"
-              onCta={() => onTabChange?.("schedule")}
-              testId="guide-step-agenda"
-            />
-          </>
-        )}
-      </div>
+      )}
     </section>
   );
 }

--- a/src/app/trips/[tripId]/components/setup-guide/LocationGraphic.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/LocationGraphic.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { MapPin } from "lucide-react";
+import { getLocationInfo } from "@/lib/locationUtils";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+
+// ── LocationGraphic ──────────────────────────────────────────────────────
+//
+// Stylized destination thumbnail for the FreshTripGuide welcome header.
+// US locations render their state silhouette with a teal pin on the
+// matching city; everywhere else falls back to a centered MapPin glyph.
+// Square tile with a subtle radial glow toward the upper-right so the
+// thumbnail reads as raised on the home surface.
+
+export function LocationGraphic({
+  location,
+  size = 96,
+}: {
+  /** Trip's destination string — e.g. "Bandon, OR" or "Pinehurst, NC". */
+  location: string;
+  /** Square tile size in px. Defaults to 96 (desktop / tablet); the mock
+   *  uses ~110 on phone-portrait. */
+  size?: number;
+}) {
+  const accent = DOMAIN_COLORS.home.color;
+  const accentFaint = DOMAIN_COLORS.home.faint;
+  const { outline, cityPin, showPin, rotation } = getLocationInfo(location);
+
+  return (
+    <div
+      className="relative flex flex-shrink-0 overflow-hidden rounded-2xl"
+      style={{
+        width: size,
+        height: size,
+        background:
+          "radial-gradient(120% 90% at 80% 15%, color-mix(in srgb, var(--color-bt-accent) 14%, transparent) 0%, transparent 70%), var(--color-bt-base)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      aria-hidden="true"
+    >
+      {outline ? (
+        <svg
+          viewBox={outline.viewBox}
+          className="absolute inset-0 h-full w-full p-3"
+          preserveAspectRatio="xMidYMid meet"
+          style={rotation ? { transform: `rotate(${rotation}deg)` } : undefined}
+        >
+          <path
+            d={outline.path}
+            fill="rgba(255,255,255,0.10)"
+            stroke="rgba(255,255,255,0.30)"
+            strokeWidth={1.2}
+          />
+          {showPin && cityPin && (
+            <>
+              {/* Glow halo */}
+              <circle
+                cx={cityPin.x}
+                cy={cityPin.y}
+                r={6}
+                fill={accentFaint}
+              />
+              {/* Pin dot */}
+              <circle
+                cx={cityPin.x}
+                cy={cityPin.y}
+                r={3}
+                fill={accent}
+              />
+            </>
+          )}
+        </svg>
+      ) : (
+        // International / unrecognized fallback — just a centered pin
+        // with the same accent glow.
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          style={{ color: accent }}
+        >
+          <MapPin size={Math.round(size * 0.28)} strokeWidth={1.6} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -215,9 +215,11 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             ? {
                 // Unfilled outline — the done card already carries the
                 // accent-tinted backdrop; a filled button would compete.
+                // Border stays the neutral border token (not accent) so
+                // it reads as a quiet control, not another teal element.
                 background: "transparent",
                 color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-accent-border)",
+                border: "1px solid var(--color-bt-border)",
               }
             : {
                 background: tint.color,

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -350,20 +350,26 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   );
 
   return (
-    <div className="relative" style={{ perspective: 1200, minHeight }}>
+    <div
+      className="relative h-full w-full"
+      style={{ perspective: 1200, minHeight }}
+    >
       <div
-        className="relative h-full w-full"
+        className="absolute inset-0 h-full w-full"
         style={{
           transformStyle: "preserve-3d",
           transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
           transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
-          minHeight,
         }}
         data-testid="guide-step-dates"
       >
-        {/* Front */}
+        {/* Front — absolutely positioned so it stretches to the wrapper's
+            minHeight. Same treatment as the back face; without this, the
+            front face sized to its content (~230px) while the wrapper
+            held the 420px minHeight, so the card looked shorter than its
+            siblings. */}
         <div
-          className="rounded-xl"
+          className="absolute inset-0 rounded-xl"
           style={{
             ...cardSurface,
             backfaceVisibility: "hidden",

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -207,7 +207,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
       <button
         type="button"
         onClick={() => setFlipped(true)}
-        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
+        className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
           datesSet
             ? {

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -417,8 +417,8 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             className="text-[12px] leading-snug"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
-            It's just you so far — invite at least one more person and
-            you can poll everyone for the dates that work.
+            It&rsquo;s just you so far — invite at least one more person
+            and you can poll everyone for the dates that work.
           </p>
           <button
             type="button"

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -6,7 +6,6 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
-  Pencil,
   User,
   UserPlus,
   Vote,
@@ -203,9 +202,12 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           : "Pick a range or poll the crew. Sets the bookends everything else lands between."}
       </p>
 
-      {/* CTA — primary teal for Set dates; ghost for Edit dates.
-          `mt-auto` keeps it pinned to the bottom even if the preview
-          area stops growing. */}
+      {/* Bottom slot — pre-completion this is the filled-accent "Set
+          dates" CTA. Post-completion it becomes a teal confirmation
+          chip ("✓ Set May 22-26") in the same shape as the other
+          cards' CTAs so the row stays visually aligned. The chip is
+          still clickable so editing remains one tap away — the
+          user just gets a positive indicator instead of a hammer. */}
       <button
         type="button"
         onClick={() => setFlipped(true)}
@@ -213,13 +215,9 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         style={
           datesSet
             ? {
-                // Unfilled outline — the done card already carries the
-                // accent-tinted backdrop; a filled button would compete.
-                // Border stays the neutral border token (not accent) so
-                // it reads as a quiet control, not another teal element.
-                background: "transparent",
-                color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-border)",
+                background: tint.faint,
+                color: tint.color,
+                border: `1px solid ${tint.color}`,
               }
             : {
                 background: tint.color,
@@ -229,11 +227,13 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         data-testid={datesSet ? "guide-step-dates-edit" : "guide-step-dates-cta"}
       >
         {datesSet ? (
-          <Pencil size={14} strokeWidth={2} />
+          <Check size={14} strokeWidth={2.6} />
         ) : (
           <Calendar size={14} strokeWidth={2} />
         )}
-        {datesSet ? "Edit dates" : "Set dates"}
+        {datesSet
+          ? `Set ${formatDateRangeCompact(trip.start_date, trip.end_date)}`
+          : "Set dates"}
       </button>
     </div>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -7,7 +7,9 @@ import {
   ChevronLeft,
   ChevronRight,
   Pencil,
-  Users,
+  User,
+  UserPlus,
+  Vote,
   X,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
@@ -296,50 +298,50 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           }
         />
       ) : crewCount < 2 ? (
-        <div className="flex flex-1 flex-col items-start gap-2">
+        // Centered redirect — matches the no-crew Poll-tab mock.
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-2 text-center">
           <span
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full"
+            className="inline-flex h-12 w-12 items-center justify-center rounded-full"
             style={{ background: tint.faint, color: tint.color }}
             aria-hidden="true"
           >
-            <Users size={16} />
+            <User size={22} strokeWidth={1.9} />
           </span>
           <p
-            className="text-[13px] font-semibold leading-tight"
+            className="text-[15px] font-semibold leading-tight"
             style={{ color: "var(--color-bt-text)" }}
           >
             Add the crew first
           </p>
           <p
-            className="text-[11px] leading-snug"
+            className="text-[12px] leading-snug"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
-            Polling needs at least two people — invite the crew, then come
-            back to set up the date poll.
+            It's just you so far — invite at least one more person and
+            you can poll everyone for the dates that work.
           </p>
-          <div className="mt-1 flex flex-col gap-1.5">
-            <button
-              type="button"
-              onClick={() => onTabChange?.("crew")}
-              className="rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
-              style={{
-                background: tint.color,
-                color: "var(--color-bt-on-accent, #0d1f1a)",
-              }}
-              data-testid="guide-dates-poll-invite-crew"
-            >
-              Invite crew
-            </button>
-            <button
-              type="button"
-              onClick={() => setTab("pick")}
-              className="text-[11px] transition-opacity hover:opacity-80"
-              style={{ color: "var(--color-bt-text-dim)" }}
-              data-testid="guide-dates-poll-fallback-pick"
-            >
-              or just pick the dates yourself
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => onTabChange?.("crew")}
+            className="mt-1 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+            style={{
+              background: tint.color,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="guide-dates-poll-invite-crew"
+          >
+            <UserPlus size={14} strokeWidth={2.2} />
+            Invite crew
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("pick")}
+            className="text-[12px] transition-opacity hover:opacity-80"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="guide-dates-poll-fallback-pick"
+          >
+            or just pick the dates yourself
+          </button>
         </div>
       ) : pollMode ? (
         <PollBuilderPlaceholder
@@ -359,15 +361,24 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           }}
         />
       ) : (
-        <div className="flex flex-1 flex-col items-start gap-2">
+        // ≥2 crew — same centered cadence as the no-crew state so the
+        // Poll tab feels like one consistent surface across both modes.
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-2 text-center">
+          <span
+            className="inline-flex h-12 w-12 items-center justify-center rounded-full"
+            style={{ background: tint.faint, color: tint.color }}
+            aria-hidden="true"
+          >
+            <Vote size={22} strokeWidth={1.9} />
+          </span>
           <p
-            className="text-[13px] font-semibold leading-tight"
+            className="text-[15px] font-semibold leading-tight"
             style={{ color: "var(--color-bt-text)" }}
           >
             Poll the crew
           </p>
           <p
-            className="text-[11px] leading-snug"
+            className="text-[12px] leading-snug"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             Propose a few date ranges and the crew votes — pick a
@@ -376,14 +387,24 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           <button
             type="button"
             onClick={() => onPollExpand?.()}
-            className="mt-1 rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
+            className="mt-1 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
             style={{
               background: tint.color,
               color: "var(--color-bt-on-accent, #0d1f1a)",
             }}
             data-testid="guide-dates-poll-launch"
           >
-            Set up date poll →
+            <Vote size={14} strokeWidth={2.2} />
+            Set up date poll
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("pick")}
+            className="text-[12px] transition-opacity hover:opacity-80"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="guide-dates-poll-fallback-pick-withcrew"
+          >
+            or just pick the dates yourself
           </button>
         </div>
       )}

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useState, type FC, type ReactNode } from "react";
+import { Calendar, RotateCcw, Users } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { DatePickerPanel } from "../../tabs/components/DatePickerPanel";
+import { DOMAIN_COLORS } from "@/lib/domainColors";
+import type { TripData } from "../../tabs/types";
+
+// ── SetDatesFlipCard ──────────────────────────────────────────────────────
+//
+// Step 1 of the FreshTripGuide. The card flips in place on tap to reveal a
+// compact Pick / Poll date picker (no navigation). Pick mode uses the same
+// DatePickerPanel as the DatesSheet, so the lock behaviour stays consistent.
+// Poll mode is gated on crew size: under 2 crew the tab shows an
+// "Add the crew first" redirect with an Invite-crew CTA + a quiet
+// "or just pick the dates yourself" link that flips back to Pick. ≥2 crew
+// surfaces a simpler "Set up date poll" hand-off — the full inline poll
+// builder lives in DatesSheet (we route there instead of duplicating it).
+
+export interface SetDatesFlipCardProps {
+  tripId: string;
+  trip: TripData;
+  /** Open the existing DatesSheet — used for the Poll branch (>=2 crew)
+   *  since the full poll builder already lives there. */
+  onOpenDatesSheet?: () => void;
+  /** Navigate to the Crew tab — the "Add the crew first" redirect uses
+   *  this when crew < 2. */
+  onTabChange?: (tab: string) => void;
+  /** Set to true once trip.start_date is locked. Renders the done state
+   *  (no flip; "Change" link replaces the CTA). */
+  done?: boolean;
+  /** Summary shown in the done state, e.g. "May 26 – Jun 14". */
+  doneSummary?: string;
+}
+
+type PickerTab = "pick" | "poll";
+
+const STEP_NUMBER = 1;
+
+export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
+  tripId,
+  trip,
+  onOpenDatesSheet,
+  onTabChange,
+  done = false,
+  doneSummary,
+}) => {
+  const tint = DOMAIN_COLORS.home;
+  const [flipped, setFlipped] = useState(false);
+  const [tab, setTab] = useState<PickerTab>("pick");
+  const utils = trpc.useUtils();
+
+  // Crew count — drives the poll-tab gate. Cheap because HomeTab already
+  // prefetches tripMembers.list at page load.
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+  const crewCount = members.length;
+
+  const lockDates = trpc.trips.lockDates.useMutation({
+    async onMutate(vars) {
+      await utils.trips.getById.cancel({ tripId });
+      const prev = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old
+          ? {
+              ...old,
+              start_date: vars.startDate,
+              end_date: vars.endDate,
+              poll_mode: false,
+            }
+          : old,
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prev);
+    },
+    onSuccess() {
+      // Lock succeeded — flip back so the card shows the done state.
+      setFlipped(false);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+      utils.trips.list.invalidate();
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  const handleSave = (startDate: string, endDate: string) => {
+    lockDates.mutate({ tripId, startDate, endDate });
+  };
+
+  // ── Front face (default) ──────────────────────────────────────────────
+  const front: ReactNode = (
+    <div className="flex h-full flex-col">
+      <div
+        className="mb-3 flex h-20 items-center justify-center overflow-hidden rounded-lg"
+        style={{
+          background: tint.faint,
+          color: tint.color,
+          opacity: done ? 0.55 : 1,
+        }}
+        aria-hidden="true"
+      >
+        <MiniCalendarThumbnail />
+      </div>
+      <p
+        className="text-[13px] font-semibold leading-tight"
+        style={{ color: "var(--color-bt-text)" }}
+      >
+        Set your dates
+      </p>
+      {done && doneSummary ? (
+        <p
+          className="mt-1 text-[12px]"
+          style={{ color: tint.color }}
+        >
+          {doneSummary}
+        </p>
+      ) : (
+        <p
+          className="mt-1 text-[11px] leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Lock a range or poll the crew — bookends the day-by-day timeline.
+        </p>
+      )}
+      <div className="mt-3">
+        {done ? (
+          <button
+            type="button"
+            onClick={() => setFlipped(true)}
+            className="text-[12px] font-medium transition-opacity hover:opacity-80"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="guide-step-dates-change"
+          >
+            Change
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setFlipped(true)}
+            className="w-full rounded-lg py-2 text-[12px] font-semibold transition-opacity hover:opacity-90"
+            style={{
+              background: tint.color,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="guide-step-dates-cta"
+          >
+            Set dates
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  // ── Back face (flipped — picker) ──────────────────────────────────────
+  const back: ReactNode = (
+    <div className="flex h-full flex-col">
+      {/* Tab strip */}
+      <div className="mb-3 inline-flex self-start rounded-lg p-0.5"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {(["pick", "poll"] as const).map((value) => {
+          const active = tab === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setTab(value)}
+              className="rounded-md px-2.5 py-1 text-[11px] font-semibold transition-colors"
+              style={
+                active
+                  ? {
+                      background: tint.faint,
+                      color: tint.color,
+                    }
+                  : {
+                      background: "transparent",
+                      color: "var(--color-bt-text-dim)",
+                    }
+              }
+              data-testid={`guide-dates-tab-${value}`}
+            >
+              {value === "pick" ? "Pick" : "Poll"}
+            </button>
+          );
+        })}
+      </div>
+
+      {tab === "pick" ? (
+        <div className="flex-1">
+          <DatePickerPanel
+            tripId={tripId}
+            initialStartDate={trip.start_date ?? null}
+            initialEndDate={trip.end_date ?? null}
+            onSave={handleSave}
+            isSaving={lockDates.isPending}
+            onCancel={() => setFlipped(false)}
+            showDescription={false}
+          />
+        </div>
+      ) : crewCount < 2 ? (
+        // Poll requires ≥2 crew — show the "add the crew first" redirect.
+        <div className="flex flex-1 flex-col items-start gap-2">
+          <span
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full"
+            style={{
+              background: tint.faint,
+              color: tint.color,
+            }}
+            aria-hidden="true"
+          >
+            <Users size={16} />
+          </span>
+          <p
+            className="text-[13px] font-semibold leading-tight"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            Add the crew first
+          </p>
+          <p
+            className="text-[11px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Polling needs at least two people — invite the crew, then come
+            back to set up the date poll.
+          </p>
+          <div className="mt-2 flex flex-col gap-1.5">
+            <button
+              type="button"
+              onClick={() => onTabChange?.("crew")}
+              className="rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
+              style={{
+                background: tint.color,
+                color: "var(--color-bt-on-accent, #0d1f1a)",
+              }}
+              data-testid="guide-dates-poll-invite-crew"
+            >
+              Invite crew
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab("pick")}
+              className="text-[11px] transition-opacity hover:opacity-80"
+              style={{ color: "var(--color-bt-text-dim)" }}
+              data-testid="guide-dates-poll-fallback-pick"
+            >
+              or just pick the dates yourself
+            </button>
+          </div>
+        </div>
+      ) : (
+        // ≥2 crew — hand off to the existing poll builder in DatesSheet.
+        <div className="flex flex-1 flex-col items-start gap-2">
+          <p
+            className="text-[13px] font-semibold leading-tight"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            Poll the crew
+          </p>
+          <p
+            className="text-[11px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Propose a few date ranges and the crew votes. Set up the
+            options in the dates sheet.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              setFlipped(false);
+              onOpenDatesSheet?.();
+            }}
+            className="mt-2 rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
+            style={{
+              background: tint.color,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="guide-dates-poll-launch"
+          >
+            Set up date poll →
+          </button>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setFlipped(false)}
+        aria-label="Back"
+        className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{ color: "var(--color-bt-text-dim)" }}
+        data-testid="guide-dates-flip-back"
+      >
+        <RotateCcw size={13} />
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="relative" style={{ perspective: 1200 }}>
+      {/* Step number badge — sits above both faces. */}
+      <span
+        className="absolute -top-2 left-3 z-10 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full px-1 text-[10px] font-bold tabular-nums"
+        style={{
+          background: tint.color,
+          color: "var(--color-bt-on-accent, #0d1f1a)",
+        }}
+        aria-hidden="true"
+      >
+        {STEP_NUMBER}
+      </span>
+      <div
+        className="relative w-full"
+        style={{
+          transformStyle: "preserve-3d",
+          transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
+          transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
+        }}
+        data-testid="guide-step-dates"
+      >
+        {/* Front */}
+        <div
+          className="rounded-xl p-4"
+          style={{
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+          }}
+        >
+          {front}
+        </div>
+        {/* Back */}
+        <div
+          className="absolute inset-0 rounded-xl p-4"
+          style={{
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+            transform: "rotateY(180deg)",
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+            overflow: "auto",
+          }}
+        >
+          {back}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── Mini calendar thumbnail (front face) ─────────────────────────────────
+//
+// Tiny stylized 7-column calendar grid — just enough to read as "a calendar"
+// without being literal. The current row highlights the "selected" range.
+
+function MiniCalendarThumbnail() {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <Calendar size={18} strokeWidth={1.8} />
+      <div className="grid grid-cols-7 gap-[3px]">
+        {Array.from({ length: 21 }).map((_, i) => {
+          // Highlight a 5-day range in the middle row.
+          const inRange = i >= 9 && i <= 13;
+          return (
+            <span
+              key={i}
+              className="h-1.5 w-1.5 rounded-[1px]"
+              style={{
+                background: inRange
+                  ? "currentColor"
+                  : "rgba(255,255,255,0.15)",
+                opacity: inRange ? 0.85 : 1,
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -45,20 +45,22 @@ export interface SetDatesFlipCardProps {
   onOpenDatesSheet?: () => void;
   /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect. */
   onTabChange?: (tab: string) => void;
+  /** Card min-height in px. FreshTripGuide passes this so all four step
+   *  cards (this one and the three StepCards) share the same shape. */
+  minHeight?: number;
 }
 
 type PickerTab = "pick" | "poll";
 
 // Compact day cell so a 6-row month fits inside the flipped card.
 const DAY_CELL_PX = 27;
-// Min height when flipped so the picker never has to scroll on its own.
-const FLIPPED_MIN_H = 420;
 
 export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   tripId,
   trip,
   onOpenDatesSheet,
   onTabChange,
+  minHeight,
 }) => {
   const tint = DOMAIN_COLORS.home;
   const [flipped, setFlipped] = useState(false);
@@ -129,10 +131,10 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
 
   // ── Front face (default + done) ──────────────────────────────────────
   const front: ReactNode = (
-    <div className="flex flex-col gap-3 p-3">
+    <div className="flex h-full flex-col gap-3 p-3">
       <div
-        className="flex h-[120px] items-stretch justify-stretch overflow-hidden rounded-lg"
-        style={previewSurface}
+        className="flex flex-1 items-stretch justify-stretch overflow-hidden rounded-lg"
+        style={{ ...previewSurface, minHeight: 120 }}
         aria-hidden="true"
       >
         <CalendarThumbnail accent={tint.color} />
@@ -168,11 +170,13 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           : "Pick a range or poll the crew. Sets the bookends everything else lands between."}
       </p>
 
-      {/* CTA — primary teal for Set dates; ghost for Edit dates */}
+      {/* CTA — primary teal for Set dates; ghost for Edit dates.
+          `mt-auto` keeps it pinned to the bottom even if the preview
+          area stops growing. */}
       <button
         type="button"
         onClick={() => setFlipped(true)}
-        className="flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
         style={
           datesSet
             ? {
@@ -346,14 +350,14 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   );
 
   return (
-    <div className="relative" style={{ perspective: 1200 }}>
+    <div className="relative" style={{ perspective: 1200, minHeight }}>
       <div
-        className="relative w-full"
+        className="relative h-full w-full"
         style={{
           transformStyle: "preserve-3d",
           transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
           transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
-          minHeight: flipped ? FLIPPED_MIN_H : undefined,
+          minHeight,
         }}
         data-testid="guide-step-dates"
       >

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -508,6 +508,31 @@ function InlineRangeCalendar({
   const presets = useMemo(() => rangePresets(today), [today]);
   const nights = range.start && range.end ? nightsBetween(range.start, range.end) : null;
 
+  // Has the user's current selection matched the trip's already-saved
+  // dates? If so we replace the Save row with a confirmation chip —
+  // there's nothing to save until they change something. Compare
+  // against the local YYYY-MM-DD parts so timezone offset (e.g. EDT,
+  // -4h) doesn't shift the Date's .toISOString() back a day on the
+  // trip's saved string.
+  const localYMD = (d: Date): string => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  };
+  const sameAsInitial =
+    !!initialStart &&
+    !!initialEnd &&
+    !!range.start &&
+    !!range.end &&
+    localYMD(range.start) === initialStart &&
+    localYMD(range.end) === initialEnd;
+
+  const initialRangeLabel =
+    initialStart && initialEnd
+      ? formatDateRangeCompact(initialStart, initialEnd)
+      : "";
+
   const monthLabel = view.toLocaleDateString("en-US", {
     month: "long",
     year: "numeric",
@@ -633,45 +658,66 @@ function InlineRangeCalendar({
         })}
       </div>
 
-      <div className="mt-2 flex items-center justify-between gap-2">
-        <span
-          className="text-[10px]"
-          style={{ color: "var(--color-bt-text-dim)" }}
+      {sameAsInitial ? (
+        // Confirmation chip — selection matches what's already saved,
+        // so there's nothing to commit. Same shape as the row's other
+        // CTAs (full-width pill); reads as a positive indicator and
+        // not as an action.
+        <div
+          className="mt-2 flex w-full items-center justify-center gap-2 rounded-md py-1.5 text-[11px] font-semibold"
+          style={{
+            background: accentFaint,
+            color: accent,
+            border: `1px solid ${accent}`,
+          }}
+          data-testid="guide-dates-confirm-chip"
         >
-          {nights != null ? `${nights} night${nights === 1 ? "" : "s"}` : "Pick a range"}
-        </span>
-        <div className="flex items-center gap-1.5">
-          {/* Quiet Clear — only renders when something is selected. Wipes
-              the working range so the user can start over without
-              hunting through months to deselect. */}
-          {(range.start || range.end) && (
+          <Check size={12} strokeWidth={2.6} />
+          Set {initialRangeLabel}
+        </div>
+      ) : (
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <span
+            className="text-[10px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {nights != null
+              ? `${nights} night${nights === 1 ? "" : "s"}`
+              : "Pick a range"}
+          </span>
+          <div className="flex items-center gap-1.5">
+            {/* Quiet Clear — only renders when something is selected.
+                Wipes the working range so the user can start over
+                without hunting through months to deselect. */}
+            {(range.start || range.end) && (
+              <button
+                type="button"
+                onClick={() => setRange({ start: null, end: null })}
+                className="rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+                data-testid="guide-dates-clear"
+              >
+                Clear
+              </button>
+            )}
             <button
               type="button"
-              onClick={() => setRange({ start: null, end: null })}
-              className="rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
-              style={{ color: "var(--color-bt-text-dim)" }}
-              data-testid="guide-dates-clear"
+              disabled={!canSave || saving}
+              onClick={() => {
+                if (canSave) onSave(range.start!, range.end!);
+              }}
+              className="rounded-md px-3 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+              style={{
+                background: accent,
+                color: "var(--color-bt-on-accent, #0d1f1a)",
+              }}
+              data-testid="guide-dates-save"
             >
-              Clear
+              {saving ? "Saving…" : "Set dates"}
             </button>
-          )}
-          <button
-            type="button"
-            disabled={!canSave || saving}
-            onClick={() => {
-              if (canSave) onSave(range.start!, range.end!);
-            }}
-            className="rounded-md px-3 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
-            style={{
-              background: accent,
-              color: "var(--color-bt-on-accent, #0d1f1a)",
-            }}
-            data-testid="guide-dates-save"
-          >
-            {saving ? "Saving…" : "Set dates"}
-          </button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -41,13 +41,24 @@ import type { TripData } from "../../tabs/types";
 export interface SetDatesFlipCardProps {
   tripId: string;
   trip: TripData;
-  /** Opens the existing DatesSheet — used by the Poll branch (≥2 crew). */
+  /** Opens the existing DatesSheet — only used as a deep fallback if the
+   *  parent decides not to handle pollMode itself. With the inline poll
+   *  builder we now expand the card in place via onPollExpand. */
   onOpenDatesSheet?: () => void;
   /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect. */
   onTabChange?: (tab: string) => void;
   /** Card min-height in px. FreshTripGuide passes this so all four step
    *  cards (this one and the three StepCards) share the same shape. */
   minHeight?: number;
+  /** True when the parent has expanded this card to span the whole grid
+   *  so the poll builder has room to grow horizontally. The card stays
+   *  flipped to its back face while this is on. */
+  pollMode?: boolean;
+  /** Called when the user taps "Set up date poll →" with ≥2 crew. The
+   *  parent flips pollMode on and re-renders the grid full-width. */
+  onPollExpand?: () => void;
+  /** Cancels poll mode and returns the parent to the regular 4-up grid. */
+  onPollCancel?: () => void;
 }
 
 type PickerTab = "pick" | "poll";
@@ -61,9 +72,16 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   onOpenDatesSheet,
   onTabChange,
   minHeight,
+  pollMode = false,
+  onPollExpand,
+  onPollCancel,
 }) => {
   const tint = DOMAIN_COLORS.home;
+  // While pollMode is on, the card stays on its back face — the parent
+  // has already widened the column, so flipping back to the front face
+  // mid-poll would just show a stretched-out Set Dates card.
   const [flipped, setFlipped] = useState(false);
+  const showBack = flipped || pollMode;
   const [tab, setTab] = useState<PickerTab>("pick");
   const utils = trpc.useUtils();
 
@@ -214,7 +232,12 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         </p>
         <button
           type="button"
-          onClick={() => setFlipped(false)}
+          onClick={() => {
+            // Always cancel pollMode if active, so the parent collapses
+            // the card back to its column; then flip back to the front.
+            if (pollMode) onPollCancel?.();
+            setFlipped(false);
+          }}
           aria-label="Close picker"
           className="inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
           style={{ color: "var(--color-bt-text-dim)" }}
@@ -224,7 +247,10 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         </button>
       </div>
 
-      {/* Pick / Poll tabs — full width segmented control */}
+      {/* Pick / Poll tabs — full width segmented control. Hidden once
+          the parent has committed to pollMode; the builder is a
+          single-purpose surface and tab-switching mid-build is noise. */}
+      {!pollMode && (
       <div
         className="mb-2 grid grid-cols-2 rounded-lg p-0.5"
         style={{
@@ -252,8 +278,9 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           );
         })}
       </div>
+      )}
 
-      {tab === "pick" ? (
+      {tab === "pick" && !pollMode ? (
         <InlineRangeCalendar
           initialStart={trip.start_date ?? null}
           initialEnd={trip.end_date ?? null}
@@ -314,6 +341,23 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             </button>
           </div>
         </div>
+      ) : pollMode ? (
+        <PollBuilderPlaceholder
+          accent={tint.color}
+          accentFaint={tint.faint}
+          onCancel={() => {
+            onPollCancel?.();
+            // When the parent collapses the card back to its column,
+            // we also flip back to the front face so the next open
+            // starts clean.
+            setFlipped(false);
+          }}
+          onOpenSheet={() => {
+            onPollCancel?.();
+            setFlipped(false);
+            onOpenDatesSheet?.();
+          }}
+        />
       ) : (
         <div className="flex flex-1 flex-col items-start gap-2">
           <p
@@ -326,15 +370,12 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             className="text-[11px] leading-snug"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
-            Propose a few date ranges and the crew votes. Set up the
-            options in the dates sheet.
+            Propose a few date ranges and the crew votes — pick a
+            window, add a few more, then launch.
           </p>
           <button
             type="button"
-            onClick={() => {
-              setFlipped(false);
-              onOpenDatesSheet?.();
-            }}
+            onClick={() => onPollExpand?.()}
             className="mt-1 rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
             style={{
               background: tint.color,
@@ -358,10 +399,11 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         className="absolute inset-0 h-full w-full"
         style={{
           transformStyle: "preserve-3d",
-          transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
+          transform: showBack ? "rotateY(180deg)" : "rotateY(0deg)",
           transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
         }}
         data-testid="guide-step-dates"
+        data-pollmode={pollMode ? "true" : "false"}
       >
         {/* Front — absolutely positioned so it stretches to the wrapper's
             minHeight. Same treatment as the back face; without this, the
@@ -575,6 +617,153 @@ function InlineRangeCalendar({
         >
           {saving ? "Saving…" : "Set dates"}
         </button>
+      </div>
+    </div>
+  );
+}
+
+// ── PollBuilderPlaceholder ───────────────────────────────────────────────
+//
+// First-cut inline poll builder rendered when the parent grid has
+// expanded the Set Dates card to full width. Lays out a two-column row:
+// the same InlineRangeCalendar on the left for picking a date range +
+// a proposed-ranges rail on the right that grows horizontally as the
+// user adds windows. Launch + Cancel sit in the footer. The polished
+// design lands once the reference screenshot is back in play — this
+// placeholder proves the layout (card expansion + horizontal growth)
+// works and offers a working hand-off to the existing DatesSheet so
+// the underlying feature stays usable while the inline build matures.
+
+function PollBuilderPlaceholder({
+  accent,
+  accentFaint,
+  onCancel,
+  onOpenSheet,
+}: {
+  accent: string;
+  accentFaint: string;
+  onCancel: () => void;
+  onOpenSheet: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col gap-3" data-testid="poll-builder">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p
+            className="text-[14px] font-semibold leading-tight"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            Set up the date poll
+          </p>
+          <p
+            className="mt-1 text-[12px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Propose a few windows the crew can vote on. Add another date
+            range to the right — the rail grows as you go.
+          </p>
+        </div>
+      </div>
+
+      {/* Inline builder canvas — left calendar / right proposed-ranges
+          rail. Right side scrolls horizontally as proposals exceed the
+          available width. */}
+      <div
+        className="flex flex-1 gap-3 overflow-hidden rounded-lg"
+        style={{
+          background: "var(--color-bt-base)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        <div
+          className="flex w-[280px] flex-shrink-0 items-center justify-center p-4 text-center"
+          style={{ borderRight: "1px solid var(--color-bt-border)" }}
+        >
+          <p
+            className="text-[12px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            The inline calendar lives here.
+            <br />
+            Pick a range and add it as a proposal.
+          </p>
+        </div>
+        <div className="flex flex-1 items-center gap-3 overflow-x-auto p-3">
+          {[1, 2, 3].map((n) => (
+            <div
+              key={n}
+              className="flex h-full w-[170px] flex-shrink-0 flex-col items-center justify-center rounded-md text-center"
+              style={{
+                background: "var(--color-bt-card)",
+                border: `1px dashed ${accent}`,
+              }}
+            >
+              <p
+                className="text-[11px] uppercase tracking-[0.08em]"
+                style={{ color: accent }}
+              >
+                Proposal {n}
+              </p>
+              <p
+                className="mt-1 text-[12px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                — pending —
+              </p>
+            </div>
+          ))}
+          <button
+            type="button"
+            className="flex h-full w-[120px] flex-shrink-0 flex-col items-center justify-center rounded-md text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-card-raised)]"
+            style={{
+              border: `1px dashed var(--color-bt-border)`,
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            + Add another
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+          data-testid="poll-builder-cancel"
+        >
+          Cancel
+        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onOpenSheet}
+            className="rounded-lg px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{
+              color: "var(--color-bt-text-dim)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+            data-testid="poll-builder-handoff"
+          >
+            Open in dates sheet
+          </button>
+          <button
+            type="button"
+            disabled
+            className="rounded-lg px-3 py-1.5 text-[12px] font-semibold disabled:opacity-40"
+            style={{
+              background: accent,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="poll-builder-launch"
+          >
+            Launch poll
+          </button>
+          {/* accentFaint reserved for the highlighted-range fill that
+              will sit on the inline calendar once it's wired up. */}
+          <span className="sr-only" style={{ background: accentFaint }} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  Pencil,
   User,
   UserPlus,
   Vote,
@@ -199,11 +200,11 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
       </p>
 
       {/* Bottom slot — pre-completion this is the filled-accent "Set
-          dates" CTA. Post-completion it becomes a teal confirmation
-          chip ("✓ Set May 22-26") in the same shape as the other
-          cards' CTAs so the row stays visually aligned. The chip is
-          still clickable so editing remains one tap away — the
-          user just gets a positive indicator instead of a hammer. */}
+          dates" CTA. Post-completion it becomes "Edit dates" in the
+          same ghost outline used by the other steps' done CTAs (the
+          actual date range is reinforced on the back face via the
+          confirmation chip in the picker footer, so we don't need to
+          double-print it here). */}
       <button
         type="button"
         onClick={() => setFlipped(true)}
@@ -211,9 +212,9 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         style={
           datesSet
             ? {
-                background: tint.faint,
+                background: "transparent",
                 color: tint.color,
-                border: `1px solid ${tint.color}`,
+                border: "1px solid var(--color-bt-border)",
               }
             : {
                 background: tint.color,
@@ -223,13 +224,11 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         data-testid={datesSet ? "guide-step-dates-edit" : "guide-step-dates-cta"}
       >
         {datesSet ? (
-          <Check size={14} strokeWidth={2.6} />
+          <Pencil size={14} strokeWidth={2} />
         ) : (
           <Calendar size={14} strokeWidth={2} />
         )}
-        {datesSet
-          ? `Set ${formatDateRangeCompact(trip.start_date, trip.end_date)}`
-          : "Set dates"}
+        {datesSet ? "Edit dates" : "Set dates"}
       </button>
     </div>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -640,21 +640,37 @@ function InlineRangeCalendar({
         >
           {nights != null ? `${nights} night${nights === 1 ? "" : "s"}` : "Pick a range"}
         </span>
-        <button
-          type="button"
-          disabled={!canSave || saving}
-          onClick={() => {
-            if (canSave) onSave(range.start!, range.end!);
-          }}
-          className="rounded-md px-3 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
-          style={{
-            background: accent,
-            color: "var(--color-bt-on-accent, #0d1f1a)",
-          }}
-          data-testid="guide-dates-save"
-        >
-          {saving ? "Saving…" : "Set dates"}
-        </button>
+        <div className="flex items-center gap-1.5">
+          {/* Quiet Clear — only renders when something is selected. Wipes
+              the working range so the user can start over without
+              hunting through months to deselect. */}
+          {(range.start || range.end) && (
+            <button
+              type="button"
+              onClick={() => setRange({ start: null, end: null })}
+              className="rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{ color: "var(--color-bt-text-dim)" }}
+              data-testid="guide-dates-clear"
+            >
+              Clear
+            </button>
+          )}
+          <button
+            type="button"
+            disabled={!canSave || saving}
+            onClick={() => {
+              if (canSave) onSave(range.start!, range.end!);
+            }}
+            className="rounded-md px-3 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+            style={{
+              background: accent,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="guide-dates-save"
+          >
+            {saving ? "Saving…" : "Set dates"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -1,34 +1,46 @@
 "use client";
 
-import { useState, type FC, type ReactNode } from "react";
-import { Calendar, RotateCcw, Users } from "lucide-react";
+import { useMemo, useState, type FC, type ReactNode } from "react";
+import { ChevronLeft, ChevronRight, RotateCcw, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { DatePickerPanel } from "../../tabs/components/DatePickerPanel";
+import {
+  addMonths,
+  applyRangeClick,
+  atNoon,
+  isOutOfBounds,
+  isSameDay,
+  isWithinRange,
+  monthMatrix,
+  nightsBetween,
+  rangePresets,
+  startOfMonth,
+  type DateRange,
+} from "@/lib/calendar";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { CalendarThumbnail } from "./thumbnails";
 import type { TripData } from "../../tabs/types";
 
 // ── SetDatesFlipCard ──────────────────────────────────────────────────────
 //
 // Step 1 of the FreshTripGuide. The card flips in place on tap to reveal a
-// compact Pick / Poll date picker (no navigation). Pick mode uses the same
-// DatePickerPanel as the DatesSheet, so the lock behaviour stays consistent.
-// Poll mode is gated on crew size: under 2 crew the tab shows an
-// "Add the crew first" redirect with an Invite-crew CTA + a quiet
-// "or just pick the dates yourself" link that flips back to Pick. ≥2 crew
-// surfaces a simpler "Set up date poll" hand-off — the full inline poll
-// builder lives in DatesSheet (we route there instead of duplicating it).
+// compact range calendar (no navigation, no native date inputs). The same
+// reusable calendar primitives `@/lib/calendar` exposes drive the grid —
+// what the rest of the app uses everywhere else — just rendered inline at
+// a tighter cell size so the month fits inside a step-card-sized container.
+//
+// Poll tab gating:
+//   - <2 crew  → "Add the crew first" redirect with Invite + quiet fallback
+//   - ≥2 crew  → hand off to DatesSheet's existing poll builder (we don't
+//                duplicate the inline poll UI).
 
 export interface SetDatesFlipCardProps {
   tripId: string;
   trip: TripData;
-  /** Open the existing DatesSheet — used for the Poll branch (>=2 crew)
-   *  since the full poll builder already lives there. */
+  /** Opens the existing DatesSheet — used by the Poll branch (≥2 crew). */
   onOpenDatesSheet?: () => void;
-  /** Navigate to the Crew tab — the "Add the crew first" redirect uses
-   *  this when crew < 2. */
+  /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect. */
   onTabChange?: (tab: string) => void;
-  /** Set to true once trip.start_date is locked. Renders the done state
-   *  (no flip; "Change" link replaces the CTA). */
+  /** Set to true once trip.start_date is locked. Renders the done state. */
   done?: boolean;
   /** Summary shown in the done state, e.g. "May 26 – Jun 14". */
   doneSummary?: string;
@@ -37,6 +49,14 @@ export interface SetDatesFlipCardProps {
 type PickerTab = "pick" | "poll";
 
 const STEP_NUMBER = 1;
+
+// Compact day-cell height tuned so a 6-row month fits without the card
+// scrolling on its own.
+const DAY_CELL_PX = 27;
+// Minimum flipped-card height — covers the picker tab strip + presets +
+// month grid + Save row at the tightest viewport so the card grows to fit
+// instead of clamping the calendar.
+const FLIPPED_MIN_H = 390;
 
 export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   tripId,
@@ -51,8 +71,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   const [tab, setTab] = useState<PickerTab>("pick");
   const utils = trpc.useUtils();
 
-  // Crew count — drives the poll-tab gate. Cheap because HomeTab already
-  // prefetches tripMembers.list at page load.
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
   const crewCount = members.length;
 
@@ -77,7 +95,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         utils.trips.getById.setData({ tripId }, ctx.prev);
     },
     onSuccess() {
-      // Lock succeeded — flip back so the card shows the done state.
       setFlipped(false);
     },
     onSettled() {
@@ -86,10 +103,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
       utils.datePoll.get.invalidate({ tripId });
     },
   });
-
-  const handleSave = (startDate: string, endDate: string) => {
-    lockDates.mutate({ tripId, startDate, endDate });
-  };
 
   // ── Front face (default) ──────────────────────────────────────────────
   const front: ReactNode = (
@@ -103,7 +116,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         }}
         aria-hidden="true"
       >
-        <MiniCalendarThumbnail />
+        <CalendarThumbnail />
       </div>
       <p
         className="text-[13px] font-semibold leading-tight"
@@ -112,10 +125,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         Set your dates
       </p>
       {done && doneSummary ? (
-        <p
-          className="mt-1 text-[12px]"
-          style={{ color: tint.color }}
-        >
+        <p className="mt-1 text-[12px]" style={{ color: tint.color }}>
           {doneSummary}
         </p>
       ) : (
@@ -158,61 +168,67 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   // ── Back face (flipped — picker) ──────────────────────────────────────
   const back: ReactNode = (
     <div className="flex h-full flex-col">
-      {/* Tab strip */}
-      <div className="mb-3 inline-flex self-start rounded-lg p-0.5"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        {(["pick", "poll"] as const).map((value) => {
-          const active = tab === value;
-          return (
-            <button
-              key={value}
-              type="button"
-              onClick={() => setTab(value)}
-              className="rounded-md px-2.5 py-1 text-[11px] font-semibold transition-colors"
-              style={
-                active
-                  ? {
-                      background: tint.faint,
-                      color: tint.color,
-                    }
-                  : {
-                      background: "transparent",
-                      color: "var(--color-bt-text-dim)",
-                    }
-              }
-              data-testid={`guide-dates-tab-${value}`}
-            >
-              {value === "pick" ? "Pick" : "Poll"}
-            </button>
-          );
-        })}
+      {/* Tab strip + back button */}
+      <div className="mb-2 flex items-center justify-between">
+        <div
+          className="inline-flex rounded-lg p-0.5"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            border: "1px solid var(--color-bt-border)",
+          }}
+        >
+          {(["pick", "poll"] as const).map((value) => {
+            const active = tab === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setTab(value)}
+                className="rounded-md px-2.5 py-1 text-[11px] font-semibold transition-colors"
+                style={
+                  active
+                    ? { background: tint.faint, color: tint.color }
+                    : { background: "transparent", color: "var(--color-bt-text-dim)" }
+                }
+                data-testid={`guide-dates-tab-${value}`}
+              >
+                {value === "pick" ? "Pick" : "Poll"}
+              </button>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          onClick={() => setFlipped(false)}
+          aria-label="Back to step card"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+          data-testid="guide-dates-flip-back"
+        >
+          <RotateCcw size={13} />
+        </button>
       </div>
 
       {tab === "pick" ? (
-        <div className="flex-1">
-          <DatePickerPanel
-            tripId={tripId}
-            initialStartDate={trip.start_date ?? null}
-            initialEndDate={trip.end_date ?? null}
-            onSave={handleSave}
-            isSaving={lockDates.isPending}
-            onCancel={() => setFlipped(false)}
-            showDescription={false}
-          />
-        </div>
+        <InlineRangeCalendar
+          initialStart={trip.start_date ?? null}
+          initialEnd={trip.end_date ?? null}
+          saving={lockDates.isPending}
+          accent={tint.color}
+          accentFaint={tint.faint}
+          onSave={(start, end) =>
+            lockDates.mutate({
+              tripId,
+              startDate: start.toISOString().slice(0, 10),
+              endDate: end.toISOString().slice(0, 10),
+            })
+          }
+        />
       ) : crewCount < 2 ? (
-        // Poll requires ≥2 crew — show the "add the crew first" redirect.
         <div className="flex flex-1 flex-col items-start gap-2">
           <span
             className="inline-flex h-9 w-9 items-center justify-center rounded-full"
-            style={{
-              background: tint.faint,
-              color: tint.color,
-            }}
+            style={{ background: tint.faint, color: tint.color }}
             aria-hidden="true"
           >
             <Users size={16} />
@@ -230,7 +246,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             Polling needs at least two people — invite the crew, then come
             back to set up the date poll.
           </p>
-          <div className="mt-2 flex flex-col gap-1.5">
+          <div className="mt-1 flex flex-col gap-1.5">
             <button
               type="button"
               onClick={() => onTabChange?.("crew")}
@@ -255,7 +271,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           </div>
         </div>
       ) : (
-        // ≥2 crew — hand off to the existing poll builder in DatesSheet.
         <div className="flex flex-1 flex-col items-start gap-2">
           <p
             className="text-[13px] font-semibold leading-tight"
@@ -276,7 +291,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
               setFlipped(false);
               onOpenDatesSheet?.();
             }}
-            className="mt-2 rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
+            className="mt-1 rounded-lg px-3 py-1.5 text-[12px] font-semibold transition-opacity hover:opacity-90"
             style={{
               background: tint.color,
               color: "var(--color-bt-on-accent, #0d1f1a)",
@@ -287,17 +302,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           </button>
         </div>
       )}
-
-      <button
-        type="button"
-        onClick={() => setFlipped(false)}
-        aria-label="Back"
-        className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-        style={{ color: "var(--color-bt-text-dim)" }}
-        data-testid="guide-dates-flip-back"
-      >
-        <RotateCcw size={13} />
-      </button>
     </div>
   );
 
@@ -320,6 +324,9 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           transformStyle: "preserve-3d",
           transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
           transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
+          // Grow to the picker's height when flipped so the calendar never
+          // has to scroll inside the card; collapse back when front-side.
+          minHeight: flipped ? FLIPPED_MIN_H : undefined,
         }}
         data-testid="guide-step-dates"
       >
@@ -331,6 +338,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             border: "1px solid var(--color-bt-border)",
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",
+            overflow: "hidden",
           }}
         >
           {front}
@@ -344,7 +352,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
             transform: "rotateY(180deg)",
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",
-            overflow: "auto",
+            overflow: "hidden",
           }}
         >
           {back}
@@ -354,32 +362,192 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   );
 };
 
-// ── Mini calendar thumbnail (front face) ─────────────────────────────────
+// ── InlineRangeCalendar ──────────────────────────────────────────────────
 //
-// Tiny stylized 7-column calendar grid — just enough to read as "a calendar"
-// without being literal. The current row highlights the "selected" range.
+// Compact always-open range calendar driven by `@/lib/calendar` primitives.
+// Same selection mechanic as the global DatePicker (click start → click
+// end → range fills in), but rendered inline at tighter cell sizes so a
+// full month fits inside the flip-card-sized container without scroll.
 
-function MiniCalendarThumbnail() {
+function InlineRangeCalendar({
+  initialStart,
+  initialEnd,
+  saving,
+  accent,
+  accentFaint,
+  onSave,
+}: {
+  initialStart: string | null;
+  initialEnd: string | null;
+  saving: boolean;
+  accent: string;
+  accentFaint: string;
+  onSave: (start: Date, end: Date) => void;
+}) {
+  const today = atNoon(new Date());
+  const [range, setRange] = useState<DateRange>(() => ({
+    start: initialStart ? atNoon(new Date(initialStart)) : null,
+    end: initialEnd ? atNoon(new Date(initialEnd)) : null,
+  }));
+  const [view, setView] = useState<Date>(() =>
+    range.start ? startOfMonth(range.start) : startOfMonth(today),
+  );
+
+  const matrix = useMemo(() => monthMatrix(view), [view]);
+  const presets = useMemo(() => rangePresets(today), [today]);
+  const nights = range.start && range.end ? nightsBetween(range.start, range.end) : null;
+
+  const monthLabel = view.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const handleDayClick = (day: Date) => {
+    if (isOutOfBounds(day, null, null)) return;
+    setRange((cur) => applyRangeClick(cur, day));
+  };
+
+  const canSave = !!(range.start && range.end);
+
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <Calendar size={18} strokeWidth={1.8} />
-      <div className="grid grid-cols-7 gap-[3px]">
-        {Array.from({ length: 21 }).map((_, i) => {
-          // Highlight a 5-day range in the middle row.
-          const inRange = i >= 9 && i <= 13;
+    <div className="flex flex-1 flex-col">
+      {/* Presets */}
+      <div className="mb-2 flex flex-wrap gap-1">
+        {presets.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => {
+              setRange(p.range);
+              if (p.range.start) setView(startOfMonth(p.range.start));
+            }}
+            className="rounded-md px-2 py-1 text-[10px] font-medium transition-colors"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Month header */}
+      <div className="mb-1 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setView((v) => addMonths(v, -1))}
+          aria-label="Previous month"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <ChevronLeft size={13} />
+        </button>
+        <span
+          className="text-[11px] font-semibold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {monthLabel}
+        </span>
+        <button
+          type="button"
+          onClick={() => setView((v) => addMonths(v, 1))}
+          aria-label="Next month"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <ChevronRight size={13} />
+        </button>
+      </div>
+
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 text-center">
+        {["S", "M", "T", "W", "T", "F", "S"].map((w, i) => (
+          <span
+            key={`${w}-${i}`}
+            className="text-[9px] font-semibold uppercase"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {w}
+          </span>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      <div className="grid grid-cols-7 gap-y-px">
+        {matrix.flat().map((day, idx) => {
+          const inMonth = day.getMonth() === view.getMonth();
+          const isStart = isSameDay(day, range.start);
+          const isEnd = isSameDay(day, range.end);
+          const inRange = isWithinRange(day, range);
+          const isToday = isSameDay(day, today);
           return (
-            <span
-              key={i}
-              className="h-1.5 w-1.5 rounded-[1px]"
+            <button
+              key={idx}
+              type="button"
+              onClick={() => handleDayClick(day)}
+              className="relative flex items-center justify-center text-[11px] font-medium transition-colors"
               style={{
-                background: inRange
-                  ? "currentColor"
-                  : "rgba(255,255,255,0.15)",
-                opacity: inRange ? 0.85 : 1,
+                height: DAY_CELL_PX,
+                color: !inMonth
+                  ? "var(--color-bt-text-dim)"
+                  : isStart || isEnd
+                    ? "var(--color-bt-on-accent, #0d1f1a)"
+                    : "var(--color-bt-text)",
+                background: isStart || isEnd
+                  ? accent
+                  : inRange
+                    ? accentFaint
+                    : "transparent",
+                borderRadius:
+                  isStart && isEnd
+                    ? 6
+                    : isStart
+                      ? "6px 0 0 6px"
+                      : isEnd
+                        ? "0 6px 6px 0"
+                        : 0,
+                opacity: inMonth ? 1 : 0.4,
               }}
-            />
+              data-testid={`day-${day.toISOString().slice(0, 10)}`}
+            >
+              {day.getDate()}
+              {isToday && !isStart && !isEnd && (
+                <span
+                  className="absolute bottom-[2px] h-[3px] w-[3px] rounded-full"
+                  style={{ background: accent }}
+                  aria-hidden="true"
+                />
+              )}
+            </button>
           );
         })}
+      </div>
+
+      {/* Save row */}
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <span
+          className="text-[10px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {nights != null ? `${nights} night${nights === 1 ? "" : "s"}` : "Pick a range"}
+        </span>
+        <button
+          type="button"
+          disabled={!canSave || saving}
+          onClick={() => {
+            if (canSave) onSave(range.start!, range.end!);
+          }}
+          className="rounded-md px-3 py-1.5 text-[11px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-40"
+          style={{
+            background: accent,
+            color: "var(--color-bt-on-accent, #0d1f1a)",
+          }}
+          data-testid="guide-dates-save"
+        >
+          {saving ? "Saving…" : "Set dates"}
+        </button>
       </div>
     </div>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -133,8 +133,8 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   const front: ReactNode = (
     <div className="flex h-full flex-col gap-3 p-3">
       <div
-        className="flex flex-1 items-stretch justify-stretch overflow-hidden rounded-lg"
-        style={{ ...previewSurface, minHeight: 120 }}
+        className="flex items-stretch justify-stretch overflow-hidden rounded-lg"
+        style={{ ...previewSurface, height: 130 }}
         aria-hidden="true"
       >
         <CalendarThumbnail accent={tint.color} />
@@ -154,7 +154,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           {datesSet ? <Check size={12} strokeWidth={2.6} /> : 1}
         </span>
         <p
-          className="text-[14px] font-semibold leading-tight"
+          className="text-[15px] font-semibold leading-tight"
           style={{ color: "var(--color-bt-text)" }}
         >
           {datesSet ? "Dates set" : "Set your dates"}
@@ -162,7 +162,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
       </div>
 
       <p
-        className="text-[12px] leading-snug"
+        className="text-[13px] leading-snug"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         {datesSet

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -48,9 +48,6 @@ export interface SetDatesFlipCardProps {
   onOpenDatesSheet?: () => void;
   /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect. */
   onTabChange?: (tab: string) => void;
-  /** Card min-height in px. FreshTripGuide passes this so all four step
-   *  cards (this one and the three StepCards) share the same shape. */
-  minHeight?: number;
   /** True when the parent has expanded this card to span the whole grid
    *  so the poll builder has room to grow horizontally. The card stays
    *  flipped to its back face while this is on. */
@@ -72,7 +69,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   trip,
   onOpenDatesSheet,
   onTabChange,
-  minHeight,
   pollMode = false,
   onPollExpand,
   onPollCancel,
@@ -428,28 +424,30 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
     </div>
   );
 
+  // Calendar + presets + Save row need ≈420px of vertical room. We only
+  // pin that height while the back face is up (flipped or pollMode);
+  // the front face sizes to its own content so we don't push the
+  // resting card taller than it needs to be.
+  const FLIPPED_MIN_H = 420;
+
   return (
-    <div
-      className="relative h-full w-full"
-      style={{ perspective: 1200, minHeight }}
-    >
+    <div className="relative" style={{ perspective: 1200 }}>
       <div
-        className="absolute inset-0 h-full w-full"
+        className="relative w-full"
         style={{
           transformStyle: "preserve-3d",
           transform: showBack ? "rotateY(180deg)" : "rotateY(0deg)",
           transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
+          minHeight: showBack ? FLIPPED_MIN_H : undefined,
         }}
         data-testid="guide-step-dates"
         data-pollmode={pollMode ? "true" : "false"}
       >
-        {/* Front — absolutely positioned so it stretches to the wrapper's
-            minHeight. Same treatment as the back face; without this, the
-            front face sized to its content (~230px) while the wrapper
-            held the 420px minHeight, so the card looked shorter than its
-            siblings. */}
+        {/* Front — sizes to its own content. Not absolute so it
+            collapses cleanly when the back face's minHeight isn't
+            applied. */}
         <div
-          className="absolute inset-0 rounded-xl"
+          className="rounded-xl"
           style={{
             ...cardSurface,
             backfaceVisibility: "hidden",
@@ -459,7 +457,8 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         >
           {front}
         </div>
-        {/* Back */}
+        {/* Back — absolute inset-0; relies on the wrapper's minHeight
+            (set above only when showBack) to give it vertical room. */}
         <div
           className="absolute inset-0 rounded-xl"
           style={{

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useMemo, useState, type FC, type ReactNode } from "react";
-import { ChevronLeft, ChevronRight, RotateCcw, Users } from "lucide-react";
+import {
+  Calendar,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Pencil,
+  Users,
+  X,
+} from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import {
   addMonths,
@@ -17,21 +25,18 @@ import {
   type DateRange,
 } from "@/lib/calendar";
 import { DOMAIN_COLORS } from "@/lib/domainColors";
+import { formatDateRangeCompact } from "@/lib/dates";
 import { CalendarThumbnail } from "./thumbnails";
 import type { TripData } from "../../tabs/types";
 
 // ── SetDatesFlipCard ──────────────────────────────────────────────────────
 //
-// Step 1 of the FreshTripGuide. The card flips in place on tap to reveal a
-// compact range calendar (no navigation, no native date inputs). The same
-// reusable calendar primitives `@/lib/calendar` exposes drive the grid —
-// what the rest of the app uses everywhere else — just rendered inline at
-// a tighter cell size so the month fits inside a step-card-sized container.
-//
-// Poll tab gating:
-//   - <2 crew  → "Add the crew first" redirect with Invite + quiet fallback
-//   - ≥2 crew  → hand off to DatesSheet's existing poll builder (we don't
-//                duplicate the inline poll UI).
+// Step 1 of the FreshTripGuide. Same outer card shape as StepCard so the
+// grid lines up; flips in place to a compact Pick/Poll picker (no
+// navigation, no native date inputs). When trip.start_date is locked the
+// whole card paints in accent-faint with an accent border (the "done"
+// treatment from the mock), and the CTA flips to a ghost Edit dates
+// button instead of a quiet text link.
 
 export interface SetDatesFlipCardProps {
   tripId: string;
@@ -40,31 +45,20 @@ export interface SetDatesFlipCardProps {
   onOpenDatesSheet?: () => void;
   /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect. */
   onTabChange?: (tab: string) => void;
-  /** Set to true once trip.start_date is locked. Renders the done state. */
-  done?: boolean;
-  /** Summary shown in the done state, e.g. "May 26 – Jun 14". */
-  doneSummary?: string;
 }
 
 type PickerTab = "pick" | "poll";
 
-const STEP_NUMBER = 1;
-
-// Compact day-cell height tuned so a 6-row month fits without the card
-// scrolling on its own.
+// Compact day cell so a 6-row month fits inside the flipped card.
 const DAY_CELL_PX = 27;
-// Minimum flipped-card height — covers the picker tab strip + presets +
-// month grid + Save row at the tightest viewport so the card grows to fit
-// instead of clamping the calendar.
-const FLIPPED_MIN_H = 390;
+// Min height when flipped so the picker never has to scroll on its own.
+const FLIPPED_MIN_H = 420;
 
 export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   tripId,
   trip,
   onOpenDatesSheet,
   onTabChange,
-  done = false,
-  doneSummary,
 }) => {
   const tint = DOMAIN_COLORS.home;
   const [flipped, setFlipped] = useState(false);
@@ -73,6 +67,19 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
 
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
   const crewCount = members.length;
+
+  const datesSet = !!(trip.start_date && trip.end_date);
+  const doneSummary = datesSet
+    ? (() => {
+        const range = formatDateRangeCompact(trip.start_date, trip.end_date);
+        const nights = nightsBetween(
+          atNoon(new Date(trip.start_date!)),
+          atNoon(new Date(trip.end_date!)),
+        );
+        const days = nights + 1;
+        return `${range}, ${days} ${days === 1 ? "day" : "days"}. These frame your whole itinerary.`;
+      })()
+    : null;
 
   const lockDates = trpc.trips.lockDates.useMutation({
     async onMutate(vars) {
@@ -104,109 +111,142 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
     },
   });
 
-  // ── Front face (default) ──────────────────────────────────────────────
+  // ── Done state — paint card with the accent-faint treatment ──────────
+  const cardSurface: React.CSSProperties = datesSet
+    ? {
+        background: tint.faint,
+        border: `1px solid ${tint.color}`,
+      }
+    : {
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      };
+  // Preview area on the done state darkens for contrast vs the tinted
+  // card surface; idle preview matches the StepCard preview surface.
+  const previewSurface: React.CSSProperties = datesSet
+    ? { background: "rgba(0,0,0,0.30)" }
+    : { background: "var(--color-bt-base)" };
+
+  // ── Front face (default + done) ──────────────────────────────────────
   const front: ReactNode = (
-    <div className="flex h-full flex-col">
+    <div className="flex flex-col gap-3 p-3">
       <div
-        className="mb-3 flex h-20 items-center justify-center overflow-hidden rounded-lg"
-        style={{
-          background: tint.faint,
-          color: tint.color,
-          opacity: done ? 0.55 : 1,
-        }}
+        className="flex h-[120px] items-stretch justify-stretch overflow-hidden rounded-lg"
+        style={previewSurface}
         aria-hidden="true"
       >
-        <CalendarThumbnail />
+        <CalendarThumbnail accent={tint.color} />
       </div>
-      <p
-        className="text-[13px] font-semibold leading-tight"
-        style={{ color: "var(--color-bt-text)" }}
-      >
-        Set your dates
-      </p>
-      {done && doneSummary ? (
-        <p className="mt-1 text-[12px]" style={{ color: tint.color }}>
-          {doneSummary}
-        </p>
-      ) : (
-        <p
-          className="mt-1 text-[11px] leading-snug"
-          style={{ color: "var(--color-bt-text-dim)" }}
+
+      {/* Title row — number badge / check inline */}
+      <div className="flex items-center gap-2">
+        <span
+          className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] font-bold tabular-nums"
+          style={{
+            background: tint.faint,
+            color: tint.color,
+            border: `1px solid ${tint.color}`,
+          }}
+          aria-hidden="true"
         >
-          Lock a range or poll the crew — bookends the day-by-day timeline.
+          {datesSet ? <Check size={12} strokeWidth={2.6} /> : 1}
+        </span>
+        <p
+          className="text-[14px] font-semibold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {datesSet ? "Dates set" : "Set your dates"}
         </p>
-      )}
-      <div className="mt-3">
-        {done ? (
-          <button
-            type="button"
-            onClick={() => setFlipped(true)}
-            className="text-[12px] font-medium transition-opacity hover:opacity-80"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            data-testid="guide-step-dates-change"
-          >
-            Change
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setFlipped(true)}
-            className="w-full rounded-lg py-2 text-[12px] font-semibold transition-opacity hover:opacity-90"
-            style={{
-              background: tint.color,
-              color: "var(--color-bt-on-accent, #0d1f1a)",
-            }}
-            data-testid="guide-step-dates-cta"
-          >
-            Set dates
-          </button>
-        )}
       </div>
+
+      <p
+        className="text-[12px] leading-snug"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {datesSet
+          ? doneSummary
+          : "Pick a range or poll the crew. Sets the bookends everything else lands between."}
+      </p>
+
+      {/* CTA — primary teal for Set dates; ghost for Edit dates */}
+      <button
+        type="button"
+        onClick={() => setFlipped(true)}
+        className="flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+        style={
+          datesSet
+            ? {
+                background: "var(--color-bt-card-raised)",
+                color: "var(--color-bt-text)",
+                border: "1px solid var(--color-bt-border)",
+              }
+            : {
+                background: tint.color,
+                color: "var(--color-bt-on-accent, #0d1f1a)",
+              }
+        }
+        data-testid={datesSet ? "guide-step-dates-edit" : "guide-step-dates-cta"}
+      >
+        {datesSet ? (
+          <Pencil size={14} strokeWidth={2} />
+        ) : (
+          <Calendar size={14} strokeWidth={2} />
+        )}
+        {datesSet ? "Edit dates" : "Set dates"}
+      </button>
     </div>
   );
 
   // ── Back face (flipped — picker) ──────────────────────────────────────
   const back: ReactNode = (
-    <div className="flex h-full flex-col">
-      {/* Tab strip + back button */}
+    <div className="flex h-full flex-col p-3">
+      {/* Title bar — keeps the "Set your dates" identity, X closes the flip */}
       <div className="mb-2 flex items-center justify-between">
-        <div
-          className="inline-flex rounded-lg p-0.5"
-          style={{
-            background: "var(--color-bt-card-raised)",
-            border: "1px solid var(--color-bt-border)",
-          }}
+        <p
+          className="text-[14px] font-semibold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
         >
-          {(["pick", "poll"] as const).map((value) => {
-            const active = tab === value;
-            return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setTab(value)}
-                className="rounded-md px-2.5 py-1 text-[11px] font-semibold transition-colors"
-                style={
-                  active
-                    ? { background: tint.faint, color: tint.color }
-                    : { background: "transparent", color: "var(--color-bt-text-dim)" }
-                }
-                data-testid={`guide-dates-tab-${value}`}
-              >
-                {value === "pick" ? "Pick" : "Poll"}
-              </button>
-            );
-          })}
-        </div>
+          Set your dates
+        </p>
         <button
           type="button"
           onClick={() => setFlipped(false)}
-          aria-label="Back to step card"
+          aria-label="Close picker"
           className="inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
           style={{ color: "var(--color-bt-text-dim)" }}
           data-testid="guide-dates-flip-back"
         >
-          <RotateCcw size={13} />
+          <X size={14} />
         </button>
+      </div>
+
+      {/* Pick / Poll tabs — full width segmented control */}
+      <div
+        className="mb-2 grid grid-cols-2 rounded-lg p-0.5"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {(["pick", "poll"] as const).map((value) => {
+          const active = tab === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setTab(value)}
+              className="rounded-md py-1 text-center text-[11px] font-semibold transition-colors"
+              style={
+                active
+                  ? { background: tint.faint, color: tint.color }
+                  : { background: "transparent", color: "var(--color-bt-text-dim)" }
+              }
+              data-testid={`guide-dates-tab-${value}`}
+            >
+              {value === "pick" ? "Pick" : "Poll"}
+            </button>
+          );
+        })}
       </div>
 
       {tab === "pick" ? (
@@ -307,35 +347,21 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
 
   return (
     <div className="relative" style={{ perspective: 1200 }}>
-      {/* Step number badge — sits above both faces. */}
-      <span
-        className="absolute -top-2 left-3 z-10 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full px-1 text-[10px] font-bold tabular-nums"
-        style={{
-          background: tint.color,
-          color: "var(--color-bt-on-accent, #0d1f1a)",
-        }}
-        aria-hidden="true"
-      >
-        {STEP_NUMBER}
-      </span>
       <div
         className="relative w-full"
         style={{
           transformStyle: "preserve-3d",
           transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
           transition: "transform 450ms cubic-bezier(.2,.8,.2,1)",
-          // Grow to the picker's height when flipped so the calendar never
-          // has to scroll inside the card; collapse back when front-side.
           minHeight: flipped ? FLIPPED_MIN_H : undefined,
         }}
         data-testid="guide-step-dates"
       >
         {/* Front */}
         <div
-          className="rounded-xl p-4"
+          className="rounded-xl"
           style={{
-            background: "var(--color-bt-card)",
-            border: "1px solid var(--color-bt-border)",
+            ...cardSurface,
             backfaceVisibility: "hidden",
             WebkitBackfaceVisibility: "hidden",
             overflow: "hidden",
@@ -345,7 +371,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         </div>
         {/* Back */}
         <div
-          className="absolute inset-0 rounded-xl p-4"
+          className="absolute inset-0 rounded-xl"
           style={{
             background: "var(--color-bt-card)",
             border: "1px solid var(--color-bt-border)",
@@ -363,11 +389,6 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
 };
 
 // ── InlineRangeCalendar ──────────────────────────────────────────────────
-//
-// Compact always-open range calendar driven by `@/lib/calendar` primitives.
-// Same selection mechanic as the global DatePicker (click start → click
-// end → range fills in), but rendered inline at tighter cell sizes so a
-// full month fits inside the flip-card-sized container without scroll.
 
 function InlineRangeCalendar({
   initialStart,
@@ -433,7 +454,6 @@ function InlineRangeCalendar({
         ))}
       </div>
 
-      {/* Month header */}
       <div className="mb-1 flex items-center justify-between">
         <button
           type="button"
@@ -461,7 +481,6 @@ function InlineRangeCalendar({
         </button>
       </div>
 
-      {/* Weekday header */}
       <div className="grid grid-cols-7 text-center">
         {["S", "M", "T", "W", "T", "F", "S"].map((w, i) => (
           <span
@@ -474,7 +493,6 @@ function InlineRangeCalendar({
         ))}
       </div>
 
-      {/* Day grid */}
       <div className="grid grid-cols-7 gap-y-px">
         {matrix.flat().map((day, idx) => {
           const inMonth = day.getMonth() === view.getMonth();
@@ -525,7 +543,6 @@ function InlineRangeCalendar({
         })}
       </div>
 
-      {/* Save row */}
       <div className="mt-2 flex items-center justify-between gap-2">
         <span
           className="text-[10px]"

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -3,12 +3,14 @@
 import { useMemo, useState, type FC, type ReactNode } from "react";
 import {
   Calendar,
+  CalendarCheck,
   Check,
   ChevronLeft,
   ChevronRight,
   Pencil,
   User,
   UserPlus,
+  Users,
   Vote,
   X,
 } from "lucide-react";
@@ -29,6 +31,7 @@ import {
 import { DOMAIN_COLORS } from "@/lib/domainColors";
 import { formatDateRangeCompact } from "@/lib/dates";
 import { CalendarThumbnail } from "./thumbnails";
+import { DatePollCard } from "../../tabs/components/DatePollCard";
 import type { TripData } from "../../tabs/types";
 
 // ── SetDatesFlipCard ──────────────────────────────────────────────────────
@@ -43,11 +46,8 @@ import type { TripData } from "../../tabs/types";
 export interface SetDatesFlipCardProps {
   tripId: string;
   trip: TripData;
-  /** Opens the existing DatesSheet — only used as a deep fallback if the
-   *  parent decides not to handle pollMode itself. With the inline poll
-   *  builder we now expand the card in place via onPollExpand. */
-  onOpenDatesSheet?: () => void;
-  /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect. */
+  /** Navigate to the Crew tab — used by the Poll-branch <2 crew redirect
+   *  and by DatePollCard's "Manage crew →" header link. */
   onTabChange?: (tab: string) => void;
   /** True when the parent has expanded this card to span the whole grid
    *  so the poll builder has room to grow horizontally. The card stays
@@ -62,13 +62,21 @@ export interface SetDatesFlipCardProps {
 
 type PickerTab = "pick" | "poll";
 
-// Compact day cell so a 6-row month fits inside the flipped card.
-const DAY_CELL_PX = 27;
+// Compact row + cap so a 6-row month fits the flipped card without losing
+// the round-cap / fill-bar styling shared with the lodging DatePicker.
+//   ROW_H — height of the day row (the fill bar inset by 2px lives here)
+//   CAP_PX — the round cap circle inside the row. Slightly narrower than
+//   the row so the fill bar peeks out on either side of the cap, matching
+//   the visual rhythm of <DatePicker> (which uses 36 / 32 at full size).
+const ROW_H = 30;
+const CAP_PX = 26;
+// Dark ink on the accent fill — same token DatePicker uses; keeps cap
+// text readable across every domain hue.
+const CAP_TEXT = "var(--color-bt-on-accent, #0d1f1a)";
 
 export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   tripId,
   trip,
-  onOpenDatesSheet,
   onTabChange,
   pollMode = false,
   onPollExpand,
@@ -81,6 +89,12 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   const [flipped, setFlipped] = useState(false);
   const showBack = flipped || pollMode;
   const [tab, setTab] = useState<PickerTab>("pick");
+  // Two-step confirm before launching a poll when dates are already
+  // locked. Tapping "Set up date poll" while datesSet swaps the centered
+  // Poll-tab content for a warning ("you already picked dates — this
+  // will clear them"). Confirming clears the dates AND launches the
+  // poll; cancel just dismisses the warning back to the pitch.
+  const [confirmReplaceWithPoll, setConfirmReplaceWithPoll] = useState(false);
   const utils = trpc.useUtils();
 
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
@@ -125,6 +139,62 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
       utils.trips.list.invalidate();
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  // Clearing locked dates routes through datePoll.unlock — same procedure
+  // DatesSheet uses for its Clear flow. It wipes start_date / end_date
+  // back to null and deletes the underlying window if it had no votes
+  // (so we don't leave orphan windows behind when an owner sets a range
+  // directly and then changes their mind). Used by the calendar's Clear
+  // button when the trip has dates saved: clears the working selection
+  // AND the DB row in one action.
+  const clearLockedDates = trpc.datePoll.unlock.useMutation({
+    async onMutate() {
+      await utils.trips.getById.cancel({ tripId });
+      const prev = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old ? { ...old, start_date: null, end_date: null } : old,
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prev);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
+      utils.trips.list.invalidate();
+      utils.datePoll.get.invalidate({ tripId });
+    },
+  });
+
+  // Flips trip.poll_mode = true the instant the owner taps "Set up date
+  // poll". Doing this server-side here — instead of waiting for the first
+  // window to land — means:
+  //   1. The home tab's pollMode derivation (trip.poll_mode || local) is
+  //      true everywhere, not just on this owner's screen, so members
+  //      who open the trip see the empty-state poll surface immediately.
+  //   2. The card stays expanded across navigation / reload, even with
+  //      zero windows yet — local state alone wouldn't survive that.
+  // Optimistic so the UI doesn't bounce between the resting Set Dates
+  // pitch and the poll surface while the round-trip lands.
+  const activatePoll = trpc.datePoll.setPollMode.useMutation({
+    async onMutate() {
+      await utils.trips.getById.cancel({ tripId });
+      const prev = utils.trips.getById.getData({ tripId });
+      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
+        old ? { ...old, poll_mode: true } : old,
+      );
+      return { prev };
+    },
+    onError(_e, _v, ctx) {
+      if (ctx?.prev !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prev);
+    },
+    onSettled() {
+      utils.trips.getById.invalidate({ tripId });
       utils.datePoll.get.invalidate({ tripId });
     },
   });
@@ -244,54 +314,64 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         >
           Set your dates
         </p>
-        <button
-          type="button"
-          onClick={() => {
-            // Always cancel pollMode if active, so the parent collapses
-            // the card back to its column; then flip back to the front.
-            if (pollMode) onPollCancel?.();
-            setFlipped(false);
-          }}
-          aria-label="Close picker"
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-          style={{ color: "var(--color-bt-text-dim)" }}
-          data-testid="guide-dates-flip-back"
-        >
-          <X size={14} />
-        </button>
+        {/* Hide the X when a poll is *server-active* — once the owner has
+            added a window, the only sensible exits are "lock a window"
+            (via DatePollCard's Select-this-date) or "Clear poll" (also
+            inside DatePollCard). A drive-by X that just hides the local
+            pollMode would leave the poll running with no way back to
+            it on the home tab. The X stays when we're flipped only
+            locally (no poll started yet) so users can back out of a
+            curious-tap. */}
+        {!trip.poll_mode && (
+          <button
+            type="button"
+            onClick={() => {
+              if (pollMode) onPollCancel?.();
+              setFlipped(false);
+            }}
+            aria-label="Close picker"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="guide-dates-flip-back"
+          >
+            <X size={14} />
+          </button>
+        )}
       </div>
 
-      {/* Pick / Poll tabs — full width segmented control. Hidden once
-          the parent has committed to pollMode; the builder is a
-          single-purpose surface and tab-switching mid-build is noise. */}
+      {/* Pick / Poll tabs — mirrors the ModeButton segmented control in
+          DatesSheet (the trip dates modal). Same wrapper (rounded-xl +
+          border + overflow-hidden), same active treatment (card-float
+          surface), same vertical 1px divider between the two halves.
+          Labels are shortened to "Pick" / "Poll" because the full
+          "Pick dates" / "Poll the crew" don't fit the card-column width
+          alongside the leading icons. Hidden once the parent has
+          committed to pollMode; the builder is a single-purpose surface
+          and tab-switching mid-build is noise. */}
       {!pollMode && (
-      <div
-        className="mb-2 grid grid-cols-2 rounded-lg p-0.5"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        {(["pick", "poll"] as const).map((value) => {
-          const active = tab === value;
-          return (
-            <button
-              key={value}
-              type="button"
-              onClick={() => setTab(value)}
-              className="rounded-md py-1 text-center text-[11px] font-semibold transition-colors"
-              style={
-                active
-                  ? { background: tint.faint, color: tint.color }
-                  : { background: "transparent", color: "var(--color-bt-text-dim)" }
-              }
-              data-testid={`guide-dates-tab-${value}`}
-            >
-              {value === "pick" ? "Pick" : "Poll"}
-            </button>
-          );
-        })}
-      </div>
+        <div
+          className="mb-3 flex overflow-hidden rounded-xl"
+          style={{ border: "1px solid var(--color-bt-border)" }}
+        >
+          <FlipModeButton
+            active={tab === "pick"}
+            onClick={() => setTab("pick")}
+            icon={<CalendarCheck size={13} />}
+            label="Pick"
+            testId="guide-dates-tab-pick"
+          />
+          <div
+            className="w-px self-stretch"
+            style={{ background: "var(--color-bt-border)" }}
+          />
+          <FlipModeButton
+            active={tab === "poll"}
+            onClick={() => setTab("poll")}
+            icon={<Users size={13} />}
+            label="Poll"
+            testId="guide-dates-tab-poll"
+          />
+        </div>
       )}
 
       {tab === "pick" && !pollMode ? (
@@ -299,6 +379,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           initialStart={trip.start_date ?? null}
           initialEnd={trip.end_date ?? null}
           saving={lockDates.isPending}
+          clearing={clearLockedDates.isPending}
           accent={tint.color}
           accentFaint={tint.faint}
           onSave={(start, end) =>
@@ -307,6 +388,13 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
               startDate: start.toISOString().slice(0, 10),
               endDate: end.toISOString().slice(0, 10),
             })
+          }
+          // When dates were already saved, Clear wipes them in the DB too —
+          // not just the working selection. Without this the calendar
+          // would visually empty but the trip would still show the same
+          // bookends elsewhere in the app.
+          onClearSaved={
+            datesSet ? () => clearLockedDates.mutate({ tripId }) : undefined
           }
         />
       ) : crewCount < 2 ? (
@@ -356,22 +444,112 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           </button>
         </div>
       ) : pollMode ? (
-        <PollBuilderPlaceholder
-          accent={tint.color}
-          accentFaint={tint.faint}
-          onCancel={() => {
-            onPollCancel?.();
-            // When the parent collapses the card back to its column,
-            // we also flip back to the front face so the next open
-            // starts clean.
-            setFlipped(false);
-          }}
-          onOpenSheet={() => {
-            onPollCancel?.();
-            setFlipped(false);
-            onOpenDatesSheet?.();
-          }}
-        />
+        // The real DatePollCard takes over the expanded back face. This
+        // is the same surface DatesSheet renders in its poll mode, kept
+        // canonical so there's only one polling UI in the app. Once the
+        // owner adds the first window, DatePollCard sets trip.poll_mode
+        // = true, which keeps pollMode latched on (FreshTripGuide ORs
+        // the server flag with the local flag) — so navigating away and
+        // back, or any member opening the home tab, lands on the poll.
+        // Wrapped in an overflow-y-auto pane so a long crew × windows
+        // grid scrolls inside the card instead of pushing the layout. */}
+        <div
+          className="-mx-3 -mt-1 flex-1 overflow-y-auto px-3"
+          data-testid="poll-builder"
+        >
+          <DatePollCard
+            trip={trip}
+            isOwner
+            onManageCrew={
+              onTabChange ? () => onTabChange("crew") : undefined
+            }
+          />
+        </div>
+      ) : confirmReplaceWithPoll ? (
+        // ≥2 crew + dates already locked + owner tapped "Set up date
+        // poll": red-tinted warning that committing the poll will clear
+        // the existing dates. Both the lock and the (now blank) date
+        // need to be wiped so the poll surface renders cleanly — the
+        // server's datePoll.unlock handles both (start_date/end_date
+        // null + drops the locked window). Then activatePoll launches.
+        <div
+          className="flex flex-1 flex-col items-center justify-center gap-3 px-3 text-center"
+          data-testid="guide-dates-poll-confirm"
+        >
+          <span
+            className="inline-flex h-12 w-12 items-center justify-center rounded-full"
+            style={{
+              background: "var(--color-bt-danger-faint)",
+              color: "var(--color-bt-danger)",
+            }}
+            aria-hidden="true"
+          >
+            <Vote size={22} strokeWidth={1.9} />
+          </span>
+          <p
+            className="text-[15px] font-semibold leading-tight"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            Start a poll instead?
+          </p>
+          <p
+            className="text-[12px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            You&rsquo;ve already picked dates for this trip. Starting a
+            poll will clear them and ask the crew which window works
+            best.
+          </p>
+          <div className="mt-1 flex w-full max-w-xs items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirmReplaceWithPoll(false)}
+              className="flex-1 rounded-lg py-2 text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{
+                background: "transparent",
+                color: "var(--color-bt-text-dim)",
+                border: "1px solid var(--color-bt-border)",
+              }}
+              data-testid="guide-dates-poll-confirm-cancel"
+            >
+              Keep dates
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                // Clear the locked dates (also drops the unvoted
+                // backing window) then launch the poll. Sequential to
+                // avoid the same race the DatesSheet save flow had
+                // (concurrent endPoll + lockDates could leave dangling
+                // state). Optimistic updates inside each mutation
+                // keep the UI snappy.
+                clearLockedDates.mutate(
+                  { tripId },
+                  {
+                    onSettled: () => {
+                      onPollExpand?.();
+                      if (!trip.poll_mode) {
+                        activatePoll.mutate({ tripId, pollMode: true });
+                      }
+                      setConfirmReplaceWithPoll(false);
+                    },
+                  },
+                );
+              }}
+              disabled={clearLockedDates.isPending || activatePoll.isPending}
+              className="flex-1 rounded-lg py-2 text-[12px] font-semibold transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{
+                background: "var(--color-bt-danger)",
+                color: "#ffffff",
+              }}
+              data-testid="guide-dates-poll-confirm-proceed"
+            >
+              {clearLockedDates.isPending || activatePoll.isPending
+                ? "Starting…"
+                : "Start poll"}
+            </button>
+          </div>
+        </div>
       ) : (
         // ≥2 crew — same centered cadence as the no-crew state so the
         // Poll tab feels like one consistent surface across both modes.
@@ -398,7 +576,24 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
           </p>
           <button
             type="button"
-            onClick={() => onPollExpand?.()}
+            onClick={() => {
+              // When dates are already locked, route through the
+              // confirm tray first — clearing the existing pick is a
+              // destructive side-effect the owner needs to opt into,
+              // not a silent consequence of starting a poll.
+              if (datesSet) {
+                setConfirmReplaceWithPoll(true);
+                return;
+              }
+              // Local pollMode latches the takeover immediately so the
+              // tap feels instant; activatePoll flips trip.poll_mode
+              // server-side so the home tab defaults to the poll for
+              // every other member, even before any windows exist.
+              onPollExpand?.();
+              if (!trip.poll_mode) {
+                activatePoll.mutate({ tripId, pollMode: true });
+              }
+            }}
             className="mt-1 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
             style={{
               background: tint.color,
@@ -476,22 +671,77 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
   );
 };
 
+// ── FlipModeButton ───────────────────────────────────────────────────────
+//
+// Half of the Pick / Poll segmented control on the flip card's back face.
+// Mirrors DatesSheet's ModeButton (icon + label, card-float surface when
+// active, transparent + dim when not) but sized down a touch — smaller
+// gap, font-size, py — so the row fits the card column without wrapping.
+
+function FlipModeButton({
+  active,
+  onClick,
+  icon,
+  label,
+  testId,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className="flex flex-1 items-center justify-center gap-1.5 py-2 text-[12px] font-semibold transition-colors"
+      style={
+        active
+          ? {
+              background: "var(--color-bt-card-float)",
+              color: "var(--color-bt-text)",
+            }
+          : {
+              background: "transparent",
+              color: "var(--color-bt-text-dim)",
+            }
+      }
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
 // ── InlineRangeCalendar ──────────────────────────────────────────────────
 
 function InlineRangeCalendar({
   initialStart,
   initialEnd,
   saving,
+  clearing = false,
   accent,
   accentFaint,
   onSave,
+  onClearSaved,
 }: {
   initialStart: string | null;
   initialEnd: string | null;
   saving: boolean;
+  /** True while the parent's clear mutation is in flight — disables the
+   *  Clear button so a double-tap can't fire twice. */
+  clearing?: boolean;
   accent: string;
   accentFaint: string;
   onSave: (start: Date, end: Date) => void;
+  /** Called when the user taps Clear AND the trip already had dates
+   *  locked. The picker wipes the working selection locally; this
+   *  callback wipes the persisted dates in the DB so the rest of the
+   *  app reflects the cleared state too. Undefined when the trip has
+   *  no locked dates (then Clear just resets the local selection). */
+  onClearSaved?: () => void;
 }) {
   const today = atNoon(new Date());
   const [range, setRange] = useState<DateRange>(() => ({
@@ -501,6 +751,11 @@ function InlineRangeCalendar({
   const [view, setView] = useState<Date>(() =>
     range.start ? startOfMonth(range.start) : startOfMonth(today),
   );
+  // Hover state for the day cells. Mirrors the lodging DatePicker (and
+  // DatesSheet's FullRangeCalendar) — non-cap in-bounds days draw a 1px
+  // inset accent ring on hover so the pointer always reads as a primed
+  // target. Kept at this compact picker too for consistency.
+  const [hovered, setHovered] = useState<Date | null>(null);
 
   const matrix = useMemo(() => monthMatrix(view), [view]);
   const presets = useMemo(() => rangePresets(today), [today]);
@@ -545,8 +800,11 @@ function InlineRangeCalendar({
 
   return (
     <div className="flex flex-1 flex-col">
-      {/* Presets */}
-      <div className="mb-2 flex flex-wrap gap-1">
+      {/* Presets — round-pill quick selections. Same shape as the lodging
+          DatePicker (src/components/DatePicker.tsx) but with slightly
+          smaller padding to keep the wrap to one row in the narrow card
+          column. */}
+      <div className="mb-2 flex flex-wrap gap-1.5">
         {presets.map((p) => (
           <button
             key={p.id}
@@ -555,7 +813,7 @@ function InlineRangeCalendar({
               setRange(p.range);
               if (p.range.start) setView(startOfMonth(p.range.start));
             }}
-            className="rounded-md px-2 py-1 text-[10px] font-medium transition-colors"
+            className="rounded-full px-2 py-0.5 text-[10px] font-semibold transition-colors hover:bg-[var(--color-bt-hover)]"
             style={{
               background: "var(--color-bt-card-raised)",
               color: "var(--color-bt-text-dim)",
@@ -594,64 +852,87 @@ function InlineRangeCalendar({
         </button>
       </div>
 
-      <div className="grid grid-cols-7 text-center">
+      {/* Weekday header — same SMTWTFS row used by DatePicker, just sized
+          smaller to match the row height below. */}
+      <div className="grid grid-cols-7">
         {["S", "M", "T", "W", "T", "F", "S"].map((w, i) => (
-          <span
+          <div
             key={`${w}-${i}`}
-            className="text-[9px] font-semibold uppercase"
+            className="flex h-5 items-center justify-center text-[9px] font-semibold uppercase"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             {w}
-          </span>
+          </div>
         ))}
       </div>
 
-      <div className="grid grid-cols-7 gap-y-px">
+      {/* Day grid — same round-cap + fill-bar pattern as the lodging
+          DatePicker (src/components/DatePicker.tsx). Each cell is a
+          positioned row; the in-range fill is an inset bar that sits
+          BEHIND the round cap, with the bar clipped to half the cell on
+          either side of a cap so the cap appears to float on a continuous
+          range strip. Sized down to ROW_H/CAP_PX for the flip card. */}
+      <div className="grid grid-cols-7">
         {matrix.flat().map((day, idx) => {
           const inMonth = day.getMonth() === view.getMonth();
           const isStart = isSameDay(day, range.start);
           const isEnd = isSameDay(day, range.end);
-          const inRange = isWithinRange(day, range);
+          const isCap = isStart || isEnd;
+          const between = isWithinRange(day, range);
+          const hasEnd = !!range.end;
           const isToday = isSameDay(day, today);
+          // Continuous range fill: a bar behind the caps. Bar appears
+          // when we're between the caps OR on a cap that has a partner
+          // (start with an end set, or end itself).
+          const showFill = between || (isStart && hasEnd) || isEnd;
           return (
-            <button
-              key={idx}
-              type="button"
-              onClick={() => handleDayClick(day)}
-              className="relative flex items-center justify-center text-[11px] font-medium transition-colors"
-              style={{
-                height: DAY_CELL_PX,
-                color: !inMonth
-                  ? "var(--color-bt-text-dim)"
-                  : isStart || isEnd
-                    ? "var(--color-bt-on-accent, #0d1f1a)"
-                    : "var(--color-bt-text)",
-                background: isStart || isEnd
-                  ? accent
-                  : inRange
-                    ? accentFaint
-                    : "transparent",
-                borderRadius:
-                  isStart && isEnd
-                    ? 6
-                    : isStart
-                      ? "6px 0 0 6px"
-                      : isEnd
-                        ? "0 6px 6px 0"
-                        : 0,
-                opacity: inMonth ? 1 : 0.4,
-              }}
-              data-testid={`day-${day.toISOString().slice(0, 10)}`}
-            >
-              {day.getDate()}
-              {isToday && !isStart && !isEnd && (
-                <span
-                  className="absolute bottom-[2px] h-[3px] w-[3px] rounded-full"
-                  style={{ background: accent }}
-                  aria-hidden="true"
+            <div key={idx} className="relative" style={{ height: ROW_H }}>
+              {showFill && (
+                <div
+                  className="absolute inset-y-1"
+                  style={{
+                    left: isStart ? "50%" : 0,
+                    right: isEnd ? "50%" : 0,
+                    background: accentFaint,
+                  }}
                 />
               )}
-            </button>
+              <button
+                type="button"
+                onClick={() => handleDayClick(day)}
+                onMouseEnter={() => setHovered(day)}
+                onMouseLeave={() => setHovered(null)}
+                className="relative mx-auto flex items-center justify-center rounded-full text-[11px] transition-colors"
+                style={{
+                  width: CAP_PX,
+                  height: CAP_PX,
+                  background: isCap ? accent : "transparent",
+                  color: isCap
+                    ? CAP_TEXT
+                    : inMonth
+                      ? "var(--color-bt-text)"
+                      : "var(--color-bt-text-dim)",
+                  fontWeight: isCap ? 700 : 400,
+                  opacity: inMonth ? 1 : 0.45,
+                  // 1px teal inset ring on hover for non-cap days, same
+                  // treatment as DatePicker / DatesSheet's full picker.
+                  boxShadow:
+                    isSameDay(day, hovered) && !isCap
+                      ? `inset 0 0 0 1px ${accent}`
+                      : "none",
+                }}
+                data-testid={`day-${day.toISOString().slice(0, 10)}`}
+              >
+                {day.getDate()}
+                {isToday && !isCap && (
+                  <span
+                    className="absolute bottom-1 h-1 w-1 rounded-full"
+                    style={{ background: accent }}
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            </div>
           );
         })}
       </div>
@@ -660,18 +941,39 @@ function InlineRangeCalendar({
         // Confirmation chip — selection matches what's already saved,
         // so there's nothing to commit. Same shape as the row's other
         // CTAs (full-width pill); reads as a positive indicator and
-        // not as an action.
-        <div
-          className="mt-2 flex w-full items-center justify-center gap-2 rounded-md py-1.5 text-[11px] font-semibold"
-          style={{
-            background: accentFaint,
-            color: accent,
-            border: `1px solid ${accent}`,
-          }}
-          data-testid="guide-dates-confirm-chip"
-        >
-          <Check size={12} strokeWidth={2.6} />
-          Set {initialRangeLabel}
+        // not as an action. Pairs with a quiet Clear link on the right
+        // so the user still has an escape hatch — without it, dates
+        // pre-populated from `initialStart/End` would be uncleanable
+        // from this view (the local Clear branch below only renders
+        // when the working range differs from the saved one).
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <div
+            className="flex flex-1 items-center justify-center gap-2 rounded-md py-1.5 text-[11px] font-semibold"
+            style={{
+              background: accentFaint,
+              color: accent,
+              border: `1px solid ${accent}`,
+            }}
+            data-testid="guide-dates-confirm-chip"
+          >
+            <Check size={12} strokeWidth={2.6} />
+            Set {initialRangeLabel}
+          </div>
+          {onClearSaved && (
+            <button
+              type="button"
+              disabled={clearing}
+              onClick={() => {
+                onClearSaved();
+                setRange({ start: null, end: null });
+              }}
+              className="rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)] disabled:opacity-40"
+              style={{ color: "var(--color-bt-text-dim)" }}
+              data-testid="guide-dates-clear-saved"
+            >
+              {clearing ? "Clearing…" : "Clear"}
+            </button>
+          )}
         </div>
       ) : (
         <div className="mt-2 flex items-center justify-between gap-2">
@@ -684,18 +986,24 @@ function InlineRangeCalendar({
               : "Pick a range"}
           </span>
           <div className="flex items-center gap-1.5">
-            {/* Quiet Clear — only renders when something is selected.
-                Wipes the working range so the user can start over
-                without hunting through months to deselect. */}
-            {(range.start || range.end) && (
+            {/* Quiet Clear — renders when something is selected OR when
+                the trip already had saved dates. Wipes the working
+                range; if onClearSaved was supplied (i.e. there are
+                persisted dates) it also clears them in the DB so the
+                rest of the app reflects the same empty state. */}
+            {(range.start || range.end || !!onClearSaved) && (
               <button
                 type="button"
-                onClick={() => setRange({ start: null, end: null })}
-                className="rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+                disabled={clearing}
+                onClick={() => {
+                  setRange({ start: null, end: null });
+                  onClearSaved?.();
+                }}
+                className="rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)] disabled:opacity-40"
                 style={{ color: "var(--color-bt-text-dim)" }}
                 data-testid="guide-dates-clear"
               >
-                Clear
+                {clearing ? "Clearing…" : "Clear"}
               </button>
             )}
             <button
@@ -720,149 +1028,3 @@ function InlineRangeCalendar({
   );
 }
 
-// ── PollBuilderPlaceholder ───────────────────────────────────────────────
-//
-// First-cut inline poll builder rendered when the parent grid has
-// expanded the Set Dates card to full width. Lays out a two-column row:
-// the same InlineRangeCalendar on the left for picking a date range +
-// a proposed-ranges rail on the right that grows horizontally as the
-// user adds windows. Launch + Cancel sit in the footer. The polished
-// design lands once the reference screenshot is back in play — this
-// placeholder proves the layout (card expansion + horizontal growth)
-// works and offers a working hand-off to the existing DatesSheet so
-// the underlying feature stays usable while the inline build matures.
-
-function PollBuilderPlaceholder({
-  accent,
-  accentFaint,
-  onCancel,
-  onOpenSheet,
-}: {
-  accent: string;
-  accentFaint: string;
-  onCancel: () => void;
-  onOpenSheet: () => void;
-}) {
-  return (
-    <div className="flex flex-1 flex-col gap-3" data-testid="poll-builder">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p
-            className="text-[14px] font-semibold leading-tight"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            Set up the date poll
-          </p>
-          <p
-            className="mt-1 text-[12px] leading-snug"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Propose a few windows the crew can vote on. Add another date
-            range to the right — the rail grows as you go.
-          </p>
-        </div>
-      </div>
-
-      {/* Inline builder canvas — left calendar / right proposed-ranges
-          rail. Right side scrolls horizontally as proposals exceed the
-          available width. */}
-      <div
-        className="flex flex-1 gap-3 overflow-hidden rounded-lg"
-        style={{
-          background: "var(--color-bt-base)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        <div
-          className="flex w-[280px] flex-shrink-0 items-center justify-center p-4 text-center"
-          style={{ borderRight: "1px solid var(--color-bt-border)" }}
-        >
-          <p
-            className="text-[12px] leading-snug"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            The inline calendar lives here.
-            <br />
-            Pick a range and add it as a proposal.
-          </p>
-        </div>
-        <div className="flex flex-1 items-center gap-3 overflow-x-auto p-3">
-          {[1, 2, 3].map((n) => (
-            <div
-              key={n}
-              className="flex h-full w-[170px] flex-shrink-0 flex-col items-center justify-center rounded-md text-center"
-              style={{
-                background: "var(--color-bt-card)",
-                border: `1px dashed ${accent}`,
-              }}
-            >
-              <p
-                className="text-[11px] uppercase tracking-[0.08em]"
-                style={{ color: accent }}
-              >
-                Proposal {n}
-              </p>
-              <p
-                className="mt-1 text-[12px]"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                — pending —
-              </p>
-            </div>
-          ))}
-          <button
-            type="button"
-            className="flex h-full w-[120px] flex-shrink-0 flex-col items-center justify-center rounded-md text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-card-raised)]"
-            style={{
-              border: `1px dashed var(--color-bt-border)`,
-              color: "var(--color-bt-text-dim)",
-            }}
-          >
-            + Add another
-          </button>
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded-lg px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
-          style={{ color: "var(--color-bt-text-dim)" }}
-          data-testid="poll-builder-cancel"
-        >
-          Cancel
-        </button>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onOpenSheet}
-            className="rounded-lg px-3 py-1.5 text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{
-              color: "var(--color-bt-text-dim)",
-              border: "1px solid var(--color-bt-border)",
-            }}
-            data-testid="poll-builder-handoff"
-          >
-            Open in dates sheet
-          </button>
-          <button
-            type="button"
-            disabled
-            className="rounded-lg px-3 py-1.5 text-[12px] font-semibold disabled:opacity-40"
-            style={{
-              background: accent,
-              color: "var(--color-bt-on-accent, #0d1f1a)",
-            }}
-            data-testid="poll-builder-launch"
-          >
-            Launch poll
-          </button>
-          {/* accentFaint reserved for the highlighted-range fill that
-              will sit on the inline calendar once it's wired up. */}
-          <span className="sr-only" style={{ background: accentFaint }} />
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -133,11 +133,15 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
     },
   });
 
-  // ── Done state — paint card with the accent-faint treatment ──────────
+  // ── Done state — accent-faint vertical fade + accent-border outline.
+  // Mirrors the .hiw-face.front.done treatment from the design spec:
+  //   background: linear-gradient(180deg, accent-faint, transparent 60%);
+  //   border-color: accent-border;
   const cardSurface: React.CSSProperties = datesSet
     ? {
-        background: tint.faint,
-        border: `1px solid ${tint.color}`,
+        background:
+          "linear-gradient(180deg, var(--color-bt-accent-faint), transparent 60%)",
+        border: "1px solid var(--color-bt-accent-border)",
       }
     : {
         background: "var(--color-bt-card)",
@@ -160,18 +164,27 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
         <CalendarThumbnail accent={tint.color} />
       </div>
 
-      {/* Title row — number badge / check inline */}
+      {/* Title row — number badge / check inline. Done state inverts the
+          badge: solid accent fill with dark checkmark ink (the rest of
+          the cards' idle badges stay accent-faint with teal numerals). */}
       <div className="flex items-center gap-2">
         <span
           className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] font-bold tabular-nums"
-          style={{
-            background: tint.faint,
-            color: tint.color,
-            border: `1px solid ${tint.color}`,
-          }}
+          style={
+            datesSet
+              ? {
+                  background: tint.color,
+                  color: "var(--color-bt-on-accent, #0d1f1a)",
+                }
+              : {
+                  background: tint.faint,
+                  color: tint.color,
+                  border: `1px solid ${tint.color}`,
+                }
+          }
           aria-hidden="true"
         >
-          {datesSet ? <Check size={12} strokeWidth={2.6} /> : 1}
+          {datesSet ? <Check size={12} strokeWidth={2.8} /> : 1}
         </span>
         <p
           className="text-[15px] font-semibold leading-tight"
@@ -196,13 +209,15 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
       <button
         type="button"
         onClick={() => setFlipped(true)}
-        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
           datesSet
             ? {
-                background: "var(--color-bt-card-raised)",
+                // Unfilled outline — the done card already carries the
+                // accent-tinted backdrop; a filled button would compete.
+                background: "transparent",
                 color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-border)",
+                border: "1px solid var(--color-bt-accent-border)",
               }
             : {
                 background: tint.color,

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -122,16 +122,17 @@ export const StepCard: FC<StepCardProps> = ({
         {done && doneSummary ? doneSummary : body}
       </p>
 
-      {/* CTA — mt-auto pins to the bottom; the gap between body text
-          and button is the visible empty space in the middle of the
-          card, intentionally preserved. When done, the CTA becomes an
-          unfilled outline button (the tinted card surface already
-          carries weight; a filled button would compete). */}
+      {/* CTA — generous breathing room above (mt-6) separates the
+          actionable button from the explanatory body so the card
+          reads as "here's the pitch / here's the action" instead of
+          one wall of content. When done, the CTA becomes an unfilled
+          outline button (the tinted card surface already carries
+          weight; a filled button would compete). */}
       <button
         type="button"
         onClick={onCta}
         data-testid={testId}
-        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
+        className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
           done
             ? {

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -82,14 +82,15 @@ export const StepCard: FC<StepCardProps> = ({
       data-testid={`step-card-${number}`}
     >
       {/* Preview area — dark surface that hosts the mini-UI thumbnail.
-          flex-1 so it stretches to fill the card's spare height; the
-          text + CTA below stay their natural size and the button gets
-          pinned to the bottom. */}
+          Fixed 130px height so the thumbnail keeps the same proportions
+          across cards. Any spare card height becomes empty space
+          between the body text and the CTA (which mt-auto pins to the
+          bottom). */}
       <div
-        className="flex flex-1 items-stretch justify-stretch overflow-hidden rounded-lg"
+        className="flex items-stretch justify-stretch overflow-hidden rounded-lg"
         style={{
           background: "var(--color-bt-base)",
-          minHeight: 120,
+          height: 130,
         }}
         aria-hidden="true"
       >
@@ -102,7 +103,7 @@ export const StepCard: FC<StepCardProps> = ({
           {number}
         </NumberBadge>
         <p
-          className="text-[14px] font-semibold leading-tight"
+          className="text-[15px] font-semibold leading-tight"
           style={{ color: "var(--color-bt-text)" }}
         >
           {title}
@@ -111,15 +112,15 @@ export const StepCard: FC<StepCardProps> = ({
 
       {/* Body / done-summary */}
       <p
-        className="text-[12px] leading-snug"
+        className="text-[13px] leading-snug"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         {done && doneSummary ? doneSummary : body}
       </p>
 
-      {/* CTA — `mt-auto` is a no-op given flex-col + flex-1 above, but
-          keeps the bottom-anchored intent legible if the preview ever
-          loses its flex-grow. */}
+      {/* CTA — mt-auto pins to the bottom; the gap between body text
+          and button is the visible empty space in the middle of the
+          card, intentionally preserved. */}
       <button
         type="button"
         onClick={onCta}

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -47,10 +47,6 @@ export interface StepCardProps {
   /** Shown above the body when done — what the user actually picked,
    *  e.g. "May 22 – 26, 2026 · 5 days. These frame your whole itinerary." */
   doneSummary?: string;
-  /** Outer card min-height in px. Defaults to none. FreshTripGuide sets
-   *  this so every step card matches the flipped Set-dates height and
-   *  nothing jars when the picker opens. */
-  minHeight?: number;
   /** Test id for the CTA. */
   testId?: string;
 }
@@ -67,7 +63,6 @@ export const StepCard: FC<StepCardProps> = ({
   onCta,
   done = false,
   doneSummary,
-  minHeight,
   testId,
 }) => {
   const tint = DOMAIN_COLORS[domain];
@@ -79,12 +74,10 @@ export const StepCard: FC<StepCardProps> = ({
         background:
           "linear-gradient(180deg, var(--color-bt-accent-faint), transparent 60%)",
         border: "1px solid var(--color-bt-accent-border)",
-        minHeight,
       }
     : {
         background: "var(--color-bt-card)",
         border: "1px solid var(--color-bt-border)",
-        minHeight,
       };
   return (
     <div

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -71,14 +71,25 @@ export const StepCard: FC<StepCardProps> = ({
   testId,
 }) => {
   const tint = DOMAIN_COLORS[domain];
-  return (
-    <div
-      className="flex flex-col gap-3 rounded-xl p-3"
-      style={{
+  // Done treatment — accent-faint vertical fade + accent-border outline.
+  // Mirrors SetDatesFlipCard's done state so completed steps speak the
+  // same visual language.
+  const surface: React.CSSProperties = done
+    ? {
+        background:
+          "linear-gradient(180deg, var(--color-bt-accent-faint), transparent 60%)",
+        border: "1px solid var(--color-bt-accent-border)",
+        minHeight,
+      }
+    : {
         background: "var(--color-bt-card)",
         border: "1px solid var(--color-bt-border)",
         minHeight,
-      }}
+      };
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-xl p-3"
+      style={surface}
       data-testid={`step-card-${number}`}
     >
       {/* Preview area — dark surface that hosts the mini-UI thumbnail.
@@ -120,23 +131,31 @@ export const StepCard: FC<StepCardProps> = ({
 
       {/* CTA — mt-auto pins to the bottom; the gap between body text
           and button is the visible empty space in the middle of the
-          card, intentionally preserved. */}
+          card, intentionally preserved. When done, the CTA becomes an
+          unfilled outline button (the tinted card surface already
+          carries weight; a filled button would compete). */}
       <button
         type="button"
         onClick={onCta}
         data-testid={testId}
-        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
-          ctaVariant === "primary"
+          done
             ? {
-                background: tint.color,
-                color: "var(--color-bt-on-accent, #0d1f1a)",
-              }
-            : {
-                background: "var(--color-bt-card-raised)",
+                background: "transparent",
                 color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-border)",
+                border: "1px solid var(--color-bt-accent-border)",
               }
+            : ctaVariant === "primary"
+              ? {
+                  background: tint.color,
+                  color: "var(--color-bt-on-accent, #0d1f1a)",
+                }
+              : {
+                  background: "var(--color-bt-card-raised)",
+                  color: "var(--color-bt-text)",
+                  border: "1px solid var(--color-bt-border)",
+                }
         }
       >
         {ctaIcon}
@@ -166,14 +185,22 @@ function NumberBadge({
   return (
     <span
       className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] font-bold tabular-nums"
-      style={{
-        background: faint,
-        color: tint,
-        border: `1px solid ${tint}`,
-      }}
+      style={
+        done
+          ? {
+              // Inverted — solid accent fill with dark check ink.
+              background: tint,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }
+          : {
+              background: faint,
+              color: tint,
+              border: `1px solid ${tint}`,
+            }
+      }
       aria-hidden="true"
     >
-      {done ? <Check size={12} strokeWidth={2.6} /> : children}
+      {done ? <Check size={12} strokeWidth={2.8} /> : children}
     </span>
   );
 }

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -142,9 +142,12 @@ export const StepCard: FC<StepCardProps> = ({
         style={
           done
             ? {
+                // Border stays the neutral border token (not accent) so
+                // the button reads as a quiet control next to the
+                // tinted card surface.
                 background: "transparent",
                 color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-accent-border)",
+                border: "1px solid var(--color-bt-border)",
               }
             : ctaVariant === "primary"
               ? {

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -47,6 +47,10 @@ export interface StepCardProps {
   /** Shown above the body when done — what the user actually picked,
    *  e.g. "May 22 – 26, 2026 · 5 days. These frame your whole itinerary." */
   doneSummary?: string;
+  /** Outer card min-height in px. Defaults to none. FreshTripGuide sets
+   *  this so every step card matches the flipped Set-dates height and
+   *  nothing jars when the picker opens. */
+  minHeight?: number;
   /** Test id for the CTA. */
   testId?: string;
 }
@@ -63,6 +67,7 @@ export const StepCard: FC<StepCardProps> = ({
   onCta,
   done = false,
   doneSummary,
+  minHeight,
   testId,
 }) => {
   const tint = DOMAIN_COLORS[domain];
@@ -72,14 +77,19 @@ export const StepCard: FC<StepCardProps> = ({
       style={{
         background: "var(--color-bt-card)",
         border: "1px solid var(--color-bt-border)",
+        minHeight,
       }}
       data-testid={`step-card-${number}`}
     >
-      {/* Preview area — dark surface that hosts the mini-UI thumbnail. */}
+      {/* Preview area — dark surface that hosts the mini-UI thumbnail.
+          flex-1 so it stretches to fill the card's spare height; the
+          text + CTA below stay their natural size and the button gets
+          pinned to the bottom. */}
       <div
-        className="flex h-[120px] items-stretch justify-stretch overflow-hidden rounded-lg"
+        className="flex flex-1 items-stretch justify-stretch overflow-hidden rounded-lg"
         style={{
           background: "var(--color-bt-base)",
+          minHeight: 120,
         }}
         aria-hidden="true"
       >
@@ -107,12 +117,14 @@ export const StepCard: FC<StepCardProps> = ({
         {done && doneSummary ? doneSummary : body}
       </p>
 
-      {/* CTA */}
+      {/* CTA — `mt-auto` is a no-op given flex-col + flex-1 above, but
+          keeps the bottom-anchored intent legible if the preview ever
+          loses its flex-grow. */}
       <button
         type="button"
         onClick={onCta}
         data-testid={testId}
-        className="flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
         style={
           ctaVariant === "primary"
             ? {

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -142,9 +142,13 @@ export const StepCard: FC<StepCardProps> = ({
         style={
           done && doneCta
             ? {
-                background: "var(--color-bt-accent-faint)",
+                // Done — transparent fill, neutral border, teal text.
+                // Mirrors the resting ghost CTA shape so the row reads
+                // consistently; the check icon + teal label carry the
+                // confirmation signal without a heavy chip fill.
+                background: "transparent",
                 color: "var(--color-bt-accent)",
-                border: "1px solid var(--color-bt-accent)",
+                border: "1px solid var(--color-bt-border)",
               }
             : ctaVariant === "primary"
               ? {

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -47,6 +47,10 @@ export interface StepCardProps {
   /** Shown above the body when done — what the user actually picked,
    *  e.g. "May 22 – 26, 2026 · 5 days. These frame your whole itinerary." */
   doneSummary?: string;
+  /** CTA label when done. Pairs with the inverted teal styling and a
+   *  leading check (e.g. "3 added", "Pinehurst Resort"). Falls back to
+   *  the normal `cta` label if not supplied. */
+  doneCta?: string;
   /** Test id for the CTA. */
   testId?: string;
 }
@@ -63,6 +67,7 @@ export const StepCard: FC<StepCardProps> = ({
   onCta,
   done = false,
   doneSummary,
+  doneCta,
   testId,
 }) => {
   const tint = DOMAIN_COLORS[domain];
@@ -125,23 +130,21 @@ export const StepCard: FC<StepCardProps> = ({
       {/* CTA — generous breathing room above (mt-6) separates the
           actionable button from the explanatory body so the card
           reads as "here's the pitch / here's the action" instead of
-          one wall of content. When done, the CTA becomes an unfilled
-          outline button (the tinted card surface already carries
-          weight; a filled button would compete). */}
+          one wall of content. When done with a doneCta label, the
+          button flips to a teal confirmation chip ("✓ 3 added" /
+          "✓ Pinehurst Resort"), mirroring SetDatesFlipCard's done
+          state. */}
       <button
         type="button"
         onClick={onCta}
         data-testid={testId}
         className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
-          done
+          done && doneCta
             ? {
-                // Border stays the neutral border token (not accent) so
-                // the button reads as a quiet control next to the
-                // tinted card surface.
-                background: "transparent",
-                color: "var(--color-bt-text)",
-                border: "1px solid var(--color-bt-border)",
+                background: "var(--color-bt-accent-faint)",
+                color: "var(--color-bt-accent)",
+                border: "1px solid var(--color-bt-accent)",
               }
             : ctaVariant === "primary"
               ? {
@@ -158,8 +161,12 @@ export const StepCard: FC<StepCardProps> = ({
                 }
         }
       >
-        {ctaIcon}
-        {cta}
+        {done && doneCta ? (
+          <Check size={14} strokeWidth={2.6} />
+        ) : (
+          ctaIcon
+        )}
+        {done && doneCta ? doneCta : cta}
       </button>
     </div>
   );

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -1,40 +1,53 @@
 "use client";
 
 import type { FC, ReactNode } from "react";
+import { Check } from "lucide-react";
 import { DOMAIN_COLORS, type Domain } from "@/lib/domainColors";
 
 // ── StepCard ─────────────────────────────────────────────────────────────
 //
-// One of the four step cards in FreshTripGuide. Owns the layout shared by
-// every step (number badge + thumbnail + title + body + CTA); the caller
-// supplies the thumbnail SVG and the click handler. Domain-tinted via the
-// shared DOMAIN_COLORS map so each step picks up its tab's color.
+// One of the four step cards in FreshTripGuide. Layout:
+//   1. dark "preview" area at the top — owns the mini-UI thumbnail. The
+//      thumbnail renders flush on this surface; no inner panel/border.
+//   2. Number badge inline with the title (number-circle is faint-teal
+//      background + teal numeral; the badge collapses to a check icon
+//      when `done`).
+//   3. One-line body or done-summary.
+//   4. CTA at the bottom. Primary variant = solid accent (use for the
+//      single "attention grabber" — Set dates), ghost variant = card-raised
+//      bg + subtle border + leading icon (matches the "Add another item"
+//      buttons under each tab).
 
 export interface StepCardProps {
-  /** Step number rendered as a small badge in the top-left. */
+  /** Step number rendered as a small badge to the LEFT of the title. */
   number: number;
-  /** Domain that drives the accent tint of the number badge + thumbnail
-   *  background + CTA. Maps to a `--color-bt-domain-*` token. */
+  /** Domain that drives the badge tint (and any future per-step
+   *  accent). Maps to a `--color-bt-domain-*` token. */
   domain: Domain;
   /** Numbered title — short noun-phrase. */
   title: string;
   /** One-line description under the title. */
   body: string;
-  /** Tiny stylized thumbnail rendered in the card's preview area. SVG or
-   *  arbitrary JSX — caller controls sizing. */
+  /** Stylized mini-UI preview. Rendered into the dark preview area. */
   thumbnail: ReactNode;
-  /** CTA button label, e.g. "Add a property". */
+  /** CTA button label, e.g. "Add lodging". */
   cta: string;
+  /** Leading icon for the CTA, e.g. <Home size={14} />. */
+  ctaIcon?: ReactNode;
+  /** "primary" → solid teal attention-grabber.
+   *  "ghost"   → translucent + bordered (matches add-another-item style).
+   *  Default ghost; only set "primary" on the single attention step. */
+  ctaVariant?: "primary" | "ghost";
   /** CTA click handler. */
   onCta: () => void;
-  /** Optional "done" mode — collapsed visual state once the step is
-   *  satisfied (e.g. dates set). The CTA becomes a quiet "Change" link;
-   *  the thumbnail and body fade back. */
+  /** Optional "done" mode — when the step is satisfied. Currently
+   *  flips the number badge to a check; the parent card may also swap
+   *  its own background to accent-faint (see SetDatesFlipCard). */
   done?: boolean;
-  /** Shown above the body when done — what the user actually picked.
-   *  E.g. "May 26 – Jun 14". */
+  /** Shown above the body when done — what the user actually picked,
+   *  e.g. "May 22 – 26, 2026 · 5 days. These frame your whole itinerary." */
   doneSummary?: string;
-  /** Optional test id for the CTA. */
+  /** Test id for the CTA. */
   testId?: string;
 }
 
@@ -45,6 +58,8 @@ export const StepCard: FC<StepCardProps> = ({
   body,
   thumbnail,
   cta,
+  ctaIcon,
+  ctaVariant = "ghost",
   onCta,
   done = false,
   doneSummary,
@@ -53,90 +68,99 @@ export const StepCard: FC<StepCardProps> = ({
   const tint = DOMAIN_COLORS[domain];
   return (
     <div
-      className="relative flex flex-col rounded-xl p-4"
+      className="flex flex-col gap-3 rounded-xl p-3"
       style={{
         background: "var(--color-bt-card)",
         border: "1px solid var(--color-bt-border)",
       }}
       data-testid={`step-card-${number}`}
     >
-      {/* Number badge */}
-      <span
-        className="absolute -top-2 left-3 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full px-1 text-[10px] font-bold tabular-nums"
-        style={{
-          background: tint.color,
-          color: "var(--color-bt-on-accent, #0d1f1a)",
-        }}
-        aria-hidden="true"
-      >
-        {number}
-      </span>
-
-      {/* Thumbnail — domain-tinted background */}
+      {/* Preview area — dark surface that hosts the mini-UI thumbnail. */}
       <div
-        className="mb-3 flex h-20 items-center justify-center overflow-hidden rounded-lg"
+        className="flex h-[120px] items-stretch justify-stretch overflow-hidden rounded-lg"
         style={{
-          background: tint.faint,
-          color: tint.color,
-          opacity: done ? 0.55 : 1,
+          background: "var(--color-bt-base)",
         }}
         aria-hidden="true"
       >
         {thumbnail}
       </div>
 
-      {/* Title */}
-      <p
-        className="text-[13px] font-semibold leading-tight"
-        style={{ color: "var(--color-bt-text)" }}
-      >
-        {title}
-      </p>
+      {/* Title row — number badge inline */}
+      <div className="flex items-center gap-2">
+        <NumberBadge done={done} tint={tint.color} faint={tint.faint}>
+          {number}
+        </NumberBadge>
+        <p
+          className="text-[14px] font-semibold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {title}
+        </p>
+      </div>
 
       {/* Body / done-summary */}
-      {done && doneSummary ? (
-        <p
-          className="mt-1 text-[12px]"
-          style={{ color: tint.color }}
-        >
-          {doneSummary}
-        </p>
-      ) : (
-        <p
-          className="mt-1 text-[11px] leading-snug"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          {body}
-        </p>
-      )}
+      <p
+        className="text-[12px] leading-snug"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {done && doneSummary ? doneSummary : body}
+      </p>
 
       {/* CTA */}
-      <div className="mt-3">
-        {done ? (
-          <button
-            type="button"
-            onClick={onCta}
-            data-testid={testId}
-            className="text-[12px] font-medium transition-opacity hover:opacity-80"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Change
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onCta}
-            data-testid={testId}
-            className="w-full rounded-lg py-2 text-[12px] font-semibold transition-opacity hover:opacity-90"
-            style={{
-              background: tint.color,
-              color: "var(--color-bt-on-accent, #0d1f1a)",
-            }}
-          >
-            {cta}
-          </button>
-        )}
-      </div>
+      <button
+        type="button"
+        onClick={onCta}
+        data-testid={testId}
+        className="flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+        style={
+          ctaVariant === "primary"
+            ? {
+                background: tint.color,
+                color: "var(--color-bt-on-accent, #0d1f1a)",
+              }
+            : {
+                background: "var(--color-bt-card-raised)",
+                color: "var(--color-bt-text)",
+                border: "1px solid var(--color-bt-border)",
+              }
+        }
+      >
+        {ctaIcon}
+        {cta}
+      </button>
     </div>
   );
 };
+
+// ── NumberBadge ─────────────────────────────────────────────────────────
+//
+// 20px circle. Idle: faint-teal background + teal numeral (inverted from
+// the previous "solid teal + dark numeral" treatment). Done: check icon
+// in the same colors.
+
+function NumberBadge({
+  children,
+  done,
+  tint,
+  faint,
+}: {
+  children: ReactNode;
+  done: boolean;
+  tint: string;
+  faint: string;
+}) {
+  return (
+    <span
+      className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] font-bold tabular-nums"
+      style={{
+        background: faint,
+        color: tint,
+        border: `1px solid ${tint}`,
+      }}
+      aria-hidden="true"
+    >
+      {done ? <Check size={12} strokeWidth={2.6} /> : children}
+    </span>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -155,7 +155,10 @@ export const StepCard: FC<StepCardProps> = ({
                   color: "var(--color-bt-on-accent, #0d1f1a)",
                 }
               : {
-                  background: "var(--color-bt-card-raised)",
+                  // Ghost — transparent so only Set dates carries a
+                  // filled accent. Border keeps the row legible at a
+                  // glance without competing for attention.
+                  background: "transparent",
                   color: "var(--color-bt-text)",
                   border: "1px solid var(--color-bt-border)",
                 }

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import type { FC, ReactNode } from "react";
+import { DOMAIN_COLORS, type Domain } from "@/lib/domainColors";
+
+// ── StepCard ─────────────────────────────────────────────────────────────
+//
+// One of the four step cards in FreshTripGuide. Owns the layout shared by
+// every step (number badge + thumbnail + title + body + CTA); the caller
+// supplies the thumbnail SVG and the click handler. Domain-tinted via the
+// shared DOMAIN_COLORS map so each step picks up its tab's color.
+
+export interface StepCardProps {
+  /** Step number rendered as a small badge in the top-left. */
+  number: number;
+  /** Domain that drives the accent tint of the number badge + thumbnail
+   *  background + CTA. Maps to a `--color-bt-domain-*` token. */
+  domain: Domain;
+  /** Numbered title — short noun-phrase. */
+  title: string;
+  /** One-line description under the title. */
+  body: string;
+  /** Tiny stylized thumbnail rendered in the card's preview area. SVG or
+   *  arbitrary JSX — caller controls sizing. */
+  thumbnail: ReactNode;
+  /** CTA button label, e.g. "Add a property". */
+  cta: string;
+  /** CTA click handler. */
+  onCta: () => void;
+  /** Optional "done" mode — collapsed visual state once the step is
+   *  satisfied (e.g. dates set). The CTA becomes a quiet "Change" link;
+   *  the thumbnail and body fade back. */
+  done?: boolean;
+  /** Shown above the body when done — what the user actually picked.
+   *  E.g. "May 26 – Jun 14". */
+  doneSummary?: string;
+  /** Optional test id for the CTA. */
+  testId?: string;
+}
+
+export const StepCard: FC<StepCardProps> = ({
+  number,
+  domain,
+  title,
+  body,
+  thumbnail,
+  cta,
+  onCta,
+  done = false,
+  doneSummary,
+  testId,
+}) => {
+  const tint = DOMAIN_COLORS[domain];
+  return (
+    <div
+      className="relative flex flex-col rounded-xl p-4"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      data-testid={`step-card-${number}`}
+    >
+      {/* Number badge */}
+      <span
+        className="absolute -top-2 left-3 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full px-1 text-[10px] font-bold tabular-nums"
+        style={{
+          background: tint.color,
+          color: "var(--color-bt-on-accent, #0d1f1a)",
+        }}
+        aria-hidden="true"
+      >
+        {number}
+      </span>
+
+      {/* Thumbnail — domain-tinted background */}
+      <div
+        className="mb-3 flex h-20 items-center justify-center overflow-hidden rounded-lg"
+        style={{
+          background: tint.faint,
+          color: tint.color,
+          opacity: done ? 0.55 : 1,
+        }}
+        aria-hidden="true"
+      >
+        {thumbnail}
+      </div>
+
+      {/* Title */}
+      <p
+        className="text-[13px] font-semibold leading-tight"
+        style={{ color: "var(--color-bt-text)" }}
+      >
+        {title}
+      </p>
+
+      {/* Body / done-summary */}
+      {done && doneSummary ? (
+        <p
+          className="mt-1 text-[12px]"
+          style={{ color: tint.color }}
+        >
+          {doneSummary}
+        </p>
+      ) : (
+        <p
+          className="mt-1 text-[11px] leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {body}
+        </p>
+      )}
+
+      {/* CTA */}
+      <div className="mt-3">
+        {done ? (
+          <button
+            type="button"
+            onClick={onCta}
+            data-testid={testId}
+            className="text-[12px] font-medium transition-opacity hover:opacity-80"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Change
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onCta}
+            data-testid={testId}
+            className="w-full rounded-lg py-2 text-[12px] font-semibold transition-opacity hover:opacity-90"
+            style={{
+              background: tint.color,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+          >
+            {cta}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/trips/[tripId]/components/setup-guide/index.ts
+++ b/src/app/trips/[tripId]/components/setup-guide/index.ts
@@ -1,0 +1,3 @@
+export { FreshTripGuide } from "./FreshTripGuide";
+export { DismissedEmptyState } from "./DismissedEmptyState";
+export { useGuideDismissed } from "./useGuideDismissed";

--- a/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
@@ -53,24 +53,32 @@ export function CalendarThumbnail({ accent }: { accent?: string } = {}) {
 
 // ── Lodging (Step 2) ─────────────────────────────────────────────────────
 //
-// Property card: blue gradient image block on top + a long title bar +
-// a shorter detail bar with a small button on the right.
+// Property card — exaggerated to fill the preview area:
+//   • Big blue-gradient image block (~55% of the height) sits on top
+//   • A thick title bar
+//   • A shorter detail bar with a chunky trailing pill (price/CTA)
 
 export function LodgingThumbnail() {
   return (
-    <div className="flex h-full w-full flex-col gap-2 p-3" aria-hidden="true">
+    <div className="flex h-full w-full flex-col gap-4 p-5" aria-hidden="true">
       <div
-        className="h-[40%] w-full rounded-md"
+        className="w-full flex-1 rounded-lg"
         style={{
           background:
-            "linear-gradient(135deg, rgba(96,165,250,0.95) 0%, rgba(59,130,246,0.85) 70%, rgba(37,99,235,0.75) 100%)",
+            "linear-gradient(135deg, rgba(96,165,250,0.95) 0%, rgba(59,130,246,0.90) 65%, rgba(37,99,235,0.85) 100%)",
         }}
       />
-      <span className="h-[5px] w-full rounded-sm" style={{ background: DIM_BRIGHTER }} />
-      <div className="flex items-center gap-2">
-        <span className="h-[5px] flex-1 rounded-sm" style={{ background: DIM }} />
+      <span
+        className="h-3 w-full rounded-md"
+        style={{ background: DIM_BRIGHTER }}
+      />
+      <div className="flex items-center gap-3">
         <span
-          className="h-[12px] w-[24px] rounded-sm"
+          className="h-3 flex-1 rounded-md"
+          style={{ background: DIM }}
+        />
+        <span
+          className="h-7 w-14 flex-shrink-0 rounded-md"
           style={{ background: DIM_BRIGHTER }}
         />
       </div>
@@ -80,29 +88,29 @@ export function LodgingThumbnail() {
 
 // ── Crew (Step 3) ────────────────────────────────────────────────────────
 //
-// Three roster rows: colored dot + name line. Distinct dot colors so the
-// roster reads as different people even with the domain palette in its
-// placeholder-teal state.
+// Three roster rows — bigger avatar circles + thicker name bars so the
+// roster reads from across the room. Distinct dot colors keep "different
+// people" legible even while the domain palette is in placeholder-teal.
 
 export function CrewThumbnail() {
   const rows: [string, number][] = [
-    ["rgba(244,114,182,0.95)", 70], // rose
-    ["rgba(45,212,191,0.95)", 60], // teal
+    ["rgba(244,114,182,0.95)", 80], // rose
+    ["rgba(45,212,191,0.95)", 65], // teal
     ["rgba(96,165,250,0.95)", 55], // blue
   ];
   return (
     <div
-      className="flex h-full w-full flex-col justify-center gap-3 p-4"
+      className="flex h-full w-full flex-col justify-center gap-5 p-5"
       aria-hidden="true"
     >
       {rows.map(([color, widthPct], i) => (
-        <div key={i} className="flex items-center gap-3">
+        <div key={i} className="flex items-center gap-4">
           <span
-            className="h-3 w-3 flex-shrink-0 rounded-full"
+            className="h-9 w-9 flex-shrink-0 rounded-full"
             style={{ background: color }}
           />
           <span
-            className="h-[5px] rounded-sm"
+            className="h-3 rounded-md"
             style={{ background: DIM_BRIGHTER, width: `${widthPct}%` }}
           />
         </div>
@@ -113,31 +121,31 @@ export function CrewThumbnail() {
 
 // ── Agenda (Step 4) ──────────────────────────────────────────────────────
 //
-// Two event chips: tiny amber/orange outlined squares (event markers) +
-// title line + a small trailing time pill.
+// Two event chips — exaggerated: bigger amber/orange outlined event
+// markers, thicker title bar, chunkier trailing time pill.
 
 export function AgendaThumbnail() {
   const items = [
-    { ring: "rgba(251,191,36,0.85)", line: 60 },
-    { ring: "rgba(251,113,36,0.85)", line: 70 },
+    { ring: "rgba(251,191,36,0.95)", line: 65 },
+    { ring: "rgba(251,113,36,0.95)", line: 75 },
   ];
   return (
     <div
-      className="flex h-full w-full flex-col justify-center gap-3 p-4"
+      className="flex h-full w-full flex-col justify-center gap-5 p-5"
       aria-hidden="true"
     >
       {items.map(({ ring, line }, i) => (
-        <div key={i} className="flex items-center gap-3">
+        <div key={i} className="flex items-center gap-4">
           <span
-            className="h-3 w-3 flex-shrink-0 rounded-[3px]"
-            style={{ border: `1.5px solid ${ring}` }}
+            className="h-9 w-9 flex-shrink-0 rounded-md"
+            style={{ border: `2.5px solid ${ring}` }}
           />
           <span
-            className="h-[5px] rounded-sm"
+            className="h-3 rounded-md"
             style={{ background: DIM_BRIGHTER, width: `${line}%` }}
           />
           <span
-            className="h-[5px] w-[28px] flex-shrink-0 rounded-sm"
+            className="h-3 w-12 flex-shrink-0 rounded-md"
             style={{ background: TEXT_DIMMER }}
           />
         </div>

--- a/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Home, Users, MapPin } from "lucide-react";
+
+// ── Mini thumbnails for steps 2–4 ────────────────────────────────────────
+//
+// Tiny stylized previews — not literal screenshots, just enough visual
+// cue per step so the grid scans at a glance. SetDatesFlipCard owns its
+// own calendar thumbnail since it sits inside a flipping container.
+
+export function LodgingThumbnail() {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <Home size={18} strokeWidth={1.8} />
+      <div className="flex h-2 w-14 rounded-sm" style={{ background: "currentColor", opacity: 0.25 }} />
+      <div className="flex h-1.5 w-10 rounded-sm" style={{ background: "currentColor", opacity: 0.4 }} />
+    </div>
+  );
+}
+
+export function CrewThumbnail() {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <Users size={18} strokeWidth={1.8} />
+      <div className="flex gap-1">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <span
+            key={i}
+            className="h-2.5 w-2.5 rounded-full"
+            style={{
+              background: "currentColor",
+              opacity: i === 0 ? 0.85 : i === 1 ? 0.65 : 0.35,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AgendaThumbnail() {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <MapPin size={18} strokeWidth={1.8} />
+      <div className="space-y-[3px]">
+        {[14, 10, 12].map((w, i) => (
+          <div
+            key={i}
+            className="h-1 rounded-sm"
+            style={{
+              width: w * 2,
+              background: "currentColor",
+              opacity: 0.45 - i * 0.1,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
@@ -2,169 +2,108 @@
 
 // ── Step thumbnails ──────────────────────────────────────────────────────
 //
-// Tiny stylized previews of each tab's UI — not literal screenshots, just
-// enough cue per step that the grid scans at a glance. Each thumbnail
-// renders into a domain-tinted backing in StepCard; colors come from
-// currentColor + small alpha plates so individual rebrands sweep through.
+// Each thumbnail renders flush into StepCard's dark preview area — no
+// inner border, no inner panel. Just the stylized mini-UI on the parent
+// surface. Colors are explicit so each step reads as its own UI rather
+// than a single tinted plate (lodging blue gradient, crew rose/teal/blue
+// dots, agenda amber outlines, etc.).
 
-const TILE_BG = "rgba(255,255,255,0.04)";
-const TILE_BORDER = "rgba(255,255,255,0.08)";
+const DIM = "rgba(255,255,255,0.10)";
+const DIM_BRIGHTER = "rgba(255,255,255,0.18)";
+const TEXT_DIM = "rgba(255,255,255,0.35)";
+const TEXT_DIMMER = "rgba(255,255,255,0.22)";
 
 // ── Calendar (Step 1: Set dates) ─────────────────────────────────────────
 //
-// A 3x5 month grid with a highlighted range across the middle row — reads
-// as "calendar with dates selected" without needing dates to be legible.
+// Sparse grid (5×7) on the dark preview surface. Two cells filled in
+// accent teal hint at the selected range without literally drawing a
+// month — the picker itself does that.
 
-export function CalendarThumbnail() {
+export function CalendarThumbnail({ accent }: { accent?: string } = {}) {
+  const ACCENT = accent ?? "var(--color-bt-accent)";
+  // Cells filled solid teal — the "selected range" hint.
+  const filled = new Set([10, 26]);
+  // Cells faintly tinted to soften the grid before the picker opens.
+  const tinted = new Set([11, 27]);
   return (
     <div
-      className="flex flex-col gap-[3px] rounded-md p-2"
-      style={{
-        background: TILE_BG,
-        border: `1px solid ${TILE_BORDER}`,
-        width: 64,
-      }}
+      className="grid h-full w-full grid-cols-7 gap-[6px] p-3"
       aria-hidden="true"
     >
-      {/* Header strip */}
-      <div className="mb-[2px] flex items-center justify-between">
-        <span
-          className="block h-[3px] w-3 rounded-sm"
-          style={{ background: "currentColor", opacity: 0.7 }}
-        />
-        <span className="flex gap-[2px]">
+      {/* Tiny header strip — top-left bar */}
+      <span className="col-span-2 h-[3px] rounded-sm" style={{ background: TEXT_DIM }} />
+      <span className="col-span-5" />
+      {Array.from({ length: 35 }).map((_, i) => {
+        const fill = filled.has(i)
+          ? ACCENT
+          : tinted.has(i)
+            ? "color-mix(in srgb, var(--color-bt-accent) 28%, transparent)"
+            : DIM;
+        return (
           <span
-            className="block h-[3px] w-[3px] rounded-full"
-            style={{ background: "currentColor", opacity: 0.4 }}
+            key={i}
+            className="aspect-square rounded-[3px]"
+            style={{ background: fill }}
           />
-          <span
-            className="block h-[3px] w-[3px] rounded-full"
-            style={{ background: "currentColor", opacity: 0.4 }}
-          />
-        </span>
-      </div>
-      {/* Weekday row */}
-      <div className="grid grid-cols-7 gap-[2px]">
-        {Array.from({ length: 7 }).map((_, i) => (
-          <span
-            key={`h-${i}`}
-            className="block h-[2px]"
-            style={{ background: "currentColor", opacity: 0.35 }}
-          />
-        ))}
-      </div>
-      {/* Day grid — middle row highlighted as a 5-day range */}
-      {Array.from({ length: 4 }).map((_, row) => (
-        <div key={`r-${row}`} className="grid grid-cols-7 gap-[2px]">
-          {Array.from({ length: 7 }).map((_, col) => {
-            const idx = row * 7 + col;
-            const inRange = idx >= 8 && idx <= 12;
-            const isCap = idx === 8 || idx === 12;
-            return (
-              <span
-                key={`d-${idx}`}
-                className="block h-[5px] rounded-[1px]"
-                style={{
-                  background: isCap
-                    ? "currentColor"
-                    : inRange
-                      ? "currentColor"
-                      : "rgba(255,255,255,0.10)",
-                  opacity: isCap ? 1 : inRange ? 0.45 : 1,
-                }}
-              />
-            );
-          })}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
 
 // ── Lodging (Step 2) ─────────────────────────────────────────────────────
 //
-// Tiny lodging card: image block on top, two text lines below, a pill on
-// the right of the title line.
+// Property card: blue gradient image block on top + a long title bar +
+// a shorter detail bar with a small button on the right.
 
 export function LodgingThumbnail() {
   return (
-    <div
-      className="flex flex-col gap-[3px] rounded-md p-1.5"
-      style={{
-        background: TILE_BG,
-        border: `1px solid ${TILE_BORDER}`,
-        width: 64,
-      }}
-      aria-hidden="true"
-    >
-      {/* Image block */}
+    <div className="flex h-full w-full flex-col gap-2 p-3" aria-hidden="true">
       <div
-        className="h-[18px] w-full rounded-[2px]"
-        style={{ background: "currentColor", opacity: 0.30 }}
+        className="h-[40%] w-full rounded-md"
+        style={{
+          background:
+            "linear-gradient(135deg, rgba(96,165,250,0.95) 0%, rgba(59,130,246,0.85) 70%, rgba(37,99,235,0.75) 100%)",
+        }}
       />
-      {/* Title row with pill */}
-      <div className="flex items-center justify-between gap-1">
+      <span className="h-[5px] w-full rounded-sm" style={{ background: DIM_BRIGHTER }} />
+      <div className="flex items-center gap-2">
+        <span className="h-[5px] flex-1 rounded-sm" style={{ background: DIM }} />
         <span
-          className="block h-[3px] flex-1 rounded-sm"
-          style={{ background: "currentColor", opacity: 0.75 }}
-        />
-        <span
-          className="block h-[5px] w-[10px] rounded-full"
-          style={{ background: "currentColor", opacity: 0.55 }}
+          className="h-[12px] w-[24px] rounded-sm"
+          style={{ background: DIM_BRIGHTER }}
         />
       </div>
-      {/* Subtitle line */}
-      <span
-        className="block h-[2px] w-9 rounded-sm"
-        style={{ background: "currentColor", opacity: 0.4 }}
-      />
-      {/* Detail line */}
-      <span
-        className="block h-[2px] w-7 rounded-sm"
-        style={{ background: "currentColor", opacity: 0.3 }}
-      />
     </div>
   );
 }
 
 // ── Crew (Step 3) ────────────────────────────────────────────────────────
 //
-// Three roster rows — colored avatar dot + name line + status pill.
+// Three roster rows: colored dot + name line. Distinct dot colors so the
+// roster reads as different people even with the domain palette in its
+// placeholder-teal state.
 
 export function CrewThumbnail() {
-  // Distinct dot colors so the roster reads as "different people" even
-  // without the rest of the domain-color system lit up yet.
-  const dots = [
-    "rgba(96,165,250,0.85)", // blue
-    "rgba(251,191,36,0.85)", // amber
-    "rgba(251,113,133,0.85)", // rose
+  const rows: [string, number][] = [
+    ["rgba(244,114,182,0.95)", 70], // rose
+    ["rgba(45,212,191,0.95)", 60], // teal
+    ["rgba(96,165,250,0.95)", 55], // blue
   ];
   return (
     <div
-      className="flex flex-col gap-[3px] rounded-md p-1.5"
-      style={{
-        background: TILE_BG,
-        border: `1px solid ${TILE_BORDER}`,
-        width: 64,
-      }}
+      className="flex h-full w-full flex-col justify-center gap-3 p-4"
       aria-hidden="true"
     >
-      {dots.map((dot, i) => (
-        <div key={i} className="flex items-center gap-1">
+      {rows.map(([color, widthPct], i) => (
+        <div key={i} className="flex items-center gap-3">
           <span
-            className="block h-[6px] w-[6px] flex-shrink-0 rounded-full"
-            style={{ background: dot }}
+            className="h-3 w-3 flex-shrink-0 rounded-full"
+            style={{ background: color }}
           />
           <span
-            className="block h-[3px] flex-1 rounded-sm"
-            style={{
-              background: "currentColor",
-              opacity: 0.55 - i * 0.1,
-            }}
-          />
-          <span
-            className="block h-[3px] w-[8px] rounded-full"
-            style={{ background: "currentColor", opacity: 0.35 }}
+            className="h-[5px] rounded-sm"
+            style={{ background: DIM_BRIGHTER, width: `${widthPct}%` }}
           />
         </div>
       ))}
@@ -174,43 +113,32 @@ export function CrewThumbnail() {
 
 // ── Agenda (Step 4) ──────────────────────────────────────────────────────
 //
-// A day cluster: small day badge on top, then three event rows each with a
-// colored left marker and a title bar.
+// Two event chips: tiny amber/orange outlined squares (event markers) +
+// title line + a small trailing time pill.
 
 export function AgendaThumbnail() {
-  const markers = [
-    "currentColor", // primary
-    "rgba(251,191,36,0.85)", // amber accent
-    "currentColor",
+  const items = [
+    { ring: "rgba(251,191,36,0.85)", line: 60 },
+    { ring: "rgba(251,113,36,0.85)", line: 70 },
   ];
   return (
     <div
-      className="flex flex-col gap-[3px] rounded-md p-1.5"
-      style={{
-        background: TILE_BG,
-        border: `1px solid ${TILE_BORDER}`,
-        width: 64,
-      }}
+      className="flex h-full w-full flex-col justify-center gap-3 p-4"
       aria-hidden="true"
     >
-      {/* Day badge */}
-      <span
-        className="block h-[4px] w-[20px] rounded-sm"
-        style={{ background: "currentColor", opacity: 0.45 }}
-      />
-      {/* Event chips */}
-      {markers.map((marker, i) => (
-        <div
-          key={i}
-          className="flex items-center gap-1 rounded-[2px] py-[1.5px] pl-1"
-          style={{
-            background: "rgba(255,255,255,0.06)",
-            borderLeft: `2px solid ${marker}`,
-          }}
-        >
+      {items.map(({ ring, line }, i) => (
+        <div key={i} className="flex items-center gap-3">
           <span
-            className="block h-[3px] flex-1 rounded-sm"
-            style={{ background: "currentColor", opacity: 0.6 - i * 0.05 }}
+            className="h-3 w-3 flex-shrink-0 rounded-[3px]"
+            style={{ border: `1.5px solid ${ring}` }}
+          />
+          <span
+            className="h-[5px] rounded-sm"
+            style={{ background: DIM_BRIGHTER, width: `${line}%` }}
+          />
+          <span
+            className="h-[5px] w-[28px] flex-shrink-0 rounded-sm"
+            style={{ background: TEXT_DIMMER }}
           />
         </div>
       ))}

--- a/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
@@ -53,32 +53,27 @@ export function CalendarThumbnail({ accent }: { accent?: string } = {}) {
 
 // ── Lodging (Step 2) ─────────────────────────────────────────────────────
 //
-// Property card — exaggerated to fill the preview area:
-//   • Big blue-gradient image block (~55% of the height) sits on top
-//   • A thick title bar
-//   • A shorter detail bar with a chunky trailing pill (price/CTA)
+// Property card: blue gradient image block on top + a long title bar +
+// a shorter detail bar with a small button on the right.
 
 export function LodgingThumbnail() {
   return (
-    <div className="flex h-full w-full flex-col gap-4 p-5" aria-hidden="true">
+    <div className="flex h-full w-full flex-col gap-2 p-3" aria-hidden="true">
       <div
-        className="w-full flex-1 rounded-lg"
+        className="h-[40%] w-full rounded-md"
         style={{
           background:
-            "linear-gradient(135deg, rgba(96,165,250,0.95) 0%, rgba(59,130,246,0.90) 65%, rgba(37,99,235,0.85) 100%)",
+            "linear-gradient(135deg, rgba(96,165,250,0.95) 0%, rgba(59,130,246,0.85) 70%, rgba(37,99,235,0.75) 100%)",
         }}
       />
       <span
-        className="h-3 w-full rounded-md"
+        className="h-[5px] w-full rounded-sm"
         style={{ background: DIM_BRIGHTER }}
       />
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2">
+        <span className="h-[5px] flex-1 rounded-sm" style={{ background: DIM }} />
         <span
-          className="h-3 flex-1 rounded-md"
-          style={{ background: DIM }}
-        />
-        <span
-          className="h-7 w-14 flex-shrink-0 rounded-md"
+          className="h-[12px] w-[24px] rounded-sm"
           style={{ background: DIM_BRIGHTER }}
         />
       </div>
@@ -88,29 +83,29 @@ export function LodgingThumbnail() {
 
 // ── Crew (Step 3) ────────────────────────────────────────────────────────
 //
-// Three roster rows — bigger avatar circles + thicker name bars so the
-// roster reads from across the room. Distinct dot colors keep "different
-// people" legible even while the domain palette is in placeholder-teal.
+// Three roster rows: colored dot + name line. Distinct dot colors so the
+// roster reads as different people even with the domain palette in its
+// placeholder-teal state.
 
 export function CrewThumbnail() {
   const rows: [string, number][] = [
-    ["rgba(244,114,182,0.95)", 80], // rose
-    ["rgba(45,212,191,0.95)", 65], // teal
+    ["rgba(244,114,182,0.95)", 70], // rose
+    ["rgba(45,212,191,0.95)", 60], // teal
     ["rgba(96,165,250,0.95)", 55], // blue
   ];
   return (
     <div
-      className="flex h-full w-full flex-col justify-center gap-5 p-5"
+      className="flex h-full w-full flex-col justify-center gap-3 p-4"
       aria-hidden="true"
     >
       {rows.map(([color, widthPct], i) => (
-        <div key={i} className="flex items-center gap-4">
+        <div key={i} className="flex items-center gap-3">
           <span
-            className="h-9 w-9 flex-shrink-0 rounded-full"
+            className="h-3 w-3 flex-shrink-0 rounded-full"
             style={{ background: color }}
           />
           <span
-            className="h-3 rounded-md"
+            className="h-[5px] rounded-sm"
             style={{ background: DIM_BRIGHTER, width: `${widthPct}%` }}
           />
         </div>
@@ -121,31 +116,31 @@ export function CrewThumbnail() {
 
 // ── Agenda (Step 4) ──────────────────────────────────────────────────────
 //
-// Two event chips — exaggerated: bigger amber/orange outlined event
-// markers, thicker title bar, chunkier trailing time pill.
+// Two event chips: tiny amber/orange outlined squares (event markers) +
+// title line + a small trailing time pill.
 
 export function AgendaThumbnail() {
   const items = [
-    { ring: "rgba(251,191,36,0.95)", line: 65 },
-    { ring: "rgba(251,113,36,0.95)", line: 75 },
+    { ring: "rgba(251,191,36,0.85)", line: 60 },
+    { ring: "rgba(251,113,36,0.85)", line: 70 },
   ];
   return (
     <div
-      className="flex h-full w-full flex-col justify-center gap-5 p-5"
+      className="flex h-full w-full flex-col justify-center gap-3 p-4"
       aria-hidden="true"
     >
       {items.map(({ ring, line }, i) => (
-        <div key={i} className="flex items-center gap-4">
+        <div key={i} className="flex items-center gap-3">
           <span
-            className="h-9 w-9 flex-shrink-0 rounded-md"
-            style={{ border: `2.5px solid ${ring}` }}
+            className="h-3 w-3 flex-shrink-0 rounded-[3px]"
+            style={{ border: `1.5px solid ${ring}` }}
           />
           <span
-            className="h-3 rounded-md"
+            className="h-[5px] rounded-sm"
             style={{ background: DIM_BRIGHTER, width: `${line}%` }}
           />
           <span
-            className="h-3 w-12 flex-shrink-0 rounded-md"
+            className="h-[5px] w-[28px] flex-shrink-0 rounded-sm"
             style={{ background: TEXT_DIMMER }}
           />
         </div>

--- a/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/thumbnails.tsx
@@ -1,60 +1,219 @@
 "use client";
 
-import { Home, Users, MapPin } from "lucide-react";
-
-// ── Mini thumbnails for steps 2–4 ────────────────────────────────────────
+// ── Step thumbnails ──────────────────────────────────────────────────────
 //
-// Tiny stylized previews — not literal screenshots, just enough visual
-// cue per step so the grid scans at a glance. SetDatesFlipCard owns its
-// own calendar thumbnail since it sits inside a flipping container.
+// Tiny stylized previews of each tab's UI — not literal screenshots, just
+// enough cue per step that the grid scans at a glance. Each thumbnail
+// renders into a domain-tinted backing in StepCard; colors come from
+// currentColor + small alpha plates so individual rebrands sweep through.
+
+const TILE_BG = "rgba(255,255,255,0.04)";
+const TILE_BORDER = "rgba(255,255,255,0.08)";
+
+// ── Calendar (Step 1: Set dates) ─────────────────────────────────────────
+//
+// A 3x5 month grid with a highlighted range across the middle row — reads
+// as "calendar with dates selected" without needing dates to be legible.
+
+export function CalendarThumbnail() {
+  return (
+    <div
+      className="flex flex-col gap-[3px] rounded-md p-2"
+      style={{
+        background: TILE_BG,
+        border: `1px solid ${TILE_BORDER}`,
+        width: 64,
+      }}
+      aria-hidden="true"
+    >
+      {/* Header strip */}
+      <div className="mb-[2px] flex items-center justify-between">
+        <span
+          className="block h-[3px] w-3 rounded-sm"
+          style={{ background: "currentColor", opacity: 0.7 }}
+        />
+        <span className="flex gap-[2px]">
+          <span
+            className="block h-[3px] w-[3px] rounded-full"
+            style={{ background: "currentColor", opacity: 0.4 }}
+          />
+          <span
+            className="block h-[3px] w-[3px] rounded-full"
+            style={{ background: "currentColor", opacity: 0.4 }}
+          />
+        </span>
+      </div>
+      {/* Weekday row */}
+      <div className="grid grid-cols-7 gap-[2px]">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <span
+            key={`h-${i}`}
+            className="block h-[2px]"
+            style={{ background: "currentColor", opacity: 0.35 }}
+          />
+        ))}
+      </div>
+      {/* Day grid — middle row highlighted as a 5-day range */}
+      {Array.from({ length: 4 }).map((_, row) => (
+        <div key={`r-${row}`} className="grid grid-cols-7 gap-[2px]">
+          {Array.from({ length: 7 }).map((_, col) => {
+            const idx = row * 7 + col;
+            const inRange = idx >= 8 && idx <= 12;
+            const isCap = idx === 8 || idx === 12;
+            return (
+              <span
+                key={`d-${idx}`}
+                className="block h-[5px] rounded-[1px]"
+                style={{
+                  background: isCap
+                    ? "currentColor"
+                    : inRange
+                      ? "currentColor"
+                      : "rgba(255,255,255,0.10)",
+                  opacity: isCap ? 1 : inRange ? 0.45 : 1,
+                }}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Lodging (Step 2) ─────────────────────────────────────────────────────
+//
+// Tiny lodging card: image block on top, two text lines below, a pill on
+// the right of the title line.
 
 export function LodgingThumbnail() {
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <Home size={18} strokeWidth={1.8} />
-      <div className="flex h-2 w-14 rounded-sm" style={{ background: "currentColor", opacity: 0.25 }} />
-      <div className="flex h-1.5 w-10 rounded-sm" style={{ background: "currentColor", opacity: 0.4 }} />
+    <div
+      className="flex flex-col gap-[3px] rounded-md p-1.5"
+      style={{
+        background: TILE_BG,
+        border: `1px solid ${TILE_BORDER}`,
+        width: 64,
+      }}
+      aria-hidden="true"
+    >
+      {/* Image block */}
+      <div
+        className="h-[18px] w-full rounded-[2px]"
+        style={{ background: "currentColor", opacity: 0.30 }}
+      />
+      {/* Title row with pill */}
+      <div className="flex items-center justify-between gap-1">
+        <span
+          className="block h-[3px] flex-1 rounded-sm"
+          style={{ background: "currentColor", opacity: 0.75 }}
+        />
+        <span
+          className="block h-[5px] w-[10px] rounded-full"
+          style={{ background: "currentColor", opacity: 0.55 }}
+        />
+      </div>
+      {/* Subtitle line */}
+      <span
+        className="block h-[2px] w-9 rounded-sm"
+        style={{ background: "currentColor", opacity: 0.4 }}
+      />
+      {/* Detail line */}
+      <span
+        className="block h-[2px] w-7 rounded-sm"
+        style={{ background: "currentColor", opacity: 0.3 }}
+      />
     </div>
   );
 }
+
+// ── Crew (Step 3) ────────────────────────────────────────────────────────
+//
+// Three roster rows — colored avatar dot + name line + status pill.
 
 export function CrewThumbnail() {
+  // Distinct dot colors so the roster reads as "different people" even
+  // without the rest of the domain-color system lit up yet.
+  const dots = [
+    "rgba(96,165,250,0.85)", // blue
+    "rgba(251,191,36,0.85)", // amber
+    "rgba(251,113,133,0.85)", // rose
+  ];
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <Users size={18} strokeWidth={1.8} />
-      <div className="flex gap-1">
-        {Array.from({ length: 4 }).map((_, i) => (
+    <div
+      className="flex flex-col gap-[3px] rounded-md p-1.5"
+      style={{
+        background: TILE_BG,
+        border: `1px solid ${TILE_BORDER}`,
+        width: 64,
+      }}
+      aria-hidden="true"
+    >
+      {dots.map((dot, i) => (
+        <div key={i} className="flex items-center gap-1">
           <span
-            key={i}
-            className="h-2.5 w-2.5 rounded-full"
+            className="block h-[6px] w-[6px] flex-shrink-0 rounded-full"
+            style={{ background: dot }}
+          />
+          <span
+            className="block h-[3px] flex-1 rounded-sm"
             style={{
               background: "currentColor",
-              opacity: i === 0 ? 0.85 : i === 1 ? 0.65 : 0.35,
+              opacity: 0.55 - i * 0.1,
             }}
           />
-        ))}
-      </div>
+          <span
+            className="block h-[3px] w-[8px] rounded-full"
+            style={{ background: "currentColor", opacity: 0.35 }}
+          />
+        </div>
+      ))}
     </div>
   );
 }
 
+// ── Agenda (Step 4) ──────────────────────────────────────────────────────
+//
+// A day cluster: small day badge on top, then three event rows each with a
+// colored left marker and a title bar.
+
 export function AgendaThumbnail() {
+  const markers = [
+    "currentColor", // primary
+    "rgba(251,191,36,0.85)", // amber accent
+    "currentColor",
+  ];
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <MapPin size={18} strokeWidth={1.8} />
-      <div className="space-y-[3px]">
-        {[14, 10, 12].map((w, i) => (
-          <div
-            key={i}
-            className="h-1 rounded-sm"
-            style={{
-              width: w * 2,
-              background: "currentColor",
-              opacity: 0.45 - i * 0.1,
-            }}
+    <div
+      className="flex flex-col gap-[3px] rounded-md p-1.5"
+      style={{
+        background: TILE_BG,
+        border: `1px solid ${TILE_BORDER}`,
+        width: 64,
+      }}
+      aria-hidden="true"
+    >
+      {/* Day badge */}
+      <span
+        className="block h-[4px] w-[20px] rounded-sm"
+        style={{ background: "currentColor", opacity: 0.45 }}
+      />
+      {/* Event chips */}
+      {markers.map((marker, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-1 rounded-[2px] py-[1.5px] pl-1"
+          style={{
+            background: "rgba(255,255,255,0.06)",
+            borderLeft: `2px solid ${marker}`,
+          }}
+        >
+          <span
+            className="block h-[3px] flex-1 rounded-sm"
+            style={{ background: "currentColor", opacity: 0.6 - i * 0.05 }}
           />
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/app/trips/[tripId]/components/setup-guide/useGuideDismissed.ts
+++ b/src/app/trips/[tripId]/components/setup-guide/useGuideDismissed.ts
@@ -17,16 +17,33 @@ const KEY = (tripId: string) => `bt-trip-${tripId}-setup-guide-dismissed`;
 export function useGuideDismissed(
   tripId: string,
 ): [boolean, (next: boolean) => void] {
-  const [dismissed, setDismissedState] = useState<boolean>(false);
+  // Lazy useState initializer reads localStorage on the very first
+  // render. SSR returns false (window is undefined); on the client the
+  // initial render reflects the persisted value. This sidesteps the
+  // react-hooks/set-state-in-effect lint rule that hydration-via-effect
+  // patterns trigger.
+  const [dismissed, setDismissedState] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(KEY(tripId)) === "1";
+    } catch {
+      return false;
+    }
+  });
 
-  // Hydrate once on mount from localStorage. Guarded so SSR (Next.js
-  // server render) doesn't trip on `window`.
+  // Re-read when tripId changes (rare — usually a route swap, since
+  // each trip page has its own URL). The localStorage read is the
+  // external system this effect synchronises against — exactly the
+  // "subscribe for updates from an external system" case the lint
+  // rule docs whitelist — so the directive below is intentional.
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
-      setDismissedState(window.localStorage.getItem(KEY(tripId)) === "1");
+      const next = window.localStorage.getItem(KEY(tripId)) === "1";
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDismissedState((cur) => (cur === next ? cur : next));
     } catch {
-      // Storage disabled / private mode — fall through with default false.
+      // Storage disabled / private mode — keep current state.
     }
   }, [tripId]);
 

--- a/src/app/trips/[tripId]/components/setup-guide/useGuideDismissed.ts
+++ b/src/app/trips/[tripId]/components/setup-guide/useGuideDismissed.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+// ── useGuideDismissed ────────────────────────────────────────────────────
+//
+// Persists the setup-guide dismiss state per trip in localStorage. The flag
+// is scoped to the *trip*, not the user, because the guide is owner-only
+// and an owner who switches devices in the middle of setup probably wants
+// to see it again on the new device — there's no harm in re-showing it.
+//
+// Returns a tuple: [dismissed, setDismissed]. setDismissed(true) hides,
+// setDismissed(false) restores (used by the "Show setup guide" link).
+
+const KEY = (tripId: string) => `bt-trip-${tripId}-setup-guide-dismissed`;
+
+export function useGuideDismissed(
+  tripId: string,
+): [boolean, (next: boolean) => void] {
+  const [dismissed, setDismissedState] = useState<boolean>(false);
+
+  // Hydrate once on mount from localStorage. Guarded so SSR (Next.js
+  // server render) doesn't trip on `window`.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      setDismissedState(window.localStorage.getItem(KEY(tripId)) === "1");
+    } catch {
+      // Storage disabled / private mode — fall through with default false.
+    }
+  }, [tripId]);
+
+  const setDismissed = useCallback(
+    (next: boolean) => {
+      setDismissedState(next);
+      if (typeof window === "undefined") return;
+      try {
+        if (next) window.localStorage.setItem(KEY(tripId), "1");
+        else window.localStorage.removeItem(KEY(tripId));
+      } catch {
+        // Best-effort — state still flips in memory.
+      }
+    },
+    [tripId],
+  );
+
+  return [dismissed, setDismissed];
+}

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -412,6 +412,7 @@ export default function TripDetailPage() {
                 onEnableComp={effectiveCanEdit ? () => { setCompUnlocked(true); setActiveTab("comp"); } : undefined}
                 compActivated={showComp}
                 onOpenChat={() => setChatOpen(true)}
+                onOpenDatesSheet={canEdit ? () => setDatesSheetOpen(true) : undefined}
               />
             )}
           </main>
@@ -491,6 +492,7 @@ export default function TripDetailPage() {
                     onWriteInvitation={() => setShowWriteInvitationModal(true)}
                     onAdvanceToGoing={isOwner ? () => setShowInvitationModal(true) : undefined}
                     actionCenterTitleAction={summaryButton}
+                    onOpenDatesSheet={canEdit ? () => setDatesSheetOpen(true) : undefined}
                   />
                 )}
                 {activeTab === "schedule" && (

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -585,7 +585,6 @@ export default function TripDetailPage() {
           tripId={tripId}
           trip={trip}
           isOwner={isOwner}
-          onTabChange={(tab) => setActiveTab(tab as TabId)}
         />
       )}
 

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -34,7 +34,8 @@ export function HomeTab({
   isOwner,
   onTabChange,
   onOpenChat,
-}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; compActivated?: boolean; onOpenChat?: () => void; onWriteInvitation?: () => void; onAdvanceToGoing?: () => void; actionCenterTitleAction?: React.ReactNode }) {
+  onOpenDatesSheet,
+}: TabProps & { displayStatus?: TripDisplayStatus; onTabChange?: (tab: string) => void; onEnableComp?: () => void; compActivated?: boolean; onOpenChat?: () => void; onWriteInvitation?: () => void; onAdvanceToGoing?: () => void; actionCenterTitleAction?: React.ReactNode; onOpenDatesSheet?: () => void }) {
   // Prefetch ideas so IdeaZonePanel renders instantly when stage === "idea".
   trpc.ideas.list.useQuery({ tripId: trip.id });
 
@@ -88,6 +89,8 @@ export function HomeTab({
             trip={trip}
             isOwner={!!isOwner}
             isActivated={!!trip.itinerary_enabled}
+            onOpenDatesSheet={onOpenDatesSheet}
+            onTabChange={onTabChange}
           />
         </>
       )}

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -60,16 +60,22 @@ export function HomeTab({
     stage === "planning" ||
     (stage === "going" && (status === "going" || status === "now"));
 
+  // FreshTripGuide owns its own welcoming header when it renders, so the
+  // generic "You're driving this trip" TabHeader collapses to avoid two
+  // intros stacked on top of each other. The guide renders for owners
+  // who haven't dismissed it AND don't yet have a populated itinerary —
+  // matched against the same gates ItineraryPanel uses.
+  const guideOwnsHeader =
+    !!isOwner && !!showFullPanels;
+
   return (
     <div className="space-y-4 px-4">
       {showFullPanels && (
         <>
-          {/* Owner intro — same marketing-style typography as the other tabs'
-              TabHeader, but without an eyebrow (the trip header above already
-              announces context). Reinforces what the owner controls and the
-              fact that the crew sees only what's published. Members and
-              planners don't see this — it's owner-coaching copy. */}
-          {isOwner && (
+          {/* Owner intro — only shown when FreshTripGuide isn't (because
+              the guide carries its own welcoming header that already
+              announces context). */}
+          {isOwner && !guideOwnsHeader && (
             <TabHeader
               headline="You're driving this trip"
               body="Lock in dates and destination, invite the crew, and add logistics as they firm up. You decide what the crew sees — from travel plans to a live competition leaderboard — and everyone stays in sync in real time."

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -69,7 +69,7 @@ export function HomeTab({
     !!isOwner && !!showFullPanels;
 
   return (
-    <div className="space-y-4 px-4">
+    <div className="space-y-4 px-4 pt-3">
       {showFullPanels && (
         <>
           {/* Owner intro — only shown when FreshTripGuide isn't (because

--- a/src/app/trips/[tripId]/tabs/HomeTab.tsx
+++ b/src/app/trips/[tripId]/tabs/HomeTab.tsx
@@ -68,8 +68,12 @@ export function HomeTab({
   const guideOwnsHeader =
     !!isOwner && !!showFullPanels;
 
+  // pt-1 (4px) lands the guide / ITINERARY eyebrow level with the
+  // other tabs' TabHeader eyebrow (Crew/Lodging/Agenda/Receipts). The
+  // wrapper previously used pt-3, which stacked 12px on top of the
+  // parent's pt-4 and pushed the heading a few pixels below its peers.
   return (
-    <div className="space-y-4 px-4 pt-3">
+    <div className="space-y-4 px-4 pt-1">
       {showFullPanels && (
         <>
           {/* Owner intro — only shown when FreshTripGuide isn't (because

--- a/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollCard.tsx
@@ -1,18 +1,17 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import { Info, Pencil, RotateCcw, ThumbsUp, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ThumbsUp } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
-import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { parseLocalDate } from "@/lib/dates";
 import type { TripData } from "../types";
-import {
-  DatePollGrid,
-  type PollMember,
-  type PollWindow,
-  type VoteAnswer,
+import type {
+  PollMember,
+  PollWindow,
+  VoteAnswer,
 } from "./DatePollGrid";
+import { DatePollStackedCards } from "./DatePollStackedCards";
 import { ConfirmDatesModal } from "../../components/ConfirmDatesModal";
 
 export interface DatePollCardProps {
@@ -21,9 +20,6 @@ export interface DatePollCardProps {
   /** Owner / planner only — shown as "Manage →" in the Crew column header. */
   onManageCrew?: () => void;
 }
-
-const DEFAULT_POLL_NOTE =
-  "We're trying to get a feel for everyone's availability before locking in a date — let us know what you think about these options.";
 
 function sortWindows(ws: PollWindow[]): PollWindow[] {
   return ws.slice().sort((a, b) => {
@@ -50,18 +46,11 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
 
-  const [showAddDateModal, setShowAddDateModal] = useState(false);
-  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
-  const [showResetConfirm, setShowResetConfirm] = useState(false);
-  // Pending window to lock — set when owner clicks "Select this date";
+  // Pending window to lock — set when owner clicks "Lock in [range]";
   // cleared when the ConfirmDatesModal is confirmed or cancelled.
+  // Add/remove confirms live inside DatePollStackedCards (inline confirm
+  // pattern); reset/cancel-poll likewise (footer escape hatch).
   const [pendingLockWindowId, setPendingLockWindowId] = useState<string | null>(null);
-
-  // Poll note modal + editor
-  const [showNoteModal, setShowNoteModal] = useState(false);
-  const [editingNote, setEditingNote] = useState(false);
-  const [noteValue, setNoteValue] = useState<string>("");
-  const noteTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const { data: poll } = trpc.datePoll.get.useQuery({ tripId });
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
@@ -70,9 +59,6 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
     () => sortWindows((poll?.windows ?? []) as PollWindow[]),
     [poll?.windows]
   );
-
-  const pollNote = poll?.pollNote ?? null;
-  const displayNote = pollNote ?? DEFAULT_POLL_NOTE;
 
   const pollMembers: PollMember[] = useMemo(
     () =>
@@ -83,6 +69,16 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
       })),
     [members]
   );
+
+  // Owner's display name — surfaced in the member view's "Dates are being
+  // picked" intro header and the empty-state body ("{Owner} hasn't posted
+  // any windows yet"). Falls back to a neutral noun if the owner record
+  // isn't loaded yet (or somehow missing — defensive).
+  const ownerName = useMemo(() => {
+    const owner = (members as Array<{ role?: string | null; displayName: string }>)
+      .find((m) => m.role === "Owner");
+    return owner?.displayName ?? "The organizer";
+  }, [members]);
 
   // Has the current user voted on every available window?
   const allWindowsVoted =
@@ -306,9 +302,6 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
     onError(_e, _v, ctx) {
       if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
     },
-    onSuccess() {
-      setShowResetConfirm(false);
-    },
     onSettled() {
       utils.datePoll.get.invalidate({ tripId });
     },
@@ -353,26 +346,6 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
     },
   });
 
-  const updatePollNote = trpc.datePoll.updatePollNote.useMutation({
-    async onMutate(vars) {
-      await utils.datePoll.get.cancel({ tripId });
-      const prev = utils.datePoll.get.getData({ tripId });
-      utils.datePoll.get.setData({ tripId }, (old) =>
-        old ? { ...old, pollNote: vars.note } : old
-      );
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.datePoll.get.setData({ tripId }, ctx.prev);
-    },
-    onSuccess() {
-      setEditingNote(false);
-    },
-    onSettled() {
-      utils.datePoll.get.invalidate({ tripId });
-    },
-  });
-
   // ── Poll-open view ─────────────────────────────────────────────────────
 
   const handleVote = (windowId: string, answer: VoteAnswer, userId: string) => {
@@ -383,153 +356,98 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
     }
   };
 
-  const anyVotes = windows.some((w) => w.votes.length > 0);
-
-  const pendingRemoveWindow = confirmRemoveId
-    ? windows.find((w) => w.id === confirmRemoveId) ?? null
-    : null;
-
-  const handleSaveNote = () => {
-    const trimmed = noteValue.trim();
-    updatePollNote.mutate({ tripId, note: trimmed || null });
-  };
-
-  const handleStartEditNote = () => {
-    setNoteValue(pollNote ?? "");
-    setEditingNote(true);
-    setShowNoteModal(true);
-    setTimeout(() => {
-      noteTextareaRef.current?.focus();
-      noteTextareaRef.current?.select();
-    }, 0);
-  };
+  // Touch unused symbols so a future refactor can rewire them cleanly.
+  // `anyVotes` was the gate for the legacy Reset row (now superseded by
+  // the per-card delete / cancel-poll flow inside DatePollStackedCards);
+  // `resetPoll` is still wired in case we add a "clear my votes" affordance.
+  void windows.some((w) => w.votes.length > 0);
+  void resetPoll;
 
   return (
     <>
-      <div className="space-y-2">
-        {/* ── Instructions button — opens note modal ── */}
-        {windows.length > 0 && (
-          <div className="flex items-center justify-between">
-            <button
-              type="button"
-              onClick={() => {
-                setNoteValue(pollNote ?? "");
-                setEditingNote(false);
-                setShowNoteModal(true);
+      {/* Cap the whole poll surface at 720px so the cards stay readable
+          on wide screens — beyond that the tally bar + roster chips
+          spread too thin and the eye loses the per-card unit. The cap
+          covers the member intro header too so it aligns with the
+          panel underneath. */}
+      <div className="space-y-2" style={{ maxWidth: 720 }}>
+        {/* ── Member intro header ─────────────────────────────────────
+            The owner sees the FreshTripGuide header upstream ("Now let's
+            lock the dates" — see FreshTripGuide.tsx); members come into
+            this surface cold via ItineraryPanel and need the same context
+            framing. Eyebrow + headline + body matches the shared
+            TabHeader cadence (11px accent eyebrow, clamp-scaled
+            semibold headline, 15px body at 1.65 line-height). */}
+        {!isOwner && (
+          <header className="mb-3">
+            <p
+              className="mb-3 text-[11px] font-semibold uppercase"
+              style={{ color: "var(--color-bt-accent)", letterSpacing: "0.1em" }}
+            >
+              Date poll
+            </p>
+            <h2
+              className="mb-3 font-semibold"
+              style={{
+                color: "var(--color-bt-text)",
+                fontSize: "clamp(20px, 2.8vw, 26px)",
+                lineHeight: 1.15,
+                letterSpacing: "-0.015em",
               }}
-              className="flex items-center gap-1.5 text-xs font-medium transition-opacity hover:opacity-70"
-              style={{ color: "var(--color-bt-text-dim)", background: "transparent", border: "none" }}
             >
-              <Info size={13} />
-              Crew Instructions
-              {isOwner && <Pencil size={11} style={{ color: "var(--color-bt-accent)", opacity: 0.7 }} />}
-            </button>
-          </div>
+              Dates are being picked
+            </h2>
+            <p
+              className="max-w-prose"
+              style={{
+                color: "var(--color-bt-text-dim)",
+                fontSize: 15,
+                lineHeight: 1.65,
+              }}
+            >
+              {ownerName}&rsquo;s lining up a few date options for the trip.
+              Once they&rsquo;re posted, you&rsquo;ll vote on each one right
+              here.
+            </p>
+          </header>
         )}
 
-        {/* ── Note modal ── */}
-        {showNoteModal && (
-          <div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
-            style={{ background: "rgba(0,0,0,0.6)" }}
-            onClick={(e) => { if (e.target === e.currentTarget) { setShowNoteModal(false); setEditingNote(false); } }}
-          >
-            <div
-              className="w-full max-w-md rounded-2xl p-5 shadow-xl"
-              style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-            >
-              <div className="mb-4 flex items-center justify-between gap-2">
-                <h3 className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                  Crew Instructions
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => { setShowNoteModal(false); setEditingNote(false); }}
-                  className="rounded-lg p-1 transition-opacity hover:opacity-70"
-                  style={{ color: "var(--color-bt-text-dim)" }}
-                >
-                  <X size={16} />
-                </button>
-              </div>
-
-              {editingNote ? (
-                <div className="space-y-3">
-                  <textarea
-                    ref={noteTextareaRef}
-                    value={noteValue}
-                    onChange={(e) => setNoteValue(e.target.value)}
-                    rows={4}
-                    maxLength={500}
-                    placeholder={DEFAULT_POLL_NOTE}
-                    className="w-full resize-none rounded-xl px-3 py-2.5 text-[13px] leading-relaxed outline-none"
-                    style={{
-                      background: "var(--color-bt-card-raised)",
-                      border: "1px solid var(--color-bt-accent)",
-                      color: "var(--color-bt-text)",
-                    }}
-                  />
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setEditingNote(false)}
-                      className="flex-1 rounded-xl py-2 text-[13px] font-medium"
-                      style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => { handleSaveNote(); setShowNoteModal(false); }}
-                      disabled={updatePollNote.isPending}
-                      className="flex-1 rounded-xl py-2 text-[13px] font-semibold disabled:opacity-40"
-                      style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-                    >
-                      {updatePollNote.isPending ? "Saving…" : "Save"}
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-3">
-                  <p
-                    className="text-[13px] leading-relaxed"
-                    style={{
-                      color: pollNote ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
-                      fontStyle: pollNote ? "normal" : "italic",
-                    }}
-                  >
-                    {displayNote}
-                  </p>
-                  {isOwner && (
-                    <button
-                      type="button"
-                      onClick={handleStartEditNote}
-                      className="flex items-center gap-1.5 text-xs font-medium transition-opacity hover:opacity-70"
-                      style={{ color: "var(--color-bt-accent)", background: "transparent", border: "none" }}
-                    >
-                      <Pencil size={12} /> Edit instructions
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* ── Date poll grid ─────────────────────────────────────────────── */}
-        <DatePollGrid
-          dateWindows={windows}
+        {/* ── Stacked option cards — new presentation layer per
+            HANDOFF-datepoll.md. DatePollGrid (Doodle-style table) is
+            superseded; deleting it is flagged as a follow-up. The card
+            component owns all per-card UX (radio select, expand to
+            roster, override popover, inline remove confirm, inline add
+            calendar, cancel-poll confirm). Mutations stay here. ──── */}
+        <DatePollStackedCards
+          windows={windows}
           members={pollMembers}
           currentUserId={currentUser?.id ?? ""}
           isOwner={isOwner}
+          ownerName={ownerName}
           onVote={handleVote}
-          onAddDateWindow={isOwner ? () => setShowAddDateModal(true) : undefined}
-          onLockDateWindow={
+          onAddWindow={
             isOwner
-              ? (windowId) => setPendingLockWindowId(windowId)
+              ? (startDate, endDate) =>
+                  addWindow.mutate({
+                    tripId,
+                    id: crypto.randomUUID(),
+                    startDate,
+                    endDate,
+                  })
               : undefined
           }
-          onRemoveDateWindow={
-            isOwner ? (windowId) => setConfirmRemoveId(windowId) : undefined
+          onRemoveWindow={
+            isOwner
+              ? (windowId) => removeWindow.mutate({ tripId, windowId })
+              : undefined
+          }
+          onLockWindow={
+            isOwner ? (windowId) => setPendingLockWindowId(windowId) : undefined
+          }
+          onCancelPoll={
+            isOwner
+              ? () => endPoll.mutate({ tripId, pollMode: false })
+              : undefined
           }
           onManageCrew={onManageCrew}
         />
@@ -555,65 +473,12 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
             </p>
           </div>
         )}
-
-        {/* ── Owner footer: Reset (only once votes exist) ─────────────── */}
-        {windows.length > 0 && isOwner && anyVotes && (
-          <div className="flex items-center gap-2 pt-1">
-            {showResetConfirm ? (
-              /* Reset hides; three confirm buttons fill the row */
-              <>
-                <button
-                  type="button"
-                  onClick={() => setShowResetConfirm(false)}
-                  className="flex-1 rounded-xl py-2 text-[13px] font-medium"
-                  style={{
-                    background: "var(--color-bt-card-raised)",
-                    color: "var(--color-bt-text-dim)",
-                    border: "1px solid var(--color-bt-border)",
-                  }}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={() => resetPoll.mutate({ tripId })}
-                  disabled={resetPoll.isPending}
-                  className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
-                  style={{ background: "var(--color-bt-danger)", color: "var(--color-bt-base)" }}
-                >
-                  {resetPoll.isPending ? "Clearing…" : "Clear votes?"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => endPoll.mutate({ tripId, pollMode: false })}
-                  disabled={endPoll.isPending}
-                  className="flex-1 rounded-xl py-2 text-[13px] font-semibold"
-                  style={{ background: "var(--color-bt-danger)", color: "var(--color-bt-base)" }}
-                >
-                  {endPoll.isPending ? "Clearing…" : "Clear poll?"}
-                </button>
-              </>
-            ) : (
-              <button
-                type="button"
-                onClick={() => setShowResetConfirm(true)}
-                className="flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2 text-[13px] font-medium transition-opacity"
-                style={{
-                  background: "var(--color-bt-card-raised)",
-                  color: "var(--color-bt-text-dim)",
-                  border: "1px solid var(--color-bt-border)",
-                }}
-                aria-label="Reset votes"
-              >
-                <RotateCcw size={13} />
-                Reset
-              </button>
-            )}
-          </div>
-        )}
       </div>
 
-      {/* Confirm dates modal — shown when owner clicks "Select this date" */}
+      {/* Confirm dates modal — shown when owner clicks "Lock in [range]".
+          Kept as a final guard before changing the trip dates; the rest
+          of the poll's confirm gates (remove option, cancel poll) live
+          inline inside the card. */}
       {(() => {
         const win = pendingLockWindowId
           ? windows.find((w) => w.id === pendingLockWindowId) ?? null
@@ -634,224 +499,7 @@ export function DatePollCard({ trip, isOwner, onManageCrew }: DatePollCardProps)
           />
         );
       })()}
-
-      {/* Add date window modal */}
-      {showAddDateModal && (
-        <AddDateWindowModal
-          pending={addWindow.isPending}
-          onClose={() => setShowAddDateModal(false)}
-          onSubmit={(startDate, endDate) => {
-            addWindow.mutate(
-              {
-                tripId,
-                id: crypto.randomUUID(),
-                startDate,
-                endDate,
-              },
-              {
-                onSuccess() {
-                  setShowAddDateModal(false);
-                },
-              }
-            );
-          }}
-        />
-      )}
-
-      {/* Confirm remove dialog */}
-      {pendingRemoveWindow && (
-        <ConfirmDialog
-          title="Remove this date option?"
-          body="This will delete the option and any votes already cast for it."
-          cancelLabel="Cancel"
-          confirmLabel={removeWindow.isPending ? "Removing…" : "Remove"}
-          confirmDanger
-          onCancel={() => setConfirmRemoveId(null)}
-          onConfirm={() =>
-            removeWindow.mutate(
-              { tripId, windowId: pendingRemoveWindow.id },
-              { onSuccess: () => setConfirmRemoveId(null) }
-            )
-          }
-        />
-      )}
     </>
   );
 }
 
-// ── AddDateWindowModal ───────────────────────────────────────────────────
-
-function AddDateWindowModal({
-  pending,
-  onClose,
-  onSubmit,
-}: {
-  pending: boolean;
-  onClose: () => void;
-  onSubmit: (startDate: string, endDate: string) => void;
-}) {
-  useModalBackButton(onClose);
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
-  const valid = !!startDate && !!endDate && startDate < endDate;
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
-      style={{ background: "var(--color-bt-overlay)" }}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
-    >
-      <div
-        className="w-full max-w-sm rounded-t-2xl p-5 lg:rounded-2xl"
-        style={{ background: "var(--color-bt-card)" }}
-      >
-        <div className="mb-2 flex items-center justify-between">
-          <p
-            className="text-base font-semibold"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            Add a date option
-          </p>
-          <button
-            onClick={onClose}
-            className="flex h-7 w-7 items-center justify-center rounded-lg"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            aria-label="Close"
-          >
-            <X size={16} />
-          </button>
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          <div className="space-y-1">
-            <label
-              className="text-[11px] font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              Start date
-            </label>
-            <input
-              type="date"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
-              className="w-full rounded-xl px-3 py-2.5 text-sm"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-          </div>
-          <div className="space-y-1">
-            <label
-              className="text-[11px] font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              End date
-            </label>
-            <input
-              type="date"
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
-              className="w-full rounded-xl px-3 py-2.5 text-sm"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                border: "1px solid var(--color-bt-border)",
-                color: "var(--color-bt-text)",
-              }}
-            />
-          </div>
-        </div>
-        <div className="mt-4 flex gap-2">
-          <button
-            onClick={onClose}
-            className="flex-1 rounded-xl py-2.5 text-sm font-medium"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              color: "var(--color-bt-text)",
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            disabled={!valid || pending}
-            onClick={() => valid && onSubmit(startDate, endDate)}
-            className="flex-1 rounded-xl py-2.5 text-sm font-semibold"
-            style={{
-              background: valid ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-              color: valid ? "var(--color-bt-base)" : "var(--color-bt-text-dim)",
-              opacity: valid ? 1 : 0.6,
-              cursor: valid ? "pointer" : "not-allowed",
-            }}
-          >
-            {pending ? "Adding…" : "Add date"}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── ConfirmDialog ────────────────────────────────────────────────────────
-
-function ConfirmDialog({
-  title,
-  body,
-  cancelLabel,
-  confirmLabel,
-  confirmDanger,
-  onCancel,
-  onConfirm,
-}: {
-  title: string;
-  body: string;
-  cancelLabel: string;
-  confirmLabel: string;
-  confirmDanger?: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  useModalBackButton(onCancel);
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center px-6"
-      style={{ background: "var(--color-bt-overlay)" }}
-      onClick={(e) => e.target === e.currentTarget && onCancel()}
-    >
-      <div
-        className="w-full max-w-sm rounded-2xl p-5"
-        style={{ background: "var(--color-bt-card)" }}
-      >
-        <p className="text-base font-semibold" style={{ color: "var(--color-bt-text)" }}>
-          {title}
-        </p>
-        <p className="mt-1 text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
-          {body}
-        </p>
-        <div className="mt-4 flex gap-3">
-          <button
-            onClick={onCancel}
-            className="flex-1 rounded-xl py-2.5 text-sm font-medium"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              color: "var(--color-bt-text)",
-            }}
-          >
-            {cancelLabel}
-          </button>
-          <button
-            onClick={onConfirm}
-            className="flex-1 rounded-xl py-2.5 text-sm font-semibold"
-            style={{
-              background: confirmDanger
-                ? "var(--color-bt-danger)"
-                : "var(--color-bt-accent)",
-              color: "var(--color-bt-base)",
-            }}
-          >
-            {confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/src/app/trips/[tripId]/tabs/components/DatePollStackedCards.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollStackedCards.tsx
@@ -1,0 +1,1337 @@
+"use client";
+
+// ── DatePollStackedCards ──────────────────────────────────────────────────
+//
+// New presentation layer for the date poll. Replaces the Doodle-style
+// DatePollGrid with stacked option cards that scale from 4 to 20+ people
+// without a wall-sized grid.
+//
+// Source of truth: HANDOFF-datepoll.md.
+//
+// What lives here:
+//   • Owner view:
+//       - One OptionCard per date_window. Collapsed shows: select radio,
+//         date range, Most popular badge (trophy on the highest-yes
+//         option, informational only), stacked tally bar + legend, expand
+//         chevron.
+//       - Expanded shows: roster grouped Yes / Maybe / No / Waiting as
+//         avatar+name chips. Tapping any chip opens VotePopover (3-way
+//         Yes/Maybe/No + Clear) so the owner can log answers for anyone,
+//         including placeholders. Below the roster: quiet "Remove this
+//         date option" with inline confirm when votes exist.
+//       - "+ Add a date option" reveals an inline compact range calendar
+//         (no modal) so the owner can add several back-to-back.
+//       - Footer: primary "Lock in [range]" on the selected option +
+//         quiet "Cancel this poll" link (escape hatch — confirm-gated
+//         since it discards every vote).
+//   • Member view:
+//       - Per-window card with a Yes/Maybe/No segmented control. Their
+//         pick highlights in its vote color (teal/amber/red). Faint
+//         consensus line shows the group's leaning. No add/delete/lock/
+//         cancel — members only set their own answer.
+//
+// The mutations themselves live in DatePollCard (the parent). This file
+// is pure presentation + per-card local state. Callbacks fire upward
+// when the user takes an action; DatePollCard runs the optimistic
+// update + tRPC mutation.
+
+import { useMemo, useRef, useState } from "react";
+import { Avatar } from "@/components/Avatar";
+import {
+  Calendar as CalendarIcon,
+  CalendarPlus,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Plus,
+  Trash2,
+  Trophy,
+  X,
+} from "lucide-react";
+import {
+  addMonths,
+  applyRangeClick,
+  atNoon,
+  isOutOfBounds,
+  isSameDay,
+  isWithinRange,
+  monthMatrix,
+  nightsBetween,
+  rangePresets,
+  startOfMonth,
+  type DateRange,
+} from "@/lib/calendar";
+import { parseLocalDate } from "@/lib/dates";
+import type { PollMember, PollWindow, VoteAnswer } from "./DatePollGrid";
+
+// ── Public types (re-export the bits callers already use) ────────────────
+
+export type { PollMember, PollWindow, VoteAnswer } from "./DatePollGrid";
+
+export interface DatePollStackedCardsProps {
+  windows: PollWindow[];
+  members: PollMember[];
+  currentUserId: string;
+  isOwner: boolean;
+  /** Owner's display name — surfaced in the member empty state body
+   *  ("{Owner} hasn't posted any windows…"). Falls back to a neutral
+   *  noun upstream when the owner record isn't loaded yet. */
+  ownerName?: string;
+  /** Owner can vote for any member; non-owners can only vote for themselves.
+   *  Caller enforces this; we just emit the chosen target. */
+  onVote: (windowId: string, answer: VoteAnswer, userId: string) => void;
+  /** Owner-only — caller passes the start/end strings; we own the inline
+   *  calendar UI. */
+  onAddWindow?: (startDate: string, endDate: string) => void;
+  onRemoveWindow?: (windowId: string) => void;
+  onLockWindow?: (windowId: string) => void;
+  /** Owner-only — cancels the whole poll (windows + votes wiped). */
+  onCancelPoll?: () => void;
+  /** Owner / planner only — opens the Crew tab from the empty / managed-by
+   *  affordances. */
+  onManageCrew?: () => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+const ANSWERS: VoteAnswer[] = ["yes", "maybe", "no"];
+
+const VOTE_BG: Record<NonNullable<VoteAnswer>, string> = {
+  yes: "var(--color-bt-vote-yes)",
+  maybe: "var(--color-bt-vote-maybe)",
+  no: "var(--color-bt-vote-no)",
+};
+const VOTE_TEXT: Record<NonNullable<VoteAnswer>, string> = {
+  // The vote-yes-text token exists for the yes pill specifically; for the
+  // other two, dark + white reads cleanly across the brand palette.
+  yes: "var(--color-bt-vote-yes-text, #0d1f1a)",
+  maybe: "#0d1f1a",
+  no: "#ffffff",
+};
+const VOTE_LABEL: Record<NonNullable<VoteAnswer>, string> = {
+  yes: "Yes",
+  maybe: "Maybe",
+  no: "No",
+};
+
+function answerOf(window: PollWindow, userId: string | null): VoteAnswer {
+  if (!userId) return null;
+  const v = window.votes.find((x) => x.user_id === userId);
+  if (!v || v.answer == null) return null;
+  const a = v.answer as string;
+  if (a === "yes" || a === "maybe" || a === "no") return a;
+  return null;
+}
+
+function tallyOf(window: PollWindow, members: PollMember[]): {
+  yes: number;
+  maybe: number;
+  no: number;
+  waiting: number;
+} {
+  let yes = 0;
+  let maybe = 0;
+  let no = 0;
+  let waiting = 0;
+  for (const m of members) {
+    const a = answerOf(window, m.user_id);
+    if (a === "yes") yes++;
+    else if (a === "maybe") maybe++;
+    else if (a === "no") no++;
+    else waiting++;
+  }
+  return { yes, maybe, no, waiting };
+}
+
+function fmtRangeShort(start: string, end: string): string {
+  const s = parseLocalDate(start);
+  const e = parseLocalDate(end);
+  const fmt = (d: Date) => d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return `${fmt(s)} – ${fmt(e)}`;
+}
+
+// Days-of-week + nights — e.g. "Fri – Tue · 4 nights". Used as the
+// sub-label under the date range on each option card.
+function fmtDaysAndNights(start: string, end: string): string {
+  const s = parseLocalDate(start);
+  const e = parseLocalDate(end);
+  const day = (d: Date) =>
+    d.toLocaleDateString("en-US", { weekday: "short" });
+  const nights = Math.round((e.getTime() - s.getTime()) / 86400000);
+  return `${day(s)} – ${day(e)} · ${nights} night${nights === 1 ? "" : "s"}`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function DatePollStackedCards({
+  windows,
+  members,
+  currentUserId,
+  isOwner,
+  ownerName = "The organizer",
+  onVote,
+  onAddWindow,
+  onRemoveWindow,
+  onLockWindow,
+  onCancelPoll,
+  onManageCrew,
+}: DatePollStackedCardsProps) {
+  // Which option the owner has selected to lock. Defaults to whichever is
+  // currently the most popular so the primary CTA is meaningful from the
+  // jump. Updated on radio click.
+  const tallies = useMemo(
+    () => Object.fromEntries(windows.map((w) => [w.id, tallyOf(w, members)])),
+    [windows, members],
+  );
+
+  // The "Most popular" trophy lands on whichever option has the most yes
+  // votes. Tie → no trophy (no false leader). Independent of selection.
+  const mostPopularId = useMemo(() => {
+    if (windows.length === 0) return null;
+    const maxYes = Math.max(...windows.map((w) => tallies[w.id]?.yes ?? 0));
+    if (maxYes === 0) return null;
+    const top = windows.filter((w) => (tallies[w.id]?.yes ?? 0) === maxYes);
+    if (top.length !== 1) return null;
+    return top[0]!.id;
+  }, [windows, tallies]);
+
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => mostPopularId ?? windows[0]?.id ?? null,
+  );
+
+  // Inline add-option calendar. Hidden by default; "+ Add a date option"
+  // reveals it. Stays inline so the owner can fire several proposals
+  // back-to-back without bouncing through a modal.
+  const [addingOpen, setAddingOpen] = useState(false);
+
+  // Cancel-poll confirm. Owner-only, red-bordered surface per HANDOFF.
+  const [confirmCancelPoll, setConfirmCancelPoll] = useState(false);
+
+  // Voted progress — used in the header strip. Counts members who've
+  // weighed in on EVERY available window (matches "N of N voted" in spec).
+  const votedCount = useMemo(() => {
+    if (windows.length === 0) return 0;
+    return members.filter((m) =>
+      windows.every((w) => answerOf(w, m.user_id) != null),
+    ).length;
+  }, [windows, members]);
+
+  // ── Empty state — no windows yet ─────────────────────────────────────
+  if (windows.length === 0) {
+    // When the owner has tapped "Add the first date option," the inline
+    // picker takes over the empty-state slot entirely — no glyph, no
+    // headline, no dashed frame. The dashed pitch is the affordance to
+    // open the picker; once it's open, the picker IS the surface.
+    if (isOwner && onAddWindow && addingOpen) {
+      return (
+        <InlineAddOption
+          onCancel={() => setAddingOpen(false)}
+          onAdd={(s, e) => {
+            onAddWindow(s, e);
+            setAddingOpen(false);
+          }}
+        />
+      );
+    }
+    // Member empty state — clock glyph + "No date options yet" headline +
+    // owner-attributed body. Members can't act here so we make the
+    // surface read as "stand by," not as a target zone — same dashed
+    // frame as the owner empty (visual consistency across roles).
+    if (!isOwner) {
+      return (
+        <div
+          className="rounded-xl px-6 py-10 text-center"
+          style={{
+            background: "transparent",
+            border: "1px dashed var(--color-bt-border)",
+          }}
+          data-testid="poll-empty-state-member"
+        >
+          <div
+            className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-xl"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-accent)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+            aria-hidden="true"
+          >
+            <Clock size={24} strokeWidth={1.9} />
+          </div>
+          <p className="text-[16px] font-semibold" style={{ color: "var(--color-bt-text)" }}>
+            No date options yet
+          </p>
+          <p
+            className="mx-auto mt-2 max-w-md text-[13px] leading-snug"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {ownerName} hasn&rsquo;t posted any windows to vote on. We&rsquo;ll
+            let you know the moment they&rsquo;re up &mdash; nothing for you
+            to do yet.
+          </p>
+        </div>
+      );
+    }
+    // Owner empty state — calendar glyph + "Add the windows" pitch +
+    // primary CTA that opens the inline picker (handled above).
+    return (
+      <div
+        className="rounded-xl p-6 text-center"
+        style={{
+          // Transparent — the empty state sits flush against the
+          // FreshTripGuide background. Keeps the dashed border so the
+          // "Add the windows" affordance still reads as a target zone.
+          background: "transparent",
+          border: "1px dashed var(--color-bt-border)",
+        }}
+        data-testid="poll-empty-state"
+      >
+        <div
+          className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full"
+          style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }}
+          aria-hidden="true"
+        >
+          <CalendarIcon size={22} strokeWidth={1.9} />
+        </div>
+        <p className="text-[15px] font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          Add the windows you&apos;re considering
+        </p>
+        <p
+          className="mx-auto mt-1 max-w-md text-[13px] leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Drop in a few date ranges and the crew votes yes / maybe / no on
+          each. You lock the one that works once it&apos;s clear.
+        </p>
+        {onAddWindow && (
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => setAddingOpen(true)}
+              className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-[13px] font-semibold transition-opacity hover:opacity-90"
+              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-on-accent, #0d1f1a)" }}
+              data-testid="poll-empty-add"
+            >
+              <CalendarPlus size={14} strokeWidth={2} />
+              Add the first date option
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ── Main render ──────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-3" data-testid="poll-stacked-cards">
+      {/* Voted progress strip — quietly shows momentum without competing
+          with the cards. Hidden when there are no members to vote (e.g.
+          solo trip mid-setup) since the math is uninteresting. */}
+      {members.length > 0 && (
+        <div className="flex items-center gap-3">
+          <span
+            className="text-[11px] font-semibold uppercase"
+            style={{ color: "var(--color-bt-text-dim)", letterSpacing: "0.08em" }}
+          >
+            {votedCount} of {members.length} voted
+          </span>
+          <div
+            className="h-1 flex-1 overflow-hidden rounded-full"
+            style={{ background: "var(--color-bt-card-raised)" }}
+            aria-hidden="true"
+          >
+            <div
+              className="h-full rounded-full transition-all"
+              style={{
+                width: `${members.length === 0 ? 0 : Math.round((votedCount / members.length) * 100)}%`,
+                background: "var(--color-bt-accent)",
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Stacked option cards. Each owns its own expanded/confirm state. */}
+      <div className="space-y-2.5">
+        {windows.map((w) => (
+          <OptionCard
+            key={w.id}
+            window={w}
+            members={members}
+            currentUserId={currentUserId}
+            isOwner={isOwner}
+            isSelected={selectedId === w.id}
+            isMostPopular={mostPopularId === w.id}
+            tally={tallies[w.id]!}
+            onSelect={() => setSelectedId(w.id)}
+            onVote={onVote}
+            onRemove={onRemoveWindow ? () => onRemoveWindow(w.id) : undefined}
+            onManageCrew={onManageCrew}
+          />
+        ))}
+      </div>
+
+      {/* "+ Add a date option" — owner only. Inline calendar takes over
+          this row when revealed (matches HANDOFF "back to the list so the
+          owner can add several back-to-back"). */}
+      {isOwner && onAddWindow && (
+        addingOpen ? (
+          <InlineAddOption
+            onCancel={() => setAddingOpen(false)}
+            onAdd={(s, e) => {
+              onAddWindow(s, e);
+              setAddingOpen(false);
+            }}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setAddingOpen(true)}
+            className="flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-[13px] font-semibold transition-opacity hover:opacity-80"
+            style={{
+              background: "transparent",
+              color: "var(--color-bt-accent)",
+              border: "none",
+            }}
+            data-testid="poll-add-option"
+          >
+            <Plus size={14} />
+            Add a date option
+          </button>
+        )
+      )}
+
+      {/* Footer — owner only. Primary Lock action + quiet Cancel-poll
+          escape hatch. Members get a separate "Save my answers" CTA on
+          the per-card segmented control (votes save on click), so no
+          dedicated footer is needed. */}
+      {isOwner && onLockWindow && selectedId && (
+        <div className="space-y-2 pt-1">
+          <button
+            type="button"
+            onClick={() => onLockWindow(selectedId)}
+            className="flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-[14px] font-semibold transition-opacity hover:opacity-90"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="poll-lock"
+          >
+            <Check size={16} strokeWidth={2.6} />
+            Lock in {(() => {
+              const w = windows.find((x) => x.id === selectedId);
+              return w ? fmtRangeShort(w.start_date, w.end_date) : "selected dates";
+            })()}
+          </button>
+          {onCancelPoll && (
+            confirmCancelPoll ? (
+              <CancelPollConfirm
+                voteCount={windows.reduce((sum, w) => sum + w.votes.length, 0)}
+                onKeep={() => setConfirmCancelPoll(false)}
+                onConfirm={() => {
+                  onCancelPoll();
+                  setConfirmCancelPoll(false);
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setConfirmCancelPoll(true)}
+                className="flex w-full items-center justify-center rounded-xl px-4 py-3 text-[14px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+                style={{
+                  background: "transparent",
+                  color: "var(--color-bt-text-dim)",
+                  border: "1px solid var(--color-bt-border)",
+                }}
+                data-testid="poll-cancel-link"
+              >
+                Cancel this poll
+              </button>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── OptionCard ───────────────────────────────────────────────────────────
+
+function OptionCard({
+  window: w,
+  members,
+  currentUserId,
+  isOwner,
+  isSelected,
+  isMostPopular,
+  tally,
+  onSelect,
+  onVote,
+  onRemove,
+  onManageCrew,
+}: {
+  window: PollWindow;
+  members: PollMember[];
+  currentUserId: string;
+  isOwner: boolean;
+  isSelected: boolean;
+  isMostPopular: boolean;
+  tally: { yes: number; maybe: number; no: number; waiting: number };
+  onSelect: () => void;
+  onVote: (windowId: string, answer: VoteAnswer, userId: string) => void;
+  onRemove?: () => void;
+  onManageCrew?: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  // Two-step delete for cards with existing votes — matches HANDOFF
+  // "Remove this option? N votes discarded." inline confirm.
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
+  const myAnswer = answerOf(w, currentUserId);
+  const memberView = !isOwner;
+
+  // ── Member card layout — no select radio, no roster expand. Just the
+  // date + Yes/Maybe/No segmented control + faint consensus line. The
+  // expanded roster is owner-only by spec. ──────────────────────────
+  if (memberView) {
+    return (
+      <div
+        className="rounded-xl p-3.5"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+        data-testid={`poll-option-${w.id}`}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[14px] font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {fmtRangeShort(w.start_date, w.end_date)}
+            </p>
+            <p className="mt-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              {fmtDaysAndNights(w.start_date, w.end_date)}
+            </p>
+            {isMostPopular && (
+              <div className="mt-2">
+                <MostPopularBadge />
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Faint consensus line — shows the group's leaning without
+            making the page about everyone else's votes. */}
+        <p
+          className="mt-2 text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {tally.yes} yes · {tally.maybe} maybe · {tally.no} no
+          {tally.waiting > 0 ? ` · ${tally.waiting} waiting` : ""}
+        </p>
+
+        {/* Yes / Maybe / No segmented control — sets the member's own
+            answer directly. Highlighted in the vote color when picked.
+            Tapping the active one again clears it (toggle off). */}
+        <div className="mt-3 grid grid-cols-3 gap-1.5">
+          {ANSWERS.map((ans) => {
+            const active = myAnswer === ans;
+            return (
+              <button
+                key={ans}
+                type="button"
+                onClick={() => onVote(w.id, active ? null : ans, currentUserId)}
+                className="rounded-lg py-2 text-[13px] font-semibold transition-colors"
+                style={
+                  active
+                    ? { background: VOTE_BG[ans!], color: VOTE_TEXT[ans!] }
+                    : {
+                        background: "var(--color-bt-card-raised)",
+                        color: "var(--color-bt-text-dim)",
+                        border: "1px solid var(--color-bt-border)",
+                      }
+                }
+                data-testid={`poll-vote-${w.id}-${ans}`}
+              >
+                {VOTE_LABEL[ans!]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Owner card layout ─────────────────────────────────────────────
+  // Selection signals only through the border: a 1px accent stroke
+  // around the card + the filled accent radio. The card background
+  // stays neutral (no accent-faint fill) so the row reads against the
+  // rest of the panel without a competing surface.
+  const tintBorder = isSelected
+    ? "var(--color-bt-accent)"
+    : "var(--color-bt-border)";
+
+  return (
+    <div
+      className="rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: `1px solid ${tintBorder}`,
+        transition: "border-color 150ms",
+      }}
+      data-testid={`poll-option-${w.id}`}
+    >
+      {/* Collapsed header — radio | left column (range + days/nights +
+          Most popular badge) | right column (tally bar + vote count) |
+          chevron. The whole row is the expand target; the radio
+          handles its own click (stopPropagation) so selecting doesn't
+          also expand. */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-start gap-3 p-3.5 text-left"
+      >
+        {/* Radio — owner picks which option to lock. */}
+        <span
+          role="radio"
+          aria-checked={isSelected}
+          tabIndex={0}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === " " || e.key === "Enter") {
+              e.preventDefault();
+              e.stopPropagation();
+              onSelect();
+            }
+          }}
+          className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full transition-colors"
+          style={{
+            background: isSelected ? "var(--color-bt-accent)" : "transparent",
+            border: `1.5px solid ${isSelected ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
+            color: "var(--color-bt-on-accent, #0d1f1a)",
+            cursor: "pointer",
+          }}
+          data-testid={`poll-radio-${w.id}`}
+        >
+          {isSelected && <Check size={12} strokeWidth={3} />}
+        </span>
+
+        {/* Body column — fills the row between the radio and the
+            chevron. Date range / days+nights / Most popular badge
+            stacked at top; full-width tally bar + per-bucket count
+            run beneath them so the bar stretches across the entire
+            content area (including the date area) rather than living
+            in a constrained right rail. */}
+        <div className="min-w-0 flex-1">
+          <p
+            className="text-[14px] font-semibold leading-tight"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            {fmtRangeShort(w.start_date, w.end_date)}
+          </p>
+          <p
+            className="mt-0.5 text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {fmtDaysAndNights(w.start_date, w.end_date)}
+          </p>
+          {isMostPopular && (
+            <div className="mt-2">
+              <MostPopularBadge />
+            </div>
+          )}
+          <TallyBar tally={tally} className="mt-3" />
+          <p
+            className="mt-1.5 text-[11px]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            <VoteCount n={tally.yes} kind="yes" /> ·{" "}
+            <VoteCount n={tally.maybe} kind="maybe" /> ·{" "}
+            <VoteCount n={tally.no} kind="no" />
+            {tally.waiting > 0 && <> · <span>{tally.waiting} waiting</span></>}
+          </p>
+        </div>
+
+        {/* Chevron — rotated when expanded. Pure indicator; the whole
+            header is the click target. */}
+        <ChevronDown
+          size={18}
+          className="mt-1 flex-shrink-0 transition-transform"
+          style={{
+            color: "var(--color-bt-text-dim)",
+            transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+          aria-hidden="true"
+        />
+      </button>
+
+      {/* Expanded — roster grouped by answer + remove affordance. */}
+      {expanded && (
+        <div
+          className="space-y-3 px-3.5 pb-3.5"
+          style={{ borderTop: "1px solid var(--color-bt-border)", paddingTop: 12 }}
+        >
+          <RosterGroup
+            label="Yes"
+            answer="yes"
+            members={members}
+            currentUserId={currentUserId}
+            window={w}
+            onVote={onVote}
+          />
+          <RosterGroup
+            label="Maybe"
+            answer="maybe"
+            members={members}
+            currentUserId={currentUserId}
+            window={w}
+            onVote={onVote}
+          />
+          <RosterGroup
+            label="No"
+            answer="no"
+            members={members}
+            currentUserId={currentUserId}
+            window={w}
+            onVote={onVote}
+          />
+          <RosterGroup
+            label="Waiting"
+            answer={null}
+            members={members}
+            currentUserId={currentUserId}
+            window={w}
+            onVote={onVote}
+          />
+
+          <p className="text-[11px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
+            Tap anyone to set their answer — including placeholders.
+            {onManageCrew && (
+              <>
+                {" "}
+                <button
+                  type="button"
+                  onClick={onManageCrew}
+                  className="not-italic transition-opacity hover:opacity-80"
+                  style={{ color: "var(--color-bt-accent)" }}
+                >
+                  Manage crew →
+                </button>
+              </>
+            )}
+          </p>
+
+          {/* Remove affordance — quiet by default, inline confirm when
+              the option has votes (HANDOFF: "Remove this option? N
+              votes discarded."). No-vote options skip the confirm. */}
+          {onRemove && (
+            <div
+              className="pt-2"
+              style={{ borderTop: "1px solid var(--color-bt-border)" }}
+            >
+              {confirmRemove ? (
+                <div
+                  className="flex items-center gap-2 rounded-lg px-3 py-2"
+                  style={{
+                    background: "var(--color-bt-danger-faint)",
+                    border: "1px solid var(--color-bt-danger-border)",
+                  }}
+                >
+                  <span
+                    className="min-w-0 flex-1 truncate text-[12px] font-medium"
+                    style={{ color: "var(--color-bt-danger)" }}
+                  >
+                    Remove this option?
+                    {w.votes.length > 0
+                      ? ` ${w.votes.length} vote${w.votes.length === 1 ? "" : "s"} discarded.`
+                      : ""}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmRemove(false)}
+                    className="rounded-md px-2 py-1 text-[12px] font-medium"
+                    style={{
+                      background: "transparent",
+                      color: "var(--color-bt-text-dim)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
+                  >
+                    Keep it
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onRemove();
+                      setConfirmRemove(false);
+                    }}
+                    className="rounded-md px-2 py-1 text-[12px] font-semibold"
+                    style={{ background: "var(--color-bt-danger)", color: "#ffffff" }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (w.votes.length === 0) onRemove();
+                    else setConfirmRemove(true);
+                  }}
+                  className="flex items-center gap-1.5 text-[12px] font-medium transition-opacity hover:opacity-80"
+                  style={{ color: "var(--color-bt-text-dim)" }}
+                  data-testid={`poll-remove-${w.id}`}
+                >
+                  <Trash2 size={12} />
+                  Remove this date option
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── TallyBar ─────────────────────────────────────────────────────────────
+
+function TallyBar({
+  tally,
+  className,
+}: {
+  tally: { yes: number; maybe: number; no: number; waiting: number };
+  className?: string;
+}) {
+  const total = tally.yes + tally.maybe + tally.no + tally.waiting;
+  if (total === 0) {
+    return (
+      <div
+        className={`h-2 w-full overflow-hidden rounded-full ${className ?? ""}`}
+        style={{ background: "var(--color-bt-card-raised)" }}
+        aria-hidden="true"
+      />
+    );
+  }
+  const pct = (n: number) => (n / total) * 100;
+  return (
+    <div
+      className={`flex h-2 w-full overflow-hidden rounded-full ${className ?? ""}`}
+      style={{ background: "var(--color-bt-card-raised)" }}
+      aria-hidden="true"
+    >
+      <div style={{ width: `${pct(tally.yes)}%`, background: VOTE_BG.yes }} />
+      <div style={{ width: `${pct(tally.maybe)}%`, background: VOTE_BG.maybe }} />
+      <div style={{ width: `${pct(tally.no)}%`, background: VOTE_BG.no }} />
+      {/* waiting is the visible trough — no inline div, the bar background
+          shows through. */}
+    </div>
+  );
+}
+
+function VoteCount({ n, kind }: { n: number; kind: NonNullable<VoteAnswer> }) {
+  return (
+    <span style={{ color: VOTE_BG[kind], fontWeight: 600 }}>
+      {n} {kind}
+    </span>
+  );
+}
+
+function MostPopularBadge() {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase"
+      style={{
+        background: "var(--color-bt-vote-yes)",
+        color: "var(--color-bt-vote-yes-text, #0d1f1a)",
+        letterSpacing: "0.06em",
+      }}
+      title="The option with the most yes votes"
+      aria-label="Most popular"
+    >
+      <Trophy size={10} strokeWidth={2.4} />
+      Most popular
+    </span>
+  );
+}
+
+// ── RosterGroup ──────────────────────────────────────────────────────────
+//
+// A single answer-bucket row in the expanded option card. Renders the
+// label + a wrapping row of member chips. Tapping a chip opens
+// VotePopover (owner can re-bucket anyone, including placeholders).
+
+function RosterGroup({
+  label,
+  answer,
+  members,
+  currentUserId,
+  window: w,
+  onVote,
+}: {
+  label: string;
+  answer: VoteAnswer;
+  members: PollMember[];
+  currentUserId: string;
+  window: PollWindow;
+  onVote: (windowId: string, answer: VoteAnswer, userId: string) => void;
+}) {
+  const inBucket = members.filter((m) => answerOf(w, m.user_id) === answer);
+  if (inBucket.length === 0) return null;
+
+  return (
+    <div>
+      <p
+        className="mb-1.5 text-[10px] font-semibold uppercase"
+        style={{
+          color: answer ? VOTE_BG[answer] : "var(--color-bt-text-dim)",
+          letterSpacing: "0.08em",
+        }}
+      >
+        {label} · {inBucket.length}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {inBucket.map((m) => (
+          <MemberChip
+            key={`${m.user_id ?? m.displayName}-${w.id}`}
+            member={m}
+            isYou={!!m.user_id && m.user_id === currentUserId}
+            currentAnswer={answer}
+            onSetAnswer={(ans) => onVote(w.id, ans, m.user_id ?? "")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── MemberChip + VotePopover ─────────────────────────────────────────────
+
+function MemberChip({
+  member,
+  isYou,
+  currentAnswer,
+  onSetAnswer,
+}: {
+  member: PollMember;
+  isYou: boolean;
+  currentAnswer: VoteAnswer;
+  onSetAnswer: (a: VoteAnswer) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const isPlaceholder = !member.user_id;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 rounded-full py-1 pl-1 pr-2.5 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          color: "var(--color-bt-text)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {/* Standard app Avatar — sm=30/34px is too large for an inline
+            chip, so we hand it an explicit 22px sizePx. Placeholders
+            stay muted (gray) so the teal foreground reads as "real
+            actionable identity"; the placeholder PH tag below carries
+            the explicit labelling. */}
+        <Avatar
+          name={member.displayName}
+          avatarIcon={member.avatarIcon ?? null}
+          sizePx={22}
+          muted={isPlaceholder}
+        />
+        <span className="truncate" style={{ maxWidth: 120 }}>
+          {member.displayName}
+          {isYou && (
+            <span style={{ color: "var(--color-bt-text-dim)" }}> (you)</span>
+          )}
+        </span>
+        {isPlaceholder && (
+          <span
+            className="rounded px-1 text-[8px] font-bold uppercase"
+            style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)" }}
+            title="Placeholder — owner-managed"
+          >
+            PH
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <VotePopover
+          currentAnswer={currentAnswer}
+          onPick={(ans) => {
+            onSetAnswer(ans);
+            setOpen(false);
+          }}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function VotePopover({
+  currentAnswer,
+  onPick,
+  onClose,
+}: {
+  currentAnswer: VoteAnswer;
+  onPick: (a: VoteAnswer) => void;
+  onClose: () => void;
+}) {
+  // Tiny click-outside via global mousedown listener. The popover is
+  // absolute-positioned beneath the chip so the rect is anchored
+  // naturally; no portal needed for the small surface.
+  const ref = useRef<HTMLDivElement | null>(null);
+  useMemo(() => {
+    if (typeof document === "undefined") return;
+    const fn = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener("mousedown", fn);
+    return () => document.removeEventListener("mousedown", fn);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute left-0 top-full z-20 mt-1.5 flex items-center gap-1 rounded-lg p-1"
+      style={{
+        background: "var(--color-bt-card-float)",
+        border: "1px solid var(--color-bt-border)",
+        boxShadow: "var(--shadow-floating)",
+      }}
+      role="menu"
+    >
+      {ANSWERS.map((ans) => {
+        const active = currentAnswer === ans;
+        return (
+          <button
+            key={ans}
+            type="button"
+            onClick={() => onPick(ans)}
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-semibold transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{
+              color: VOTE_BG[ans!],
+              background: active ? "var(--color-bt-hover)" : "transparent",
+            }}
+          >
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ background: VOTE_BG[ans!] }}
+              aria-hidden="true"
+            />
+            {VOTE_LABEL[ans!]}
+            {active && <Check size={12} strokeWidth={2.6} />}
+          </button>
+        );
+      })}
+      <div
+        className="mx-1 h-4 w-px"
+        style={{ background: "var(--color-bt-border)" }}
+        aria-hidden="true"
+      />
+      <button
+        type="button"
+        onClick={() => onPick(null)}
+        className="rounded-md px-2 py-1 text-[12px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Clear
+      </button>
+    </div>
+  );
+}
+
+// ── InlineAddOption — compact range calendar to add a date window ────────
+
+function InlineAddOption({
+  onCancel,
+  onAdd,
+}: {
+  onCancel: () => void;
+  onAdd: (startDate: string, endDate: string) => void;
+}) {
+  const today = useMemo(() => atNoon(new Date()), []);
+  const [range, setRange] = useState<DateRange>({ start: null, end: null });
+  const [view, setView] = useState<Date>(startOfMonth(today));
+  const [hovered, setHovered] = useState<Date | null>(null);
+
+  const matrix = useMemo(() => monthMatrix(view), [view]);
+  const presets = useMemo(() => rangePresets(today), [today]);
+  const nights = range.start && range.end ? nightsBetween(range.start, range.end) : null;
+  const monthLabel = view.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+
+  const accent = "var(--color-bt-accent)";
+  const accentFaint = "var(--color-bt-accent-faint)";
+
+  const localYMD = (d: Date): string => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  };
+
+  const handleDayClick = (day: Date) => {
+    if (isOutOfBounds(day, null, null)) return;
+    setRange((cur) => applyRangeClick(cur, day));
+  };
+
+  const canAdd = !!(range.start && range.end);
+
+  return (
+    <div
+      className="rounded-xl p-3"
+      style={{
+        // Constrained width so the inline picker reads as a popover
+        // anchored to the row, not as a full-bleed banner. ~320px matches
+        // the lodging DatePicker popover footprint per HANDOFF spec.
+        maxWidth: 320,
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-accent-border)",
+      }}
+      data-testid="poll-add-inline"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-[12px] font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          Add a date option
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <X size={13} />
+        </button>
+      </div>
+
+      {/* Presets */}
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {presets.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => {
+              setRange(p.range);
+              if (p.range.start) setView(startOfMonth(p.range.start));
+            }}
+            className="rounded-full px-2 py-0.5 text-[10px] font-semibold transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text-dim)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Month nav */}
+      <div className="mb-1 flex items-center justify-between">
+        <button
+          type="button"
+          aria-label="Previous month"
+          onClick={() => setView((v) => addMonths(v, -1))}
+          className="flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <ChevronLeft size={14} />
+        </button>
+        <span className="text-[11px] font-semibold" style={{ color: "var(--color-bt-text)" }}>
+          {monthLabel}
+        </span>
+        <button
+          type="button"
+          aria-label="Next month"
+          onClick={() => setView((v) => addMonths(v, 1))}
+          className="flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <ChevronRight size={14} />
+        </button>
+      </div>
+
+      {/* Weekday header */}
+      <div className="grid grid-cols-7">
+        {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
+          <div
+            key={`${d}-${i}`}
+            className="flex h-5 items-center justify-center text-[9px] font-semibold uppercase"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid — round caps + fill bar, same vocab as the lodging
+          DatePicker. Sized for the compact inline use. */}
+      <div className="grid grid-cols-7">
+        {matrix.flat().map((day, idx) => {
+          const inMonth = day.getMonth() === view.getMonth();
+          const isStart = isSameDay(day, range.start);
+          const isEnd = isSameDay(day, range.end);
+          const isCap = isStart || isEnd;
+          const between = isWithinRange(day, range);
+          const hasEnd = !!range.end;
+          const isToday = isSameDay(day, today);
+          const showFill = between || (isStart && hasEnd) || isEnd;
+          return (
+            <div key={idx} className="relative" style={{ height: 30 }}>
+              {showFill && (
+                <div
+                  className="absolute inset-y-1"
+                  style={{
+                    left: isStart ? "50%" : 0,
+                    right: isEnd ? "50%" : 0,
+                    background: accentFaint,
+                  }}
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => handleDayClick(day)}
+                onMouseEnter={() => setHovered(day)}
+                onMouseLeave={() => setHovered(null)}
+                className="relative mx-auto flex items-center justify-center rounded-full text-[11px] transition-colors"
+                style={{
+                  width: 26,
+                  height: 26,
+                  background: isCap ? accent : "transparent",
+                  color: isCap
+                    ? "var(--color-bt-on-accent, #0d1f1a)"
+                    : inMonth
+                      ? "var(--color-bt-text)"
+                      : "var(--color-bt-text-dim)",
+                  fontWeight: isCap ? 700 : 400,
+                  opacity: inMonth ? 1 : 0.45,
+                  boxShadow:
+                    isSameDay(day, hovered) && !isCap
+                      ? `inset 0 0 0 1px ${accent}`
+                      : "none",
+                }}
+              >
+                {day.getDate()}
+                {isToday && !isCap && (
+                  <span
+                    className="absolute bottom-1 h-1 w-1 rounded-full"
+                    style={{ background: accent }}
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer — live summary + Cancel/Add */}
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          {nights != null
+            ? `${nights} night${nights === 1 ? "" : "s"}`
+            : range.start
+              ? "Pick an end date"
+              : "Pick a range"}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[var(--color-bt-hover)]"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canAdd}
+            onClick={() => {
+              if (range.start && range.end) {
+                onAdd(localYMD(range.start), localYMD(range.end));
+              }
+            }}
+            className="rounded-md px-3 py-1 text-[11px] font-semibold transition-opacity disabled:opacity-40"
+            style={{
+              background: accent,
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="poll-add-confirm"
+          >
+            Add option
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── CancelPollConfirm ────────────────────────────────────────────────────
+//
+// Inline confirm for "Cancel this poll". Renders as a red-bordered tray
+// in place of the quiet text link. Matches HANDOFF's red-bordered
+// confirm shape.
+
+function CancelPollConfirm({
+  voteCount,
+  onKeep,
+  onConfirm,
+}: {
+  voteCount: number;
+  onKeep: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-lg px-3 py-2 text-left"
+      style={{
+        background: "var(--color-bt-danger-faint)",
+        border: "1px solid var(--color-bt-danger-border)",
+      }}
+    >
+      <span
+        className="min-w-0 flex-1 text-[12px] leading-snug"
+        style={{ color: "var(--color-bt-danger)" }}
+      >
+        Cancel the date poll? All proposed dates
+        {voteCount > 0 ? ` and ${voteCount} vote${voteCount === 1 ? "" : "s"}` : ""}{" "}
+        will be discarded.
+      </span>
+      <button
+        type="button"
+        onClick={onKeep}
+        className="rounded-md px-2 py-1 text-[12px] font-medium"
+        style={{
+          background: "transparent",
+          color: "var(--color-bt-text-dim)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        Keep polling
+      </button>
+      <button
+        type="button"
+        onClick={onConfirm}
+        className="rounded-md px-2 py-1 text-[12px] font-semibold"
+        style={{ background: "var(--color-bt-danger)", color: "#ffffff" }}
+        data-testid="poll-cancel-confirm"
+      >
+        Cancel poll
+      </button>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -182,7 +182,12 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction 
         // same typography pattern the shared TabHeader uses across
         // every entry tab. Row 2: filter pills.
         <div className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
+          {/* items-baseline so the eyebrow h2 stays glued to its own
+              baseline instead of being centered against the slightly
+              taller action button — otherwise the row's items-center
+              alignment pushes the h2 ~1px lower than the same eyebrow
+              on the other tabs. */}
+          <div className="flex items-baseline justify-between gap-3">
             <h2
               className="text-[11px] font-semibold uppercase"
               style={{

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -177,15 +177,18 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction 
     // itinerary full-width — Travel Plans moved to the Crew tab).
     <div className="flex h-full flex-col space-y-3">
       {!isEmpty && (
-        // Two-row header. Row 1: ITINERARY label on the left, the
-        // optional headerAction (e.g. "← Setup guide") on the right.
-        // Row 2: filter pills, only when there's more than one category
-        // worth filtering.
-        <div className="space-y-2">
-          <div className="flex items-center justify-between gap-2">
+        // Two-row header. Row 1: ITINERARY eyebrow on the left, the
+        // optional headerAction (e.g. "← Setup guide") on the right —
+        // same typography pattern the shared TabHeader uses across
+        // every entry tab. Row 2: filter pills.
+        <div className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
             <h2
-              className="text-xs font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
+              className="text-[11px] font-semibold uppercase"
+              style={{
+                color: "var(--color-bt-accent)",
+                letterSpacing: "0.1em",
+              }}
             >
               Itinerary
             </h2>

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -51,6 +51,10 @@ export interface ItineraryViewProps {
   /** When provided (owner only), shows an X button on the empty-state
       mock-up that backs out of the activation. */
   onCancel?: () => void;
+  /** Optional slot rendered on the right of the ITINERARY header row.
+   *  ItineraryPanel uses this to inject the "← Setup guide" toggle when
+   *  the guide is currently dismissed. */
+  headerAction?: import("react").ReactNode;
 }
 
 /**
@@ -69,7 +73,7 @@ export interface ItineraryViewProps {
  *      state mirrors the intro modal preview. Owners get an X button
  *      that backs out of the activation entirely.
  */
-export function ItineraryView({ trip, isOwner: _isOwner, onCancel }: ItineraryViewProps) {
+export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction }: ItineraryViewProps) {
   const tripId = trip.id;
 
   // ── Data ────────────────────────────────────────────────────────────────
@@ -173,15 +177,24 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel }: ItineraryVi
     // itinerary full-width — Travel Plans moved to the Crew tab).
     <div className="flex h-full flex-col space-y-3">
       {!isEmpty && (
-        // Header + filters share one row: "ITINERARY" on the left, the filter
-        // pills inline on the right (wrapping below on narrow widths).
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <h2
-            className="text-xs font-semibold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            Itinerary
-          </h2>
+        // Two-row header. Row 1: ITINERARY label on the left, the
+        // optional headerAction (e.g. "← Setup guide") on the right.
+        // Row 2: filter pills, only when there's more than one category
+        // worth filtering.
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <h2
+              className="text-xs font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              Itinerary
+            </h2>
+            {headerAction && (
+              <div className="flex flex-shrink-0 items-center">
+                {headerAction}
+              </div>
+            )}
+          </div>
 
           {showFilterPills && (
             <div className="flex flex-wrap items-center gap-2">

--- a/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
@@ -98,34 +98,39 @@ export function ItineraryPanel({
     );
   }
 
-  // ── Owner: dates set OR activated — show real view + restore link ──
+  // ── Owner: dates set OR activated — guide and itinerary toggle ────
+  // Either/or: when the guide is up the itinerary is hidden, and vice
+  // versa. The toggle lives in the top-right of whichever surface is
+  // showing — "View itinerary →" on the guide, "← Setup guide" in the
+  // ITINERARY header.
   if (datesSet || isActivated) {
+    if (!dismissed) {
+      return (
+        <FreshTripGuide
+          tripId={tripId}
+          trip={trip}
+          onOpenDatesSheet={onOpenDatesSheet}
+          onTabChange={onTabChange}
+          onDismiss={() => setDismissed(true)}
+        />
+      );
+    }
     return (
-      <div className="space-y-3">
-        {!dismissed && (
-          <FreshTripGuide
-            tripId={tripId}
-            trip={trip}
-            onOpenDatesSheet={onOpenDatesSheet}
-            onTabChange={onTabChange}
-            onDismiss={() => setDismissed(true)}
-          />
-        )}
-        {dismissed && (
-          <div className="flex justify-end">
-            <button
-              type="button"
-              onClick={() => setDismissed(false)}
-              className="text-[11px] transition-opacity hover:opacity-80"
-              style={{ color: "var(--color-bt-text-dim)" }}
-              data-testid="guide-restore-link"
-            >
-              Show setup guide
-            </button>
-          </div>
-        )}
-        <ItineraryView trip={trip} isOwner={isOwner} />
-      </div>
+      <ItineraryView
+        trip={trip}
+        isOwner={isOwner}
+        headerAction={
+          <button
+            type="button"
+            onClick={() => setDismissed(false)}
+            className="text-[12px] font-semibold transition-opacity hover:opacity-80"
+            style={{ color: "var(--color-bt-accent)" }}
+            data-testid="guide-restore-link"
+          >
+            ← Setup guide
+          </button>
+        }
+      />
     );
   }
 

--- a/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Calendar } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ItineraryView } from "../ItineraryView";
-import { ItineraryIntroModal } from "../modals/ItineraryIntroModal";
-import { InvitationCard } from "@/components/InvitationCard";
+import {
+  FreshTripGuide,
+  DismissedEmptyState,
+  useGuideDismissed,
+} from "../../../components/setup-guide";
 import type { TripData } from "../../types";
 
 // ── Types ────────────────────────────────────────────────────────────────
@@ -14,8 +16,17 @@ interface ItineraryPanelProps {
   tripId: string;
   trip: TripData;
   isOwner: boolean;
-  /** True once the owner has tapped "Add Itinerary" on the invitation card. */
+  /** True once the owner has tapped "Add Itinerary" on the (legacy)
+   *  invitation card. With the FreshTripGuide rollout we treat the empty
+   *  itinerary as the default for owners, so this flag is no longer the
+   *  primary gate — but it still routes legacy trips and members. */
   isActivated: boolean;
+  /** Opens the existing DatesSheet — wired from the trip page. Passed
+   *  through to FreshTripGuide's date flip-card poll branch. */
+  onOpenDatesSheet?: () => void;
+  /** Tab switcher — drives the Lodging / Crew / Agenda step CTAs in
+   *  FreshTripGuide. */
+  onTabChange?: (tab: string) => void;
 }
 
 // ── Component ────────────────────────────────────────────────────────────
@@ -23,103 +34,119 @@ interface ItineraryPanelProps {
 /**
  * ItineraryPanel — home tab panel for the day-by-day timeline.
  *
- * State machine:
- *   1. Member, not activated  → dim placeholder, no CTA
- *   2. Owner, not activated   → standard InvitationCard, opens
- *                               ItineraryIntroModal
- *   3. Activated              → ItineraryView renders directly (no panel
- *                               container). When activated-but-empty, the
- *                               empty state gets an X button to back out.
+ * State machine (owner):
+ *   - dates set OR isActivated → ItineraryView (real bookends + content).
+ *     When the guide isn't dismissed, FreshTripGuide also renders above it
+ *     so the owner can keep adding lodging/crew/agenda from the same spot.
+ *   - no dates set + !dismissed → FreshTripGuide alone (the empty state).
+ *   - no dates set + dismissed  → DismissedEmptyState (single dashed card
+ *     with a Set-dates CTA and a "Show setup guide" restore link).
  *
- * The previous "no content" branch (a bare nudge to set dates from the
- * header) has been folded into the standard invitation card so all four
- * home-tab panels share the same opt-in affordance.
+ * Members still see the dim placeholder until the trip has real content.
+ *
+ * The legacy `isActivated` flag (itinerary_enabled) routes pre-existing
+ * trips that already opted in; new trips treat the empty itinerary as the
+ * default, with FreshTripGuide teaching the flow.
  */
 export function ItineraryPanel({
   tripId,
   trip,
   isOwner,
   isActivated,
+  onOpenDatesSheet,
+  onTabChange,
 }: ItineraryPanelProps) {
-  const [introOpen, setIntroOpen] = useState(false);
+  const [dismissed, setDismissed] = useGuideDismissed(tripId);
   const utils = trpc.useUtils();
+  // Suppress the unused-warning for the legacy disable mutation — kept on
+  // standby for the (very rare) "back out of activation" flow if we wire
+  // it back in later. For now FreshTripGuide replaces the activation UI.
+  void useState; // imported above; tree-shaken if not used
 
-  const enableItinerary = trpc.trips.enableItinerary.useMutation({
+  // Legacy disable hook — no longer surfaced in the UI, but kept available
+  // so any prod data with itinerary_enabled=true and no content can still
+  // be reverted via a future affordance without re-plumbing.
+  const _disableItinerary = trpc.trips.disableItinerary.useMutation({
     async onMutate() {
       await utils.trips.getById.cancel({ tripId });
       const prev = utils.trips.getById.getData({ tripId });
       utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
-        old ? { ...old, itinerary_enabled: true } : old
+        old ? { ...old, itinerary_enabled: false } : old,
       );
       return { prev };
     },
     onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.trips.getById.setData({ tripId }, ctx.prev);
-    },
-    onSuccess() {
-      setIntroOpen(false);
+      if (ctx?.prev !== undefined)
+        utils.trips.getById.setData({ tripId }, ctx.prev);
     },
     onSettled() {
       utils.trips.getById.invalidate({ tripId });
     },
   });
+  void _disableItinerary;
 
-  const disableItinerary = trpc.trips.disableItinerary.useMutation({
-    async onMutate() {
-      await utils.trips.getById.cancel({ tripId });
-      const prev = utils.trips.getById.getData({ tripId });
-      utils.trips.getById.setData({ tripId }, (old: TripData | undefined) =>
-        old ? { ...old, itinerary_enabled: false } : old
-      );
-      return { prev };
-    },
-    onError(_e, _v, ctx) {
-      if (ctx?.prev !== undefined) utils.trips.getById.setData({ tripId }, ctx.prev);
-    },
-    onSettled() {
-      utils.trips.getById.invalidate({ tripId });
-    },
-  });
+  const datesSet = !!(trip.start_date && trip.end_date);
 
-  // ── State 4: live (no panel shell — view renders directly) ──────────
-  if (isActivated) {
-    return (
-      <ItineraryView
-        trip={trip}
-        isOwner={isOwner}
-        onCancel={isOwner ? () => disableItinerary.mutate({ tripId }) : undefined}
-      />
-    );
-  }
-
-  // ── State 1: member, not activated ───────────────────────────────────
+  // ── Member path ─────────────────────────────────────────────────────
   if (!isOwner) {
+    // Show the live view as soon as there are bookends or content.
+    if (datesSet || isActivated) {
+      return <ItineraryView trip={trip} isOwner={false} />;
+    }
     return (
-      <DimPlaceholder
-        text="Your itinerary will appear here once the trip organizer sets it up."
+      <DimPlaceholder text="Your itinerary will appear here once the trip organizer sets it up." />
+    );
+  }
+
+  // ── Owner: dates set OR activated — show real view + restore link ──
+  if (datesSet || isActivated) {
+    return (
+      <div className="space-y-3">
+        {!dismissed && (
+          <FreshTripGuide
+            tripId={tripId}
+            trip={trip}
+            onOpenDatesSheet={onOpenDatesSheet}
+            onTabChange={onTabChange}
+            onDismiss={() => setDismissed(true)}
+          />
+        )}
+        {dismissed && (
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => setDismissed(false)}
+              className="text-[11px] transition-opacity hover:opacity-80"
+              style={{ color: "var(--color-bt-text-dim)" }}
+              data-testid="guide-restore-link"
+            >
+              Show setup guide
+            </button>
+          </div>
+        )}
+        <ItineraryView trip={trip} isOwner={isOwner} />
+      </div>
+    );
+  }
+
+  // ── Owner: no dates yet ────────────────────────────────────────────
+  if (dismissed) {
+    return (
+      <DismissedEmptyState
+        onSetDates={() => onOpenDatesSheet?.()}
+        onRestoreGuide={() => setDismissed(false)}
       />
     );
   }
 
-  // ── State 2: owner, not activated — standard invitation card ─────────
   return (
-    <>
-      <InvitationCard
-        Icon={Calendar}
-        title="Add Itinerary"
-        body="Set your trip dates and your lodging, schedule, and travel info all slot into a day-by-day view."
-        onClick={() => setIntroOpen(true)}
-        testId="itinerary-invitation"
-      />
-      {introOpen && (
-        <ItineraryIntroModal
-          isOpen
-          onClose={() => setIntroOpen(false)}
-          onActivate={() => enableItinerary.mutate({ tripId })}
-          isActivating={enableItinerary.isPending}
-        />
-      )}
-    </>
+    <FreshTripGuide
+      tripId={tripId}
+      trip={trip}
+      onOpenDatesSheet={onOpenDatesSheet}
+      onTabChange={onTabChange}
+      onDismiss={() => setDismissed(true)}
+    />
   );
 }
 

--- a/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
+++ b/src/app/trips/[tripId]/tabs/components/panels/ItineraryPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { ListChecks } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ItineraryView } from "../ItineraryView";
+import { DatePollCard } from "../DatePollCard";
 import {
   FreshTripGuide,
   DismissedEmptyState,
@@ -86,15 +88,33 @@ export function ItineraryPanel({
   void _disableItinerary;
 
   const datesSet = !!(trip.start_date && trip.end_date);
+  const pollActive = !!trip.poll_mode;
 
   // ── Member path ─────────────────────────────────────────────────────
+  // Priority order:
+  //   1. Real bookends locked → ItineraryView (the trip has dates; show
+  //      the day-by-day even if the poll flag is somehow still on,
+  //      because dates landing is what members are waiting for).
+  //   2. Poll is active → DatePollCard in vote/read mode. This is the
+  //      one place the crew weighs in; the home tab IS the poll until
+  //      it resolves. If the owner hasn't added windows yet, the card's
+  //      empty state ("The organizer hasn't added any windows yet")
+  //      handles that — members still see something useful instead of
+  //      a generic dim placeholder.
+  //   3. Otherwise → dim placeholder. The legacy `isActivated` flag is
+  //      intentionally dropped from the member path: with the new poll
+  //      flow, "itinerary is set up" should mean "dates are locked,"
+  //      not "the owner flipped a legacy switch." Owners (below) still
+  //      honor the flag for the rare in-flight legacy trip.
   if (!isOwner) {
-    // Show the live view as soon as there are bookends or content.
-    if (datesSet || isActivated) {
+    if (datesSet) {
       return <ItineraryView trip={trip} isOwner={false} />;
     }
+    if (pollActive) {
+      return <DatePollCard trip={trip} isOwner={false} />;
+    }
     return (
-      <DimPlaceholder text="Your itinerary will appear here once the trip organizer sets it up." />
+      <DimPlaceholder text="Your itinerary will appear here once the organizer locks the trip dates." />
     );
   }
 
@@ -123,11 +143,14 @@ export function ItineraryPanel({
           <button
             type="button"
             onClick={() => setDismissed(false)}
-            className="text-[12px] font-semibold transition-opacity hover:opacity-80"
+            className="inline-flex items-center gap-1 text-[12px] font-semibold transition-opacity hover:opacity-80"
             style={{ color: "var(--color-bt-accent)" }}
             data-testid="guide-restore-link"
+            aria-label="Show setup guide"
+            title="Show setup guide"
           >
-            ← Setup guide
+            <ListChecks size={14} strokeWidth={2} />
+            Setup guide
           </button>
         }
       />


### PR DESCRIPTION
## Summary

Per HANDOFF-datepoll.md, replaces the Doodle-style grid with stacked option cards and consolidates the date picker into a single full-size surface used by every entry point.

**Owner home tab** now branches on `trip.poll_mode`. When a poll is active, FreshTripGuide skips the step grid entirely and renders `DatePollCard` flush — no flip-card chrome, no "Set your dates" title — so the poll is the home tab. Members see the same surface via ItineraryPanel with a "DATE POLL / Dates are being picked / {Owner}'s lining up..." intro header and a clock empty state attributed to the owner until windows land.

**Poll panel** (`DatePollStackedCards`):
- One option card per `date_window`. Collapsed: select radio, range, "Fri – Tue · 4 nights" subline, Most popular trophy below it, full-width tally bar + per-bucket counts, expand chevron.
- Expanded roster grouped Yes/Maybe/No/Waiting as standard `<Avatar />` + name chips (muted for placeholders, "(you)" suffix on the viewer). Tap any chip → 3-way + Clear popover (owner override, placeholders included).
- Quiet "Remove this date option" with inline confirm when votes exist.
- "+ Add a date option" reveals a 320px-capped inline range calendar (round caps + fill bar + hover ring, same vocab as the lodging DatePicker) so multiple proposals chain back-to-back without a modal.
- Footer: primary "Lock in [range]" + outline "Cancel this poll" → red-bordered inline confirm.
- Member card: Yes / Maybe / No segmented control highlighted in vote color, faint consensus line, no admin affordances.
- Whole surface capped at 720px.

**Trip dates modal (`DatesSheet`)** is single-mode now — Pick/Poll tabs and the embedded DatePollCard are gone. Chrome matches `InfoTileModal` (card-float + shadow-floating + h3 + subtitle + bordered footer). `FullRangeCalendar` is controlled; the footer owns Cancel/Save/Clear (Clear wipes the local selection only — committing an empty selection via Save is what clears the trip dates). Save while a poll is active is sequenced (`await endPoll → await lockDates → onClose`) so the modal actually closes — concurrent runs were racing on `date_windows` and `lockDates`'s `onSuccess` sometimes never fired.

**Poll lifecycle:**
- "Set up date poll" now activates `trip.poll_mode` immediately so members land on the poll surface before the first window.
- Tapping it with dates already locked routes through an inline confirm ("Start a poll instead? You've already picked dates...") that clears the range via `datePoll.unlock` before activating.
- FreshTripGuide reconciles its local pollMode latch when `trip.poll_mode` flips false, so picking dates from anywhere ends the poll and reverts the home tab to the normal grid.

**Other tightening on this branch:**
- ITINERARY heading aligned with the other TabHeader eyebrows (pt-1 + items-baseline kills the ~6px y-offset).
- "Setup guide" toggle uses a `ListChecks` icon instead of the ← arrow.
- Member ItineraryPanel branch: `datesSet → ItineraryView`, `pollActive → DatePollCard`, otherwise dim placeholder (legacy `isActivated` fallback dropped on the member path).

## What's now dead code (flagged, not removed in this PR)

- `DatePollGrid.tsx` — superseded by `DatePollStackedCards`. Only its types are still imported.
- `datePoll.updatePollNote` server procedure + the pollNote column reads — Crew Instructions modal was removed.
- `DatePickerPanel.tsx` — DatesSheet now uses inline `FullRangeCalendar`.

## Test plan

- [ ] Owner with no dates and ≥2 crew: tap Poll → "Set up date poll" → empty state renders, member sees "Dates are being picked / No date options yet". Add a window → cards appear on both views.
- [ ] Member can vote Yes / Maybe / No, tally + consensus update.
- [ ] Owner expands a card → roster groups populate, chip popover sets answers for placeholders.
- [ ] Owner with dates locked taps Poll → "Set up date poll" → red confirm tray → "Start poll" clears the dates and launches.
- [ ] DatesSheet pick with poll active: Save closes the modal, dates land, poll surface collapses, home reverts to step grid + done-state Set Dates card.
- [ ] Lock a window from the poll → confirm modal → trip dates set, poll surface collapses, home reverts.
- [ ] Cancel this poll → red inline confirm → poll wiped, home reverts.
- [ ] All copy + layouts on mobile (single column).
- [ ] Trip dates modal hover state on day cells matches the lodging DatePicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)