### PR TITLE
Perf — faster cold-load to first paint, profile shell + dropdown fixes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,151 +1,55 @@
-"use client";
-
-import { useEffect, useMemo, useRef } from "react";
-import { useRouter } from "next/navigation";
-import { useAuthLoaded, useAuthUser } from "@/lib/auth-context";
-import { trpc } from "@/lib/trpc-client";
-import { getEffectiveStatus } from "@/lib/tripStatus";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase-server";
 import { MarketingPage } from "@/components/marketing/MarketingPage";
 
 /**
- * Root route `/`.
+ * Root route `/` — Server Component.
  *
  * Two completely separate experiences live here:
  *
- *  1. Unauthenticated visitors → full marketing page (`<MarketingPage />`)
- *  2. Authenticated users     → redirect to their most relevant trip via:
- *       a. last visited (localStorage `bt-last-trip-id`, if still a member)
- *       b. NOW (within 3 days of start, or mid-trip)
- *       c. UPCOMING > IDEA
- *       d. /dashboard if they have no trips (the dashboard renders the
- *          shared AuthenticatedEmptyState as its body)
+ *  1. Unauthenticated visitors → the public marketing page.
+ *  2. Authenticated users     → redirect to their last-visited trip
+ *     (read from the `bt-last-trip-id` cookie, which the trip page
+ *     writes alongside its localStorage entry on every visit) or
+ *     /dashboard if no cookie is set.
  *
- * To avoid flashing the marketing page to a logged-in user, we render a
- * minimal full-screen loader while auth + the trips list are still
- * resolving. The marketing page never appears for authed users.
+ * Running this on the server eliminates the cold-load waterfall the
+ * old client component had — refresh used to send: blank shell → JS
+ * bundle download (including all of MarketingPage even for authed
+ * users) → auth context resolves → trips.list round-trip → client
+ * router.replace → trip route bundle download. The user sat on the
+ * full-screen loader through every step. Now the server sees the auth
+ * cookie + the last-trip-id cookie and replies with a 307 to
+ * /trips/[id] immediately. No loader, no marketing-page JS download
+ * for authed users.
+ *
+ * The cookie isn't perfectly authoritative — a user opening BuddyTrip
+ * on a new device (no cookie yet) lands on /dashboard, which already
+ * runs the trip-list priority sort and renders the empty state if
+ * they have no trips. That's a one-time fallback, not the common
+ * path.
  */
