### PR TITLE
Home tab: consistent button alignment + hide info dock without dates

### DIFF
--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -274,7 +274,7 @@ export const SetDatesFlipCard: FC<SetDatesFlipCardProps> = ({
       <button
         type="button"
         onClick={() => setFlipped(true)}
-        className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
+        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
           datesSet
             ? {

--- a/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/StepCard.tsx
@@ -138,7 +138,7 @@ export const StepCard: FC<StepCardProps> = ({
         type="button"
         onClick={onCta}
         data-testid={testId}
-        className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
+        className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg py-2 text-[13px] font-semibold transition-colors hover:bg-[rgba(255,255,255,0.04)]"
         style={
           done && doneCta
             ? {

--- a/src/components/TripHeader.tsx
+++ b/src/components/TripHeader.tsx
@@ -335,6 +335,7 @@ const PlainHeader: FC<Omit<TripHeaderProps, "isLocked"> & { countdown: LabelledC
           tripId={tripId}
           countdown={countdown}
           canEdit={!!canEdit}
+          hasDates={!!tripStartDate}
         />
       )}
     </div>
@@ -425,6 +426,7 @@ const HeroHeader: FC<Omit<TripHeaderProps, "isLocked"> & { countdown: LabelledCo
           tripId={tripId}
           countdown={countdown}
           canEdit={!!canEdit}
+          hasDates={!!tripStartDate}
         />
       )}
     </LocationHero>

--- a/src/components/TripHeaderDock.tsx
+++ b/src/components/TripHeaderDock.tsx
@@ -329,12 +329,17 @@ export interface TripHeaderDockProps {
   countdown: CountdownResult | null;
   /** Owner / Planner — gates the [+] button and tile click-to-edit. */
   canEdit: boolean;
+  /** Trip has start + end dates set. When false the dock is hidden entirely
+   *  — tiles and the empty-CTA are suppressed until the dates bookend the
+   *  trip, keeping the onboarding surface focused on the setup guide. */
+  hasDates: boolean;
 }
 
 export function TripHeaderDock({
   tripId,
   countdown,
   canEdit,
+  hasDates,
 }: TripHeaderDockProps) {
   const { data: tiles = [] } =
     trpc.quickInfoTiles.list.useQuery({ tripId });
@@ -418,6 +423,11 @@ export function TripHeaderDock({
     // on the empty-state edge, not every time it flips.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasTiles]);
+
+  // No dates yet → hide the dock entirely. The setup guide cards already
+  // occupy the onboarding surface; adding the tile rail (or its empty-CTA)
+  // before the trip is bookended just adds noise before planning has started.
+  if (!hasDates) return null;
 
   // Nothing to show? Hide the dock entirely.
   if (!hasCountdown && !hasTiles && !canEdit) {


### PR DESCRIPTION
## Summary

Two focused fixes for the home-tab setup guide.

**1. Step card CTA button alignment**

All four setup cards are equal-height grid items, but the CTA buttons were floating at different vertical positions because body text wraps differently across cards at different viewport widths. Switching from `mt-6` (fixed top margin) to `mt-auto` (flex spacer) pins each button to the bottom of its card — buttons are now on the same horizontal line at every width.

Applied to both `StepCard` (steps 2–4) and `SetDatesFlipCard` (step 1). The code comment already said `mt-auto pins to the bottom`; the implementation hadn't caught up.

**2. TripHeaderDock hidden until dates are set**

The countdown ring was already hidden when no dates were set (`countdown = null` gates the ring). But the info tile rail — and its owner-facing "Add quick info" empty CTA — still showed, adding surface noise before any planning has started. Hiding it keeps the onboarding view focused on the setup cards.

New `hasDates: boolean` prop on `TripHeaderDock`. When false the dock returns null entirely. `TripHeader` passes `hasDates={!!tripStartDate}` at both call sites (PlainHeader + HeroHeader). Once dates land, the dock appears with countdown + tiles as before.

## Test plan

- [ ] Setup guide: all 4 CTA buttons aligned at the same vertical position at each breakpoint (1-col, 2-col, 4-col)
- [ ] New trip with no dates: TripHeaderDock is not visible
- [ ] After setting dates: TripHeaderDock appears with countdown ring and tile rail
- [ ] Existing trips with tiles but no dates: dock hidden (tiles shown once dates are added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)