### PR TITLE
About BuddyTrip modal — founder-voice dialog from the avatar dropdown

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { ExternalLink, Info, Megaphone, Shield, Tag, X } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { APP_BUILD, APP_LAST_SHIPPED } from "@/lib/version";
@@ -53,9 +54,23 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
     return `${days} days ago`;
   });
 
-  if (!open) return null;
+  // SSR-safe portal target. The modal MUST render outside the TopNav
+  // tree — TopNav sets backdrop-filter: blur(14px), which per spec
+  // creates a containing block for any descendant position:fixed
+  // element. Inline, our `fixed inset-0` was sized to the TopNav's
+  // ~56px header instead of the viewport, so the centered dialog
+  // ended up clipped above and below the title bar. document.body
+  // has no such containing block — inset-0 is viewport-relative
+  // again. Same fix we applied to TripSwitcher / UserMenu backdrops.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
 
-  return (
+  if (!open || !mounted) return null;
+
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -250,7 +265,8 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { ExternalLink, Info, Megaphone, Shield, Tag, X } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
-import { APP_BUILD, APP_LAST_SHIPPED, APP_VERSION } from "@/lib/version";
+import { APP_BUILD, APP_LAST_SHIPPED } from "@/lib/version";
 
 // ── AboutModal ───────────────────────────────────────────────────────────
 //
@@ -60,52 +60,25 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
       role="dialog"
       aria-modal="true"
       aria-label="About BuddyTrip"
-      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center sm:p-4"
+      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
       style={{ background: "var(--color-bt-overlay)" }}
       onClick={onClose}
     >
+      {/* Chrome mirrors TripSettingsModal exactly: mobile bottom-sheet
+          (top corners only, full width) → desktop centered dialog at
+          lg+ with all four corners. max-h-[85vh] + overflow-y-auto
+          keeps the modal inside the viewport on short screens — the
+          earlier version had no scroll containment and would drift off
+          the top edge when the content exceeded the viewport. */}
       <div
-        // Bottom-sheet shape on phones (top corners only, no side border);
-        // centered dialog on sm+ (full rounded-xl + shadow + border).
-        // animate-fade-in adds the spec'd 4px translateY + opacity fade.
-        className="animate-fade-in relative w-full sm:max-w-[460px]"
+        className="animate-fade-in w-full max-w-[460px] max-h-[85vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl"
         style={{
           background: "var(--color-bt-card)",
           border: "1px solid var(--color-bt-border)",
-          borderRadius: 0,
-          // CSS doesn't let us set a single token for "top-corners on
-          // mobile, all corners on desktop". Inline both via the
-          // computed style below.
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Hack the radius via inline style so mobile gets top-only and
-            desktop gets all four. Tailwind arbitrary classes don't compose
-            cleanly across breakpoints for radius. */}
-        <style>{`
-          .bt-about-shell {
-            border-radius: 18px 18px 0 0;
-            box-shadow: var(--shadow-floating);
-          }
-          @media (min-width: 640px) {
-            .bt-about-shell { border-radius: var(--radius-xl, 16px); }
-          }
-        `}</style>
-        <div className="bt-about-shell">
-          {/* ── Mobile grab handle ─────────────────────────────────── */}
-          <div className="flex justify-center pt-2 sm:hidden">
-            <span
-              aria-hidden="true"
-              style={{
-                display: "block",
-                width: 36,
-                height: 4,
-                borderRadius: 999,
-                background: "var(--color-bt-border)",
-              }}
-            />
-          </div>
-
+        <div>
           {/* ── Header row ─────────────────────────────────────────── */}
           <div
             className="flex items-center"
@@ -133,20 +106,6 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
               }}
             >
               BuddyTrip
