### PR TITLE
News PR2 — the post composer (create / edit / pin / delete)

### DIFF
--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Pin, X, Pencil, MoreHorizontal, Trash2 } from "lucide-react";
+import { Pin, X, Pencil, MoreHorizontal, Trash2, ChevronUp, ChevronDown } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { ScrollLock } from "@/hooks/useScrollLock";
@@ -321,34 +321,29 @@ function NewsPanelInner({
     </div>
   );
 
-  const feedScroll = (
-    <div
-      className="flex min-h-0 flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
-      data-testid="news-feed"
-    >
-      {/* Composing is launched from the pinned "New post" title-bar button,
-          which stays visible while the feed scrolls — so there's no in-feed
-          compose row to scroll away. */}
-      {isLoading ? null : posts.length === 0 ? (
-        <NewsEmpty canPost={canPost} />
-      ) : (
-        posts.map((p) => (
-          <NewsPostCard
-            key={p.id}
-            post={p}
-            author={authors[p.authorId]}
-            now={now}
-            canManage={canPost}
-            onEdit={() => setCompose({ mode: "edit", post: p })}
-            onTogglePin={() =>
-              setPinnedM.mutate({ tripId, postId: p.id, pinned: !p.pinned })
-            }
-            onDelete={() => deleteM.mutate({ tripId, postId: p.id })}
-          />
-        ))
-      )}
-    </div>
+  // Composing is launched from the pinned "New post" title-bar button, which
+  // stays visible while the feed scrolls.
+  const feedContent = isLoading ? null : posts.length === 0 ? (
+    <NewsEmpty canPost={canPost} />
+  ) : (
+    posts.map((p) => (
+      <NewsPostCard
+        key={p.id}
+        post={p}
+        author={authors[p.authorId]}
+        now={now}
+        canManage={canPost}
+        onEdit={() => setCompose({ mode: "edit", post: p })}
+        onTogglePin={() =>
+          setPinnedM.mutate({ tripId, postId: p.id, pinned: !p.pinned })
+        }
+        onDelete={() => deleteM.mutate({ tripId, postId: p.id })}
+      />
+    ))
   );
+  // A component (not a shared element) so the desktop rail + mobile sheet each
+  // get an independent scroll ref + arrow state.
+  const feedScroll = <NewsFeedScroll>{feedContent}</NewsFeedScroll>;
 
   // Either the composer or the feed (header + scroll), placed inside each
   // chrome's flex-col. Composer renders its own header + footer.
@@ -446,6 +441,76 @@ function NewsPanelInner({
       </ScrollLock>
     </>,
     document.body
+  );
+}
+
+// ── Scrollable feed + jump arrow ───────────────────────────────────────────
+// A component (not a shared JSX element) so the desktop rail and mobile sheet
+// each own an independent scroll ref. Mirrors chat's jump-to-latest, but the
+// arrow is position-aware: scrolled down → up-arrow to the top (newest +
+// pinned live there); at the top → down-arrow to the bottom (oldest).
+function NewsFeedScroll({ children }: { children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [dir, setDir] = useState<"up" | "down" | null>(null);
+
+  const update = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const scrollable = el.scrollHeight - el.clientHeight > 40;
+    if (!scrollable) {
+      setDir(null);
+      return;
+    }
+    setDir(el.scrollTop < 40 ? "down" : "up");
+  }, []);
+
+  // Recompute on mount, content changes, and size changes (a wider rail makes
+  // images taller, so scrollHeight shifts).
+  useEffect(() => {
+    // Measuring the scroll container is exactly the "sync from an external
+    // system" case the rule whitelists; the value comes from the DOM, not state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    update();
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => update());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [update, children]);
+
+  const jump = () => {
+    const el = ref.current;
+    if (!el) return;
+    el.scrollTo({ top: dir === "up" ? 0 : el.scrollHeight, behavior: "smooth" });
+  };
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div
+        ref={ref}
+        onScroll={update}
+        className="flex min-h-0 flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
+        data-testid="news-feed"
+      >
+        {children}
+      </div>
+      {dir && (
+        <button
+          type="button"
+          onClick={jump}
+          aria-label={dir === "up" ? "Scroll to top" : "Scroll to bottom"}
+          className="absolute bottom-3 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{
+            background: "var(--color-bt-card-float)",
+            color: "var(--color-bt-text)",
+            border: "1px solid var(--color-bt-border)",
+            boxShadow: "var(--shadow-floating)",
+          }}
+        >
+          {dir === "up" ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -326,25 +326,9 @@ function NewsPanelInner({
       className="flex min-h-0 flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
       data-testid="news-feed"
     >
-      {/* Dashed compose row — owner/organizer only, sits above the feed. */}
-      {canPost && (
-        <button
-          type="button"
-          onClick={() => setCompose({ mode: "add" })}
-          className="flex flex-shrink-0 items-center gap-2.5 rounded-[11px] transition-opacity hover:opacity-90"
-          style={{
-            padding: "11px 13px",
-            border: "1px dashed var(--color-bt-accent-border)",
-            background: "var(--color-bt-accent-faint)",
-            cursor: "pointer",
-          }}
-        >
-          <Pencil size={14} style={{ color: "var(--color-bt-accent)" }} />
-          <span style={{ flex: 1, textAlign: "left", fontSize: 13, color: "var(--color-bt-text-dim)" }}>
-            Post an update to the crew…
-          </span>
-        </button>
-      )}
+      {/* Composing is launched from the pinned "New post" title-bar button,
+          which stays visible while the feed scrolls — so there's no in-feed
+          compose row to scroll away. */}
       {isLoading ? null : posts.length === 0 ? (
         <NewsEmpty canPost={canPost} />
       ) : (

--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -323,7 +323,7 @@ function NewsPanelInner({
 
   const feedScroll = (
     <div
-      className="flex flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
+      className="flex min-h-0 flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
       data-testid="news-feed"
     >
       {/* Dashed compose row — owner/organizer only, sits above the feed. */}
@@ -331,7 +331,7 @@ function NewsPanelInner({
         <button
           type="button"
           onClick={() => setCompose({ mode: "add" })}
-          className="flex items-center gap-2.5 rounded-[11px] transition-opacity hover:opacity-90"
+          className="flex flex-shrink-0 items-center gap-2.5 rounded-[11px] transition-opacity hover:opacity-90"
           style={{
             padding: "11px 13px",
             border: "1px dashed var(--color-bt-accent-border)",
@@ -488,6 +488,7 @@ function NewsPostCard({
   const role = roleLine(author?.role ?? "Member");
   return (
     <div
+      className="flex-shrink-0"
       style={{
         border: "1px solid var(--color-bt-border)",
         borderRadius: 14,

--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -2,12 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Pin, X } from "lucide-react";
+import { Pin, X, Pencil, MoreHorizontal, Trash2 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Avatar } from "@/components/Avatar";
 import { NewsBlocks } from "@/components/news/NewsBlock";
+import { NewsComposer } from "@/components/news/NewsComposer";
 import type { NewsPost } from "@/lib/news";
 import {
   RAIL_DEFAULT_WIDTH,
@@ -249,17 +250,138 @@ function NewsPanelInner({
     </span>
   );
 
-  const feed = (
-    <>
+  // ── Compose state — null = viewing the feed ───────────────────────────────
+  const [compose, setCompose] = useState<
+    { mode: "add" } | { mode: "edit"; post: NewsPost } | null
+  >(null);
+
+  const setPinnedM = trpc.news.setPinned.useMutation({
+    onSuccess: () => utils.news.list.invalidate({ tripId }),
+  });
+  const deleteM = trpc.news.delete.useMutation({
+    onSuccess: () => {
+      utils.news.list.invalidate({ tripId });
+      utils.news.unreadCount.invalidate({ tripId });
+    },
+  });
+
+  // The "New post" header button (owner/organizer only).
+  const newPostBtn = canPost ? (
+    <button
+      type="button"
+      onClick={() => setCompose({ mode: "add" })}
+      data-testid="news-new-post"
+      className="ml-auto inline-flex items-center gap-1.5 rounded-[9px]"
+      style={{
+        background: "var(--color-bt-accent)",
+        color: "#0d1f1a",
+        padding: "6px 11px",
+        fontSize: 12.5,
+        fontWeight: 600,
+        cursor: "pointer",
+        border: "none",
+      }}
+    >
+      <Pencil size={12} /> New post
+    </button>
+  ) : null;
+
+  const closeBtn = (variant: "desktop" | "mobile") => (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label="Close news"
+      className={
+        canPost
+          ? variant === "mobile"
+            ? "flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+            : "flex h-7 w-7 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
+          : variant === "mobile"
+            ? "ml-auto flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
+            : "ml-auto flex h-7 w-7 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
+      }
+      style={
+        variant === "mobile"
+          ? { background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }
+          : { color: "var(--color-bt-text-dim)" }
+      }
+    >
+      <X size={16} />
+    </button>
+  );
+
+  const feedHeader = (variant: "desktop" | "mobile") => (
+    <div
+      className={`flex flex-shrink-0 items-center gap-2 px-3 ${variant === "mobile" ? "pb-2" : "py-2"}`}
+      style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+    >
+      {titleRow}
+      {newPostBtn}
+      {closeBtn(variant)}
+    </div>
+  );
+
+  const feedScroll = (
+    <div
+      className="flex flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
+      data-testid="news-feed"
+    >
+      {/* Dashed compose row — owner/organizer only, sits above the feed. */}
+      {canPost && (
+        <button
+          type="button"
+          onClick={() => setCompose({ mode: "add" })}
+          className="flex items-center gap-2.5 rounded-[11px] transition-opacity hover:opacity-90"
+          style={{
+            padding: "11px 13px",
+            border: "1px dashed var(--color-bt-accent-border)",
+            background: "var(--color-bt-accent-faint)",
+            cursor: "pointer",
+          }}
+        >
+          <Pencil size={14} style={{ color: "var(--color-bt-accent)" }} />
+          <span style={{ flex: 1, textAlign: "left", fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+            Post an update to the crew…
+          </span>
+        </button>
+      )}
       {isLoading ? null : posts.length === 0 ? (
         <NewsEmpty canPost={canPost} />
       ) : (
         posts.map((p) => (
-          <NewsPostCard key={p.id} post={p} author={authors[p.authorId]} now={now} />
+          <NewsPostCard
+            key={p.id}
+            post={p}
+            author={authors[p.authorId]}
+            now={now}
+            canManage={canPost}
+            onEdit={() => setCompose({ mode: "edit", post: p })}
+            onTogglePin={() =>
+              setPinnedM.mutate({ tripId, postId: p.id, pinned: !p.pinned })
+            }
+            onDelete={() => deleteM.mutate({ tripId, postId: p.id })}
+          />
         ))
       )}
-    </>
+    </div>
   );
+
+  // Either the composer or the feed (header + scroll), placed inside each
+  // chrome's flex-col. Composer renders its own header + footer.
+  const inner = (variant: "desktop" | "mobile") =>
+    compose ? (
+      <NewsComposer
+        tripId={tripId}
+        variant={variant}
+        post={compose.mode === "edit" ? compose.post : null}
+        onDone={() => setCompose(null)}
+      />
+    ) : (
+      <>
+        {feedHeader(variant)}
+        {feedScroll}
+      </>
+    );
 
   return createPortal(
     <>
@@ -291,28 +413,7 @@ function NewsPanelInner({
           </div>
         </div>
 
-        <div
-          className="flex flex-shrink-0 items-center gap-2 px-3 py-2"
-          style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
-        >
-          {titleRow}
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close news"
-            className="ml-auto flex h-7 w-7 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            <X size={16} />
-          </button>
-        </div>
-
-        <div
-          className="flex flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]"
-          data-testid="news-feed"
-        >
-          {feed}
-        </div>
+        {inner("desktop")}
       </div>
 
       {/* ── Mobile: bottom sheet ─────────────────────────────────────────────
@@ -355,22 +456,7 @@ function NewsPanelInner({
                 ))}
               </div>
             </div>
-            <div
-              className="flex flex-shrink-0 items-center gap-2 px-3 pb-2"
-              style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
-            >
-              {titleRow}
-              <button
-                type="button"
-                onClick={onClose}
-                aria-label="Close news"
-                className="ml-auto flex h-8 w-8 items-center justify-center rounded-full transition-colors hover:bg-[var(--color-bt-hover)]"
-                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
-              >
-                <X size={16} />
-              </button>
-            </div>
-            <div className="flex flex-1 flex-col gap-[13px] overflow-y-auto p-[14px]">{feed}</div>
+            {inner("mobile")}
           </div>
         </div>
       </ScrollLock>
@@ -384,10 +470,19 @@ function NewsPostCard({
   post,
   author,
   now,
+  canManage,
+  onEdit,
+  onTogglePin,
+  onDelete,
 }: {
   post: NewsPost;
   author: NewsAuthorMeta | undefined;
   now: number;
+  /** Owner/organizer (and, by construction, the author) — shows the ⋯ menu. */
+  canManage: boolean;
+  onEdit: () => void;
+  onTogglePin: () => void;
+  onDelete: () => void;
 }) {
   const name = author?.name ?? "Someone";
   const role = roleLine(author?.role ?? "Member");
@@ -431,13 +526,149 @@ function NewsPostCard({
           <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", fontFamily: "var(--font-mono)" }}>
             {relativeTime(post.createdAt, now)}
           </span>
-          {/* ⋯ manage menu (Edit / Pin / Delete) lands in PR2 with the composer. */}
+          {canManage && (
+            <PostMenu
+              pinned={post.pinned}
+              onEdit={onEdit}
+              onTogglePin={onTogglePin}
+              onDelete={onDelete}
+            />
+          )}
         </div>
       </div>
       <div style={{ padding: "12px 16px 16px" }}>
         <NewsBlocks blocks={post.blocks} />
       </div>
     </div>
+  );
+}
+
+// ── Post ⋯ menu (Edit / Pin / Delete) ──────────────────────────────────────
+function PostMenu({
+  pinned,
+  onEdit,
+  onTogglePin,
+  onDelete,
+}: {
+  pinned: boolean;
+  onEdit: () => void;
+  onTogglePin: () => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setConfirming(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        setConfirming(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-label="Manage post"
+        onClick={() => setOpen((o) => !o)}
+        className="flex h-[26px] w-[26px] items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        <MoreHorizontal size={16} />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-10 mt-1 overflow-hidden"
+          style={{
+            minWidth: 168,
+            background: "var(--color-bt-card-float)",
+            border: "1px solid var(--color-bt-border)",
+            borderRadius: 10,
+            boxShadow: "var(--shadow-floating)",
+          }}
+        >
+          <MenuItem
+            icon={<Pencil size={14} />}
+            label="Edit"
+            onClick={() => {
+              setOpen(false);
+              onEdit();
+            }}
+          />
+          <MenuItem
+            icon={<Pin size={14} />}
+            label={pinned ? "Unpin" : "Pin to top"}
+            onClick={() => {
+              setOpen(false);
+              onTogglePin();
+            }}
+          />
+          <MenuItem
+            icon={<Trash2 size={14} />}
+            label={confirming ? "Tap to confirm" : "Delete"}
+            danger
+            onClick={() => {
+              if (!confirming) {
+                setConfirming(true);
+                return;
+              }
+              setOpen(false);
+              setConfirming(false);
+              onDelete();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItem({
+  icon,
+  label,
+  onClick,
+  danger,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className="flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+      style={{
+        fontSize: 13,
+        fontWeight: 500,
+        color: danger ? "var(--color-bt-danger)" : "var(--color-bt-text)",
+        background: "transparent",
+        border: "none",
+        cursor: "pointer",
+      }}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -13,6 +13,18 @@ import type {
 // the design reference (design/design_handoff_news, .post/.blk-* CSS).
 // The composer (PR2) reuses these same renderers for its live preview.
 
+// Derive a YouTube thumbnail straight from the pasted link — no storage, no
+// API. Matches watch / youtu.be / embed / shorts URLs. Other providers
+// (Vimeo, etc.) have no zero-cost URL→thumbnail, so they fall back to the
+// gradient card; a real fix there would need an oEmbed fetch.
+function youTubeThumb(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const m = url.match(
+    /(?:youtube\.com\/(?:watch\?v=|embed\/|shorts\/)|youtu\.be\/)([\w-]{11})/
+  );
+  return m ? `https://img.youtube.com/vi/${m[1]}/hqdefault.jpg` : null;
+}
+
 // ── @Crew mention pill ──────────────────────────────────────────────────
 function MiniAvatar({ person, size = 17 }: { person: NewsPerson; size?: number }) {
   return (
@@ -184,6 +196,80 @@ export function NewsBlockView({ block }: { block: NewsBlock }) {
           </div>
         );
       }
+      {
+        const thumb = youTubeThumb(block.src);
+        // With a real thumbnail: the image fills the card, a scrim keeps the
+        // play button + title legible, and the title/meta sit on the image.
+        if (thumb) {
+          return (
+            <a
+              href={block.src ?? undefined}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                position: "relative",
+                display: "block",
+                border: "1px solid var(--color-bt-border)",
+                borderRadius: 11,
+                aspectRatio: "16 / 9",
+                overflow: "hidden",
+                textDecoration: "none",
+                background: "var(--color-bt-card-raised)",
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={thumb}
+                alt={block.title || "Video thumbnail"}
+                style={{ position: "absolute", inset: 0, height: "100%", width: "100%", objectFit: "cover" }}
+              />
+              {/* Scrim — darkens for the play glyph + bottom caption legibility. */}
+              <div
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  background:
+                    "linear-gradient(to top, rgba(0,0,0,0.7), rgba(0,0,0,0.05) 45%, rgba(0,0,0,0.25))",
+                }}
+              />
+              <span
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  top: "50%",
+                  left: "50%",
+                  transform: "translate(-50%, -50%)",
+                  width: 54,
+                  height: 54,
+                  borderRadius: "50%",
+                  background: "rgba(0,0,0,0.55)",
+                  border: "1px solid rgba(255,255,255,0.55)",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                }}
+              >
+                <Play size={22} fill="#fff" />
+              </span>
+              {(block.title || block.meta) && (
+                <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, padding: "10px 12px" }}>
+                  {block.title && (
+                    <div style={{ fontSize: 13, fontWeight: 600, color: "#fff" }}>{block.title}</div>
+                  )}
+                  {block.meta && (
+                    <div style={{ fontSize: 11, color: "rgba(255,255,255,0.8)", marginTop: 2 }}>
+                      {block.meta}
+                    </div>
+                  )}
+                </div>
+              )}
+            </a>
+          );
+        }
+      }
+      // No derivable thumbnail (non-YouTube link, or no link yet) → gradient card.
       return (
         <a
           href={block.src ?? undefined}

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -25,6 +25,20 @@ function youTubeThumb(url: string | null | undefined): string | null {
   return m ? `https://img.youtube.com/vi/${m[1]}/hqdefault.jpg` : null;
 }
 
+// A directly-renderable image/GIF URL — a file with an image extension, or a
+// known GIF CDN (Giphy/Tenor "media" hosts). Lets a pasted GIF/photo link
+// render inline with no upload pipeline. Share-PAGE links (giphy.com/gifs/…)
+// aren't direct media and return null (they'd need the provider's API).
+function imageUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const u = url.trim();
+  if (/\.(gif|png|jpe?g|webp|avif)(\?.*)?$/i.test(u)) return u;
+  if (/^https?:\/\/(?:media\d*\.giphy\.com|i\.giphy\.com|media\.tenor\.com|c\.tenor\.com)\//i.test(u)) {
+    return u;
+  }
+  return null;
+}
+
 // ── @Crew mention pill ──────────────────────────────────────────────────
 function MiniAvatar({ person, size = 17 }: { person: NewsPerson; size?: number }) {
   return (
@@ -169,6 +183,41 @@ export function NewsBlockView({ block }: { block: NewsBlock }) {
 
     case "media":
       if (block.kind === "photo") {
+        // A pasted image/GIF link renders inline at its natural aspect (GIFs
+        // animate); only when there's no renderable URL do we show the
+        // captioned placeholder.
+        const img = imageUrl(block.src);
+        if (img) {
+          return (
+            <figure
+              style={{
+                margin: 0,
+                border: "1px solid var(--color-bt-border)",
+                borderRadius: 11,
+                overflow: "hidden",
+                background: "var(--color-bt-card-raised)",
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={img}
+                alt={block.ph || "Image"}
+                style={{ display: "block", width: "100%", height: "auto", maxHeight: 480, objectFit: "contain" }}
+              />
+              {block.ph && (
+                <figcaption
+                  style={{
+                    padding: "8px 12px",
+                    fontSize: 11.5,
+                    color: "var(--color-bt-text-dim)",
+                  }}
+                >
+                  {block.ph}
+                </figcaption>
+              )}
+            </figure>
+          );
+        }
         return (
           <div
             style={{

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+import { useState } from "react";
+import {
+  X,
+  Plus,
+  Trash2,
+  Pin,
+  ChevronUp,
+  ChevronDown,
+  Type,
+  Image as ImageIcon,
+  ListOrdered,
+  Users,
+  Trophy,
+  type LucideIcon,
+} from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import type { NewsBlock, NewsBlockType, NewsPost } from "@/lib/news";
+
+// ── NewsComposer ────────────────────────────────────────────────────────────
+//
+// New-post / edit-post composer, rendered inside the News rail (NewsPanel
+// swaps it in for the feed). Returns a fragment — header + scrollable body +
+// footer — placed directly in the rail's flex-col so the header/footer pin and
+// the body scrolls.
+//
+// PR2 scope: Text · Media · Steps · Callout editors, up/down reorder, remove,
+// pin toggle, create/edit/delete. The @Crew picker, Teams-from-Competition
+// picker, drag-reorder, and the Text formatting toolbar land in PR3. When
+// EDITING a post that already contains crew/teams blocks (e.g. the seed
+// welcome post), those render as read-only reference rows here and are
+// preserved on save — never silently dropped.
+
+// Block types the composer can ADD in PR2.
+const ADDABLE: { type: NewsBlockType; label: string; icon: LucideIcon }[] = [
+  { type: "text", label: "Text", icon: Type },
+  { type: "media", label: "Media", icon: ImageIcon },
+  { type: "steps", label: "Steps", icon: ListOrdered },
+  { type: "callout", label: "Callout", icon: Pin },
+];
+
+function blankBlock(type: NewsBlockType): NewsBlock {
+  switch (type) {
+    case "text":
+      return { type: "text", text: "" };
+    case "media":
+      return { type: "media", kind: "video", src: "", title: "", meta: "" };
+    case "steps":
+      return { type: "steps", steps: [{ label: "", body: "" }] };
+    case "callout":
+      return { type: "callout", text: "" };
+    default:
+      // crew/teams aren't addable in PR2; fall back to text.
+      return { type: "text", text: "" };
+  }
+}
+
+/** Drop blocks the user left empty so we don't post hollow paragraphs/callouts.
+ *  crew/teams/media are kept as-is (media may legitimately be just a link). */
+function cleanBlocks(blocks: NewsBlock[]): NewsBlock[] {
+  const out: NewsBlock[] = [];
+  for (const b of blocks) {
+    if (b.type === "text") {
+      const hasText = (b.text ?? "").trim().length > 0;
+      const hasSegments = (b.segments?.length ?? 0) > 0;
+      if (hasText || hasSegments) out.push({ ...b, text: b.text?.trim() });
+    } else if (b.type === "callout") {
+      if (b.text.trim().length > 0) out.push({ ...b, text: b.text.trim() });
+    } else if (b.type === "steps") {
+      const steps = b.steps
+        .map((s) => ({ label: s.label.trim(), body: s.body.trim() }))
+        .filter((s) => s.label || s.body);
+      if (steps.length > 0) out.push({ type: "steps", steps });
+    } else if (b.type === "media") {
+      // Keep a video block only if it has a link; keep photo blocks as-is.
+      if (b.kind === "photo" || (b.src ?? "").trim().length > 0) {
+        out.push({ ...b, src: b.src?.trim() });
+      }
+    } else {
+      // crew / teams — preserved untouched.
+      out.push(b);
+    }
+  }
+  return out;
+}
+
+interface NewsComposerProps {
+  tripId: string;
+  variant: "desktop" | "mobile";
+  /** Editing an existing post, or null for a new post. */
+  post: NewsPost | null;
+  /** Return to the feed (Cancel / X / after a successful save). */
+  onDone: () => void;
+}
+
+export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProps) {
+  const editing = post !== null;
+  const utils = trpc.useUtils();
+
+  const [blocks, setBlocks] = useState<NewsBlock[]>(
+    () => post?.blocks ?? [{ type: "text", text: "" }]
+  );
+  const [pinned, setPinned] = useState<boolean>(post?.pinned ?? false);
+
+  const refresh = () => {
+    utils.news.list.invalidate({ tripId });
+    utils.news.unreadCount.invalidate({ tripId });
+  };
+
+  const create = trpc.news.create.useMutation({ onSuccess: () => { refresh(); onDone(); } });
+  const update = trpc.news.update.useMutation({ onSuccess: () => { refresh(); onDone(); } });
+  const del = trpc.news.delete.useMutation({ onSuccess: () => { refresh(); onDone(); } });
+
+  const pending = create.isPending || update.isPending || del.isPending;
+  const cleaned = cleanBlocks(blocks);
+  const canSubmit = cleaned.length > 0 && !pending;
+
+  const setBlock = (i: number, next: NewsBlock) =>
+    setBlocks((bs) => bs.map((b, j) => (j === i ? next : b)));
+  const removeBlock = (i: number) => setBlocks((bs) => bs.filter((_, j) => j !== i));
+  const moveBlock = (i: number, dir: -1 | 1) =>
+    setBlocks((bs) => {
+      const j = i + dir;
+      if (j < 0 || j >= bs.length) return bs;
+      const copy = bs.slice();
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+      return copy;
+    });
+  const addBlock = (type: NewsBlockType) => setBlocks((bs) => [...bs, blankBlock(type)]);
+
+  const submit = () => {
+    if (!canSubmit) return;
+    if (editing && post) {
+      update.mutate({ tripId, postId: post.id, blocks: cleaned, pinned });
+    } else {
+      create.mutate({ tripId, blocks: cleaned, pinned });
+    }
+  };
+
+  const px = variant === "mobile" ? "px-4" : "px-3";
+
+  return (
+    <>
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <div
+        className={`flex flex-shrink-0 items-center gap-2 ${px} py-2`}
+        style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        <span
+          className="inline-flex items-center gap-2"
+          style={{ fontSize: 15, fontWeight: 700, color: "var(--color-bt-text)" }}
+        >
+          <Pin size={16} style={{ color: "var(--color-bt-accent)" }} />
+          {editing ? "Edit post" : "New post"}
+        </span>
+        <button
+          type="button"
+          onClick={onDone}
+          aria-label="Cancel"
+          className="ml-auto flex h-7 w-7 items-center justify-center rounded-lg transition-colors hover:bg-[var(--color-bt-hover)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* ── Body: block editor stack + add-a-block ─────────────────────── */}
+      <div className={`flex flex-1 flex-col gap-[10px] overflow-y-auto ${px} py-3`}>
+        {blocks.map((b, i) => (
+          <BlockEditor
+            key={i}
+            block={b}
+            index={i}
+            count={blocks.length}
+            onChange={(next) => setBlock(i, next)}
+            onRemove={() => removeBlock(i)}
+            onMove={(dir) => moveBlock(i, dir)}
+          />
+        ))}
+
+        <div>
+          <div
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--color-bt-text-dim)",
+              marginBottom: 8,
+            }}
+          >
+            Add a block{variant === "mobile" ? " · swipe" : ""}
+          </div>
+          <div
+            className={
+              variant === "mobile"
+                ? "flex gap-1.5 overflow-x-auto pb-1"
+                : "flex flex-wrap gap-1.5"
+            }
+          >
+            {ADDABLE.map(({ type, label, icon: Icon }) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => addBlock(type)}
+                className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-[9px] transition-colors hover:bg-[var(--color-bt-accent-faint)]"
+                style={{
+                  padding: "8px 11px",
+                  border: "1px dashed var(--color-bt-border)",
+                  background: "transparent",
+                  color: "var(--color-bt-text)",
+                  fontSize: 12.5,
+                  fontWeight: 500,
+                }}
+              >
+                <Icon size={14} /> {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Footer ─────────────────────────────────────────────────────── */}
+      <div
+        className={`flex flex-shrink-0 items-center gap-2 ${px} py-2.5`}
+        style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        {editing ? (
+          <button
+            type="button"
+            onClick={() => post && del.mutate({ tripId, postId: post.id })}
+            disabled={pending}
+            className="inline-flex items-center gap-1.5 disabled:opacity-40"
+            style={{
+              background: "transparent",
+              border: "none",
+              color: "var(--color-bt-danger)",
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+          >
+            <Trash2 size={14} /> Delete
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setPinned((p) => !p)}
+            aria-pressed={pinned}
+            className="inline-flex items-center gap-1.5"
+            style={{
+              background: "transparent",
+              border: "none",
+              fontSize: 12.5,
+              fontWeight: 600,
+              cursor: "pointer",
+              color: pinned ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+            }}
+          >
+            <Pin size={13} style={{ color: pinned ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }} />
+            {pinned ? "Pinned to top" : "Pin to top"}
+          </button>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onDone}
+            disabled={pending}
+            style={{
+              background: "transparent",
+              border: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-text-dim)",
+              borderRadius: 9,
+              padding: "8px 14px",
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!canSubmit}
+            data-testid="news-composer-submit"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "#0d1f1a",
+              border: "none",
+              borderRadius: 9,
+              padding: "8px 16px",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: canSubmit ? "pointer" : "not-allowed",
+              opacity: canSubmit ? 1 : 0.4,
+            }}
+          >
+            {pending ? "Saving…" : editing ? "Save changes" : "Post"}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Block editor shell ──────────────────────────────────────────────────────
+function BlockEditor({
+  block,
+  index,
+  count,
+  onChange,
+  onRemove,
+  onMove,
+}: {
+  block: NewsBlock;
+  index: number;
+  count: number;
+  onChange: (b: NewsBlock) => void;
+  onRemove: () => void;
+  onMove: (dir: -1 | 1) => void;
+}) {
+  const kindLabel: Record<NewsBlockType, string> = {
+    text: "Text",
+    crew: "@Crew · from the roster",
+    teams: "Teams · from Competition",
+    media: "Media",
+    steps: "Steps",
+    callout: "Callout · panel (amber)",
+  };
+  const kindIcon: Record<NewsBlockType, LucideIcon> = {
+    text: Type,
+    crew: Users,
+    teams: Trophy,
+    media: ImageIcon,
+    steps: ListOrdered,
+    callout: Pin,
+  };
+  const Icon = kindIcon[block.type];
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        border: "1px solid var(--color-bt-border)",
+        borderRadius: 11,
+        background: "var(--color-bt-card-raised)",
+        padding: "10px 12px 12px",
+      }}
+    >
+      <div className="mb-2 flex items-center gap-2">
+        {/* Reorder (up/down — drag handle upgrade is PR3) */}
+        <div className="flex items-center">
+          <button
+            type="button"
+            aria-label="Move up"
+            onClick={() => onMove(-1)}
+            disabled={index === 0}
+            className="flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-[var(--color-bt-hover)] disabled:opacity-30"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            <ChevronUp size={14} />
+          </button>
+          <button
+            type="button"
+            aria-label="Move down"
+            onClick={() => onMove(1)}
+            disabled={index === count - 1}
+            className="flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-[var(--color-bt-hover)] disabled:opacity-30"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            <ChevronDown size={14} />
+          </button>
+        </div>
+        <span
+          className="inline-flex items-center gap-1.5"
+          style={{
+            fontSize: 9.5,
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--color-bt-text-dim)",
+          }}
+        >
+          <Icon size={11} style={{ color: "var(--color-bt-accent)" }} />
+          {kindLabel[block.type]}
+        </span>
+        <button
+          type="button"
+          aria-label="Remove block"
+          onClick={onRemove}
+          className="ml-auto flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)] hover:text-[var(--color-bt-danger)]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <BlockFields block={block} onChange={onChange} />
+    </div>
+  );
+}
+
+// ── Per-type fields ───────────────────────────────────────────────────────
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+  background: "var(--color-bt-card)",
+  border: "1px solid var(--color-bt-border)",
+  borderRadius: 8,
+  padding: "9px 10px",
+  fontSize: 14,
+  color: "var(--color-bt-text)",
+  outline: "none",
+};
+
+function BlockFields({ block, onChange }: { block: NewsBlock; onChange: (b: NewsBlock) => void }) {
+  switch (block.type) {
+    case "text":
+      return (
+        <textarea
+          value={block.text ?? ""}
+          onChange={(e) => onChange({ type: "text", text: e.target.value, dim: block.dim })}
+          rows={3}
+          placeholder="Write something for the crew…"
+          style={{ ...inputStyle, resize: "vertical", lineHeight: 1.5 }}
+        />
+      );
+
+    case "callout":
+      return (
+        <input
+          value={block.text}
+          onChange={(e) => onChange({ type: "callout", text: e.target.value })}
+          placeholder="The one must-not-miss line…"
+          style={inputStyle}
+        />
+      );
+
+    case "media":
+      return (
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-1.5">
+            {(["video", "photo"] as const).map((k) => {
+              const on = block.kind === k;
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => onChange({ ...block, kind: k })}
+                  style={{
+                    padding: "5px 11px",
+                    borderRadius: 8,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    textTransform: "capitalize",
+                    cursor: "pointer",
+                    color: on ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                    background: on ? "var(--color-bt-accent-faint)" : "transparent",
+                    border: `1px solid ${on ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+                  }}
+                >
+                  {k}
+                </button>
+              );
+            })}
+          </div>
+          {block.kind === "video" ? (
+            <>
+              <input
+                value={block.src ?? ""}
+                onChange={(e) => onChange({ ...block, src: e.target.value })}
+                placeholder="Paste a video link (YouTube, Vimeo…)"
+                style={{ ...inputStyle, fontFamily: "var(--font-mono)", fontSize: 13 }}
+              />
+              <input
+                value={block.title ?? ""}
+                onChange={(e) => onChange({ ...block, title: e.target.value })}
+                placeholder="Title (optional)"
+                style={inputStyle}
+              />
+              <input
+                value={block.meta ?? ""}
+                onChange={(e) => onChange({ ...block, meta: e.target.value })}
+                placeholder="Meta — e.g. Charlie Piper · 8 min (optional)"
+                style={inputStyle}
+              />
+            </>
+          ) : (
+            <>
+              <input
+                value={block.ph ?? ""}
+                onChange={(e) => onChange({ ...block, ph: e.target.value })}
+                placeholder="Caption — e.g. 18th green · 2024"
+                style={inputStyle}
+              />
+              <p style={{ margin: 0, fontSize: 11, color: "var(--color-bt-text-dim)" }}>
+                Photo upload is coming soon — for now this shows a captioned placeholder.
+              </p>
+            </>
+          )}
+        </div>
+      );
+
+    case "steps":
+      return <StepsFields block={block} onChange={onChange} />;
+
+    case "crew":
+    case "teams":
+      // Not editable in PR2 — shown so an edited post keeps these blocks.
+      return (
+        <p style={{ margin: 0, fontSize: 12, color: "var(--color-bt-text-dim)", lineHeight: 1.45 }}>
+          {block.type === "crew"
+            ? `${block.people.length} ${block.people.length === 1 ? "person" : "people"} tagged. `
+            : `${block.teams.length} ${block.teams.length === 1 ? "team" : "teams"} from the draw. `}
+          Editing this block type is coming soon — it&rsquo;s kept as-is when you save.
+        </p>
+      );
+
+    default:
+      return null;
+  }
+}
+
+function StepsFields({
+  block,
+  onChange,
+}: {
+  block: Extract<NewsBlock, { type: "steps" }>;
+  onChange: (b: NewsBlock) => void;
+}) {
+  const setStep = (i: number, key: "label" | "body", value: string) =>
+    onChange({
+      type: "steps",
+      steps: block.steps.map((s, j) => (j === i ? { ...s, [key]: value } : s)),
+    });
+  const addStep = () => onChange({ type: "steps", steps: [...block.steps, { label: "", body: "" }] });
+  const removeStep = (i: number) =>
+    onChange({ type: "steps", steps: block.steps.filter((_, j) => j !== i) });
+
+  return (
+    <div className="flex flex-col gap-2">
+      {block.steps.map((s, i) => (
+        <div key={i} className="flex items-center gap-1.5">
+          <span
+            className="flex flex-shrink-0 items-center justify-center"
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: "50%",
+              border: "1px solid var(--color-bt-accent-border)",
+              color: "var(--color-bt-accent)",
+              fontSize: 11,
+              fontWeight: 700,
+            }}
+          >
+            {i + 1}
+          </span>
+          <input
+            value={s.label}
+            onChange={(e) => setStep(i, "label", e.target.value)}
+            placeholder="Label"
+            style={{ ...inputStyle, flex: "0 0 110px", fontSize: 13 }}
+          />
+          <input
+            value={s.body}
+            onChange={(e) => setStep(i, "body", e.target.value)}
+            placeholder="what to do…"
+            style={{ ...inputStyle, fontSize: 13 }}
+          />
+          {block.steps.length > 1 && (
+            <button
+              type="button"
+              aria-label="Remove step"
+              onClick={() => removeStep(i)}
+              className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)] hover:text-[var(--color-bt-danger)]"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <X size={13} />
+            </button>
+          )}
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addStep}
+        className="inline-flex items-center gap-1.5 self-start rounded-[9px] transition-colors hover:bg-[var(--color-bt-hover)]"
+        style={{
+          padding: "6px 10px",
+          border: "1px solid var(--color-bt-border)",
+          background: "transparent",
+          color: "var(--color-bt-text)",
+          fontSize: 12.5,
+          fontWeight: 500,
+        }}
+      >
+        <Plus size={13} /> Add step
+      </button>
+    </div>
+  );
+}

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -166,7 +166,7 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
       </div>
 
       {/* ── Body: block editor stack + add-a-block ─────────────────────── */}
-      <div className={`flex flex-1 flex-col gap-[10px] overflow-y-auto ${px} py-3`}>
+      <div className={`flex min-h-0 flex-1 flex-col gap-[10px] overflow-y-auto ${px} py-3`}>
         {blocks.map((b, i) => (
           <BlockEditor
             key={i}
@@ -341,6 +341,7 @@ function BlockEditor({
 
   return (
     <div
+      className="flex-shrink-0"
       style={{
         position: "relative",
         border: "1px solid var(--color-bt-border)",

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -490,13 +490,19 @@ function BlockFields({ block, onChange }: { block: NewsBlock; onChange: (b: News
           ) : (
             <>
               <input
+                value={block.src ?? ""}
+                onChange={(e) => onChange({ ...block, src: e.target.value })}
+                placeholder="Paste an image or GIF link (…/clip.gif)"
+                style={{ ...inputStyle, fontFamily: "var(--font-mono)", fontSize: 13 }}
+              />
+              <input
                 value={block.ph ?? ""}
                 onChange={(e) => onChange({ ...block, ph: e.target.value })}
-                placeholder="Caption — e.g. 18th green · 2024"
+                placeholder="Caption (optional) — e.g. 18th green · 2024"
                 style={inputStyle}
               />
               <p style={{ margin: 0, fontSize: 11, color: "var(--color-bt-text-dim)" }}>
-                Photo upload is coming soon — for now this shows a captioned placeholder.
+                Paste a direct image or GIF link and it renders here. (File upload is coming soon.)
               </p>
             </>
           )}

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 // ── News block model ──────────────────────────────────────────────────────
 //
 // A News post is an ordered stack of BLOCKS. There are exactly SIX block
@@ -117,3 +119,75 @@ export const NEWS_BLOCK_TYPES: NewsBlockType[] = [
   "steps",
   "callout",
 ];
+
+// ── Validation ──────────────────────────────────────────────────────────────
+//
+// Server-side guard that a post's blocks are exactly the closed six types and
+// well-formed. The DB stores blocks as opaque JSON, so this schema is the only
+// thing enforcing the "closed set" invariant on write. Keep it in lockstep
+// with the NewsBlock union above.
+
+const personSchema = z.object({
+  userId: z.string().nullish(),
+  name: z.string().min(1).max(80),
+  initials: z.string().min(1).max(4),
+  color: z.string().min(1).max(40),
+});
+
+const segmentSchema = z.union([
+  z.string(),
+  z.object({ mention: personSchema }),
+]);
+
+export const newsBlockSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string().max(5000).optional(),
+    segments: z.array(segmentSchema).max(200).optional(),
+    dim: z.boolean().optional(),
+  }),
+  z.object({
+    type: z.literal("crew"),
+    label: z.string().max(60).optional(),
+    people: z.array(personSchema).max(50),
+  }),
+  z.object({
+    type: z.literal("teams"),
+    eventId: z.string().nullish(),
+    teams: z
+      .array(
+        z.object({
+          name: z.string().min(1).max(120),
+          color: z.string().min(1).max(40),
+          players: z.array(z.string().max(80)).max(40),
+        })
+      )
+      .max(20),
+  }),
+  z.object({
+    type: z.literal("media"),
+    kind: z.enum(["video", "photo"]),
+    src: z.string().max(2000).nullish(),
+    title: z.string().max(200).optional(),
+    meta: z.string().max(200).optional(),
+    ph: z.string().max(120).optional(),
+  }),
+  z.object({
+    type: z.literal("steps"),
+    steps: z
+      .array(
+        z.object({
+          label: z.string().max(120),
+          body: z.string().max(2000),
+        })
+      )
+      .max(30),
+  }),
+  z.object({
+    type: z.literal("callout"),
+    text: z.string().min(1).max(500),
+  }),
+]);
+
+/** A post's full block stack. Capped so a single post can't be unbounded. */
+export const newsBlocksSchema = z.array(newsBlockSchema).min(1).max(50);

--- a/src/server/routers/news.test.ts
+++ b/src/server/routers/news.test.ts
@@ -127,4 +127,110 @@ describe("news router", () => {
     const count = await ctx.callerAs("member").news.unreadCount({ tripId });
     expect(count).toBe(1);
   });
+
+  // ── create ─────────────────────────────────────────────────────────────────
+
+  it("create — owner can post; it lands in the feed", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "callout", text: "Heads up" }, { type: "text", text: "Body" }],
+      pinned: true,
+    });
+    expect(post.authorId).toBe(ctx.user.id);
+    expect(post.pinned).toBe(true);
+    expect(post.blocks).toHaveLength(2);
+
+    const posts = await ctx.caller().news.list({ tripId });
+    expect(posts.some((p) => p.id === post.id)).toBe(true);
+  });
+
+  it("create — planner can post", async () => {
+    const post = await ctx.callerAs("planner").news.create({
+      tripId,
+      blocks: [{ type: "text", text: "Planner says hi" }],
+    });
+    expect(post.pinned).toBe(false);
+  });
+
+  it("create — a plain member cannot post", async () => {
+    await expect(
+      ctx.callerAs("member").news.create({
+        tripId,
+        blocks: [{ type: "text", text: "nope" }],
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("create — rejects an unknown block type (closed set enforced)", async () => {
+    await expect(
+      ctx.caller().news.create({
+        tripId,
+        // @ts-expect-error — 'poll' is not one of the six block types
+        blocks: [{ type: "poll", options: ["a", "b"] }],
+      })
+    ).rejects.toThrow();
+  });
+
+  it("create — rejects an empty block stack", async () => {
+    await expect(
+      ctx.caller().news.create({ tripId, blocks: [] })
+    ).rejects.toThrow();
+  });
+
+  // ── update / setPinned / delete ──────────────────────────────────────────
+
+  it("update — owner edits blocks and pin state", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "text", text: "v1" }],
+    });
+    const updated = await ctx.caller().news.update({
+      tripId,
+      postId: post.id,
+      blocks: [{ type: "text", text: "v2 edited" }],
+      pinned: true,
+    });
+    expect(updated.blocks[0]).toMatchObject({ text: "v2 edited" });
+    expect(updated.pinned).toBe(true);
+  });
+
+  it("update — a member cannot edit", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "text", text: "owned by owner" }],
+    });
+    await expect(
+      ctx.callerAs("member").news.update({
+        tripId,
+        postId: post.id,
+        blocks: [{ type: "text", text: "hijack" }],
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("setPinned — toggles pin without resending blocks", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "text", text: "pin me" }],
+    });
+    const res = await ctx.caller().news.setPinned({ tripId, postId: post.id, pinned: true });
+    expect(res.pinned).toBe(true);
+    const posts = await ctx.caller().news.list({ tripId });
+    expect(posts.find((p) => p.id === post.id)?.pinned).toBe(true);
+  });
+
+  it("delete — owner removes a post; member cannot", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "text", text: "temporary" }],
+    });
+    await expect(
+      ctx.callerAs("member").news.delete({ tripId, postId: post.id })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    const res = await ctx.caller().news.delete({ tripId, postId: post.id });
+    expect(res.id).toBe(post.id);
+    const posts = await ctx.caller().news.list({ tripId });
+    expect(posts.some((p) => p.id === post.id)).toBe(false);
+  });
 });

--- a/src/server/routers/news.ts
+++ b/src/server/routers/news.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember } from "../middleware";
-import type { NewsBlock, NewsPost } from "@/lib/news";
+import { requireTripMember, requireTripRole } from "../middleware";
+import { newsBlocksSchema, type NewsBlock, type NewsPost } from "@/lib/news";
 
 // ── news router ────────────────────────────────────────────────────────────
 //
@@ -154,5 +154,139 @@ export const newsRouter = router({
       }
 
       return { lastReadAt: (data as { last_read_at: string }).last_read_at };
+    }),
+
+  // -----------------------------------------------------------------------
+  // create — Owner / Planner posts an announcement. blocks validated against
+  // the closed six-type schema (the DB stores them as opaque JSON, so this is
+  // the only guard on the invariant). INSERT then SELECT separately — the
+  // RLS-RETURNING race pattern (CLAUDE.md #4).
+  // -----------------------------------------------------------------------
+  create: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        blocks: newsBlocksSchema,
+        pinned: z.boolean().default(false),
+      })
+    )
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }): Promise<NewsPost> => {
+      const id = crypto.randomUUID();
+      const { error: insErr } = await ctx.supabase.from("news_posts").insert({
+        id,
+        trip_id: ctx.tripId!,
+        author_id: ctx.user!.id,
+        blocks: input.blocks,
+        pinned: input.pinned,
+      });
+      if (insErr) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to create post: ${insErr.message}`,
+        });
+      }
+
+      const { data, error: selErr } = await ctx.supabase
+        .from("news_posts")
+        .select("id, trip_id, author_id, blocks, pinned, created_at, updated_at")
+        .eq("id", id)
+        .single();
+      if (selErr || !data) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Post created but could not be read back",
+        });
+      }
+      return toPost(data as NewsPostRow);
+    }),
+
+  // -----------------------------------------------------------------------
+  // update — edit a post's blocks (and pin state). Owner/Planner may edit any
+  // post; since only Owner/Planner can author, this also covers "author edits
+  // own". Scoped to (id, trip_id) so a postId can't be edited cross-trip.
+  // -----------------------------------------------------------------------
+  update: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        postId: z.string(),
+        blocks: newsBlocksSchema,
+        pinned: z.boolean().optional(),
+      })
+    )
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }): Promise<NewsPost> => {
+      const patch: Record<string, unknown> = {
+        blocks: input.blocks,
+        updated_at: new Date().toISOString(),
+      };
+      if (input.pinned !== undefined) patch.pinned = input.pinned;
+
+      const { error: updErr } = await ctx.supabase
+        .from("news_posts")
+        .update(patch)
+        .eq("id", input.postId)
+        .eq("trip_id", ctx.tripId!);
+      if (updErr) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to update post: ${updErr.message}`,
+        });
+      }
+
+      const { data, error: selErr } = await ctx.supabase
+        .from("news_posts")
+        .select("id, trip_id, author_id, blocks, pinned, created_at, updated_at")
+        .eq("id", input.postId)
+        .eq("trip_id", ctx.tripId!)
+        .single();
+      if (selErr || !data) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Post not found" });
+      }
+      return toPost(data as NewsPostRow);
+    }),
+
+  // -----------------------------------------------------------------------
+  // setPinned — quick pin/unpin (the ⋯ menu shortcut). Folded separately from
+  // update so the menu toggle doesn't have to round-trip the whole block stack.
+  // -----------------------------------------------------------------------
+  setPinned: authedProcedure
+    .input(z.object({ tripId: z.string(), postId: z.string(), pinned: z.boolean() }))
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }): Promise<{ pinned: boolean }> => {
+      const { error } = await ctx.supabase
+        .from("news_posts")
+        .update({ pinned: input.pinned, updated_at: new Date().toISOString() })
+        .eq("id", input.postId)
+        .eq("trip_id", ctx.tripId!);
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to update pin: ${error.message}`,
+        });
+      }
+      return { pinned: input.pinned };
+    }),
+
+  // -----------------------------------------------------------------------
+  // delete — remove a post. Owner/Planner only (RLS also enforces).
+  // -----------------------------------------------------------------------
+  delete: authedProcedure
+    .input(z.object({ tripId: z.string(), postId: z.string() }))
+    .use(requireTripRole("Planner"))
+    .mutation(async ({ ctx, input }): Promise<{ id: string }> => {
+      const { error } = await ctx.supabase
+        .from("news_posts")
+        .delete()
+        .eq("id", input.postId)
+        .eq("trip_id", ctx.tripId!);
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to delete post: ${error.message}`,
+        });
+      }
+      return { id: input.postId };
     }),
 });


### PR DESCRIPTION
**Phase 2** of News (`design/design_handoff_news`). PR1 shipped the read-only feed + unified rail; this adds authoring. PR3 = `@`-autocomplete, drag-reorder, Teams-from-Competition, and the Text formatting toolbar.

## Server
- **`newsBlocksSchema`** (lib/news.ts) — Zod discriminated union over the closed six block types. The DB stores blocks as opaque JSON, so this is the only thing enforcing the "closed set" invariant on write.
- **`news.create / update / delete / setPinned`** — `requireTripRole("Planner")`, INSERT/SELECT split (CLAUDE.md #4). + Vitest: owner/planner can post, member can't; unknown block type and empty stack rejected; edit/delete permission gating; `setPinned`.

## Composer (`NewsComposer`)
- Block editors for **Text · Media · Steps · Callout**, with up/down reorder, per-block remove, and the "Add a block" row (horizontal swipe scroller on mobile).
- Footer: Pin-to-top toggle (new) / Delete (edit); Post / Save changes. Post disabled until there's real content.
- **Editing a post that already contains crew/teams blocks** (e.g. the seed welcome post) shows them as read-only reference rows and **preserves them on save** — never silently dropped.

## NewsPanel wiring
- "New post" header button + dashed compose row (owner/organizer only).
- Per-post **⋯ menu**: Edit (opens the prefilled composer) / Pin·Unpin / Delete (two-tap confirm).
- Feed ↔ composer swap inside the same rail, desktop + mobile.

## Scope (per the agreed phasing)
- **PR3:** `@Crew` picker, Teams-from-Competition picker, drag-reorder (up/down ships here), Text formatting toolbar + inline `@` mentions.
- Media is video-link-only; photo upload still deferred.

## Verification
- ✅ Verified end-to-end in the live preview: created a pinned post (text + amber callout), exercised the ⋯ menu, deleted to clean up — all against the real DB.
- **No new migration** — reuses PR1's `news_posts` tables (already applied). CI runs the expanded `news.test.ts` against the real DB.
- tsc + lint clean.

## Test plan
- [ ] CI green (`news.test.ts` create/update/delete/setPinned + validation pass)
- [ ] Owner/organizer: New post → add blocks → Post → appears in feed; member sees no compose affordances
- [ ] Edit prefills; Save persists; Delete (two-tap) removes
- [ ] Pin toggle from composer + ⋯ menu; pinned sorts to top with the tag
- [ ] Editing a post with crew/teams blocks keeps them after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)