### PR TITLE
Beta feedback polish — form UX, modal styling, About modal updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ GOLF_API_KEY=
 # Supabase DB connection string for `supabase db push` in CI
 # Format: postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
 # SUPABASE_DB_URL=postgresql://...
+
+# --- Feedback channel ---
+
+# Destination address for in-app beta feedback. When set, feedback.send routes
+# reports here via Resend. Omit in CI (no send needed); set in production and
+# preview to the founder's inbox.
+FEEDBACK_TO_EMAIL=

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -32,19 +32,20 @@ these tokens.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card` | `--color-bt-card` |
-| Value | `#ffffff` (white) | `#111827` |
+| Value | `#ffffff` (white) | `#161e2f` |
 
-**Use:** collapsible panels, card containers, modals, bottom sheets —
-anything that floats above the page.
+**Use:** collapsible panels, card containers, inset form bodies inside
+floating dialogs, anything that sits one level above the page but below
+a floating dialog.
 **Examples:** PlanningRow panels (Destination, Crew, Dates, Logistics),
-TripCard, AddDateSheet, LockConfirmDialog, TripSettingsModal.
+TripCard, section bodies within modals.
 
 ### Level 2 — Elevated / Raised Surface
 
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card-raised` | `--color-bt-card-raised` |
-| Value | `#f4f7fa` | `#1a2130` |
+| Value | `#f4f7fa` | `#1f2a40` |
 
 **Use:** elements sitting ON a card/panel — inactive buttons, zebra
 table rows, input backgrounds, inactive compact chips.
@@ -56,10 +57,14 @@ in the dates response grid, inactive filter chips.
 | | Light | Dark |
 |-------|-------|------|
 | Token | `--color-bt-card-float` | `--color-bt-card-float` |
-| Value | `#e8edf5` | `#222b3d` |
+| Value | `#e8edf5` | `#2a3654` |
 