-            </span>
-            <span
-              style={{
-                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                fontSize: 11,
-                fontWeight: 600,
-                color: "var(--color-bt-accent)",
-                background: "var(--color-bt-accent-faint)",
-                border: "1px solid var(--color-bt-accent-border)",
-                borderRadius: 9999,
-                padding: "2px 8px",
-              }}
-            >
-              {APP_VERSION}
             </span>
             <span
               style={{
@@ -182,11 +141,8 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
           </div>
 
           {/* ── Origin story ───────────────────────────────────────── */}
-          {/* Copy is verbatim per spec. Paragraphs 1 + 4 use the strong
-              text color; 2 + 3 use the dim color. Final clause is accent
-              + 600. ⚠️ Spec notes "BBMI is the tool we wished we'd had"
-              even though the product is BuddyTrip — flagged for founder
-              review in the handoff doc. Rendering as written. */}
+          {/* Paragraphs 1 + 4 use the strong text color; 2 + 3 use the
+              dim color. Final clause is accent + 600. */}
           <div
             style={{
               padding: "8px 18px 4px",
@@ -216,7 +172,7 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
               left in the cart.
             </p>
             <p style={{ color: "var(--color-bt-text)", margin: 0 }}>
-              BBMI is the tool we wished we&rsquo;d had from year one.{" "}
+              BuddyTrip is the tool we wished we&rsquo;d had from year one.{" "}
               <span
                 style={{ color: "var(--color-bt-accent)", fontWeight: 600 }}
               >
@@ -280,7 +236,7 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
                 color: "var(--color-bt-text-dim)",
               }}
             >
-              {APP_VERSION} · build {APP_BUILD}
+              build {APP_BUILD}
             </span>
             <span
               style={{
@@ -289,7 +245,7 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
                 color: "var(--color-bt-text-dim)",
               }}
             >
-              Made for BBMI · Pinehurst, NC
+              Made for BuddyTrip
             </span>
           </div>
         </div>

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLink, Info, Megaphone, Shield, Tag, X } from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { APP_BUILD, APP_LAST_SHIPPED, APP_VERSION } from "@/lib/version";
+
+// ── AboutModal ───────────────────────────────────────────────────────────
+//
+// Founder-voice "About BuddyTrip" dialog. Opens from the avatar dropdown
+// (UserMenu) — not a standalone button. Carries the version, the origin
+// story, a few links, and a mono build line. This is the one place the
+// brand is allowed to be plainly sentimental.
+//
+// Source spec: HANDOFF — About BuddyTrip modal (in chat).
+//
+// Layout:
+//   Desktop → centered dialog, max-width 460px, var(--radius-xl) corners,
+//             var(--shadow-floating), 1px solid var(--color-bt-border).
+//   Mobile  → bottom sheet, same content; 18px top corners, grab handle.
+//
+// Token-first: every color flows through a `var(--color-bt-*)` token so
+// the dialog tracks the rest of the app's surface treatment automatically.
+
+interface AboutModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function AboutModal({ open, onClose }: AboutModalProps) {
+  useModalBackButton(open ? onClose : () => {});
+
+  // ESC to close. Click-outside is handled by the scrim's onClick.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // "Last shipped N days ago" — computed once on mount via lazy
+  // useState init so we don't call Date.now() during render (would
+  // trip react-hooks/no-impure-in-render). The exact phrasing changing
+  // mid-session would be jarring anyway; lock it to mount time.
+  const [lastShippedLabel] = useState(() => {
+    const shipped = Date.parse(APP_LAST_SHIPPED);
+    if (Number.isNaN(shipped)) return "Recently";
+    const days = Math.max(0, Math.round((Date.now() - shipped) / 86400000));
+    if (days === 0) return "today";
+    if (days === 1) return "yesterday";
+    return `${days} days ago`;
+  });
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="About BuddyTrip"
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center sm:p-4"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        // Bottom-sheet shape on phones (top corners only, no side border);
+        // centered dialog on sm+ (full rounded-xl + shadow + border).
+        // animate-fade-in adds the spec'd 4px translateY + opacity fade.
+        className="animate-fade-in relative w-full sm:max-w-[460px]"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          borderRadius: 0,
+          // CSS doesn't let us set a single token for "top-corners on
+          // mobile, all corners on desktop". Inline both via the
+          // computed style below.
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Hack the radius via inline style so mobile gets top-only and
+            desktop gets all four. Tailwind arbitrary classes don't compose
+            cleanly across breakpoints for radius. */}
+        <style>{`
+          .bt-about-shell {
+            border-radius: 18px 18px 0 0;
+            box-shadow: var(--shadow-floating);
+          }
+          @media (min-width: 640px) {
+            .bt-about-shell { border-radius: var(--radius-xl, 16px); }
+          }
+        `}</style>
+        <div className="bt-about-shell">
+          {/* ── Mobile grab handle ─────────────────────────────────── */}
+          <div className="flex justify-center pt-2 sm:hidden">
+            <span
+              aria-hidden="true"
+              style={{
+                display: "block",
+                width: 36,
+                height: 4,
+                borderRadius: 999,
+                background: "var(--color-bt-border)",
+              }}
+            />
+          </div>
+
+          {/* ── Header row ─────────────────────────────────────────── */}
+          <div
+            className="flex items-center"
+            style={{ padding: "18px 18px 6px", gap: 11 }}
+          >
+            <svg
+              width="26"
+              height="26"
+              viewBox="0 0 100 100"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+            >
+              <path
+                d="M 28 8 L 38 8 L 76 26 L 38 44 L 38 75 L 33 92 L 28 75 Z"
+                fill="currentColor"
+              />
+            </svg>
+            <span
+              style={{
+                fontSize: 18,
+                fontWeight: 600,
+                letterSpacing: "0.06em",
+                color: "var(--color-bt-text)",
+              }}
+            >
+              BuddyTrip
+            </span>
+            <span
+              style={{
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                fontSize: 11,
+                fontWeight: 600,
+                color: "var(--color-bt-accent)",
+                background: "var(--color-bt-accent-faint)",
+                border: "1px solid var(--color-bt-accent-border)",
+                borderRadius: 9999,
+                padding: "2px 8px",
+              }}
+            >
+              {APP_VERSION}
+            </span>
+            <span
+              style={{
+                fontSize: 9.5,
+                fontWeight: 700,
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: "var(--color-bt-warning)",
+                background: "var(--color-bt-warning-faint)",
+                border: "1px solid var(--color-bt-warning-border)",
+                borderRadius: 9999,
+                padding: "2px 8px",
+              }}
+            >
+              Beta
+            </span>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              style={{
+                marginLeft: "auto",
+                background: "transparent",
+                border: "none",
+                color: "var(--color-bt-text-dim)",
+                cursor: "pointer",
+                padding: 4,
+                lineHeight: 0,
+              }}
+            >
+              <X size={17} strokeWidth={1.75} />
+            </button>
+          </div>
+
+          {/* ── Origin story ───────────────────────────────────────── */}
+          {/* Copy is verbatim per spec. Paragraphs 1 + 4 use the strong
+              text color; 2 + 3 use the dim color. Final clause is accent
+              + 600. ⚠️ Spec notes "BBMI is the tool we wished we'd had"
+              even though the product is BuddyTrip — flagged for founder
+              review in the handoff doc. Rendering as written. */}
+          <div
+            style={{
+              padding: "8px 18px 4px",
+              fontSize: 14,
+              lineHeight: 1.5,
+              textWrap: "pretty",
+            }}
+          >
+            <p style={{ color: "var(--color-bt-text)", margin: "0 0 10px" }}>
+              It started in 2005. Nine friends, one golf trip, and a
+              founding member who spent the whole thing in bed nursing a
+              stomach bug that had apparently committed to the full
+              itinerary.
+            </p>
+            <p
+              style={{ color: "var(--color-bt-text-dim)", margin: "0 0 10px" }}
+            >
+              They named the tournament after him anyway. He&rsquo;s been
+              showing up every year since &mdash; still competing, still
+              occasionally winning, still hearing about it.
+            </p>
+            <p
+              style={{ color: "var(--color-bt-text-dim)", margin: "0 0 10px" }}
+            >
+              For nearly two decades the whole thing ran on group texts, a
+              battered spreadsheet, and a paper scorecard someone always
+              left in the cart.
+            </p>
+            <p style={{ color: "var(--color-bt-text)", margin: 0 }}>
+              BBMI is the tool we wished we&rsquo;d had from year one.{" "}
+              <span
+                style={{ color: "var(--color-bt-accent)", fontWeight: 600 }}
+              >
+                Built for our trip. Built for yours.
+              </span>
+            </p>
+          </div>
+
+          {/* ── Links ──────────────────────────────────────────────── */}
+          <div
+            style={{
+              marginTop: 14,
+              padding: "6px 12px",
+              borderTop: "1px solid var(--color-bt-subtle-border)",
+            }}
+          >
+            <AboutLink
+              icon={<Tag size={15} />}
+              label={<>What&rsquo;s new</>}
+              sub={`Changelog · last shipped ${lastShippedLabel}`}
+              href="/changelog"
+            />
+            <AboutLink
+              icon={<Megaphone size={15} />}
+              label="Send feedback"
+              sub={<>Straight to the founder &mdash; it&rsquo;s beta, holler</>}
+              // The handoff says this should open the SAME feedback modal
+              // as the title-bar Feedback button. That modal doesn't exist
+              // yet (no shared FeedbackModal lives in src/components as of
+              // this writing). Falling back to a mailto: keeps the action
+              // functional; swap to the modal trigger when it lands.
+              href="mailto:hello@buddytrip.app?subject=BuddyTrip%20feedback"
+            />
+            <AboutLink
+              icon={<Shield size={15} />}
+              label="Privacy"
+              sub={<>What we keep, what we don&rsquo;t</>}
+              href="/privacy"
+            />
+          </div>
+
+          {/* ── Build line ─────────────────────────────────────────── */}
+          <div
+            className="flex items-center"
+            style={{
+              gap: 8,
+              padding: "12px 18px 16px",
+              borderTop: "1px solid var(--color-bt-subtle-border)",
+            }}
+          >
+            <Info
+              size={13}
+              strokeWidth={1.75}
+              style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+              aria-hidden="true"
+            />
+            <span
+              style={{
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                fontSize: 11,
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              {APP_VERSION} · build {APP_BUILD}
+            </span>
+            <span
+              style={{
+                marginLeft: "auto",
+                fontSize: 11,
+                color: "var(--color-bt-text-dim)",
+              }}
+            >
+              Made for BBMI · Pinehurst, NC
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── AboutLink ─────────────────────────────────────────────────────────────
+//
+// One row in the links section. Tile + label/sub + external-link affordance.
+// Always opens in a new tab per spec.
+
+function AboutLink({
+  icon,
+  label,
+  sub,
+  href,
+}: {
+  icon: React.ReactNode;
+  label: React.ReactNode;
+  sub: React.ReactNode;
+  href: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center transition-colors hover:bg-[var(--color-bt-hover)]"
+      style={{
+        gap: 11,
+        padding: 10,
+        borderRadius: 10,
+        textDecoration: "none",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="flex flex-shrink-0 items-center justify-center"
+        style={{
+          width: 30,
+          height: 30,
+          borderRadius: 8,
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+          color: "var(--color-bt-text-dim)",
+        }}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span
+          className="block"
+          style={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: "var(--color-bt-text)",
+          }}
+        >
+          {label}
+        </span>
+        <span
+          className="block"
+          style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)" }}
+        >
+          {sub}
+        </span>
+      </span>
+      <ExternalLink
+        size={14}
+        strokeWidth={1.75}
+        style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+        aria-hidden="true"
+      />
+    </a>
+  );
+}

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -29,7 +29,12 @@ interface AboutModalProps {
 }
 
 export function AboutModal({ open, onClose }: AboutModalProps) {
-  useModalBackButton(open ? onClose : () => {});
+  // AboutModal is always mounted (UserMenu renders it on every TopNav-
+  // bearing page), so pass `open` as the `enabled` flag — otherwise the
+  // hook pushes a phantom history entry on mount and silently eats the
+  // first back-press on every page. Same bug class PR #288 fixed for
+  // DatesSheet; re-introduced here when AboutModal landed.
+  useModalBackButton(onClose, open);
 
   // ESC to close. Click-outside is handled by the scrim's onClick.
   useEffect(() => {

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
-import { IconSettings, IconLogout } from "@tabler/icons-react";
+import { IconInfoCircle, IconSettings, IconLogout } from "@tabler/icons-react";
 import { trpc } from "@/lib/trpc-client";
 import { createClient } from "@/lib/supabase";
 import { Avatar } from "@/components/Avatar";
+import { AboutModal } from "@/components/AboutModal";
+import { APP_VERSION } from "@/lib/version";
 
 /**
  * Top-right user affordance — the avatar opens a dropdown menu:
@@ -28,6 +30,11 @@ export function UserMenu() {
   const { data: me } = trpc.users.getMe.useQuery();
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  // About modal — opens from the highlighted "About BuddyTrip" row below
+  // and renders on top of the standard scrim. Keeping the state up here
+  // (vs. inside a sub-component) keeps the close-the-menu-then-open-the-
+  // modal sequencing trivially correct.
+  const [aboutOpen, setAboutOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   // SSR-safe portal target — the mobile dim backdrop has to render
   // outside the TopNav (which sets backdrop-filter, creating a
@@ -172,6 +179,46 @@ export function UserMenu() {
               Account preferences
             </button>
 
+            {/* About BuddyTrip — highlighted row with version tag on the
+                right. Per spec, the row uses an accent-faint fill +
+                accent border so the entry feels distinguished without
+                competing with the primary nav actions. Tapping it
+                closes the menu and opens AboutModal. */}
+            <button
+              type="button"
+              role="menuitem"
+              data-testid="user-menu-about"
+              onClick={() => {
+                setOpen(false);
+                setAboutOpen(true);
+              }}
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-[13px] transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{
+                color: "var(--color-bt-text)",
+                background: "var(--color-bt-accent-faint)",
+                borderTop: "0.5px solid var(--color-bt-accent-border)",
+                borderBottom: "0.5px solid var(--color-bt-accent-border)",
+              }}
+            >
+              <IconInfoCircle
+                size={16}
+                stroke={1.75}
+                style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+                aria-hidden="true"
+              />
+              <span className="flex-1">About BuddyTrip</span>
+              <span
+                style={{
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, Menlo, monospace",
+                  fontSize: 11,
+                  color: "var(--color-bt-text-dim)",
+                }}
+              >
+                {APP_VERSION}
+              </span>
+            </button>
+
             {/* Log out — separate section */}
             <button
               type="button"
@@ -195,6 +242,11 @@ export function UserMenu() {
           </div>
         </>
       )}
+
+      {/* About modal — opens from the highlighted row above. Rendered as
+          a sibling of the dropdown so the dropdown's outside-click /
+          containing-block logic doesn't entangle with the modal scrim. */}
+      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
     </div>
   );
 }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -8,7 +8,6 @@ import { trpc } from "@/lib/trpc-client";
 import { createClient } from "@/lib/supabase";
 import { Avatar } from "@/components/Avatar";
 import { AboutModal } from "@/components/AboutModal";
-import { APP_VERSION } from "@/lib/version";
 
 /**
  * Top-right user affordance — the avatar opens a dropdown menu:
@@ -179,11 +178,10 @@ export function UserMenu() {
               Account preferences
             </button>
 
-            {/* About BuddyTrip — highlighted row with version tag on the
-                right. Per spec, the row uses an accent-faint fill +
-                accent border so the entry feels distinguished without
-                competing with the primary nav actions. Tapping it
-                closes the menu and opens AboutModal. */}
+            {/* About BuddyTrip — styled identically to Account
+                preferences so it sits in the same visual rhythm. The
+                highlighted teal-tinted treatment was tried first and
+                dropped — too loud for what's a static info surface. */}
             <button
               type="button"
               role="menuitem"
