### PR TITLE
News PR3 — @Crew picker, Teams-from-Competition, drag-reorder

### DIFF
--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -594,6 +594,12 @@ function NewsPostCard({
 }
 
 // ── Post ⋯ menu (Edit / Pin / Delete) ──────────────────────────────────────
+// The dropdown is portaled to <body> with fixed positioning so it escapes the
+// post card's overflow:hidden AND the feed's scroll clipping. It flips above
+// the button when there isn't room below, and closes on outside-click / Esc /
+// scroll / resize (a fixed-position menu would otherwise drift from its anchor).
+const POST_MENU_HEIGHT = 132; // ~3 rows — enough to decide flip direction
+
 function PostMenu({
   pinned,
   onEdit,
@@ -607,86 +613,112 @@ function PostMenu({
 }) {
   const [open, setOpen] = useState(false);
   const [confirming, setConfirming] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [coords, setCoords] = useState<{ top: number; right: number } | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setConfirming(false);
+  }, []);
+
+  const toggle = () => {
+    if (open) return close();
+    const r = btnRef.current?.getBoundingClientRect();
+    if (!r) return;
+    const flipUp = r.bottom + POST_MENU_HEIGHT > window.innerHeight;
+    setCoords({
+      top: flipUp ? r.top - POST_MENU_HEIGHT - 4 : r.bottom + 4,
+      right: window.innerWidth - r.right,
+    });
+    setOpen(true);
+  };
 
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setConfirming(false);
-      }
+      const t = e.target as Node;
+      if (btnRef.current?.contains(t) || menuRef.current?.contains(t)) return;
+      close();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        setConfirming(false);
-      }
+      if (e.key === "Escape") close();
     };
+    // A fixed menu can't follow the anchor — close on scroll/resize instead.
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
     return () => {
       document.removeEventListener("mousedown", onDown);
       document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
     };
