### PR TITLE
fix: portal InfoTileModal to body so tab FABs don't paint over it

### DIFF
--- a/src/components/InfoTileModal.tsx
+++ b/src/components/InfoTileModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FC } from "react";
+import { createPortal } from "react-dom";
 import {
   Lock,
   Wifi,
@@ -382,7 +383,13 @@ export function InfoTileModal({
     remove.mutate({ tripId, tileId: tile.id });
   };
 
-  return (
+  // Portaled to <body> so the modal escapes the TripHeader subtree and lands
+  // in the root stacking context. Rendered inline, the tab FABs (also
+  // position:fixed, lower z-index, but in a sibling subtree) paint on top of
+  // it once react-remove-scroll sets `position: relative` on <body> during the
+  // scroll lock. AboutModal / FeedbackModal portal for the same reason.
+  if (typeof document === "undefined") return null;
+  return createPortal(
     <ScrollLock>
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Scrim */}
@@ -570,7 +577,8 @@ export function InfoTileModal({
         </div>
       </div>
     </div>
-    </ScrollLock>
+    </ScrollLock>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
## Problem

After the scroll-lock work merged (#295), the mobile tab FABs (add buttons on **Crew**, **Lodging**, and **Agenda/Schedule**) render **on top of** the quick-info add/edit modal (`InfoTileModal`).

## Root cause

`InfoTileModal` is the only overlay rendered inside the **`TripHeader` card subtree**, which is `position: relative` + `overflow: hidden`. The tab FABs (`TabFab`, `position: fixed`, `z-30`) live in a **sibling** tab-content subtree.

In a shared stacking context the modal (`z-50`) would win — and it did before. But when `react-remove-scroll` engages the lock it sets `position: relative !important` on `<body>`, which (in Chrome) scopes the modal's `fixed`/`z-50` layer below the sibling-subtree FABs. Because it's a stacking-context/subtree boundary rather than a z-value problem, **bumping z-index can't fix it** (50 already loses to 30).

Every other modal is opened from within the same tab subtree as its FAB, so they're unaffected. `DatesSheet` is fine because it already renders at the page-root level, outside the header card.

## Fix

Portal `InfoTileModal` to `document.body` so it lands in the root stacking context, above the nested FABs. This matches the existing pattern in `AboutModal` and `FeedbackModal` (both portal for the same containing-block reason) and is the direction noted in `DEFERRED.md` (unified `<Overlay>` primitive).

- Scroll lock (`ScrollLock`) stays wrapped inside the portal content.
- No layout/styling/z-index changes; the modal renders identically, just re-parented to `<body>`.

## Testing

- `npx tsc --noEmit` clean, `eslint src` clean.
- No test depends on the modal's DOM location — e2e specs only mock the `quickInfoTiles.list` network route; the dock trigger buttons (and their testids) stay in place.
- Needs an on-device confirm on mobile Chrome: open the Crew/Lodging/Agenda tab, tap the header's add/edit info-tile modal, verify the FAB no longer shows over the scrim.

https://claude.ai/code/session_016RLY4v81WdvZBpDYVPX62z

---
_Generated by [Claude Code](https://claude.ai/code/session_016RLY4v81WdvZBpDYVPX62z)_