@@ -193,30 +191,15 @@ export function UserMenu() {
                 setAboutOpen(true);
               }}
               className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-[13px] transition-colors hover:bg-[var(--color-bt-hover)]"
-              style={{
-                color: "var(--color-bt-text)",
-                background: "var(--color-bt-accent-faint)",
-                borderTop: "0.5px solid var(--color-bt-accent-border)",
-                borderBottom: "0.5px solid var(--color-bt-accent-border)",
-              }}
+              style={{ color: "var(--color-bt-text)" }}
             >
               <IconInfoCircle
                 size={16}
                 stroke={1.75}
-                style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+                style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
                 aria-hidden="true"
               />
-              <span className="flex-1">About BuddyTrip</span>
-              <span
-                style={{
-                  fontFamily:
-                    "ui-monospace, SFMono-Regular, Menlo, monospace",
-                  fontSize: 11,
-                  color: "var(--color-bt-text-dim)",
-                }}
-              >
-                {APP_VERSION}
-              </span>
+              About BuddyTrip
             </button>
 
             {/* Log out — separate section */}

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,27 @@
+// ── App version metadata ─────────────────────────────────────────────────
+//
+// Single source of truth for the version + build strings surfaced in:
+//   • UserMenu's "About BuddyTrip" row (small "v0.9" tag on the right)
+//   • AboutModal's version pill in the header
+//   • AboutModal's mono build line at the bottom
+//
+// When bumping a release, edit APP_VERSION here. APP_BUILD is the date the
+// release went out — change it any time you cut a build the public will
+// see. Keep them in lockstep with `package.json`'s version if you wire
+// that up later; for now they live here so a non-trivial CI rewire isn't
+// required.
+
+/** Public version string (e.g. "v0.9"). Shown in the avatar-menu tag and
+ *  the about-modal header pill. */
+export const APP_VERSION = "v0.9";
+
+/** Build date in YYYY.MM.DD form. Shown in the about-modal's mono build
+ *  line. Doesn't need to be precise to the commit — release-day date is
+ *  enough for the audience. */
+export const APP_BUILD = "2026.06.04";
+
+/** When the latest user-facing changelog entry shipped. Drives the
+ *  "What's new" link's subline in the about modal ("last shipped N days
+ *  ago"). Update this alongside APP_BUILD when changelog entries land.
+ *  ISO YYYY-MM-DD. */
+export const APP_LAST_SHIPPED = "2026-06-01";

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,19 +1,10 @@
-// ── App version metadata ─────────────────────────────────────────────────
+// ── App build metadata ───────────────────────────────────────────────────
 //