-  }, [open]);
+  }, [open, close]);
 
   return (
-    <div ref={ref} className="relative">
+    <>
       <button
+        ref={btnRef}
         type="button"
         aria-label="Manage post"
-        onClick={() => setOpen((o) => !o)}
+        onClick={toggle}
         className="flex h-[26px] w-[26px] items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
         style={{ color: "var(--color-bt-text-dim)" }}
       >
         <MoreHorizontal size={16} />
       </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full z-10 mt-1 overflow-hidden"
-          style={{
-            minWidth: 168,
-            background: "var(--color-bt-card-float)",
-            border: "1px solid var(--color-bt-border)",
-            borderRadius: 10,
-            boxShadow: "var(--shadow-floating)",
-          }}
-        >
-          <MenuItem
-            icon={<Pencil size={14} />}
-            label="Edit"
-            onClick={() => {
-              setOpen(false);
-              onEdit();
+      {open &&
+        coords &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            className="fixed z-[60] overflow-hidden"
+            style={{
+              top: coords.top,
+              right: coords.right,
+              minWidth: 168,
+              background: "var(--color-bt-card-float)",
+              border: "1px solid var(--color-bt-border)",
+              borderRadius: 10,
+              boxShadow: "var(--shadow-floating)",
             }}
-          />
-          <MenuItem
-            icon={<Pin size={14} />}
-            label={pinned ? "Unpin" : "Pin to top"}
-            onClick={() => {
-              setOpen(false);
-              onTogglePin();
-            }}
-          />
-          <MenuItem
-            icon={<Trash2 size={14} />}
-            label={confirming ? "Tap to confirm" : "Delete"}
-            danger
-            onClick={() => {
-              if (!confirming) {
-                setConfirming(true);
-                return;
-              }
-              setOpen(false);
-              setConfirming(false);
-              onDelete();
-            }}
-          />
-        </div>
-      )}
-    </div>
+          >
+            <MenuItem
+              icon={<Pencil size={14} />}
+              label="Edit"
+              onClick={() => {
+                close();
+                onEdit();
+              }}
+            />
+            <MenuItem
+              icon={<Pin size={14} />}
+              label={pinned ? "Unpin" : "Pin to top"}
+              onClick={() => {
+                close();
+                onTogglePin();
+              }}
+            />
+            <MenuItem
+              icon={<Trash2 size={14} />}
+              label={confirming ? "Tap to confirm" : "Delete"}
+              danger
+              onClick={() => {
+                if (!confirming) {
+                  setConfirming(true);
+                  return;
+                }
+                close();
+                onDelete();
+              }}
+            />
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }
 

--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -547,7 +547,7 @@ function NewsPostCard({
       data-testid="news-post"
     >
       <div className="flex items-center gap-[11px]" style={{ padding: "14px 16px 0" }}>
-        <Avatar name={name} avatarIcon={author?.avatarIcon ?? null} sizePx={38} />
+        <Avatar name={name} avatarIcon={author?.avatarIcon ?? null} muted sizePx={38} />
         <div className="min-w-0 flex-1">
           <div style={{ fontSize: 14, fontWeight: 700, color: "var(--color-bt-text)" }}>{name}</div>
           <div style={{ fontSize: 11, fontWeight: 600, marginTop: 1, color: role.color }}>{role.label}</div>

--- a/src/components/NewsPanel.tsx
+++ b/src/components/NewsPanel.tsx
@@ -547,7 +547,7 @@ function NewsPostCard({
       data-testid="news-post"
     >
       <div className="flex items-center gap-[11px]" style={{ padding: "14px 16px 0" }}>
-        <Avatar name={name} avatarIcon={author?.avatarIcon ?? null} muted sizePx={38} />
+        <Avatar name={name} avatarIcon={author?.avatarIcon ?? null} sizePx={38} />
         <div className="min-w-0 flex-1">
           <div style={{ fontSize: 14, fontWeight: 700, color: "var(--color-bt-text)" }}>{name}</div>
           <div style={{ fontSize: 11, fontWeight: 600, marginTop: 1, color: role.color }}>{role.label}</div>

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -72,7 +72,7 @@ function Mention({ person }: { person: NewsPerson }) {
         name={person.name}
         avatarIcon={person.avatarIcon ?? null}
         teamColor={team ?? undefined}
-        muted={!team}
+        muted={!!person.placeholder}
         sizePx={18}
       />
       {person.name}

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -72,6 +72,7 @@ function Mention({ person }: { person: NewsPerson }) {
         name={person.name}
         avatarIcon={person.avatarIcon ?? null}
         teamColor={team ?? undefined}
+        muted={!team}
         sizePx={18}
       />
       {person.name}

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -46,14 +46,21 @@ function imageUrl(url: string | null | undefined): string | null {
 // their plain name — no "@". The chip is tinted by the same color so a team
 // captain's pill reads as their team's.
 function Mention({ person }: { person: NewsPerson }) {
+  // A color only when the member is actually on a competition team — otherwise
+  // the standard avatar + a neutral chip (no fake team color).
+  const team = person.color || null;
   return (
     <span
       className="inline-flex items-center gap-1.5"
       style={{
         padding: "2px 9px 2px 2px",
         borderRadius: 9999,
-        background: `color-mix(in srgb, ${person.color} 12%, var(--color-bt-card-raised))`,
-        border: `1px solid color-mix(in srgb, ${person.color} 40%, var(--color-bt-border))`,
+        background: team
+          ? `color-mix(in srgb, ${team} 12%, var(--color-bt-card-raised))`
+          : "var(--color-bt-card-raised)",
+        border: team
+          ? `1px solid color-mix(in srgb, ${team} 40%, var(--color-bt-border))`
+          : "1px solid var(--color-bt-border)",
         fontSize: 12.5,
         fontWeight: 600,
         color: "var(--color-bt-text)",
@@ -64,7 +71,7 @@ function Mention({ person }: { person: NewsPerson }) {
       <Avatar
         name={person.name}
         avatarIcon={person.avatarIcon ?? null}
-        teamColor={person.color}
+        teamColor={team ?? undefined}
         sizePx={18}
       />
       {person.name}

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Pin, Play } from "lucide-react";
+import { Avatar } from "@/components/Avatar";
 import type {
   NewsBlock,
   NewsPerson,
@@ -39,49 +40,34 @@ function imageUrl(url: string | null | undefined): string | null {
   return null;
 }
 
-// ── @Crew mention pill ──────────────────────────────────────────────────
-function MiniAvatar({ person, size = 17 }: { person: NewsPerson; size?: number }) {
-  return (
-    <span
-      aria-hidden="true"
-      style={{
-        width: size,
-        height: size,
-        borderRadius: "50%",
-        background: person.color,
-        color: "#fff",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        fontSize: Math.round(size * 0.5),
-        fontWeight: 700,
-        flexShrink: 0,
-      }}
-    >
-      {person.initials}
-    </span>
-  );
-}
-
+// ── @Crew person chip ─────────────────────────────────────────────────────
+// Renders like the app's member chips (TeamMemberChip): the person's real
+// Avatar (their Tabler icon, or initials) backed by their team color, plus
+// their plain name — no "@". The chip is tinted by the same color so a team
+// captain's pill reads as their team's.
 function Mention({ person }: { person: NewsPerson }) {
   return (
     <span
+      className="inline-flex items-center gap-1.5"
       style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 5,
-        padding: "1px 8px 1px 2px",
+        padding: "2px 9px 2px 2px",
         borderRadius: 9999,
-        background: "var(--color-bt-accent-faint)",
-        border: "1px solid var(--color-bt-accent-border)",
-        fontWeight: 600,
-        color: "var(--color-bt-accent)",
+        background: `color-mix(in srgb, ${person.color} 12%, var(--color-bt-card-raised))`,
+        border: `1px solid color-mix(in srgb, ${person.color} 40%, var(--color-bt-border))`,
         fontSize: 12.5,
+        fontWeight: 600,
+        color: "var(--color-bt-text)",
         lineHeight: 1,
-        verticalAlign: "-3px",
+        verticalAlign: "-5px",
       }}
     >
-      <MiniAvatar person={person} />@{person.name}
+      <Avatar
+        name={person.name}
+        avatarIcon={person.avatarIcon ?? null}
+        teamColor={person.color}
+        sizePx={18}
+      />
+      {person.name}
     </span>
   );
 }

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -741,7 +741,7 @@ function CrewFields({
                 color: "var(--color-bt-text)",
               }}
             >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} sizePx={16} />
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!p.color} sizePx={16} />
               {p.name}
               <button
                 type="button"
@@ -776,7 +776,7 @@ function CrewFields({
               className="flex items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{ background: "transparent", border: "none", cursor: "pointer" }}
             >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} sizePx={20} />
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!p.color} sizePx={20} />
               <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
             </button>
           ))}

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -18,6 +18,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { Avatar } from "@/components/Avatar";
 import type { NewsBlock, NewsBlockType, NewsPerson, NewsPost } from "@/lib/news";
 
 // ── NewsComposer ────────────────────────────────────────────────────────────
@@ -727,39 +728,23 @@ function CrewFields({
               key={i}
               className="inline-flex items-center gap-1.5"
               style={{
-                padding: "3px 6px 3px 3px",
+                padding: "2px 5px 2px 2px",
                 borderRadius: 9999,
-                background: "var(--color-bt-accent-faint)",
-                border: "1px solid var(--color-bt-accent-border)",
+                background: `color-mix(in srgb, ${p.color} 12%, var(--color-bt-card-raised))`,
+                border: `1px solid color-mix(in srgb, ${p.color} 40%, var(--color-bt-border))`,
                 fontSize: 12,
                 fontWeight: 600,
-                color: "var(--color-bt-accent)",
+                color: "var(--color-bt-text)",
               }}
             >
-              <span
-                aria-hidden="true"
-                style={{
-                  width: 16,
-                  height: 16,
-                  borderRadius: "50%",
-                  background: p.color,
-                  color: "#fff",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontSize: 8,
-                  fontWeight: 700,
-                }}
-              >
-                {p.initials}
-              </span>
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color} sizePx={16} />
               {p.name}
               <button
                 type="button"
                 aria-label={`Remove ${p.name}`}
                 onClick={() => remove(i)}
                 className="flex h-4 w-4 items-center justify-center rounded-full hover:bg-[var(--color-bt-hover)]"
-                style={{ color: "var(--color-bt-accent)" }}
+                style={{ color: "var(--color-bt-text-dim)" }}
               >
                 <X size={11} />
               </button>
@@ -787,24 +772,7 @@ function CrewFields({
               className="flex items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{ background: "transparent", border: "none", cursor: "pointer" }}
             >
-              <span
-                aria-hidden="true"
-                style={{
-                  width: 18,
-                  height: 18,
-                  borderRadius: "50%",
-                  background: p.color,
-                  color: "#fff",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontSize: 9,
-                  fontWeight: 700,
-                  flexShrink: 0,
-                }}
-              >
-                {p.initials}
-              </span>
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color} sizePx={20} />
               <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
             </button>
           ))}

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -741,7 +741,7 @@ function CrewFields({
                 color: "var(--color-bt-text)",
               }}
             >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!p.color} sizePx={16} />
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!!p.placeholder} sizePx={16} />
               {p.name}
               <button
                 type="button"
@@ -776,7 +776,7 @@ function CrewFields({
               className="flex items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{ background: "transparent", border: "none", cursor: "pointer" }}
             >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!p.color} sizePx={20} />
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!!p.placeholder} sizePx={20} />
               <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
             </button>
           ))}

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -697,7 +697,11 @@ function CrewFields({
   const q = query.trim().toLowerCase();
   const matches = roster
     .filter((p) => !chosen.has(p.userId ?? ""))
-    .filter((p) => (q ? p.name.toLowerCase().includes(q) : true))
+    // Match on word starts, not any substring — "t" matches "Taj"/"Tyler L",
+    // not the t inside "Grether".
+    .filter((p) =>
+      q ? p.name.toLowerCase().split(/\s+/).some((w) => w.startsWith(q)) : true
+    )
     .slice(0, 6);
 
   const add = (p: NewsPerson) => {

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   X,
   Plus,
@@ -8,15 +8,17 @@ import {
   Pin,
   ChevronUp,
   ChevronDown,
+  GripVertical,
   Type,
   Image as ImageIcon,
   ListOrdered,
   Users,
   Trophy,
+  RefreshCw,
   type LucideIcon,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import type { NewsBlock, NewsBlockType, NewsPost } from "@/lib/news";
+import type { NewsBlock, NewsBlockType, NewsPerson, NewsPost } from "@/lib/news";
 
 // ── NewsComposer ────────────────────────────────────────────────────────────
 //
@@ -25,16 +27,16 @@ import type { NewsBlock, NewsBlockType, NewsPost } from "@/lib/news";
 // footer — placed directly in the rail's flex-col so the header/footer pin and
 // the body scrolls.
 //
-// PR2 scope: Text · Media · Steps · Callout editors, up/down reorder, remove,
-// pin toggle, create/edit/delete. The @Crew picker, Teams-from-Competition
-// picker, drag-reorder, and the Text formatting toolbar land in PR3. When
-// EDITING a post that already contains crew/teams blocks (e.g. the seed
-// welcome post), those render as read-only reference rows here and are
-// preserved on save — never silently dropped.
+// The six block editors, drag-to-reorder, pin, create/edit/delete. @Crew pulls
+// from the trip roster; Teams pulls the draw from Competition. The inline-@
+// mentions inside Text paragraphs and the bold/italic/list/link toolbar are a
+// later pass (they need a rich-text editor); a plain textarea backs Text here.
 
-// Block types the composer can ADD in PR2.
+// Block types the composer can ADD, in catalog order.
 const ADDABLE: { type: NewsBlockType; label: string; icon: LucideIcon }[] = [
   { type: "text", label: "Text", icon: Type },
+  { type: "crew", label: "@Crew", icon: Users },
+  { type: "teams", label: "Teams", icon: Trophy },
   { type: "media", label: "Media", icon: ImageIcon },
   { type: "steps", label: "Steps", icon: ListOrdered },
   { type: "callout", label: "Callout", icon: Pin },
@@ -44,6 +46,10 @@ function blankBlock(type: NewsBlockType): NewsBlock {
   switch (type) {
     case "text":
       return { type: "text", text: "" };
+    case "crew":
+      return { type: "crew", label: "", people: [] };
+    case "teams":
+      return { type: "teams", teams: [] };
     case "media":
       return { type: "media", kind: "video", src: "", title: "", meta: "" };
     case "steps":
@@ -51,7 +57,6 @@ function blankBlock(type: NewsBlockType): NewsBlock {
     case "callout":
       return { type: "callout", text: "" };
     default:
-      // crew/teams aren't addable in PR2; fall back to text.
       return { type: "text", text: "" };
   }
 }
@@ -77,8 +82,11 @@ function cleanBlocks(blocks: NewsBlock[]): NewsBlock[] {
       if (b.kind === "photo" || (b.src ?? "").trim().length > 0) {
         out.push({ ...b, src: b.src?.trim() });
       }
+    } else if (b.type === "crew") {
+      if (b.people.length > 0) out.push(b);
+    } else if (b.type === "teams") {
+      if (b.teams.length > 0) out.push(b);
     } else {
-      // crew / teams — preserved untouched.
       out.push(b);
     }
   }
@@ -129,6 +137,18 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
     });
   const addBlock = (type: NewsBlockType) => setBlocks((bs) => [...bs, blankBlock(type)]);
 
+  // Drag-to-reorder (desktop, via the grip). Up/down arrows stay as the
+  // touch/keyboard fallback. dragFrom holds the picked-up block's index.
+  const dragFrom = useRef<number | null>(null);
+  const reorder = (from: number, to: number) =>
+    setBlocks((bs) => {
+      if (from === to || from < 0 || to < 0 || from >= bs.length || to >= bs.length) return bs;
+      const copy = bs.slice();
+      const [moved] = copy.splice(from, 1);
+      copy.splice(to, 0, moved);
+      return copy;
+    });
+
   const submit = () => {
     if (!canSubmit) return;
     if (editing && post) {
@@ -170,12 +190,20 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
         {blocks.map((b, i) => (
           <BlockEditor
             key={i}
+            tripId={tripId}
             block={b}
             index={i}
             count={blocks.length}
             onChange={(next) => setBlock(i, next)}
             onRemove={() => removeBlock(i)}
             onMove={(dir) => moveBlock(i, dir)}
+            onDragStartBlock={() => {
+              dragFrom.current = i;
+            }}
+            onDropBlock={() => {
+              if (dragFrom.current !== null) reorder(dragFrom.current, i);
+              dragFrom.current = null;
+            }}
           />
         ))}
 
@@ -307,20 +335,31 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
 
 // ── Block editor shell ──────────────────────────────────────────────────────
 function BlockEditor({
+  tripId,
   block,
   index,
   count,
   onChange,
   onRemove,
   onMove,
+  onDragStartBlock,
+  onDropBlock,
 }: {
+  tripId: string;
   block: NewsBlock;
   index: number;
   count: number;
   onChange: (b: NewsBlock) => void;
   onRemove: () => void;
   onMove: (dir: -1 | 1) => void;
+  onDragStartBlock: () => void;
+  onDropBlock: () => void;
 }) {
+  // Drag is armed only while the grip is held, so dragging the block never
+  // hijacks text selection inside its inputs.
+  const [armed, setArmed] = useState(false);
+  const [dropTarget, setDropTarget] = useState(false);
+
   const kindLabel: Record<NewsBlockType, string> = {
     text: "Text",
     crew: "@Crew · from the roster",
@@ -342,16 +381,46 @@ function BlockEditor({
   return (
     <div
       className="flex-shrink-0"
+      draggable={armed}
+      onDragStart={(e) => {
+        e.dataTransfer.effectAllowed = "move";
+        onDragStartBlock();
+      }}
+      onDragEnd={() => {
+        setArmed(false);
+        setDropTarget(false);
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDropTarget(true);
+      }}
+      onDragLeave={() => setDropTarget(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDropTarget(false);
+        onDropBlock();
+      }}
       style={{
         position: "relative",
-        border: "1px solid var(--color-bt-border)",
+        border: `1px solid ${dropTarget ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
         borderRadius: 11,
         background: "var(--color-bt-card-raised)",
         padding: "10px 12px 12px",
       }}
     >
-      <div className="mb-2 flex items-center gap-2">
-        {/* Reorder (up/down — drag handle upgrade is PR3) */}
+      <div className="mb-2 flex items-center gap-1.5">
+        {/* Drag handle — arms HTML5 drag on press (desktop). */}
+        <span
+          aria-hidden="true"
+          onMouseDown={() => setArmed(true)}
+          onMouseUp={() => setArmed(false)}
+          title="Drag to reorder"
+          className="flex h-5 w-4 cursor-grab items-center justify-center active:cursor-grabbing"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <GripVertical size={14} />
+        </span>
+        {/* Up/down — touch/keyboard fallback for reordering. */}
         <div className="flex items-center">
           <button
             type="button"
@@ -398,7 +467,7 @@ function BlockEditor({
         </button>
       </div>
 
-      <BlockFields block={block} onChange={onChange} />
+      <BlockFields tripId={tripId} block={block} onChange={onChange} />
     </div>
   );
 }
@@ -416,7 +485,15 @@ const inputStyle: React.CSSProperties = {
   outline: "none",
 };
 
-function BlockFields({ block, onChange }: { block: NewsBlock; onChange: (b: NewsBlock) => void }) {
+function BlockFields({
+  tripId,
+  block,
+  onChange,
+}: {
+  tripId: string;
+  block: NewsBlock;
+  onChange: (b: NewsBlock) => void;
+}) {
   switch (block.type) {
     case "text":
       return (
@@ -514,16 +591,10 @@ function BlockFields({ block, onChange }: { block: NewsBlock; onChange: (b: News
       return <StepsFields block={block} onChange={onChange} />;
 
     case "crew":
+      return <CrewFields tripId={tripId} block={block} onChange={onChange} />;
+
     case "teams":
-      // Not editable in PR2 — shown so an edited post keeps these blocks.
-      return (
-        <p style={{ margin: 0, fontSize: 12, color: "var(--color-bt-text-dim)", lineHeight: 1.45 }}>
-          {block.type === "crew"
-            ? `${block.people.length} ${block.people.length === 1 ? "person" : "people"} tagged. `
-            : `${block.teams.length} ${block.teams.length === 1 ? "team" : "teams"} from the draw. `}
-          Editing this block type is coming soon — it&rsquo;s kept as-is when you save.
-        </p>
-      );
+      return <TeamsFields tripId={tripId} block={block} onChange={onChange} />;
 
     default:
       return null;
@@ -604,6 +675,214 @@ function StepsFields({
       >
         <Plus size={13} /> Add step
       </button>
+    </div>
+  );
+}
+
+// ── @Crew editor ────────────────────────────────────────────────────────────
+// Optional label ("Captains") + a searchable roster picker → people pills.
+function CrewFields({
+  tripId,
+  block,
+  onChange,
+}: {
+  tripId: string;
+  block: Extract<NewsBlock, { type: "crew" }>;
+  onChange: (b: NewsBlock) => void;
+}) {
+  const { data: roster = [] } = trpc.news.roster.useQuery({ tripId });
+  const [query, setQuery] = useState("");
+
+  const chosen = new Set(block.people.map((p) => p.userId).filter(Boolean) as string[]);
+  const q = query.trim().toLowerCase();
+  const matches = roster
+    .filter((p) => !chosen.has(p.userId ?? ""))
+    .filter((p) => (q ? p.name.toLowerCase().includes(q) : true))
+    .slice(0, 6);
+
+  const add = (p: NewsPerson) => {
+    onChange({ ...block, people: [...block.people, p] });
+    setQuery("");
+  };
+  const remove = (i: number) =>
+    onChange({ ...block, people: block.people.filter((_, j) => j !== i) });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        value={block.label ?? ""}
+        onChange={(e) => onChange({ ...block, label: e.target.value })}
+        placeholder="Label (optional) — e.g. Captains, Pairing"
+        style={inputStyle}
+      />
+
+      {block.people.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {block.people.map((p, i) => (
+            <span
+              key={i}
+              className="inline-flex items-center gap-1.5"
+              style={{
+                padding: "3px 6px 3px 3px",
+                borderRadius: 9999,
+                background: "var(--color-bt-accent-faint)",
+                border: "1px solid var(--color-bt-accent-border)",
+                fontSize: 12,
+                fontWeight: 600,
+                color: "var(--color-bt-accent)",
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 16,
+                  height: 16,
+                  borderRadius: "50%",
+                  background: p.color,
+                  color: "#fff",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 8,
+                  fontWeight: 700,
+                }}
+              >
+                {p.initials}
+              </span>
+              {p.name}
+              <button
+                type="button"
+                aria-label={`Remove ${p.name}`}
+                onClick={() => remove(i)}
+                className="flex h-4 w-4 items-center justify-center rounded-full hover:bg-[var(--color-bt-hover)]"
+                style={{ color: "var(--color-bt-accent)" }}
+              >
+                <X size={11} />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Add crew — type a name…"
+        style={inputStyle}
+      />
+      {query && matches.length > 0 && (
+        <div
+          className="flex flex-col overflow-hidden"
+          style={{ border: "1px solid var(--color-bt-border)", borderRadius: 8, background: "var(--color-bt-card)" }}
+        >
+          {matches.map((p) => (
+            <button
+              key={p.userId}
+              type="button"
+              onClick={() => add(p)}
+              className="flex items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{ background: "transparent", border: "none", cursor: "pointer" }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 18,
+                  height: 18,
+                  borderRadius: "50%",
+                  background: p.color,
+                  color: "#fff",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 9,
+                  fontWeight: 700,
+                  flexShrink: 0,
+                }}
+              >
+                {p.initials}
+              </span>
+              <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      {query && matches.length === 0 && (
+        <p style={{ margin: 0, fontSize: 11, color: "var(--color-bt-text-dim)" }}>
+          No one left to add by that name.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Teams editor (pulled from Competition) ──────────────────────────────────
+function TeamsFields({
+  tripId,
+  block,
+  onChange,
+}: {
+  tripId: string;
+  block: Extract<NewsBlock, { type: "teams" }>;
+  onChange: (b: NewsBlock) => void;
+}) {
+  const { data: draw, isLoading } = trpc.news.competitionDraw.useQuery({ tripId });
+
+  // Auto-fill once when a freshly-added (empty) Teams block first sees a draw.
+  const filledRef = useRef(false);
+  useEffect(() => {
+    if (filledRef.current) return;
+    if (block.teams.length === 0 && draw && draw.teams.length > 0) {
+      filledRef.current = true;
+      onChange({ ...block, teams: draw.teams });
+    }
+  }, [draw, block, onChange]);
+
+  if (isLoading) {
+    return <p style={{ margin: 0, fontSize: 12, color: "var(--color-bt-text-dim)" }}>Loading the draw…</p>;
+  }
+
+  if (!draw || draw.teams.length === 0) {
+    return (
+      <p style={{ margin: 0, fontSize: 12, color: "var(--color-bt-text-dim)", lineHeight: 1.45 }}>
+        No draw yet — set up teams in the Competition tab, then come back and add this block.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="flex items-center gap-2"
+        style={{
+          padding: "8px 10px",
+          borderRadius: 8,
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        <Trophy size={15} style={{ color: "var(--color-bt-accent)" }} />
+        <span style={{ fontSize: 12.5, color: "var(--color-bt-text)" }}>
+          The draw · {block.teams.length || draw.teams.length} teams
+        </span>
+        <button
+          type="button"
+          onClick={() => onChange({ ...block, teams: draw.teams })}
+          className="ml-auto inline-flex items-center gap-1.5"
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "var(--color-bt-accent)",
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          <RefreshCw size={12} /> Refresh
+        </button>
+      </div>
+      <p style={{ margin: 0, fontSize: 11, color: "var(--color-bt-text-dim)" }}>
+        Rosters stay in sync with Competition — you don&rsquo;t retype them.
+      </p>
     </div>
   );
 }

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -730,14 +730,18 @@ function CrewFields({
               style={{
                 padding: "2px 5px 2px 2px",
                 borderRadius: 9999,
-                background: `color-mix(in srgb, ${p.color} 12%, var(--color-bt-card-raised))`,
-                border: `1px solid color-mix(in srgb, ${p.color} 40%, var(--color-bt-border))`,
+                background: p.color
+                  ? `color-mix(in srgb, ${p.color} 12%, var(--color-bt-card-raised))`
+                  : "var(--color-bt-card-raised)",
+                border: p.color
+                  ? `1px solid color-mix(in srgb, ${p.color} 40%, var(--color-bt-border))`
+                  : "1px solid var(--color-bt-border)",
                 fontSize: 12,
                 fontWeight: 600,
                 color: "var(--color-bt-text)",
               }}
             >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color} sizePx={16} />
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} sizePx={16} />
               {p.name}
               <button
                 type="button"
@@ -772,7 +776,7 @@ function CrewFields({
               className="flex items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
               style={{ background: "transparent", border: "none", cursor: "pointer" }}
             >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color} sizePx={20} />
+              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} sizePx={20} />
               <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
             </button>
           ))}

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -25,6 +25,9 @@ export interface NewsPerson {
   /** The member's chosen Tabler avatar icon id, so the pill shows the same
    *  avatar as everywhere else in the app. Null/absent → initials fallback. */
   avatarIcon?: string | null;
+  /** True when this person is a guest / not yet a full member — drives the
+   *  muted (gray) avatar treatment, reserving teal for real members. */
+  placeholder?: boolean;
 }
 
 /** A team card in the draw — synced from the Competition feature. */
@@ -138,6 +141,7 @@ const personSchema = z.object({
   initials: z.string().min(1).max(4),
   color: z.string().min(1).max(40).nullish(),
   avatarIcon: z.string().max(50).nullish(),
+  placeholder: z.boolean().optional(),
 });
 
 const segmentSchema = z.union([

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -18,9 +18,10 @@ export interface NewsPerson {
   userId?: string | null;
   name: string;
   initials: string;
-  /** Team / identity color, e.g. "#3b82f6" or a "var(--color-bt-*)" token.
-   *  Tints the chip and (when on a team) backs the avatar. */
-  color: string;
+  /** The member's competition TEAM color (hex), or null when they aren't on a
+   *  team. Only a real team assignment produces a color — there's no palette
+   *  fallback, so a member with no team renders the standard app avatar. */
+  color?: string | null;
   /** The member's chosen Tabler avatar icon id, so the pill shows the same
    *  avatar as everywhere else in the app. Null/absent → initials fallback. */
   avatarIcon?: string | null;
@@ -135,7 +136,7 @@ const personSchema = z.object({
   userId: z.string().nullish(),
   name: z.string().min(1).max(80),
   initials: z.string().min(1).max(4),
-  color: z.string().min(1).max(40),
+  color: z.string().min(1).max(40).nullish(),
   avatarIcon: z.string().max(50).nullish(),
 });
 

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -18,8 +18,12 @@ export interface NewsPerson {
   userId?: string | null;
   name: string;
   initials: string;
-  /** Team / identity color, e.g. "#3b82f6" or a "var(--color-bt-*)" token. */
+  /** Team / identity color, e.g. "#3b82f6" or a "var(--color-bt-*)" token.
+   *  Tints the chip and (when on a team) backs the avatar. */
   color: string;
+  /** The member's chosen Tabler avatar icon id, so the pill shows the same
+   *  avatar as everywhere else in the app. Null/absent → initials fallback. */
+  avatarIcon?: string | null;
 }
 
 /** A team card in the draw — synced from the Competition feature. */
@@ -132,6 +136,7 @@ const personSchema = z.object({
   name: z.string().min(1).max(80),
   initials: z.string().min(1).max(4),
   color: z.string().min(1).max(40),
+  avatarIcon: z.string().max(50).nullish(),
 });
 
 const segmentSchema = z.union([

--- a/src/server/routers/news.test.ts
+++ b/src/server/routers/news.test.ts
@@ -233,4 +233,67 @@ describe("news router", () => {
     const posts = await ctx.caller().news.list({ tripId });
     expect(posts.some((p) => p.id === post.id)).toBe(false);
   });
+
+  // ── roster + competitionDraw (PR3) ────────────────────────────────────────
+  // Own trip + competition so the post tests above aren't affected.
+  describe("roster + competitionDraw", () => {
+    let drawTrip: string;
+    let compId: string;
+    let teamA: string;
+    let teamB: string;
+
+    beforeAll(async () => {
+      drawTrip = await ctx.createTrip("Draw Test");
+      await ctx.addTripMember(drawTrip, "planner", "Planner");
+      await ctx.addTripMember(drawTrip, "member", "Member");
+      compId = await ctx.createCompetition(drawTrip);
+      teamA = await ctx.createTeam(compId, "The Usual Suspects", { color: "#3b82f6" });
+      teamB = await ctx.createTeam(compId, "Buddy's Last Stand", { color: "#2dd4bf" });
+      // Owner → A, planner → B; member stays unassigned.
+      await ctx.admin.from("team_assignments").insert([
+        { competition_id: compId, user_id: ctx.user.id, team_id: teamA },
+        { competition_id: compId, user_id: ctx.getUser("planner").id, team_id: teamB },
+      ]);
+    });
+
+    it("roster — returns every member with name + initials + color", async () => {
+      const people = await ctx.caller().news.roster({ tripId: drawTrip });
+      expect(people.length).toBe(3);
+      for (const p of people) {
+        expect(p.userId).toBeTruthy();
+        expect(p.name).toBeTruthy();
+        expect(p.initials).toMatch(/^[A-Z?]{1,2}$/);
+        expect(p.color).toBeTruthy();
+      }
+    });
+
+    it("roster — assigned members take their team color", async () => {
+      const people = await ctx.caller().news.roster({ tripId: drawTrip });
+      const owner = people.find((p) => p.userId === ctx.user.id);
+      const planner = people.find((p) => p.userId === ctx.getUser("planner").id);
+      expect(owner?.color).toBe("#3b82f6");
+      expect(planner?.color).toBe("#2dd4bf");
+    });
+
+    it("competitionDraw — returns the teams with their rosters", async () => {
+      const draw = await ctx.caller().news.competitionDraw({ tripId: drawTrip });
+      expect(draw).not.toBeNull();
+      expect(draw!.teams.length).toBe(2);
+      const a = draw!.teams.find((t) => t.name === "The Usual Suspects");
+      expect(a?.color).toBe("#3b82f6");
+      expect(a?.players.length).toBe(1);
+    });
+
+    it("competitionDraw — null when the trip has no competition", async () => {
+      const plain = await ctx.createTrip("No Comp Trip");
+      const draw = await ctx.caller().news.competitionDraw({ tripId: plain });
+      expect(draw).toBeNull();
+    });
+
+    it("roster — a non-member is forbidden", async () => {
+      await expect(
+        ctx.callerAs("outsider").news.roster({ tripId: drawTrip })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
 });

--- a/src/server/routers/news.test.ts
+++ b/src/server/routers/news.test.ts
@@ -256,23 +256,25 @@ describe("news router", () => {
       ]);
     });
 
-    it("roster — returns every member with name + initials + color", async () => {
+    it("roster — returns every member with name + initials", async () => {
       const people = await ctx.caller().news.roster({ tripId: drawTrip });
       expect(people.length).toBe(3);
       for (const p of people) {
         expect(p.userId).toBeTruthy();
         expect(p.name).toBeTruthy();
         expect(p.initials).toMatch(/^[A-Z?]{1,2}$/);
-        expect(p.color).toBeTruthy();
       }
     });
 
-    it("roster — assigned members take their team color", async () => {
+    it("roster — assigned members take their team color; unassigned have none", async () => {
       const people = await ctx.caller().news.roster({ tripId: drawTrip });
       const owner = people.find((p) => p.userId === ctx.user.id);
       const planner = people.find((p) => p.userId === ctx.getUser("planner").id);
+      const member = people.find((p) => p.userId === ctx.getUser("member").id);
       expect(owner?.color).toBe("#3b82f6");
       expect(planner?.color).toBe("#2dd4bf");
+      // No team assignment → no color (no palette fallback).
+      expect(member?.color ?? null).toBeNull();
     });
 
     it("competitionDraw — returns the teams with their rosters", async () => {

--- a/src/server/routers/news.ts
+++ b/src/server/routers/news.ts
@@ -2,7 +2,58 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
-import { newsBlocksSchema, type NewsBlock, type NewsPost } from "@/lib/news";
+import { listMembers } from "./tripMembers";
+import { listTeams } from "./teams";
+import { listTeamAssignments } from "./teamAssignments";
+import {
+  newsBlocksSchema,
+  type NewsBlock,
+  type NewsPerson,
+  type NewsPost,
+  type NewsTeam,
+} from "@/lib/news";
+
+// Mention/crew pill palette — used when a member isn't on a competition team.
+// Picked deterministically by user id so a person's color is stable.
+const MENTION_PALETTE = [
+  "#3b82f6", // blue
+  "#2dd4bf", // teal
+  "#a855f7", // purple
+  "#f97316", // orange
+  "#22c55e", // green
+  "#ec4899", // pink
+  "#eab308", // yellow
+  "#06b6d4", // cyan
+];
+
+function paletteColor(userId: string): string {
+  let h = 0;
+  for (let i = 0; i < userId.length; i++) h = (h + userId.charCodeAt(i)) % MENTION_PALETTE.length;
+  return MENTION_PALETTE[h];
+}
+
+/** "Zach Grether" → "ZG"; "Llama" → "L". Server-side twin of Avatar.initialsFor. */
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  return parts.map((w) => w[0] ?? "").join("").toUpperCase().slice(0, 2);
+}
+
+// Load the trip's single competition (MVP one-per-trip) — null if none.
+async function getCompetitionId(
+  ctx: { supabase: { from: (t: string) => unknown } },
+  tripId: string,
+): Promise<string | null> {
+  const { data } = await (ctx.supabase
+    .from("competitions") as unknown as {
+      select: (s: string) => { eq: (c: string, v: string) => { limit: (n: number) => { maybeSingle: () => Promise<{ data: { id: string } | null }> } } };
+    })
+    .select("id")
+    .eq("trip_id", tripId)
+    .limit(1)
+    .maybeSingle();
+  return data?.id ?? null;
+}
 
 // ── news router ────────────────────────────────────────────────────────────
 //
@@ -154,6 +205,79 @@ export const newsRouter = router({
       }
 
       return { lastReadAt: (data as { last_read_at: string }).last_read_at };
+    }),
+
+  // -----------------------------------------------------------------------
+  // roster — people for the @Crew block picker. Each carries the denormalized
+  // name/initials/color a mention pill needs, so a saved post renders without
+  // a roster round-trip. Color = the member's competition team color when
+  // assigned, else a stable per-user palette color.
+  // -----------------------------------------------------------------------
+  roster: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx }): Promise<NewsPerson[]> => {
+      const members = await listMembers(ctx, ctx.tripId!);
+      const compId = await getCompetitionId(ctx, ctx.tripId!);
+
+      const teamColor = new Map<string, string>();
+      if (compId) {
+        const [teams, assignments] = await Promise.all([
+          listTeams(ctx, compId),
+          listTeamAssignments(ctx, compId),
+        ]);
+        const colorByTeam = new Map(
+          (teams as { id: string; color: string | null }[]).map((t) => [t.id, t.color]),
+        );
+        for (const a of assignments as { user_id: string; team_id: string }[]) {
+          const c = colorByTeam.get(a.team_id);
+          if (c) teamColor.set(a.user_id, c);
+        }
+      }
+
+      return members
+        .filter((m) => !!m.user_id)
+        .map((m) => ({
+          userId: m.user_id as string,
+          name: m.displayName,
+          initials: initialsOf(m.displayName),
+          color: teamColor.get(m.user_id as string) ?? paletteColor(m.user_id as string),
+        }));
+    }),
+
+  // -----------------------------------------------------------------------
+  // competitionDraw — the team draw for the Teams block, ready to embed.
+  // null when there's no competition or no teams yet.
+  // -----------------------------------------------------------------------
+  competitionDraw: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx }): Promise<{ teams: NewsTeam[] } | null> => {
+      const compId = await getCompetitionId(ctx, ctx.tripId!);
+      if (!compId) return null;
+
+      const [teams, assignments, members] = await Promise.all([
+        listTeams(ctx, compId),
+        listTeamAssignments(ctx, compId),
+        listMembers(ctx, ctx.tripId!),
+      ]);
+      if ((teams as unknown[]).length === 0) return null;
+
+      const nameByUser = new Map(members.map((m) => [m.user_id as string, m.displayName]));
+      const playersByTeam = new Map<string, string[]>();
+      for (const a of assignments as { user_id: string; team_id: string }[]) {
+        const list = playersByTeam.get(a.team_id) ?? [];
+        list.push(nameByUser.get(a.user_id) ?? "Unknown");
+        playersByTeam.set(a.team_id, list);
+      }
+
+      return {
+        teams: (teams as { id: string; name: string; color: string | null }[]).map((t) => ({
+          name: t.name,
+          color: t.color ?? "var(--color-bt-accent)",
+          players: playersByTeam.get(t.id) ?? [],
+        })),
+      };
     }),
 
   // -----------------------------------------------------------------------

--- a/src/server/routers/news.ts
+++ b/src/server/routers/news.ts
@@ -13,25 +13,6 @@ import {
   type NewsTeam,
 } from "@/lib/news";
 
-// Mention/crew pill palette — used when a member isn't on a competition team.
-// Picked deterministically by user id so a person's color is stable.
-const MENTION_PALETTE = [
-  "#3b82f6", // blue
-  "#2dd4bf", // teal
-  "#a855f7", // purple
-  "#f97316", // orange
-  "#22c55e", // green
-  "#ec4899", // pink
-  "#eab308", // yellow
-  "#06b6d4", // cyan
-];
-
-function paletteColor(userId: string): string {
-  let h = 0;
-  for (let i = 0; i < userId.length; i++) h = (h + userId.charCodeAt(i)) % MENTION_PALETTE.length;
-  return MENTION_PALETTE[h];
-}
-
 /** "Zach Grether" → "ZG"; "Llama" → "L". Server-side twin of Avatar.initialsFor. */
 function initialsOf(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -241,7 +222,9 @@ export const newsRouter = router({
           userId: m.user_id as string,
           name: m.displayName,
           initials: initialsOf(m.displayName),
-          color: teamColor.get(m.user_id as string) ?? paletteColor(m.user_id as string),
+          // Only a real team assignment yields a color; no team → null, so the
+          // chip/avatar render in the neutral default rather than a fake color.
+          color: teamColor.get(m.user_id as string) ?? null,
           avatarIcon: m.user?.avatar_icon ?? null,
         }));
     }),

--- a/src/server/routers/news.ts
+++ b/src/server/routers/news.ts
@@ -226,6 +226,8 @@ export const newsRouter = router({
           // chip/avatar render in the neutral default rather than a fake color.
           color: teamColor.get(m.user_id as string) ?? null,
           avatarIcon: m.user?.avatar_icon ?? null,
+          // Guests aren't full members → gray (muted) avatar.
+          placeholder: m.isGuest,
         }));
     }),
 

--- a/src/server/routers/news.ts
+++ b/src/server/routers/news.ts
@@ -242,6 +242,7 @@ export const newsRouter = router({
           name: m.displayName,
           initials: initialsOf(m.displayName),
           color: teamColor.get(m.user_id as string) ?? paletteColor(m.user_id as string),
+          avatarIcon: m.user?.avatar_icon ?? null,
         }));
     }),
 


### PR DESCRIPTION
**Phase 3** of News (`design/design_handoff_news`) — the rich block interactions. Builds on PR1 (read-only feed) + PR2 (composer).

## Server
- **`news.roster`** — people for the @Crew picker; each carries denormalized name / initials / color so a saved post renders without a roster round-trip. Color = the member's **competition team color** when assigned, else a stable per-user palette color.
- **`news.competitionDraw`** — the team draw (teams + player names) ready to embed in a Teams block; `null` when there's no competition or no teams yet.
- + Vitest: roster shape + team-color mapping, the draw, and non-member FORBIDDEN.

## Composer
- **@Crew editor** — optional label ("Captains") + a searchable roster autocomplete → people pills with remove.
- **Teams editor** — auto-pulls the draw from Competition (with a Refresh), and a clean empty-state ("No draw yet — set up teams in the Competition tab") when none exists.
- Both added to the "Add a block" row — **all six block types are now authorable**.
- **Drag-to-reorder** via a grip handle (HTML5 DnD, drop-target highlight); the **up/down arrows stay** as the touch/keyboard fallback (HTML5 DnD is poor on touch).

## Deferred (a later pass)
- Inline **@-mentions inside Text paragraphs** and the **bold/italic/list/link toolbar** — both need a real rich-text/contentEditable editor, a meaningfully separate effort. A plain textarea still backs Text.

## Verification
- Verified in preview: @Crew autocomplete → pill add → round-trips into the feed as a mention row; Teams empty-state on a comp-less trip; all six types in the add-row; grips + up/down on every block.
- Drag itself isn't automation-tested (HTML5 DnD is impractical to simulate reliably) — handlers are standard and the up/down fallback is proven.
- No new migration — reuses PR1's tables + existing competition tables. tsc + lint clean.

## Test plan
- [ ] CI green (news.test.ts roster/draw + existing pass)
- [ ] @Crew: search roster, add/remove people, renders as a mention row in the feed
- [ ] Teams: auto-pulls a real draw on a trip with a competition; empty-state otherwise
- [ ] Drag a block by its grip to reorder; up/down still work
- [ ] Editing a post preserves all block types

🤖 Generated with [Claude Code](https://claude.com/claude-code)