-**Use:** deeply nested elevated elements, tooltips, popovers.
-**Examples:** reserved for future nesting needs.
+**Use:** floating dialogs (modals, bottom sheets) and deeply nested
+elevated elements (tooltips, popovers). This is the correct token for
+any panel that floats above the overlay-darkened page — `card` alone
+does not provide enough visual lift in dark mode.
+**Examples:** InfoTileModal, FeedbackModal, AboutModal, any centered
+dialog or bottom sheet rendered via `createPortal`.
 
 ### Chrome Surface (navigation elements)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,56 @@
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
+
+// ── Build metadata ────────────────────────────────────────────────────────
+//
+// Stamped at build time so AboutModal always shows the exact commit the
+// running app was built from — no manual updates needed.
+//
+// Format: YYYY.MM.DD.<short-sha>   e.g. 2026.06.05.a1b2c3d
+//
+// - Date  → from the last git commit (not the wall-clock build time),
+//            so a deploy on a different day still shows the commit date.
+// - SHA   → first 7 chars of the commit hash. Uniquely identifies the
+//            build; paste it into `git show <sha>` to see exactly what
+//            shipped. This is the industry-standard 4th segment (Vercel,
+//            Linear, etc. all show the commit SHA in their build lines).
+//
+// Both are exposed as NEXT_PUBLIC_ so client components can read them.
+// execSync falls back to placeholders when git isn't available (e.g. in
+// a bare Docker layer without .git).
+
+function gitDate(): string {
+  try {
+    return execSync("git log -1 --format=%cd --date=format:%Y.%m.%d", {
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return new Date().toISOString().slice(0, 10).replace(/-/g, ".");
+  }
+}
+
+function gitSha(): string {
+  try {
+    return execSync("git rev-parse --short=7 HEAD", {
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+const buildDate = gitDate();
+const buildSha = gitSha();
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_BUILD_DATE: buildDate,
+    NEXT_PUBLIC_BUILD_SHA: buildSha,
+  },
 };
 
 export default nextConfig;

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { ExternalLink, Info, Megaphone, Shield, Tag, X } from "lucide-react";
+import { ExternalLink, Info, Megaphone, Shield, X } from "lucide-react";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { ScrollLock } from "@/hooks/useScrollLock";
-import { APP_BUILD, APP_LAST_SHIPPED } from "@/lib/version";
+import { APP_BUILD } from "@/lib/version";
 
 // ── AboutModal ───────────────────────────────────────────────────────────
 //
@@ -50,19 +50,6 @@ export function AboutModal({ open, onClose, onOpenFeedback }: AboutModalProps) {
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [open, onClose]);
-
-  // "Last shipped N days ago" — computed once on mount via lazy
-  // useState init so we don't call Date.now() during render (would
-  // trip react-hooks/no-impure-in-render). The exact phrasing changing
-  // mid-session would be jarring anyway; lock it to mount time.
-  const [lastShippedLabel] = useState(() => {
-    const shipped = Date.parse(APP_LAST_SHIPPED);
-    if (Number.isNaN(shipped)) return "Recently";
-    const days = Math.max(0, Math.round((Date.now() - shipped) / 86400000));
-    if (days === 0) return "today";
-    if (days === 1) return "yesterday";
-    return `${days} days ago`;
-  });
 
   // SSR-safe portal target. The modal MUST render outside the TopNav
   // tree — TopNav sets backdrop-filter: blur(14px), which per spec
@@ -216,19 +203,9 @@ export function AboutModal({ open, onClose, onOpenFeedback }: AboutModalProps) {
             }}
           >
             <AboutLink
-              icon={<Tag size={15} />}
-              label={<>What&rsquo;s new</>}
-              sub={`Changelog · last shipped ${lastShippedLabel}`}
-              href="/changelog"
-            />
-            <AboutLink
               icon={<Megaphone size={15} />}
               label="Send feedback"
               sub={<>Straight to the founder &mdash; it&rsquo;s beta, holler</>}
-              // When onOpenFeedback is wired through (UserMenu → AboutModal),
-              // the row opens the shared FeedbackModal. Older call sites
-              // that don't pass the callback still get a functional mailto
-              // fallback so the row is never a dead link.
               {...(onOpenFeedback
                 ? { onClick: onOpenFeedback }
                 : {
@@ -238,8 +215,8 @@ export function AboutModal({ open, onClose, onOpenFeedback }: AboutModalProps) {
             <AboutLink
               icon={<Shield size={15} />}
               label="Privacy"
-              sub={<>What we keep, what we don&rsquo;t</>}
-              href="/privacy"
+              sub="Working on a policy — coming soon."
+              disabled
             />
           </div>
 
@@ -296,19 +273,17 @@ function AboutLink({
   sub,
   href,
   onClick,
+  disabled = false,
 }: {
   icon: React.ReactNode;
   label: React.ReactNode;
   sub: React.ReactNode;
-  /** External link target. Mutually exclusive with onClick — onClick wins
-   *  when both are passed so the in-app handler runs instead of opening
-   *  a new tab. */
   href?: string;
-  /** In-app action (e.g. open another modal). Renders as a <button>. */
   onClick?: () => void;
+  /** When true: renders as a non-interactive div, fully dimmed, no
+   *  external-link affordance. Use for rows that aren't ready yet. */
+  disabled?: boolean;
 }) {
-  const sharedClassName =
-    "flex w-full items-center transition-colors hover:bg-[var(--color-bt-hover)]";
   const sharedStyle: React.CSSProperties = {
     gap: 11,
     padding: 10,
@@ -317,9 +292,10 @@ function AboutLink({
     textAlign: "left",
     background: "transparent",
     border: "none",
-    cursor: "pointer",
+    cursor: disabled ? "default" : "pointer",
     color: "inherit",
     font: "inherit",
+    opacity: disabled ? 0.45 : 1,
   };
 
   const inner = (
@@ -356,7 +332,7 @@ function AboutLink({
           {sub}
         </span>
       </span>
-      {!onClick && (
+      {!onClick && !disabled && (
         <ExternalLink
           size={14}
           strokeWidth={1.75}
@@ -367,12 +343,20 @@ function AboutLink({
     </>
   );
 
+  if (disabled) {
+    return (
+      <div className="flex w-full items-center" style={sharedStyle}>
+        {inner}
+      </div>
+    );
+  }
+
   if (onClick) {
     return (
       <button
         type="button"
         onClick={onClick}
-        className={sharedClassName}
+        className="flex w-full items-center transition-colors hover:bg-[var(--color-bt-hover)]"
         style={sharedStyle}
       >
         {inner}
@@ -385,7 +369,7 @@ function AboutLink({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={sharedClassName}
+      className="flex w-full items-center transition-colors hover:bg-[var(--color-bt-hover)]"
       style={sharedStyle}
     >
       {inner}

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -84,13 +84,28 @@ export function AboutModal({ open, onClose, onOpenFeedback }: AboutModalProps) {
           earlier version had no scroll containment and would drift off
           the top edge when the content exceeded the viewport. */}
       <div
-        className="animate-fade-in w-full max-w-[460px] max-h-[85vh] overflow-y-auto rounded-t-2xl lg:rounded-2xl"
+        className="animate-fade-in w-full max-w-[460px] max-h-[85vh] overflow-y-auto rounded-t-[18px] lg:rounded-2xl"
         style={{
-          background: "var(--color-bt-card)",
+          background: "var(--color-bt-card-float)",
           border: "1px solid var(--color-bt-border)",
+          boxShadow: "var(--shadow-floating)",
         }}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* ── Mobile grab handle ─────────────────────────────────── */}
+        <div
+          aria-hidden="true"
+          className="mx-auto lg:hidden"
+          style={{
+            width: 36,
+            height: 4,
+            borderRadius: 9999,
+            background: "var(--color-bt-border)",
+            marginTop: 10,
+            marginBottom: 4,
+          }}
+        />
+
         <div>
           {/* ── Header row ─────────────────────────────────────────── */}
           <div
@@ -139,17 +154,16 @@ export function AboutModal({ open, onClose, onOpenFeedback }: AboutModalProps) {
               type="button"
               onClick={onClose}
               aria-label="Close"
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{
                 marginLeft: "auto",
-                background: "transparent",
+                background: "var(--color-bt-card-raised)",
                 border: "none",
                 color: "var(--color-bt-text-dim)",
                 cursor: "pointer",
-                padding: 4,
-                lineHeight: 0,
               }}
             >
-              <X size={17} strokeWidth={1.75} />
+              <X size={15} strokeWidth={1.75} />
             </button>
           </div>
 

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import { usePathname, useParams } from "next/navigation";
+import { usePathname, useParams, useSearchParams } from "next/navigation";
 import {
   Bug,
   HelpCircle,
@@ -106,7 +106,11 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   // ── Auto-captured context ──────────────────────────────────────────────
   // Read at render-time off Next's route hooks so the values reflect
   // the page the user was on when they opened the modal.
+  // useSearchParams captures ?tab= and any other query params — the trip
+  // page keeps its active tab in ?tab=<id>, so pathname alone always
+  // returns /trips/[tripId] regardless of which tab is showing.
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const params = useParams<{ tripId?: string }>();
   const currentTripId = params?.tripId ?? null;
 
@@ -115,7 +119,18 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   });
   const { data: me } = trpc.users.getMe.useQuery(undefined, { enabled: open });
 
-  const screenLabel = useMemo(() => labelForPath(pathname ?? ""), [pathname]);
+  // Full relative URL (pathname + query string) — gives exact page + tab.
+  const fullUrl = useMemo(() => {
+    const qs = searchParams.toString();
+    return qs ? `${pathname}?${qs}` : (pathname ?? "");
+  }, [pathname, searchParams]);
+
+  // Human-friendly label shown in the email subject + screen row.
+  const screenLabel = useMemo(
+    () => labelForPath(pathname ?? "", searchParams.get("tab")),
+    [pathname, searchParams],
+  );
+
   const tripLabel = useMemo(() => {
     if (!currentTripId || !trips) return null;
     const t = (trips as Array<{ id: string; title: string }>).find(
@@ -183,7 +198,12 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
       category,
       message: text.trim(),
       replyTo,
+      // Pass both the friendly label and the raw URL. The router merges them
+      // into the email context table so you see e.g.:
+      //   Screen   Trip · Crew
+      //   URL      /trips/abc123?tab=crew
       screen: screenLabel,
+      url: fullUrl,
       tripLabel,
       platform,
       build: APP_BUILD,
@@ -426,12 +446,13 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
 
 // ── labelForPath ─────────────────────────────────────────────────────────
 //
-// Friendly screen label from the pathname. Cheap and intentionally
-// shallow — the goal is to give the founder enough context to triage,
-// not to reproduce every nested route.
-function labelForPath(path: string): string {
+// Friendly screen label from the pathname + active tab query param.
+// The trip page keeps its active tab in ?tab=<id> (not a route segment),
+// so the tab must be read from searchParams and passed in here.
+function labelForPath(path: string, tab?: string | null): string {
   if (!path || path === "/") return "Landing";
   if (path.startsWith("/dashboard")) return "Dashboard";
+  if (path.startsWith("/profile/archived-ideas")) return "Profile · Archived ideas";
   if (path.startsWith("/profile")) return "Profile";
   if (path.startsWith("/changelog")) return "Changelog";
   if (path.startsWith("/privacy")) return "Privacy";
@@ -439,11 +460,21 @@ function labelForPath(path: string): string {
   if (path.startsWith("/invite")) return "Invite";
   if (path.startsWith("/trips/")) {
     const parts = path.split("/").filter(Boolean);
-    // /trips/[tripId]/[tab?]
-    const tab = parts[2];
-    return tab
-      ? `Trip · ${tab.charAt(0).toUpperCase() + tab.slice(1)}`
-      : "Trip";
+    // /trips/[tripId]/events/[eventId] — event detail page
+    if (parts[2] === "events" && parts[3]) return "Trip · Event detail";
+    // Active tab from ?tab= query param
+    if (tab) {
+      const TAB_LABELS: Record<string, string> = {
+        home: "Home",
+        schedule: "Schedule",
+        crew: "Crew",
+        lodging: "Lodging",
+        comp: "Competition",
+        expenses: "Expenses",
+      };
+      return `Trip · ${TAB_LABELS[tab] ?? tab}`;
+    }
+    return "Trip · Home";
   }
   return path;
 }

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -223,7 +223,13 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
       <div
         className="animate-fade-in w-full max-w-[480px] max-h-[90vh] overflow-y-auto rounded-t-[18px] lg:rounded-2xl"
         style={{
-          background: "var(--color-bt-card)",
+          // card-float (#2a3654 dark / #e8edf5 light) matches InfoTileModal
+          // and other floating dialogs. The style guide docs say "card" for
+          // modals, but every implemented reference (InfoTileModal, etc.) uses
+          // card-float — it's the token that actually clears the
+          // overlay-darkened page. The style guide is wrong here; card-float
+          // is correct for floating dialogs.
+          background: "var(--color-bt-card-float)",
           border: "1px solid var(--color-bt-border)",
           boxShadow: "var(--shadow-floating)",
         }}
@@ -296,16 +302,15 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           </button>
         </div>
 
-        {/* ── Body — padded card-raised panel so the interactive content
-             sits on a unified lighter surface rather than floating as
-             dark islands on the even-darker card bg. Same treatment
-             TripSettingsModal uses for its form body. ──────────────── */}
+        {/* ── Body — inset panel one step below card-float so there's clear
+             surface hierarchy: dialog (card-float) → body panel (card) →
+             chips/textarea (card-raised). ───────────────────────────── */}
         <div
           style={{
             margin: "0 14px 14px",
             padding: "14px",
             borderRadius: 12,
-            background: "var(--color-bt-card-raised)",
+            background: "var(--color-bt-card)",
             border: "1px solid var(--color-bt-border)",
             display: "flex",
             flexDirection: "column",

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -269,21 +269,6 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           >
             Send feedback
           </span>
-          <span
-            style={{
-              fontSize: 9.5,
-              fontWeight: 700,
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-              color: "var(--color-bt-warning)",
-              background: "var(--color-bt-warning-faint)",
-              border: "1px solid var(--color-bt-warning-border)",
-              borderRadius: 9999,
-              padding: "2px 8px",
-            }}
-          >
-            Beta
-          </span>
           <button
             type="button"
             onClick={onClose}
@@ -300,6 +285,29 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           >
             <X size={17} strokeWidth={1.75} />
           </button>
+        </div>
+
+        {/* ── Beta banner ──────────────────────────────────────────────── */}
+        <div
+          style={{
+            margin: "0 18px 14px",
+            padding: "10px 14px",
+            borderRadius: 10,
+            background: "var(--color-bt-accent-faint)",
+            border: "1px solid var(--color-bt-accent-border)",
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontSize: 13,
+              lineHeight: 1.5,
+              color: "var(--color-bt-text-dim)",
+            }}
+          >
+            BuddyTrip is in beta — your feedback goes straight to the developer
+            and shapes what gets built next.
+          </p>
         </div>
 
         {/* ── Category chips ───────────────────────────────────────────── */}
@@ -380,15 +388,6 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
             gap: 10,
           }}
         >
-          <span
-            className="hidden sm:inline"
-            style={{
-              fontSize: 11.5,
-              color: "var(--color-bt-text-dim)",
-            }}
-          >
-            The developer appreciates any and all feedback.
-          </span>
           <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
             <button
               type="button"

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -293,8 +293,8 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
             margin: "0 18px 14px",
             padding: "10px 14px",
             borderRadius: 10,
-            background: "var(--color-bt-accent-faint)",
-            border: "1px solid var(--color-bt-accent-border)",
+            background: "var(--color-bt-warning-faint)",
+            border: "1px solid var(--color-bt-warning-border)",
           }}
         >
           <p
@@ -302,7 +302,7 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
               margin: 0,
               fontSize: 13,
               lineHeight: 1.5,
-              color: "var(--color-bt-text-dim)",
+              color: "var(--color-bt-warning)",
             }}
           >
             BuddyTrip is in beta — your feedback goes straight to the developer

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -302,66 +302,53 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           </button>
         </div>
 
-        {/* ── Body — inset panel one step below card-float so there's clear
-             surface hierarchy: dialog (card-float) → body panel (card) →
-             chips/textarea (card-raised). ───────────────────────────── */}
+        {/* ── Category chips ───────────────────────────────────────────── */}
         <div
           style={{
-            margin: "0 14px 14px",
-            padding: "14px",
-            borderRadius: 12,
-            background: "var(--color-bt-card)",
-            border: "1px solid var(--color-bt-border)",
-            display: "flex",
-            flexDirection: "column",
-            gap: 10,
+            padding: "0 18px 10px",
+            display: "grid",
+            gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+            gap: 8,
           }}
         >
-          {/* ── Category chips ─────────────────────────────────────────── */}
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-              gap: 8,
-            }}
-          >
-            {CATEGORIES.map((c) => {
-              const selected = c.key === category;
-              const Icon = c.icon;
-              return (
-                <button
-                  key={c.key}
-                  type="button"
-                  onClick={() => setCategory(c.key)}
-                  aria-pressed={selected}
-                  data-testid={`feedback-category-${c.key}`}
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: 4,
-                    padding: "10px 4px",
-                    borderRadius: 10,
-                    cursor: "pointer",
-                    background: selected
-                      ? colorFaintToken(c)
-                      : "var(--color-bt-card)",
-                    border: `1px solid ${selected ? colorBorderToken(c) : "var(--color-bt-border)"}`,
-                    color: selected ? colorToken(c) : "var(--color-bt-text-dim)",
-                    fontSize: 11.5,
-                    fontWeight: 600,
-                    transition: "background-color 120ms, border-color 120ms, color 120ms",
-                  }}
-                >
-                  <Icon size={18} strokeWidth={2} aria-hidden="true" />
-                  <span>{c.label}</span>
-                </button>
-              );
-            })}
-          </div>
+          {CATEGORIES.map((c) => {
+            const selected = c.key === category;
+            const Icon = c.icon;
+            return (
+              <button
+                key={c.key}
+                type="button"
+                onClick={() => setCategory(c.key)}
+                aria-pressed={selected}
+                data-testid={`feedback-category-${c.key}`}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 4,
+                  padding: "10px 4px",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  background: selected
+                    ? colorFaintToken(c)
+                    : "var(--color-bt-card-raised)",
+                  border: `1px solid ${selected ? colorBorderToken(c) : "var(--color-bt-border)"}`,
+                  color: selected ? colorToken(c) : "var(--color-bt-text-dim)",
+                  fontSize: 11.5,
+                  fontWeight: 600,
+                  transition: "background-color 120ms, border-color 120ms, color 120ms",
+                }}
+              >
+                <Icon size={18} strokeWidth={2} aria-hidden="true" />
+                <span>{c.label}</span>
+              </button>
+            );
+          })}
+        </div>
 
-          {/* ── Free text ──────────────────────────────────────────────── */}
+        {/* ── Free text ────────────────────────────────────────────────── */}
+        <div style={{ padding: "0 18px 12px" }}>
           <textarea
             value={text}
             onChange={(e) => setText(e.target.value)}
@@ -375,7 +362,7 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
               padding: "10px 12px",
               borderRadius: 10,
               border: "1px solid var(--color-bt-border)",
-              background: "var(--color-bt-card)",
+              background: "var(--color-bt-card-raised)",
               color: "var(--color-bt-text)",
               fontSize: 14,
               lineHeight: 1.45,

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -273,17 +273,16 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
             type="button"
             onClick={onClose}
             aria-label="Close"
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
             style={{
               marginLeft: "auto",
-              background: "transparent",
+              background: "var(--color-bt-card-raised)",
               border: "none",
               color: "var(--color-bt-text-dim)",
               cursor: "pointer",
-              padding: 4,
-              lineHeight: 0,
             }}
           >
-            <X size={17} strokeWidth={1.75} />
+            <X size={15} strokeWidth={1.75} />
           </button>
         </div>
 

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -9,7 +9,6 @@ import {
   Heart,
   Lightbulb,
   Megaphone,
-  Paperclip,
   X,
   type LucideIcon,
 } from "lucide-react";
@@ -127,27 +126,16 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   const platform = "web";
 
   // ── Form state ─────────────────────────────────────────────────────────
-  // emailOverride is null until the user actually edits the email field —
-  // until then the rendered value falls back to the signed-in user's
-  // email. This avoids a useEffect that would otherwise cascade a render
-  // every time getMe resolves (and trips react-hooks/set-state-in-effect).
   const [category, setCategory] = useState<Category>("bug");
   const [text, setText] = useState("");
-  const [emailOverride, setEmailOverride] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
 
-  const emailValue = emailOverride ?? me?.email ?? "";
-
-  // Reset transient form state on each open transition. setState-in-effect
-  // is the right tool here: the reset is the React-side "external system"
-  // synchronization — when `open` flips true, the form must be a known
-  // blank slate. Same pattern as AboutModal's mounted-flag effect.
+  // Reset transient form state on each open transition.
   useEffect(() => {
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setCategory("bug");
     setText("");
-    setEmailOverride(null);
     setToast(null);
   }, [open]);
 
@@ -170,7 +158,7 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
 
   const send = trpc.feedback.send.useMutation({
     onSuccess: () => {
-      setToast("Thanks — sent straight to the founder.");
+      setToast("Thanks — the developer appreciates it!");
       // Brief delay so the toast is perceptible before the modal closes.
       window.setTimeout(() => onClose(), 900);
     },
@@ -185,13 +173,16 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
 
   if (!open || !mounted) return null;
 
+  // Pull the user's email from session so the tRPC procedure can include it
+  // in the report as a reply-to address — silently, without showing the field.
+  const replyTo = me?.email ?? null;
+
   const handleSubmit = () => {
     if (!canSend) return;
-    const trimmedEmail = emailValue.trim();
     send.mutate({
       category,
       message: text.trim(),
-      replyTo: trimmedEmail ? trimmedEmail : null,
+      replyTo,
       screen: screenLabel,
       tripLabel,
       platform,
@@ -355,69 +346,6 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           />
         </div>
 
-        {/* ── Email (optional) ─────────────────────────────────────────── */}
-        <div style={{ padding: "8px 18px 4px" }}>
-          <input
-            type="email"
-            value={emailValue}
-            onChange={(e) => setEmailOverride(e.target.value)}
-            placeholder="you@email.com"
-            data-testid="feedback-email"
-            style={{
-              width: "100%",
-              padding: "8px 12px",
-              borderRadius: 10,
-              border: "1px solid var(--color-bt-border)",
-              background: "var(--color-bt-card-raised)",
-              color: "var(--color-bt-text)",
-              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-              fontSize: 13,
-              outline: "none",
-            }}
-          />
-          <div
-            style={{
-              marginTop: 4,
-              fontSize: 11,
-              color: "var(--color-bt-text-dim)",
-            }}
-          >
-            Optional — drop it if you want a reply when we fix it.
-          </div>
-        </div>
-
-        {/* ── Auto-captured context ────────────────────────────────────── */}
-        <div
-          className="flex items-center"
-          style={{
-            margin: "10px 18px 0",
-            padding: "8px 10px",
-            gap: 8,
-            borderRadius: 9,
-            background: "var(--color-bt-card-raised)",
-            border: "1px solid var(--color-bt-subtle-border)",
-          }}
-        >
-          <Paperclip
-            size={13}
-            strokeWidth={1.75}
-            style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }}
-            aria-hidden="true"
-          />
-          <span
-            className="truncate"
-            style={{
-              fontSize: 11.5,
-              color: "var(--color-bt-text-dim)",
-            }}
-          >
-            Attached automatically:{" "}
-            <span style={{ color: "var(--color-bt-text)", fontWeight: 500 }}>
-              {[screenLabel, tripLabel, platform].filter(Boolean).join(" · ")}
-            </span>
-          </span>
-        </div>
-
         {/* ── Footer ───────────────────────────────────────────────────── */}
         <div
           className="flex items-center"
@@ -435,7 +363,7 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
               color: "var(--color-bt-text-dim)",
             }}
           >
-            Goes straight to the founder.
+            The developer appreciates any and all feedback.
           </span>
           <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
             <button

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { usePathname, useParams, useSearchParams } from "next/navigation";
 import {
   Bug,
+  CheckCircle,
   HelpCircle,
   Heart,
   Lightbulb,
@@ -143,7 +144,7 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   // ── Form state ─────────────────────────────────────────────────────────
   const [category, setCategory] = useState<Category>("bug");
   const [text, setText] = useState("");
-  const [toast, setToast] = useState<string | null>(null);
+  const [succeeded, setSucceeded] = useState(false);
 
   // Reset transient form state on each open transition.
   useEffect(() => {
@@ -151,10 +152,11 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setCategory("bug");
     setText("");
-    setToast(null);
+    setSucceeded(false);
   }, [open]);
 
   // ESC to close. Click-outside is handled by the scrim's onClick.
+  // Allow ESC even on the success screen so the user isn't trapped.
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -164,6 +166,13 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
     return () => document.removeEventListener("keydown", onKey);
   }, [open, onClose]);
 
+  // Auto-close 3 s after a successful send.
+  useEffect(() => {
+    if (!succeeded) return;
+    const t = window.setTimeout(() => onClose(), 3000);
+    return () => window.clearTimeout(t);
+  }, [succeeded, onClose]);
+
   // SSR-safe portal target. See AboutModal for the containing-block note.
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
@@ -172,13 +181,9 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   }, []);
 
   const send = trpc.feedback.send.useMutation({
-    onSuccess: () => {
-      setToast("Thanks — the developer appreciates it!");
-      // Brief delay so the toast is perceptible before the modal closes.
-      window.setTimeout(() => onClose(), 900);
-    },
+    onSuccess: () => setSucceeded(true),
     onError: () => {
-      setToast("Couldn't send. Try again in a moment.");
+      // Keep the form open so the user can retry.
     },
   });
 
@@ -235,6 +240,41 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
         }}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* ── Success state — replaces the form after a successful send ── */}
+        {succeeded ? (
+          <div
+            className="flex flex-col items-center justify-center text-center"
+            style={{ padding: "48px 32px" }}
+          >
+            <CheckCircle
+              size={48}
+              strokeWidth={1.5}
+              style={{ color: "var(--color-bt-accent)", marginBottom: 16 }}
+              aria-hidden="true"
+            />
+            <p
+              style={{
+                margin: "0 0 8px",
+                fontSize: 18,
+                fontWeight: 600,
+                color: "var(--color-bt-text)",
+              }}
+            >
+              Thank you!
+            </p>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 14,
+                color: "var(--color-bt-text-dim)",
+                lineHeight: 1.5,
+              }}
+            >
+              Your feedback was sent. It helps more than you know.
+            </p>
+          </div>
+        ) : (
+          <>
         {/* ── Mobile grab handle (hidden on desktop) ────────────────────── */}
         <div
           aria-hidden="true"
@@ -426,18 +466,20 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           </div>
         </div>
 
-        {toast && (
-          <div
-            role="status"
+        {send.isError && (
+          <p
+            role="alert"
             style={{
-              padding: "0 18px 14px",
+              margin: "0 18px 14px",
               fontSize: 12,
-              color: "var(--color-bt-text-dim)",
+              color: "var(--color-bt-danger)",
               textAlign: "right",
             }}
           >
-            {toast}
-          </div>
+            Couldn&apos;t send — try again in a moment.
+          </p>
+        )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -238,15 +238,15 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
             height: 4,
             borderRadius: 9999,
             background: "var(--color-bt-border)",
-            marginTop: 8,
-            marginBottom: 2,
+            marginTop: 10,
+            marginBottom: 4,
           }}
         />
 
         {/* ── Header ───────────────────────────────────────────────────── */}
         <div
           className="flex items-center"
-          style={{ padding: "16px 18px 8px", gap: 10 }}
+          style={{ padding: "18px 18px 14px", gap: 10 }}
         >
           <Megaphone
             size={20}
@@ -296,53 +296,67 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
           </button>
         </div>
 
-        {/* ── Category chips ───────────────────────────────────────────── */}
+        {/* ── Body — padded card-raised panel so the interactive content
+             sits on a unified lighter surface rather than floating as
+             dark islands on the even-darker card bg. Same treatment
+             TripSettingsModal uses for its form body. ──────────────── */}
         <div
           style={{
-            padding: "6px 18px 4px",
-            display: "grid",
-            gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-            gap: 8,
+            margin: "0 14px 14px",
+            padding: "14px",
+            borderRadius: 12,
+            background: "var(--color-bt-card-raised)",
+            border: "1px solid var(--color-bt-border)",
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
           }}
         >
-          {CATEGORIES.map((c) => {
-            const selected = c.key === category;
-            const Icon = c.icon;
-            return (
-              <button
-                key={c.key}
-                type="button"
-                onClick={() => setCategory(c.key)}
-                aria-pressed={selected}
-                data-testid={`feedback-category-${c.key}`}
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: 4,
-                  padding: "10px 4px",
-                  borderRadius: 10,
-                  cursor: "pointer",
-                  background: selected
-                    ? colorFaintToken(c)
-                    : "var(--color-bt-card-raised)",
-                  border: `1px solid ${selected ? colorBorderToken(c) : "var(--color-bt-border)"}`,
-                  color: selected ? colorToken(c) : "var(--color-bt-text-dim)",
-                  fontSize: 11.5,
-                  fontWeight: 600,
-                  transition: "background-color 120ms, border-color 120ms, color 120ms",
-                }}
-              >
-                <Icon size={18} strokeWidth={2} aria-hidden="true" />
-                <span>{c.label}</span>
-              </button>
-            );
-          })}
-        </div>
+          {/* ── Category chips ─────────────────────────────────────────── */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+              gap: 8,
+            }}
+          >
+            {CATEGORIES.map((c) => {
+              const selected = c.key === category;
+              const Icon = c.icon;
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={() => setCategory(c.key)}
+                  aria-pressed={selected}
+                  data-testid={`feedback-category-${c.key}`}
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: 4,
+                    padding: "10px 4px",
+                    borderRadius: 10,
+                    cursor: "pointer",
+                    background: selected
+                      ? colorFaintToken(c)
+                      : "var(--color-bt-card)",
+                    border: `1px solid ${selected ? colorBorderToken(c) : "var(--color-bt-border)"}`,
+                    color: selected ? colorToken(c) : "var(--color-bt-text-dim)",
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    transition: "background-color 120ms, border-color 120ms, color 120ms",
+                  }}
+                >
+                  <Icon size={18} strokeWidth={2} aria-hidden="true" />
+                  <span>{c.label}</span>
+                </button>
+              );
+            })}
+          </div>
 
-        {/* ── Free text ────────────────────────────────────────────────── */}
-        <div style={{ padding: "10px 18px 4px" }}>
+          {/* ── Free text ──────────────────────────────────────────────── */}
           <textarea
             value={text}
             onChange={(e) => setText(e.target.value)}
@@ -356,7 +370,7 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
               padding: "10px 12px",
               borderRadius: 10,
               border: "1px solid var(--color-bt-border)",
-              background: "var(--color-bt-card-raised)",
+              background: "var(--color-bt-card)",
               color: "var(--color-bt-text)",
               fontSize: 14,
               lineHeight: 1.45,
@@ -370,10 +384,8 @@ export function FeedbackModal({ open, onClose }: FeedbackModalProps) {
         <div
           className="flex items-center"
           style={{
-            padding: "14px 18px 16px",
+            padding: "0 18px 18px",
             gap: 10,
-            marginTop: 10,
-            borderTop: "1px solid var(--color-bt-subtle-border)",
           }}
         >
           <span

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FC } from "react";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { Pin, MessageCircle, Megaphone, ChevronDown } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -255,10 +255,17 @@ export const TopNav: FC<TopNavProps> = ({
         <UserMenu onOpenFeedback={() => setFeedbackOpen(true)} />
       </div>
 
-      <FeedbackModal
-        open={feedbackOpen}
-        onClose={() => setFeedbackOpen(false)}
-      />
+      {/* FeedbackModal calls useSearchParams() to capture the active tab
+          (?tab=crew etc). Next.js requires any useSearchParams() caller to
+          be wrapped in Suspense during static prerendering — without this,
+          build fails on pages like /profile/archived-ideas that are
+          statically generated. fallback={null} keeps the UX unchanged. */}
+      <Suspense fallback={null}>
+        <FeedbackModal
+          open={feedbackOpen}
+          onClose={() => setFeedbackOpen(false)}
+        />
+      </Suspense>
     </header>
   );
 };

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -234,7 +234,7 @@ export const TopNav: FC<TopNavProps> = ({
           iconColor="white"
           restingBg="var(--color-bt-accent-faint)"
           restingBorder="1px solid var(--color-bt-accent-border)"
-          labelColor="var(--color-bt-accent)"
+          labelColor="white"
           onClick={() => setFeedbackOpen(true)}
           ariaLabel="Send feedback"
           testId="feedback-button"

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -221,8 +221,9 @@ export const TopNav: FC<TopNavProps> = ({
           />
         )}
 
-        {/* Feedback — beta-only outbound channel. Megaphone in accent so
-            it visually distinguishes itself from Chat's message-circle.
+        {/* Feedback — beta-only outbound channel. Slight teal resting bg
+            so it reads as a distinct CTA in the tool cluster without
+            overwhelming the bar. White icon + text against the teal fill.
             No badge: feedback is outbound, an unread dot reads as the
             wrong signal. */}
         <ToolButton
@@ -230,7 +231,10 @@ export const TopNav: FC<TopNavProps> = ({
           label="Feedback"
           count={0}
           badgeBg="var(--color-bt-accent)"
-          iconColor="var(--color-bt-accent)"
+          iconColor="white"
+          restingBg="var(--color-bt-accent-faint)"
+          restingBorder="1px solid var(--color-bt-accent-border)"
+          labelColor="var(--color-bt-accent)"
           onClick={() => setFeedbackOpen(true)}
           ariaLabel="Send feedback"
           testId="feedback-button"
@@ -300,6 +304,9 @@ function ToolButton({
   ariaLabel,
   testId,
   iconColor,
+  restingBg,
+  restingBorder,
+  labelColor,
 }: {
   icon: LucideIcon;
   label: string;
@@ -309,9 +316,15 @@ function ToolButton({
   onClick?: () => void;
   ariaLabel: string;
   testId: string;
-  /** Override the icon stroke color. Defaults to the inherited text color so
-   *  News/Chat keep their current treatment; Feedback uses the accent. */
+  /** Override the icon stroke color. Defaults to the inherited text color. */
   iconColor?: string;
+  /** Resting background. Defaults to none; use for buttons that need a
+   *  subtle filled surface (e.g. the Feedback CTA). */
+  restingBg?: string;
+  /** Border applied in the resting state alongside restingBg. */
+  restingBorder?: string;
+  /** Override the label text color. Defaults to var(--color-bt-text). */
+  labelColor?: string;
 }) {
   const showBadge = count > 0;
   const badgeLabel = count > 99 ? "99+" : String(count);
@@ -323,8 +336,8 @@ function ToolButton({
       data-testid={testId}
       className="relative inline-flex h-9 items-center gap-[7px] rounded-[9px] px-2.5 transition-colors hover:bg-[var(--color-bt-hover)] @max-[600px]:w-9 @max-[600px]:justify-center @max-[600px]:gap-0 @max-[600px]:px-0"
       style={{
-        background: active ? "var(--color-bt-hover)" : "none",
-        border: "none",
+        background: active ? "var(--color-bt-hover)" : (restingBg ?? "none"),
+        border: restingBorder ?? "none",
         color: "var(--color-bt-text)",
         fontSize: 13,
         fontWeight: 600,
@@ -337,7 +350,12 @@ function ToolButton({
         aria-hidden="true"
         style={iconColor ? { color: iconColor } : undefined}
       />
-      <span className="@max-[600px]:hidden">{label}</span>
+      <span
+        className="@max-[600px]:hidden"
+        style={labelColor ? { color: labelColor } : undefined}
+      >
+        {label}
+      </span>
 
       {showBadge && (
         <>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -134,6 +134,7 @@ export async function sendFeedback({
   message,
   replyTo,
   screen,
+  url,
   tripLabel,
   platform,
   build,
@@ -143,7 +144,10 @@ export async function sendFeedback({
   category: "bug" | "idea" | "confusing" | "love";
   message: string;
   replyTo?: string | null;
+  /** Human-friendly page label, e.g. "Trip · Crew" */
   screen?: string | null;
+  /** Full relative URL including query string, e.g. "/trips/abc?tab=crew" */
+  url?: string | null;
   tripLabel?: string | null;
   platform?: string | null;
   build?: string | null;
@@ -161,7 +165,8 @@ export async function sendFeedback({
   if (reporterName) ctxRows.push(["From", reporterName]);
   if (reporterEmail) ctxRows.push(["Account", reporterEmail]);
   if (replyTo && replyTo !== reporterEmail) ctxRows.push(["Reply-to", replyTo]);
-  if (screen) ctxRows.push(["Screen", screen]);
+  if (screen) ctxRows.push(["Page", screen]);
+  if (url) ctxRows.push(["URL", url]);
   if (tripLabel) ctxRows.push(["Trip", tripLabel]);
   if (platform) ctxRows.push(["Platform", platform]);
   if (build) ctxRows.push(["Build", build]);
@@ -169,7 +174,7 @@ export async function sendFeedback({
   const ctxHtml = ctxRows
     .map(
       ([k, v]) =>
-        `<tr><td style="padding:2px 12px 2px 0;color:#64748b;font-size:12px">${escapeHtml(k)}</td><td style="padding:2px 0;font-size:12px;color:#0f172a">${escapeHtml(v)}</td></tr>`,
+        `<tr><td style="padding:2px 12px 2px 0;color:#64748b;font-size:12px;white-space:nowrap;vertical-align:top">${escapeHtml(k)}</td><td style="padding:2px 0;font-size:12px;color:#0f172a;font-family:${k === "URL" ? "ui-monospace,monospace" : "inherit"}">${escapeHtml(v)}</td></tr>`,
     )
     .join("");
 
@@ -184,7 +189,7 @@ export async function sendFeedback({
       <div style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px">
         <p style="margin:0 0 4px;color:#64748b;font-size:12px;text-transform:uppercase;letter-spacing:0.08em">${escapeHtml(label)}</p>
         <p style="margin:0 0 16px;white-space:pre-wrap;color:#0f172a;font-size:15px;line-height:1.5">${escapeHtml(message)}</p>
-        ${ctxRows.length ? `<table style="margin:16px 0 0;border-top:1px solid #e2e8f0;padding-top:12px">${ctxHtml}</table>` : ""}
+        ${ctxRows.length ? `<table style="margin:16px 0 0;border-top:1px solid #e2e8f0;padding-top:12px;border-spacing:0">${ctxHtml}</table>` : ""}
       </div>
     `,
   });

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,18 +1,17 @@
-// ── App build metadata ───────────────────────────────────────────────────
+// ── App build metadata ────────────────────────────────────────────────────
 //
-// Single source of truth for the build date + last-shipped date surfaced
-// in the AboutModal. A user-facing version string (e.g. "v1.0") is
-// intentionally NOT defined here yet — the app hasn't formally versioned
-// a release, so the modal omits the version pill until that lands. When
-// it does, add `APP_VERSION` here and wire it back in.
+// Stamped at build time by next.config.ts via execSync — no manual updates
+// needed. Format: YYYY.MM.DD.<short-sha>  e.g. 2026.06.05.a1b2c3d
+//
+//   Date  = last git commit date (not wall-clock build time)
+//   SHA   = first 7 chars of the commit hash — paste into `git show <sha>`
+//
+// Falls back to static strings when the env vars aren't present (local dev
+// without a Next.js build, unit tests, etc.).
 
-/** Build date in YYYY.MM.DD form. Shown in the about-modal's mono build
- *  line. Doesn't need to be precise to the commit — release-day date is
- *  enough for the audience. */
-export const APP_BUILD = "2026.06.04";
+const date = process.env.NEXT_PUBLIC_BUILD_DATE ?? "0000.00.00";
+const sha = process.env.NEXT_PUBLIC_BUILD_SHA ?? "dev";
 
-/** When the latest user-facing changelog entry shipped. Drives the
- *  "What's new" link's subline in the about modal ("last shipped N days
- *  ago"). Update this alongside APP_BUILD when changelog entries land.
- *  ISO YYYY-MM-DD. */
-export const APP_LAST_SHIPPED = "2026-06-01";
+/** Full build string shown in the AboutModal mono build line.
+ *  e.g. "2026.06.05.a1b2c3d" */
+export const APP_BUILD = `${date}.${sha}`;

--- a/src/server/routers/feedback.ts
+++ b/src/server/routers/feedback.ts
@@ -24,6 +24,9 @@ export const feedbackRouter = router({
         // Auto-captured context — all optional, all surfaced in the email
         // so the founder has enough to triage without bouncing back.
         screen: z.string().max(200).nullable().optional(),
+        // Full relative URL including query string (e.g. /trips/abc?tab=crew).
+        // Complements the friendly `screen` label with the exact location.
+        url: z.string().max(500).nullable().optional(),
         tripLabel: z.string().max(200).nullable().optional(),
         platform: z.string().max(40).nullable().optional(),
         build: z.string().max(40).nullable().optional(),
@@ -53,6 +56,7 @@ export const feedbackRouter = router({
           message: input.message,
           replyTo: input.replyTo ?? null,
           screen: input.screen ?? null,
+          url: input.url ?? null,
           tripLabel: input.tripLabel ?? null,
           platform: input.platform ?? null,
           build: input.build ?? null,


### PR DESCRIPTION
## Summary

Follow-on polish to #294 (beta feedback channel). All changes are on top of the merged feedback foundation.

**Feedback form**
- Category chips + textarea directly on `card-float` shell (no extra wrapping panel)
- `card-float` modal bg — matches InfoTileModal, correctly elevated above the overlay-darkened page; updated STYLE_GUIDE.md to document `card-float` as the correct token for floating dialogs
- Amber beta banner below the header ("BuddyTrip is in beta — your feedback goes straight to the developer and shapes what gets built next.")
- Circle close button (`h-8 w-8 rounded-full card-raised bg`) to match InfoTileModal
- Success state: form swaps to teal ✓ + "Thank you!" + "Your feedback was sent. It helps more than you know." — auto-closes after 3 seconds
- Error stays inline (red text, form stays open for retry)
- Suspense boundary around FeedbackModal to fix Vercel static prerender build failure (`useSearchParams` requirement)

**Feedback button (title bar)**
- White icon + white label on faint-teal `card-float` background pill
- `ToolButton` extended with `restingBg`, `restingBorder`, `labelColor` props

**About modal**
- Same chrome as FeedbackModal: `card-float` bg, `shadow-floating`, 18px mobile corners, grab handle, circle close button
- "What's new" row removed (no changelog page yet)
- Privacy row: disabled (dimmed, non-clickable), sub "Working on a policy — coming soon."
- Footer helper text removed; banner covers it

**Build stamp**
- `next.config.ts` runs `execSync` at build time: last commit date + 7-char SHA → `NEXT_PUBLIC_BUILD_DATE` / `NEXT_PUBLIC_BUILD_SHA`
- `version.ts` assembles `APP_BUILD = "YYYY.MM.DD.<sha>"` — no manual updates ever needed
- Format today: `2026.06.05.2132eb3`

**Feedback email**
- Captures active tab from `?tab=` query param (was blind to it before — `usePathname()` alone always returned `/trips/[id]`)
- URL field added alongside friendly label in email context table

## Test plan

- [ ] CI green
- [ ] Feedback button: white icon+text, teal bg
- [ ] Feedback modal: card-float bg, amber banner, category chips, send → success state → auto-closes ~3s
- [ ] About modal: matches feedback modal chrome, Privacy dimmed, What's new gone, build line shows git stamp
- [ ] Vercel preview deploy succeeds (Suspense fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)