-// Single source of truth for the version + build strings surfaced in:
-//   • UserMenu's "About BuddyTrip" row (small "v0.9" tag on the right)
-//   • AboutModal's version pill in the header
-//   • AboutModal's mono build line at the bottom
-//
-// When bumping a release, edit APP_VERSION here. APP_BUILD is the date the
-// release went out — change it any time you cut a build the public will
-// see. Keep them in lockstep with `package.json`'s version if you wire
-// that up later; for now they live here so a non-trivial CI rewire isn't
-// required.
-
-/** Public version string (e.g. "v0.9"). Shown in the avatar-menu tag and
- *  the about-modal header pill. */
-export const APP_VERSION = "v0.9";
+// Single source of truth for the build date + last-shipped date surfaced
+// in the AboutModal. A user-facing version string (e.g. "v1.0") is
+// intentionally NOT defined here yet — the app hasn't formally versioned
+// a release, so the modal omits the version pill until that lands. When
+// it does, add `APP_VERSION` here and wire it back in.
 
 /** Build date in YYYY.MM.DD form. Shown in the about-modal's mono build
  *  line. Doesn't need to be precise to the commit — release-day date is


### PR DESCRIPTION
## Summary

Adds the **About BuddyTrip** modal opened from the avatar dropdown in `TopNav`, per the in-chat handoff spec. Founder-voice surface that carries the origin story, three quick links, and a mono build line.

## What's in here

### New: `src/lib/version.ts`
Single source of truth for app build metadata. Exports:
- `APP_BUILD` (`"2026.06.04"`) — shown in the modal's mono build line
- `APP_LAST_SHIPPED` (`"2026-06-01"`) — drives the "What's new" subline ("last shipped N days ago")

`APP_VERSION` is intentionally **not** defined yet — the app hasn't formally versioned a release, so the modal omits the version pill until that lands. When it does, add `APP_VERSION` here and wire it back into the header.

### New: `src/components/AboutModal.tsx`
- **Chrome**: mirrors `TripSettingsModal` exactly — `fixed inset-0 z-50 flex items-end justify-center lg:items-center` outer, `w-full max-w-[460px] max-h-[85vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl` inner. Mobile bottom-sheet → desktop centered dialog.
- **Portaled to `document.body`** via `createPortal`. TopNav sets `backdrop-filter: blur(14px)`, which per CSS spec creates a containing block for descendant `position: fixed` elements — inline, the modal got sized to the header bounds and clipped above/below the title bar. Same fix we applied to the `TripSwitcher` / `UserMenu` mobile backdrops.
- **Header**: flag mark · BuddyTrip wordmark · `BETA` pill (amber: warning-faint + border) · close ×.
- **Origin story**: four paragraphs per spec (paragraphs 1 + 4 in `--color-bt-text`, 2 + 3 in `--color-bt-text-dim`, final clause `Built for our trip. Built for yours.` in accent + 600).
- **Links**: three rows above a `--color-bt-subtle-border` divider — What's new (`/changelog`), Send feedback (`mailto:hello@buddytrip.app` — placeholder; rewires to the shared feedback form once that lands), Privacy (`/privacy`). Each row is a 30×30 dim tile + label/sub + external-link affordance. Always opens in a new tab.
- **Build line**: info glyph + mono `build 2026.06.04` on the left, `Made for BuddyTrip` text-dim on the right, above a subtle-border top divider.
- ESC + scrim-click + × all dismiss; `useModalBackButton` wires Android back.
- Token-first: zero hex values.

### Modified: `src/components/UserMenu.tsx`
- New **About BuddyTrip** menu item between Account preferences and Log out.
- Styled identically to Account preferences (same padding, dim icon color, no fill, no border treatment) — the first draft had an accent-faint highlight + a `v0.9` mono tag, both dropped after review.
- Imports `AboutModal`; opens it via local state, closing the menu first.

## Spec acceptance checklist

- [x] Token-first — every color flows through a `var(--color-bt-*)` token; no hex values.
- [x] Centered dialog on desktop; bottom sheet on mobile.
- [x] Origin copy paragraphs verbatim; final line is accent + bold; no sign-off.
- [x] Opens from the avatar dropdown, not a standalone button.
- [x] Esc / scrim / × all dismiss.
- [ ] Send feedback link opens the existing feedback modal — *deferred*: the shared FeedbackModal doesn't exist yet. Currently stubbed as `mailto:hello@buddytrip.app`. A parallel task tracks building the feedback form; this row will be rewired then.

## Follow-ups (separate tasks)

- `/changelog` and `/privacy` routes don't exist yet — those links will 404 until the surfaces ship.
- The spec's open question about "BBMI vs BuddyTrip" in the final paragraph was resolved in BuddyTrip's favor.
- Beta feedback channel — spawned task; will open its own PR.
- Back-button consistency audit — spawned task; covers the Profile "two presses to leave" issue you flagged.

## Test plan

- [ ] Open avatar dropdown → tap "About BuddyTrip" — menu closes, modal opens.
- [ ] On a tall desktop window, modal is centered with all four corners rounded.
- [ ] On a short window (browser height < ~600px), modal scrolls internally inside `max-h-[85vh]` without spilling above the viewport.
- [ ] On mobile width, modal docks to the bottom with top corners rounded.
- [ ] ESC, clicking the scrim, and the × all dismiss the modal.
- [ ] The three link rows open in a new tab. The Send feedback row opens the default mail client (placeholder until FeedbackModal lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)