### PR TITLE
Beta feedback — title-bar megaphone opens categorized form

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -26,9 +26,13 @@ import { APP_BUILD, APP_LAST_SHIPPED } from "@/lib/version";
 interface AboutModalProps {
   open: boolean;
   onClose: () => void;
+  /** When provided, the "Send feedback" row opens the shared FeedbackModal
+   *  instead of the mailto: fallback. UserMenu wires this through from
+   *  TopNav so the same modal serves both entry points. */
+  onOpenFeedback?: () => void;
 }
 
-export function AboutModal({ open, onClose }: AboutModalProps) {
+export function AboutModal({ open, onClose, onOpenFeedback }: AboutModalProps) {
   // AboutModal is always mounted (UserMenu renders it on every TopNav-
   // bearing page), so pass `open` as the `enabled` flag — otherwise the
   // hook pushes a phantom history entry on mount and silently eats the
@@ -219,12 +223,15 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
               icon={<Megaphone size={15} />}
               label="Send feedback"
               sub={<>Straight to the founder &mdash; it&rsquo;s beta, holler</>}
-              // The handoff says this should open the SAME feedback modal
-              // as the title-bar Feedback button. That modal doesn't exist
-              // yet (no shared FeedbackModal lives in src/components as of
-              // this writing). Falling back to a mailto: keeps the action
-              // functional; swap to the modal trigger when it lands.
-              href="mailto:hello@buddytrip.app?subject=BuddyTrip%20feedback"
+              // When onOpenFeedback is wired through (UserMenu → AboutModal),
+              // the row opens the shared FeedbackModal. Older call sites
+              // that don't pass the callback still get a functional mailto
+              // fallback so the row is never a dead link.
+              {...(onOpenFeedback
+                ? { onClick: onOpenFeedback }
+                : {
+                    href: "mailto:hello@buddytrip.app?subject=BuddyTrip%20feedback",
+                  })}
             />
             <AboutLink
               icon={<Shield size={15} />}
@@ -285,25 +292,35 @@ function AboutLink({
   label,
   sub,
   href,
+  onClick,
 }: {
   icon: React.ReactNode;
   label: React.ReactNode;
   sub: React.ReactNode;
-  href: string;
+  /** External link target. Mutually exclusive with onClick — onClick wins
+   *  when both are passed so the in-app handler runs instead of opening
+   *  a new tab. */
+  href?: string;
+  /** In-app action (e.g. open another modal). Renders as a <button>. */
+  onClick?: () => void;
 }) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex items-center transition-colors hover:bg-[var(--color-bt-hover)]"
-      style={{
-        gap: 11,
-        padding: 10,
-        borderRadius: 10,
-        textDecoration: "none",
-      }}
-    >
+  const sharedClassName =
+    "flex w-full items-center transition-colors hover:bg-[var(--color-bt-hover)]";
+  const sharedStyle: React.CSSProperties = {
+    gap: 11,
+    padding: 10,
+    borderRadius: 10,
+    textDecoration: "none",
+    textAlign: "left",
+    background: "transparent",
+    border: "none",
+    cursor: "pointer",
+    color: "inherit",
+    font: "inherit",
+  };
+
+  const inner = (
+    <>
       <span
         aria-hidden="true"
         className="flex flex-shrink-0 items-center justify-center"
@@ -336,12 +353,39 @@ function AboutLink({
           {sub}
         </span>
       </span>
-      <ExternalLink
-        size={14}
-        strokeWidth={1.75}
-        style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
-        aria-hidden="true"
-      />
+      {!onClick && (
+        <ExternalLink
+          size={14}
+          strokeWidth={1.75}
+          style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+          aria-hidden="true"
+        />
+      )}
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={sharedClassName}
+        style={sharedStyle}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={sharedClassName}
+      style={sharedStyle}
+    >
+      {inner}
     </a>
   );
 }

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { usePathname, useParams } from "next/navigation";
+import {
+  Bug,
+  HelpCircle,
+  Heart,
+  Lightbulb,
+  Megaphone,
+  Paperclip,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { useModalBackButton } from "@/hooks/useModalBackButton";
+import { trpc } from "@/lib/trpc-client";
+import { APP_BUILD } from "@/lib/version";
+
+// ── FeedbackModal ─────────────────────────────────────────────────────────
+//
+// Beta feedback channel — opened from the title-bar megaphone tool button
+// AND from the AboutModal "Send feedback" row. The two entry points share
+// this component; do not build a second one.
+//
+// Layout: bottom sheet on mobile, centered dialog on desktop. Mirrors
+// AboutModal / TripSettingsModal chrome (var(--color-bt-card) bg,
+// var(--radius-xl) on desktop, top-only corners + grab handle on mobile).
+//
+// Containing-block gotcha: TopNav sets backdrop-filter, which per CSS
+// spec creates a containing block for any descendant position:fixed
+// element. This modal MUST render via createPortal(..., document.body)
+// to escape that — same fix as AboutModal / UserMenu backdrop.
+
+type Category = "bug" | "idea" | "confusing" | "love";
+
+interface CategoryDef {
+  key: Category;
+  label: string;
+  icon: LucideIcon;
+  /** Domain token name — used as `var(--color-bt-<token>)`. */
+  token: "danger" | "planning" | "warning" | "accent";
+  placeholder: string;
+}
+
+const CATEGORIES: CategoryDef[] = [
+  {
+    key: "bug",
+    label: "Bug",
+    icon: Bug,
+    token: "danger",
+    placeholder:
+      "What broke? What were you trying to do when it happened?",
+  },
+  {
+    key: "idea",
+    label: "Idea",
+    icon: Lightbulb,
+    token: "planning",
+    placeholder: "What would make BuddyTrip better? Don't hold back.",
+  },
+  {
+    key: "confusing",
+    label: "Confusing",
+    icon: HelpCircle,
+    token: "warning",
+    placeholder:
+      "What threw you? Where'd you expect it to go instead?",
+  },
+  {
+    key: "love",
+    label: "Love it",
+    icon: Heart,
+    token: "accent",
+    placeholder:
+      "What's working? Always good to know what not to touch.",
+  },
+];
+
+function colorToken(c: CategoryDef): string {
+  return `var(--color-bt-${c.token})`;
+}
+function colorFaintToken(c: CategoryDef): string {
+  return `var(--color-bt-${c.token}-faint)`;
+}
+function colorBorderToken(c: CategoryDef): string {
+  return `var(--color-bt-${c.token}-border)`;
+}
+
+interface FeedbackModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
+  // FeedbackModal is always mounted (TopNav renders it on every page), so
+  // pass `open` as the `enabled` flag — otherwise the hook pushes a
+  // phantom history entry on mount and silently eats any popstate that
+  // fires while the modal is closed. That bites HARD when AboutModal
+  // closes and pops its own phantom entry as part of routing through to
+  // us (UserMenu → About → onOpenFeedback): the popstate is caught here
+  // and immediately closes the feedback modal one tick after opening it.
+  // Same pattern as AboutModal.
+  useModalBackButton(onClose, open);
+
+  // ── Auto-captured context ──────────────────────────────────────────────
+  // Read at render-time off Next's route hooks so the values reflect
+  // the page the user was on when they opened the modal.
+  const pathname = usePathname();
+  const params = useParams<{ tripId?: string }>();
+  const currentTripId = params?.tripId ?? null;
+
+  const { data: trips } = trpc.trips.list.useQuery(undefined, {
+    enabled: open,
+  });
+  const { data: me } = trpc.users.getMe.useQuery(undefined, { enabled: open });
+
+  const screenLabel = useMemo(() => labelForPath(pathname ?? ""), [pathname]);
+  const tripLabel = useMemo(() => {
+    if (!currentTripId || !trips) return null;
+    const t = (trips as Array<{ id: string; title: string }>).find(
+      (x) => x.id === currentTripId,
+    );
+    return t?.title ?? null;
+  }, [currentTripId, trips]);
+  const platform = "web";
+
+  // ── Form state ─────────────────────────────────────────────────────────
+  // emailOverride is null until the user actually edits the email field —
+  // until then the rendered value falls back to the signed-in user's
+  // email. This avoids a useEffect that would otherwise cascade a render
+  // every time getMe resolves (and trips react-hooks/set-state-in-effect).
+  const [category, setCategory] = useState<Category>("bug");
+  const [text, setText] = useState("");
+  const [emailOverride, setEmailOverride] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const emailValue = emailOverride ?? me?.email ?? "";
+
+  // Reset transient form state on each open transition. setState-in-effect
+  // is the right tool here: the reset is the React-side "external system"
+  // synchronization — when `open` flips true, the form must be a known
+  // blank slate. Same pattern as AboutModal's mounted-flag effect.
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCategory("bug");
+    setText("");
+    setEmailOverride(null);
+    setToast(null);
+  }, [open]);
+
+  // ESC to close. Click-outside is handled by the scrim's onClick.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // SSR-safe portal target. See AboutModal for the containing-block note.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  const send = trpc.feedback.send.useMutation({
+    onSuccess: () => {
+      setToast("Thanks — sent straight to the founder.");
+      // Brief delay so the toast is perceptible before the modal closes.
+      window.setTimeout(() => onClose(), 900);
+    },
+    onError: () => {
+      setToast("Couldn't send. Try again in a moment.");
+    },
+  });
+
+  const activeCategory =
+    CATEGORIES.find((c) => c.key === category) ?? CATEGORIES[0];
+  const canSend = text.trim().length > 0 && !send.isPending;
+
+  if (!open || !mounted) return null;
+
+  const handleSubmit = () => {
+    if (!canSend) return;
+    const trimmedEmail = emailValue.trim();
+    send.mutate({
+      category,
+      message: text.trim(),
+      replyTo: trimmedEmail ? trimmedEmail : null,
+      screen: screenLabel,
+      tripLabel,
+      platform,
+      build: APP_BUILD,
+    });
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Send feedback"
+      className="fixed inset-0 z-50 flex items-end justify-center lg:items-center"
+      style={{ background: "var(--color-bt-overlay)" }}
+      onClick={onClose}
+    >
+      <div
+        className="animate-fade-in w-full max-w-[480px] max-h-[90vh] overflow-y-auto rounded-t-[18px] lg:rounded-2xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ── Mobile grab handle (hidden on desktop) ────────────────────── */}
+        <div
+          aria-hidden="true"
+          className="mx-auto lg:hidden"
+          style={{
+            width: 36,
+            height: 4,
+            borderRadius: 9999,
+            background: "var(--color-bt-border)",
+            marginTop: 8,
+            marginBottom: 2,
+          }}
+        />
+
+        {/* ── Header ───────────────────────────────────────────────────── */}
+        <div
+          className="flex items-center"
+          style={{ padding: "16px 18px 8px", gap: 10 }}
+        >
+          <Megaphone
+            size={20}
+            strokeWidth={2}
+            style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+            aria-hidden="true"
+          />
+          <span
+            style={{
+              fontSize: 17,
+              fontWeight: 600,
+              color: "var(--color-bt-text)",
+            }}
+          >
+            Send feedback
+          </span>
+          <span
+            style={{
+              fontSize: 9.5,
+              fontWeight: 700,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--color-bt-warning)",
+              background: "var(--color-bt-warning-faint)",
+              border: "1px solid var(--color-bt-warning-border)",
+              borderRadius: 9999,
+              padding: "2px 8px",
+            }}
+          >
+            Beta
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              marginLeft: "auto",
+              background: "transparent",
+              border: "none",
+              color: "var(--color-bt-text-dim)",
+              cursor: "pointer",
+              padding: 4,
+              lineHeight: 0,
+            }}
+          >
+            <X size={17} strokeWidth={1.75} />
+          </button>
+        </div>
+
+        {/* ── Category chips ───────────────────────────────────────────── */}
+        <div
+          style={{
+            padding: "6px 18px 4px",
+            display: "grid",
+            gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+            gap: 8,
+          }}
+        >
+          {CATEGORIES.map((c) => {
+            const selected = c.key === category;
+            const Icon = c.icon;
+            return (
+              <button
+                key={c.key}
+                type="button"
+                onClick={() => setCategory(c.key)}
+                aria-pressed={selected}
+                data-testid={`feedback-category-${c.key}`}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 4,
+                  padding: "10px 4px",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  background: selected
+                    ? colorFaintToken(c)
+                    : "var(--color-bt-card-raised)",
+                  border: `1px solid ${selected ? colorBorderToken(c) : "var(--color-bt-border)"}`,
+                  color: selected ? colorToken(c) : "var(--color-bt-text-dim)",
+                  fontSize: 11.5,
+                  fontWeight: 600,
+                  transition: "background-color 120ms, border-color 120ms, color 120ms",
+                }}
+              >
+                <Icon size={18} strokeWidth={2} aria-hidden="true" />
+                <span>{c.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* ── Free text ────────────────────────────────────────────────── */}
+        <div style={{ padding: "10px 18px 4px" }}>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={activeCategory.placeholder}
+            rows={4}
+            data-testid="feedback-message"
+            style={{
+              width: "100%",
+              minHeight: 96,
+              resize: "vertical",
+              padding: "10px 12px",
+              borderRadius: 10,
+              border: "1px solid var(--color-bt-border)",
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+              fontSize: 14,
+              lineHeight: 1.45,
+              outline: "none",
+              fontFamily: "inherit",
+            }}
+          />
+        </div>
+
+        {/* ── Email (optional) ─────────────────────────────────────────── */}
+        <div style={{ padding: "8px 18px 4px" }}>
+          <input
+            type="email"
+            value={emailValue}
+            onChange={(e) => setEmailOverride(e.target.value)}
+            placeholder="you@email.com"
+            data-testid="feedback-email"
+            style={{
+              width: "100%",
+              padding: "8px 12px",
+              borderRadius: 10,
+              border: "1px solid var(--color-bt-border)",
+              background: "var(--color-bt-card-raised)",
+              color: "var(--color-bt-text)",
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              fontSize: 13,
+              outline: "none",
+            }}
+          />
+          <div
+            style={{
+              marginTop: 4,
+              fontSize: 11,
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            Optional — drop it if you want a reply when we fix it.
+          </div>
+        </div>
+
+        {/* ── Auto-captured context ────────────────────────────────────── */}
+        <div
+          className="flex items-center"
+          style={{
+            margin: "10px 18px 0",
+            padding: "8px 10px",
+            gap: 8,
+            borderRadius: 9,
+            background: "var(--color-bt-card-raised)",
+            border: "1px solid var(--color-bt-subtle-border)",
+          }}
+        >
+          <Paperclip
+            size={13}
+            strokeWidth={1.75}
+            style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
+            aria-hidden="true"
+          />
+          <span
+            className="truncate"
+            style={{
+              fontSize: 11.5,
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            Attached automatically:{" "}
+            <span style={{ color: "var(--color-bt-text)", fontWeight: 500 }}>
+              {[screenLabel, tripLabel, platform].filter(Boolean).join(" · ")}
+            </span>
+          </span>
+        </div>
+
+        {/* ── Footer ───────────────────────────────────────────────────── */}
+        <div
+          className="flex items-center"
+          style={{
+            padding: "14px 18px 16px",
+            gap: 10,
+            marginTop: 10,
+            borderTop: "1px solid var(--color-bt-subtle-border)",
+          }}
+        >
+          <span
+            className="hidden sm:inline"
+            style={{
+              fontSize: 11.5,
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            Goes straight to the founder.
+          </span>
+          <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: "transparent",
+                border: "1px solid var(--color-bt-border)",
+                color: "var(--color-bt-text)",
+                padding: "8px 14px",
+                borderRadius: 9,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSend}
+              data-testid="feedback-send"
+              style={{
+                background: "var(--color-bt-accent)",
+                border: "1px solid var(--color-bt-accent)",
+                color: "#0d1f1a",
+                padding: "8px 14px",
+                borderRadius: 9,
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: canSend ? "pointer" : "not-allowed",
+                opacity: canSend ? 1 : 0.4,
+              }}
+            >
+              {send.isPending ? "Sending…" : "Send"}
+            </button>
+          </div>
+        </div>
+
+        {toast && (
+          <div
+            role="status"
+            style={{
+              padding: "0 18px 14px",
+              fontSize: 12,
+              color: "var(--color-bt-text-dim)",
+              textAlign: "right",
+            }}
+          >
+            {toast}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ── labelForPath ─────────────────────────────────────────────────────────
+//
+// Friendly screen label from the pathname. Cheap and intentionally
+// shallow — the goal is to give the founder enough context to triage,
+// not to reproduce every nested route.
+function labelForPath(path: string): string {
+  if (!path || path === "/") return "Landing";
+  if (path.startsWith("/dashboard")) return "Dashboard";
+  if (path.startsWith("/profile")) return "Profile";
+  if (path.startsWith("/changelog")) return "Changelog";
+  if (path.startsWith("/privacy")) return "Privacy";
+  if (path.startsWith("/login")) return "Login";
+  if (path.startsWith("/invite")) return "Invite";
+  if (path.startsWith("/trips/")) {
+    const parts = path.split("/").filter(Boolean);
+    // /trips/[tripId]/[tab?]
+    const tab = parts[2];
+    return tab
+      ? `Trip · ${tab.charAt(0).toUpperCase() + tab.slice(1)}`
+      : "Trip";
+  }
+  return path;
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,10 +3,11 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { Pin, MessageCircle, ChevronDown } from "lucide-react";
+import { Pin, MessageCircle, Megaphone, ChevronDown } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { UserMenu } from "./UserMenu";
 import { TripSwitcher } from "./TripSwitcher";
+import { FeedbackModal } from "./FeedbackModal";
 import { trpc } from "@/lib/trpc-client";
 import { useChatUnreadCount } from "./FloatingChatPanel";
 
@@ -69,6 +70,11 @@ export const TopNav: FC<TopNavProps> = ({
   const params = useParams<{ tripId?: string }>();
   const currentTripId = params?.tripId ?? null;
   const [switcherOpen, setSwitcherOpen] = useState(false);
+  // FeedbackModal lives at the TopNav level so the same modal is reachable
+  // from the title-bar megaphone AND from the AboutModal "Send feedback"
+  // row (which opens via UserMenu → AboutModal → onOpenFeedback). One
+  // form, two entry points.
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   // Drives the breadcrumb label + Owner pill. TanStack dedupes against the
   // same query the page may already be running.
@@ -215,6 +221,21 @@ export const TopNav: FC<TopNavProps> = ({
           />
         )}
 
+        {/* Feedback — beta-only outbound channel. Megaphone in accent so
+            it visually distinguishes itself from Chat's message-circle.
+            No badge: feedback is outbound, an unread dot reads as the
+            wrong signal. */}
+        <ToolButton
+          icon={Megaphone}
+          label="Feedback"
+          count={0}
+          badgeBg="var(--color-bt-accent)"
+          iconColor="var(--color-bt-accent)"
+          onClick={() => setFeedbackOpen(true)}
+          ariaLabel="Send feedback"
+          testId="feedback-button"
+        />
+
         {/* Divider between tools and identity. */}
         <span
           aria-hidden="true"
@@ -227,8 +248,13 @@ export const TopNav: FC<TopNavProps> = ({
           }}
         />
 
-        <UserMenu />
+        <UserMenu onOpenFeedback={() => setFeedbackOpen(true)} />
       </div>
+
+      <FeedbackModal
+        open={feedbackOpen}
+        onClose={() => setFeedbackOpen(false)}
+      />
     </header>
   );
 };
@@ -273,6 +299,7 @@ function ToolButton({
   onClick,
   ariaLabel,
   testId,
+  iconColor,
 }: {
   icon: LucideIcon;
   label: string;
@@ -282,6 +309,9 @@ function ToolButton({
   onClick?: () => void;
   ariaLabel: string;
   testId: string;
+  /** Override the icon stroke color. Defaults to the inherited text color so
+   *  News/Chat keep their current treatment; Feedback uses the accent. */
+  iconColor?: string;
 }) {
   const showBadge = count > 0;
   const badgeLabel = count > 99 ? "99+" : String(count);
@@ -301,7 +331,12 @@ function ToolButton({
         cursor: "pointer",
       }}
     >
-      <Icon size={16} strokeWidth={2} aria-hidden="true" />
+      <Icon
+        size={16}
+        strokeWidth={2}
+        aria-hidden="true"
+        style={iconColor ? { color: iconColor } : undefined}
+      />
       <span className="@max-[600px]:hidden">{label}</span>
 
       {showBadge && (

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -25,7 +25,14 @@ import { AboutModal } from "@/components/AboutModal";
  * panels in TopNav (mousedown-outside + Escape; fixed below the nav on
  * mobile, absolute-anchored on desktop).
  */
-export function UserMenu() {
+interface UserMenuProps {
+  /** Hands a callback through to AboutModal so the "Send feedback" row
+   *  there opens the same FeedbackModal the title-bar megaphone uses. The
+   *  modal itself lives in TopNav so both entry points share one mount. */
+  onOpenFeedback?: () => void;
+}
+
+export function UserMenu({ onOpenFeedback }: UserMenuProps = {}) {
   const { data: me } = trpc.users.getMe.useQuery();
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -229,7 +236,18 @@ export function UserMenu() {
       {/* About modal — opens from the highlighted row above. Rendered as
           a sibling of the dropdown so the dropdown's outside-click /
           containing-block logic doesn't entangle with the modal scrim. */}
-      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+      <AboutModal
+        open={aboutOpen}
+        onClose={() => setAboutOpen(false)}
+        onOpenFeedback={
+          onOpenFeedback
+            ? () => {
+                setAboutOpen(false);
+                onOpenFeedback();
+              }
+            : undefined
+        }
+      />
     </div>
   );
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -103,6 +103,93 @@ export async function sendInvitationBlast({
   });
 }
 
+// ── Beta feedback — straight to the founder inbox ──────────────────────
+//
+// Best-effort send: the caller catches and swallows errors so a flaky
+// SMTP path never blocks the user. The inbox IS the queue (no DB
+// persistence for v1) so the routing to FEEDBACK_TO_EMAIL is the whole
+// pipeline. Missing config (no API key, no destination) is reported as a
+// thrown error so the caller can decide whether to log it.
+
+const FEEDBACK_TO_EMAIL = process.env.FEEDBACK_TO_EMAIL;
+
+const FEEDBACK_CATEGORY_LABEL: Record<string, string> = {
+  bug: "Bug",
+  idea: "Idea",
+  confusing: "Confusing",
+  love: "Love it",
+};
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export async function sendFeedback({
+  category,
+  message,
+  replyTo,
+  screen,
+  tripLabel,
+  platform,
+  build,
+  reporterName,
+  reporterEmail,
+}: {
+  category: "bug" | "idea" | "confusing" | "love";
+  message: string;
+  replyTo?: string | null;
+  screen?: string | null;
+  tripLabel?: string | null;
+  platform?: string | null;
+  build?: string | null;
+  reporterName?: string | null;
+  reporterEmail?: string | null;
+}) {
+  if (!FEEDBACK_TO_EMAIL) {
+    throw new Error("FEEDBACK_TO_EMAIL not configured");
+  }
+
+  const label = FEEDBACK_CATEGORY_LABEL[category] ?? category;
+  const subject = `[BuddyTrip beta] ${label}: ${message.slice(0, 60).replace(/\s+/g, " ")}`;
+
+  const ctxRows: Array<[string, string]> = [];
+  if (reporterName) ctxRows.push(["From", reporterName]);
+  if (reporterEmail) ctxRows.push(["Account", reporterEmail]);
+  if (replyTo && replyTo !== reporterEmail) ctxRows.push(["Reply-to", replyTo]);
+  if (screen) ctxRows.push(["Screen", screen]);
+  if (tripLabel) ctxRows.push(["Trip", tripLabel]);
+  if (platform) ctxRows.push(["Platform", platform]);
+  if (build) ctxRows.push(["Build", build]);
+
+  const ctxHtml = ctxRows
+    .map(
+      ([k, v]) =>
+        `<tr><td style="padding:2px 12px 2px 0;color:#64748b;font-size:12px">${escapeHtml(k)}</td><td style="padding:2px 0;font-size:12px;color:#0f172a">${escapeHtml(v)}</td></tr>`,
+    )
+    .join("");
+
+  return resend.emails.send({
+    from: FROM,
+    to: FEEDBACK_TO_EMAIL,
+    // Drop replyTo into the email headers so hitting Reply in the inbox
+    // goes straight back to the user (instead of the noreply sender).
+    replyTo: replyTo || undefined,
+    subject,
+    html: `
+      <div style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px">
+        <p style="margin:0 0 4px;color:#64748b;font-size:12px;text-transform:uppercase;letter-spacing:0.08em">${escapeHtml(label)}</p>
+        <p style="margin:0 0 16px;white-space:pre-wrap;color:#0f172a;font-size:15px;line-height:1.5">${escapeHtml(message)}</p>
+        ${ctxRows.length ? `<table style="margin:16px 0 0;border-top:1px solid #e2e8f0;padding-top:12px">${ctxHtml}</table>` : ""}
+      </div>
+    `,
+  });
+}
+
 // ── Email for new users (no BuddyTrip account yet) ─────────────────────
 
 export async function sendInviteNewUser({

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -17,6 +17,7 @@ import { scheduleRouter } from "./routers/schedule";
 import { golfCoursesRouter } from "./routers/golfCourses";
 import { ideaLodgingRouter } from "./routers/ideaLodging";
 import { archivedIdeasRouter } from "./routers/archivedIdeas";
+import { feedbackRouter } from "./routers/feedback";
 
 export const appRouter = router({
   health: publicProcedure.query(() => {
@@ -40,6 +41,7 @@ export const appRouter = router({
   golfCourses: golfCoursesRouter,
   ideaLodging: ideaLodgingRouter,
   archivedIdeas: archivedIdeasRouter,
+  feedback: feedbackRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/feedback.test.ts
+++ b/src/server/routers/feedback.test.ts
@@ -1,0 +1,91 @@
+import { vi, describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { TestContext, createAnonCaller } from "../../__tests__/helpers/test-setup";
+import { sendFeedback } from "@/lib/email";
+
+vi.mock("@/lib/email", () => ({
+  sendFeedback: vi.fn().mockResolvedValue({ id: "mock-feedback-id" }),
+}));
+
+let ctx: TestContext;
+
+describe("feedback router", () => {
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+    delete process.env.FEEDBACK_TO_EMAIL;
+  });
+
+  beforeEach(() => {
+    vi.mocked(sendFeedback).mockClear();
+  });
+
+  it("returns delivered:false when FEEDBACK_TO_EMAIL is not set", async () => {
+    delete process.env.FEEDBACK_TO_EMAIL;
+    const result = await ctx.caller().feedback.send({
+      category: "bug",
+      message: "Something broke on the dashboard.",
+    });
+    expect(result).toEqual({ delivered: false });
+    expect(sendFeedback).not.toHaveBeenCalled();
+  });
+
+  it("delivers the report and includes the captured context", async () => {
+    process.env.FEEDBACK_TO_EMAIL = "founder@example.com";
+    const result = await ctx.caller().feedback.send({
+      category: "idea",
+      message: "Add a dark mode toggle to the trip header.",
+      replyTo: "owner@example.com",
+      screen: "Trip · Crew",
+      tripLabel: "BBMI 2026",
+      platform: "web",
+      build: "2026.06.04",
+    });
+    expect(result).toEqual({ delivered: true });
+    expect(sendFeedback).toHaveBeenCalledOnce();
+    const call = vi.mocked(sendFeedback).mock.calls[0][0];
+    expect(call.category).toBe("idea");
+    expect(call.message).toBe("Add a dark mode toggle to the trip header.");
+    expect(call.replyTo).toBe("owner@example.com");
+    expect(call.screen).toBe("Trip · Crew");
+    expect(call.tripLabel).toBe("BBMI 2026");
+    expect(call.platform).toBe("web");
+    expect(call.build).toBe("2026.06.04");
+    expect(call.reporterEmail).toBeTruthy();
+  });
+
+  it("rejects empty messages", async () => {
+    process.env.FEEDBACK_TO_EMAIL = "founder@example.com";
+    await expect(
+      ctx.caller().feedback.send({ category: "bug", message: "   " }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects unknown categories", async () => {
+    process.env.FEEDBACK_TO_EMAIL = "founder@example.com";
+    await expect(
+      // @ts-expect-error — testing runtime rejection
+      ctx.caller().feedback.send({ category: "rant", message: "ok" }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects malformed replyTo addresses", async () => {
+    process.env.FEEDBACK_TO_EMAIL = "founder@example.com";
+    await expect(
+      ctx.caller().feedback.send({
+        category: "bug",
+        message: "broke",
+        replyTo: "not-an-email",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("requires authentication", async () => {
+    process.env.FEEDBACK_TO_EMAIL = "founder@example.com";
+    await expect(
+      createAnonCaller().feedback.send({ category: "bug", message: "broke" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/src/server/routers/feedback.ts
+++ b/src/server/routers/feedback.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, authedProcedure } from "../trpc";
+
+// ── feedback router ───────────────────────────────────────────────────────
+//
+// Beta feedback channel. One procedure, `send`, that routes a report from
+// the in-app feedback form to the founder inbox via Resend. No DB
+// persistence in v1 — the inbox IS the queue. The send is gated behind
+// FEEDBACK_TO_EMAIL being configured; if it isn't, the call returns ok
+// with `delivered: false` so a missing env in preview/dev doesn't surface
+// as an error to the user.
+
+export const feedbackRouter = router({
+  send: authedProcedure
+    .input(
+      z.object({
+        category: z.enum(["bug", "idea", "confusing", "love"]),
+        message: z.string().trim().min(1).max(4000),
+        // Optional reply-to. The form pre-fills this from the signed-in
+        // user's email but lets them clear it; an empty string here means
+        // "they explicitly opted out of a reply path".
+        replyTo: z.string().email().nullable().optional(),
+        // Auto-captured context — all optional, all surfaced in the email
+        // so the founder has enough to triage without bouncing back.
+        screen: z.string().max(200).nullable().optional(),
+        tripLabel: z.string().max(200).nullable().optional(),
+        platform: z.string().max(40).nullable().optional(),
+        build: z.string().max(40).nullable().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // No destination configured (preview / local without secrets). We
+      // intentionally don't 500 — the form still closes cleanly and the
+      // user gets the success toast. Whoever runs the env logs this.
+      if (!process.env.FEEDBACK_TO_EMAIL) {
+        return { delivered: false as const };
+      }
+
+      // Best-effort: a Resend failure shouldn't surface as a tRPC error
+      // because there's no useful retry path from the client. Log and
+      // return delivered:false so the modal still closes.
+      try {
+        const { data: profile } = await ctx.supabase
+          .from("users")
+          .select("name, email")
+          .eq("id", ctx.user.id)
+          .single();
+
+        const { sendFeedback } = await import("@/lib/email");
+        await sendFeedback({
+          category: input.category,
+          message: input.message,
+          replyTo: input.replyTo ?? null,
+          screen: input.screen ?? null,
+          tripLabel: input.tripLabel ?? null,
+          platform: input.platform ?? null,
+          build: input.build ?? null,
+          reporterName: profile?.name ?? null,
+          reporterEmail: profile?.email ?? null,
+        });
+        return { delivered: true as const };
+      } catch (err) {
+        console.error("[feedback.send] failed", err);
+        // Surface as a soft failure so the client can show a different
+        // toast if it cares — most callers can just treat this as ok.
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to deliver feedback",
+        });
+      }
+    }),
+});


### PR DESCRIPTION
## Summary

- New title-bar **Feedback** tool button (megaphone, accent, no badge). Mobile collapses to icon-only like the other tools.
- New `FeedbackModal` — bottom sheet on mobile, centered dialog on desktop. 4-up category chips (Bug · Idea · Confusing · Love it) in their domain colors; placeholder swaps with category; optional email prefilled from `users.getMe`; auto-captured screen / trip / platform / build strip; Send disabled until text is non-empty.
- One modal, two entry points — AboutModal's "Send feedback" row is rewired from its `mailto:` stub to open the same form (state lifted to TopNav, threaded through UserMenu → AboutModal).
- New `feedback.send` tRPC procedure → Resend, routed to `FEEDBACK_TO_EMAIL`. No DB persistence in v1 — the inbox IS the queue. Missing env returns `delivered:false` so preview/dev don't surface an error.
- Portaled to `document.body` so it escapes TopNav's `backdrop-filter` containing block — same fix AboutModal already carries.

## Notes

- During verification, caught a back-button hook collision: `FeedbackModal`'s `useModalBackButton` was unconditionally enabled, so when AboutModal closed and popped its phantom history entry, FeedbackModal's persistent listener caught the popstate and immediately re-closed the modal one tick after opening it. Fixed by passing `open` as the `enabled` flag, same pattern AboutModal uses.
- **Stacked on top of #293** (About modal). Base is `feature/about-page`; once #293 lands this rebase-targets `main` cleanly.
- Needs `FEEDBACK_TO_EMAIL` env var configured in production (and ideally preview) for the channel to actually deliver. Without it, send is a clean no-op.

## Test plan

- [ ] CI green (Vitest + Playwright + tsc)
- [ ] Title-bar megaphone opens modal on desktop + mobile
- [ ] Avatar → About → "Send feedback" opens the same modal (and About closes)
- [ ] Category chips swap placeholder; default is Bug
- [ ] Email field prefilled from session; clearable
- [ ] Context strip surfaces the current screen / trip
- [ ] Send disabled until text entered; Send + Cancel + ESC + scrim all close

🤖 Generated with [Claude Code](https://claude.com/claude-code)