-export default function HomePage() {
-  const authLoaded = useAuthLoaded();
-  const user = useAuthUser();
-  const router = useRouter();
+export default async function HomePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  // Only fetch the trips list when we know the user is authenticated.
-  const tripsQuery = trpc.trips.list.useQuery(undefined, {
-    enabled: authLoaded && !!user,
-  });
-
-  // Track whether we've already kicked off a router.push so we don't loop
-  // on re-renders while the navigation is in flight. Ref (not state) so
-  // toggling it doesn't trigger another render.
-  const redirectedRef = useRef(false);
-
-  // Pick the priority trip from a loaded trips list.
-  const targetTripId = useMemo(() => {
-    if (!tripsQuery.data || tripsQuery.data.length === 0) return null;
-    const trips = tripsQuery.data;
-
-    // 1. localStorage last-visited (validated against current memberships)
-    if (typeof window !== "undefined") {
-      const lastId = window.localStorage.getItem("bt-last-trip-id");
-      if (lastId && trips.some((t) => t.id === lastId)) return lastId;
-    }
-
-    // 2-4. Status priority via getEffectiveStatus
-    const priority: Record<string, number> = {
-      now: 0,
-      upcoming: 1,
-      idea: 2,
-      past: 3,
-    };
-    const sorted = [...trips].sort((a, b) => {
-      const pa = priority[getEffectiveStatus(a)] ?? 99;
-      const pb = priority[getEffectiveStatus(b)] ?? 99;
-      return pa - pb;
-    });
-    return sorted[0]?.id ?? null;
-  }, [tripsQuery.data]);
-
-  useEffect(() => {
-    if (!authLoaded || !user) return;
-    if (tripsQuery.isLoading) return;
-    if (redirectedRef.current) return;
-
-    if (targetTripId) {
-      redirectedRef.current = true;
-      router.replace(`/trips/${targetTripId}`);
-      return;
-    }
-
-    // Authed but no trips → dashboard, which renders the shared
-    // AuthenticatedEmptyState as its body. Single source of truth for
-    // the no-trips experience.
-    if (tripsQuery.data && tripsQuery.data.length === 0) {
-      redirectedRef.current = true;
-      router.replace("/dashboard");
-    }
-  }, [authLoaded, user, tripsQuery.isLoading, tripsQuery.data, targetTripId, router]);
-
-  // ── Render branches ─────────────────────────────────────────────────────
-
-  // While auth is resolving — or we know we're about to redirect — keep
-  // the marketing page hidden behind a dark loader.
-  if (!authLoaded) return <FullScreenLoader />;
-
-  if (user) {
-    // Authed: either still fetching trips or about to redirect (to a
-    // trip if they have one, otherwise to /dashboard). Either way, the
-    // loader covers the gap so the marketing page never flashes.
-    return <FullScreenLoader />;
+  if (!user) {
+    return <MarketingPage />;
   }
 
-  // Unauthenticated visitor → marketing page.
-  return <MarketingPage />;
-}
+  const cookieStore = await cookies();
+  const lastTripId = cookieStore.get("bt-last-trip-id")?.value;
 
-/**
- * Dark full-screen loader with the BuddyTrip mark centered. Shown while
- * auth resolves and while the trips list loads for an authed user — keeps
- * the marketing page from flashing.
- */
-function FullScreenLoader() {
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        background: "#0a0e1a",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <div
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 8,
-          fontSize: 20,
-          fontWeight: 600,
-          letterSpacing: "0.06em",
-          color: "#f1f5f9",
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-        }}
-      >
-        <svg
-          width="22"
-          height="22"
-          viewBox="0 0 100 100"
-          xmlns="http://www.w3.org/2000/svg"
-          aria-hidden="true"
-          style={{ color: "#2dd4bf", flexShrink: 0 }}
-        >
-          <path
-            d="M 28 8 L 38 8 L 76 26 L 38 44 L 38 75 L 33 92 L 28 75 Z"
-            fill="currentColor"
-          />
-        </svg>
-        BuddyTrip
-      </div>
-    </div>
-  );
+  if (lastTripId) {
+    redirect(`/trips/${lastTripId}`);
+  }
+
+  // Authed but we don't know which trip to send them to. /dashboard
+  // shares the same data path the old client redirector used (trips
+  // list + priority sort) and falls back to the AuthenticatedEmptyState
+  // when the user has no trips at all.
+  redirect("/dashboard");
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import { ChevronRight } from "lucide-react";
 import {
   IconUser,
@@ -17,8 +18,54 @@ import { createClient } from "@/lib/supabase";
 import { useAuthLoaded, useAuthUser } from "@/lib/auth-context";
 import { TopNav } from "@/components/TopNav";
 import { Avatar } from "@/components/Avatar";
-import { AvatarIconPicker } from "@/components/AvatarIconPicker";
-import { ArchivedIdeasPanel } from "@/components/profile/ArchivedIdeasPanel";
+
+// Lazy-loaded — both panels are heavy (AvatarIconPicker statically
+// references all 96 Tabler icons via AVATAR_ICON_COMPONENTS; the
+// archived-ideas panel pulls its own tRPC query and list UI). Splitting
+// them into their own chunks keeps the profile route's initial JS
+// payload small so the page paints sooner. Each ships a tiny skeleton
+// placeholder so the layout doesn't reflow when the chunk lands.
+const AvatarIconPicker = dynamic(
+  () =>
+    import("@/components/AvatarIconPicker").then((m) => ({
+      default: m.AvatarIconPicker,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="rounded-xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "0.5px solid var(--color-bt-border)",
+          height: 244,
+        }}
+        aria-hidden
+      />
+    ),
+  },
+);
+
+const ArchivedIdeasPanel = dynamic(
+  () =>
+    import("@/components/profile/ArchivedIdeasPanel").then((m) => ({
+      default: m.ArchivedIdeasPanel,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex justify-center py-12">
+        <div
+          className="h-5 w-5 animate-spin rounded-full border-2"
+          style={{
+            borderColor: "var(--color-bt-accent)",
+            borderTopColor: "transparent",
+          }}
+        />
+      </div>
+    ),
+  },
+);
 
 // ── Constants ─────────────────────────────────────────────────────────────
 
@@ -101,21 +148,11 @@ export default function ProfilePage() {
   // ── OAuth detection ───────────────────────────────────────────────────
   const isGoogleUser = authUser?.app_metadata?.provider === "google";
 
-  if (!authLoaded || isLoading || !me) {
-    return (
-      <div className="min-h-screen" style={{ background: "var(--color-bt-base)" }}>
-        <TopNav hideTripSwitcher hideNews />
-        <div className="flex justify-center py-16">
-          <div
-            className="h-6 w-6 animate-spin rounded-full border-2"
-            style={{ borderColor: "var(--color-bt-accent)", borderTopColor: "transparent" }}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  const displayName = me.name ?? me.email ?? "You";
+  // Page-data readiness — gates ONLY the content area. The chrome
+  // (TopNav, sidebar, mobile back button) renders immediately so the
+  // user sees something useful while users.getMe is in flight.
+  const dataReady = authLoaded && !!me;
+  const displayName = me?.name ?? me?.email ?? "You";
 
   return (
     <div
@@ -152,6 +189,22 @@ export default function ProfilePage() {
               </button>
             </div>
 
+            {!dataReady ? (
+              // Content-area loading state. The shell above (TopNav +
+              // sidebar) has already rendered, so the page reads as
+              // "loaded" while users.getMe finishes. Subsumes both the
+              // auth-hydration race and the initial query.
+              <div className="flex justify-center py-16">
+                <div
+                  className="h-6 w-6 animate-spin rounded-full border-2"
+                  style={{
+                    borderColor: "var(--color-bt-accent)",
+                    borderTopColor: "transparent",
+                  }}
+                />
+              </div>
+            ) : (
+            <>
             {/* Mobile shows everything stacked. Desktop renders only the
                 section matching the active sidebar tab. */}
 
@@ -365,15 +418,17 @@ export default function ProfilePage() {
                 </button>
               </Section>
             </div>
+            </>
+            )}
           </div>
         </main>
       </div>
 
       {/* ── Sheets ─────────────────────────────────────────────────────── */}
-      {openSheet === "name" && (
+      {me && openSheet === "name" && (
         <NameSheet currentName={me.name ?? ""} onClose={() => setOpenSheet(null)} />
       )}
-      {openSheet === "email" && (
+      {me && openSheet === "email" && (
         <EmailSheet currentEmail={me.email ?? ""} onClose={() => setOpenSheet(null)} />
       )}
       {openSheet === "password" && (

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -128,11 +128,20 @@ export default function TripDetailPage() {
   // until their tripMembers.list cache goes stale or they reload.
   useRealtimeMembers(tripId);
 
-  // Remember the most recently visited trip so root-route redirect
-  // (src/app/page.tsx) can drop the user back here on return visits.
+  // Remember the most recently visited trip so the root-route Server
+  // Component (src/app/page.tsx) can 307 the user back here on return
+  // visits without any client work. The cookie has to be readable
+  // server-side, so document.cookie writes the same value the
+  // localStorage entry holds — kept in sync here and in the same
+  // tick. 1 year expiry, lax SameSite (sent on direct navigation
+  // back to /), Path=/ so / and /trips/* both see it.
   useEffect(() => {
     if (tripId && typeof window !== "undefined") {
       window.localStorage.setItem("bt-last-trip-id", tripId);
+      const oneYearSec = 60 * 60 * 24 * 365;
+      document.cookie =
+        `bt-last-trip-id=${encodeURIComponent(tripId)}; ` +
+        `Max-Age=${oneYearSec}; Path=/; SameSite=Lax`;
     }
   }, [tripId]);
 

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -158,7 +158,10 @@ export const TopNav: FC<TopNavProps> = ({
               onClick={() => setSwitcherOpen((p) => !p)}
               className="flex min-w-0 items-center gap-1.5 transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{
-                background: "var(--color-bt-card-raised)",
+                // Transparent fill — the border alone is enough
+                // affordance and a card-raised surface read as a heavy
+                // chip against the translucent title bar.
+                background: "transparent",
                 border: "1px solid var(--color-bt-border)",
                 borderRadius: 9,
                 padding: "5px 9px 5px 7px",

--- a/src/components/TripSwitcher.tsx
+++ b/src/components/TripSwitcher.tsx
@@ -146,9 +146,14 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
     <>
       {/* Mobile dim backdrop — sm:hidden so it disappears once the panel
           switches to absolute positioning on larger screens. Mirrors the
-          same pattern as the notifications bell panel. */}
+          same pattern as the notifications bell panel.
+          z-30 keeps the backdrop UNDER the TopNav header (z-40) so the
+          title bar stays at full clarity while the page content below
+          dims. Equal z-indices defer to DOM order; the backdrop is a
+          child of TopNav and rendered after, so a tied z-40 would
+          inadvertently cover the header. */}
       <div
-        className="fixed inset-0 z-40 sm:hidden"
+        className="fixed inset-0 z-30 sm:hidden"
         style={{ background: "var(--color-bt-overlay)" }}
         onClick={onClose}
         aria-hidden="true"

--- a/src/components/TripSwitcher.tsx
+++ b/src/components/TripSwitcher.tsx
@@ -80,7 +80,13 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
   // otherwise the backdrop is sized to the header bounds and only
   // dims the title bar — exactly the bug this whole component had.
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    // Canonical "are we in the browser" flag for the portal target.
+    // Synchronizing with an external system (document) is exactly the
+    // setState-in-effect use the React docs whitelist.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
   const { data: trips = [] } = trpc.trips.list.useQuery(undefined, {
     enabled: open, // don't fire query until user opens the switcher

--- a/src/components/TripSwitcher.tsx
+++ b/src/components/TripSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useRouter, useParams } from "next/navigation";
 import { IconCheck, IconPlus } from "@tabler/icons-react";
 import { trpc } from "@/lib/trpc-client";
@@ -72,6 +73,14 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
   const router = useRouter();
   const params = useParams<{ tripId?: string }>();
   const currentTripId = params?.tripId ?? null;
+
+  // SSR-safe portal target. The mobile dim backdrop needs to render
+  // outside the TopNav (which sets backdrop-filter and therefore
+  // becomes a containing block for any descendant position:fixed),
+  // otherwise the backdrop is sized to the header bounds and only
+  // dims the title bar — exactly the bug this whole component had.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const { data: trips = [] } = trpc.trips.list.useQuery(undefined, {
     enabled: open, // don't fire query until user opens the switcher
@@ -145,19 +154,21 @@ export function TripSwitcher({ open, onClose }: TripSwitcherProps) {
   return (
     <>
       {/* Mobile dim backdrop — sm:hidden so it disappears once the panel
-          switches to absolute positioning on larger screens. Mirrors the
-          same pattern as the notifications bell panel.
-          z-30 keeps the backdrop UNDER the TopNav header (z-40) so the
-          title bar stays at full clarity while the page content below
-          dims. Equal z-indices defer to DOM order; the backdrop is a
-          child of TopNav and rendered after, so a tied z-40 would
-          inadvertently cover the header. */}
-      <div
-        className="fixed inset-0 z-30 sm:hidden"
-        style={{ background: "var(--color-bt-overlay)" }}
-        onClick={onClose}
-        aria-hidden="true"
-      />
+          switches to absolute positioning on larger screens.
+          Portaled to <body> so it escapes TopNav's containing block
+          (the header sets backdrop-filter, which per spec creates a
+          containing block for descendant position:fixed elements — a
+          backdrop rendered inline here would be sized to the header
+          and only dim the title bar). */}
+      {mounted && createPortal(
+        <div
+          className="fixed inset-0 z-30 sm:hidden"
+          style={{ background: "var(--color-bt-overlay)" }}
+          onClick={onClose}
+          aria-hidden="true"
+        />,
+        document.body,
+      )}
 
       {/* Panel — fixed on mobile (drops below nav), absolute on desktop.
           fixed top-14 = 56px from the header's own top edge (backdrop-filter

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -35,7 +35,13 @@ export function UserMenu() {
   // backdrop is sized to the header bounds and only dims the title
   // bar instead of the content below.
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    // Canonical "are we in the browser" flag for the portal target.
+    // Synchronizing with an external system (document) is exactly the
+    // setState-in-effect use the React docs whitelist.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
   // Warm the /profile route chunk the moment the menu opens. The user
   // has signalled intent (they tapped the avatar); by the time they

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { IconSettings, IconLogout } from "@tabler/icons-react";
 import { trpc } from "@/lib/trpc-client";
@@ -28,6 +29,13 @@ export function UserMenu() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  // SSR-safe portal target — the mobile dim backdrop has to render
+  // outside the TopNav (which sets backdrop-filter, creating a
+  // containing block for position:fixed descendants), otherwise the
+  // backdrop is sized to the header bounds and only dims the title
+  // bar instead of the content below.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   // Warm the /profile route chunk the moment the menu opens. The user
   // has signalled intent (they tapped the avatar); by the time they
@@ -91,19 +99,20 @@ export function UserMenu() {
 
       {open && (
         <>
-          {/* Mobile dim backdrop — sm:hidden so it disappears once the
-              panel switches to absolute positioning on larger screens.
-              z-30 keeps the backdrop UNDER the TopNav header (z-40) so
-              the title bar stays at full clarity while the page content
-              below dims. Equal z-indices defer to DOM order; this
-              backdrop is rendered after the header in the same tree,
-              so a tied z-40 would inadvertently cover the title bar. */}
-          <div
-            className="fixed inset-0 z-30 sm:hidden"
-            style={{ background: "var(--color-bt-overlay)" }}
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
+          {/* Mobile dim backdrop — portaled to <body> so it escapes
+              TopNav's containing block (the header sets backdrop-filter,
+              which per spec creates a containing block for descendant
+              position:fixed elements — a backdrop rendered inline would
+              be sized to the header and only dim the title bar). */}
+          {mounted && createPortal(
+            <div
+              className="fixed inset-0 z-30 sm:hidden"
+              style={{ background: "var(--color-bt-overlay)" }}
+              onClick={() => setOpen(false)}
+              aria-hidden="true"
+            />,
+            document.body,
+          )}
 
           <div
             role="menu"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -92,9 +92,14 @@ export function UserMenu() {
       {open && (
         <>
           {/* Mobile dim backdrop — sm:hidden so it disappears once the
-              panel switches to absolute positioning on larger screens. */}
+              panel switches to absolute positioning on larger screens.
+              z-30 keeps the backdrop UNDER the TopNav header (z-40) so
+              the title bar stays at full clarity while the page content
+              below dims. Equal z-indices defer to DOM order; this
+              backdrop is rendered after the header in the same tree,
+              so a tied z-40 would inadvertently cover the title bar. */}
           <div
-            className="fixed inset-0 z-40 sm:hidden"
+            className="fixed inset-0 z-30 sm:hidden"
             style={{ background: "var(--color-bt-overlay)" }}
             onClick={() => setOpen(false)}
             aria-hidden="true"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -29,6 +29,16 @@ export function UserMenu() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
+  // Warm the /profile route chunk the moment the menu opens. The user
+  // has signalled intent (they tapped the avatar); by the time they
+  // pick "Account preferences" the JS for /profile is already downloaded
+  // so router.push lands the page instantly instead of waiting on the
+  // route bundle.
+  useEffect(() => {
+    if (!open) return;
+    router.prefetch("/profile");
+  }, [open, router]);
+
   // Outside-click + Escape to close. Listeners are only attached while
   // open, so they're registered AFTER the click that opened the menu —
   // the opening tap's mousedown has already fired and won't self-close.


### PR DESCRIPTION
## Summary

Three perf wins plus a real bug fix on the mobile title bar, all driven by the user's report that the app's loading spinner felt slow on a clear-browser refresh.

## What changed, by commit

### `3be7850` Cold-load: redirect `/` server-side via cookie

Refresh of `/` as an authed user used to walk a brutal serial chain:

```
HTML loader → / route bundle (incl. 646 lines of MarketingPage + 5 sub-components
  even though we never render them) → React hydrate → AuthProvider effect →
  getSession from localStorage → setLoaded(true) → still FullScreenLoader (about
  to redirect) → trpc.trips.list round-trip → useMemo priority sort →
  router.replace → /trips/[id] bundle download → trip queries → paint
```

`/app/page.tsx` is now a Server Component. Two cookie reads:
- `supabase.auth.getUser()` (server JWT validation)
- `bt-last-trip-id` cookie

Branches:
- Authed + cookie → `redirect('/trips/[id]')` (server 307, browser jumps straight to the trip route bundle)
- Authed + no cookie → `redirect('/dashboard')` — one-time fallback for new device / first sign-in / cleared cookies. Dashboard already runs the priority sort + empty-state.
- Unauthed → render `<MarketingPage />` server-side. No `\"use client\"` anywhere in `src/components/marketing/`, so unauthed visitors also pay zero client JS for marketing.

The trip page now writes `bt-last-trip-id` as a cookie (1y `Max-Age`, `Path=/`, `SameSite=Lax`) alongside its existing localStorage write, so subsequent refreshes hit the fast path immediately.

**New cold-load chain**: middleware → page.tsx → 307 → bundle → paint. No FullScreenLoader, no MarketingPage chunk for authed users, no client-side redirect dance.

### `5e0771d` Portal mobile backdrops out of TopNav + drop trip-switcher fill

Mobile bug: tapping the trip switcher or avatar menu dimmed the **title bar only**, not the content below it. Looked like a z-index issue but wasn't — TopNav uses `backdrop-filter: blur(14px)`, which per spec creates a containing block for `position: fixed` descendants. The backdrops inside TripSwitcher/UserMenu were `fixed inset-0`, so they were sized to the header bounds instead of the viewport.

Fix: `createPortal(..., document.body)` so each backdrop renders as a sibling of the page root, escapes the header's containing block, and `fixed inset-0` is once again viewport-relative. SSR-safe `mounted` flag so it doesn't trip on `document` during prerender.

Also dropped the trip-switcher trigger's `background: card-raised` to `transparent` — the filled chip clashed with the translucent title bar; border alone is enough affordance.

### `1985140` TopNav backdrops z-30

The first attempt at fixing the title-bar dim bug — dropped the backdrop z-index from 40 to 30. Didn't actually help (containing block was the real cause, not z-order), but left the commit in for honest history. Superseded by `5e0771d`.

### `6cadd05` Profile page perf

Three changes to make `/profile` feel ~instant after the first tap on Account preferences:

1. **Shell renders before `users.getMe` resolves.** The previous full-page spinner gated TopNav + sidebar + the entire scroll container on `!authLoaded || isLoading || !me`. Now the shell paints immediately and the spinner only covers the content area.

2. **`AvatarIconPicker` + `ArchivedIdeasPanel` are `next/dynamic`.** AvatarIconPicker statically references all 96 Tabler icons via `AVATAR_ICON_COMPONENTS`; most profile visitors never expand it. Each ships a tiny skeleton placeholder so the layout doesn't reflow when the chunk lands.

3. **UserMenu prefetches `/profile`** when the menu opens. By the time the user picks \"Account preferences\" the Next.js route bundle is already downloaded. `users.getMe` was *not* the bottleneck — UserMenu lives in TopNav on every page and fires the same query key with no `enabled` gate, so the cache is already warm.

## Cookie change worth flagging

New cookie written from the trip page: `bt-last-trip-id`. 1-year Max-Age, `Path=/`, `SameSite=Lax`. Not sensitive (just a trip UUID the user already has access to). Synced with the existing `bt-last-trip-id` localStorage entry on every trip mount.

## Test plan

- [ ] Clear cookies + localStorage, log in fresh. First load lands on `/dashboard` (no cookie yet). Open a trip. Refresh `/` — lands directly on `/trips/[id]` with no FullScreenLoader.
- [ ] Refresh `/` while logged out — marketing page renders server-side, no client JS for marketing.
- [ ] Mobile (narrow viewport): tap the trip switcher chip → dropdown opens, page content below dims, **title bar stays clear**. Same with the avatar menu.
- [ ] Desktop: no backdrop dim on either dropdown (mobile-only by design).
- [ ] Open the avatar menu → wait a sec → tap \"Account preferences\". Profile lands quickly (route was prefetched).
- [ ] Profile page paints the chrome (TopNav + sidebar + back button) immediately, content area shows a spinner only until `users.getMe` resolves (it's usually cached).
- [ ] Switch to the Ideas sidebar tab → ArchivedIdeasPanel loads via its dynamic chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)