### PR TITLE
Fix double back-press on the trip page (DatesSheet phantom history entry)

### DIFF
--- a/src/app/trips/[tripId]/components/DatesSheet.tsx
+++ b/src/app/trips/[tripId]/components/DatesSheet.tsx
@@ -89,7 +89,11 @@ export function DatesSheet({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
-  useModalBackButton(isOpen ? onClose : () => {});
+  // DatesSheet is always mounted on the trip page (visibility gated by
+  // isOpen), so pass isOpen as the `enabled` flag — otherwise the hook
+  // pushes a phantom history entry even while closed and silently eats the
+  // first back-press on every trip page.
+  useModalBackButton(onClose, isOpen);
 
   // ── Mutations ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

On mobile, opening a trip from the dashboard and pressing back required **two** presses to actually leave the page.

## Cause

`DatesSheet` is always mounted on the trip page (visibility gated by `isOpen`, with `if (!isOpen) return null` inside). It called:

```ts
useModalBackButton(isOpen ? onClose : () => {});
```

The hook's second `enabled` argument was never passed, so it defaulted to `true`. That meant the hook pushed a **phantom history entry the entire time the trip page was open**, even while the sheet was closed. The first back-press popped that phantom — the hook's `stopImmediatePropagation()` blocked Next's navigation and ran a no-op close — so nothing visibly happened. The second press finally navigated.

This affected every trip page on mobile, independent of trip state. (Pre-existing — `git blame` dates the line to 2026-05-18; it surfaced during testing of the recent merge.)

## Fix

Pass `isOpen` as the `enabled` flag — the hook's documented pattern for always-mounted modals — so the phantom entry only exists while the sheet is actually open:

```ts
useModalBackButton(onClose, isOpen);
```

Checked the other `useModalBackButton` callers: `InfoTileModal` and the rest are conditionally rendered (pattern 1), and `ItineraryIntroModal` already passes `isOpen`. `DatesSheet` was the only offender.

https://claude.ai/code/session_01JvAfemJeHtGEontY2tjRBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvAfemJeHtGEontY2tjRBo)_