### PR TITLE
News PR4: rich-text Text editor + Heading block

### DIFF
--- a/design/design_handoff_news/SPEC-news.md
+++ b/design/design_handoff_news/SPEC-news.md
@@ -53,6 +53,15 @@ syntax, and there is **no free text color** (brand discipline). The six:
 > poll / table / quote / divider / heading / free-color blocks. If a use case
 > seems unmet, stop and ask — it maps to one of the six.
 
+> 📝 **Post-handoff decision (PR4):** a **Heading** block (a plain title line,
+> `{ type: "heading", text }`) was added as a 7th type at the product owner's
+> request — long posts needed section titles, which none of the six covered.
+> The "stop and ask" rule was followed; this is the agreed exception, not a
+> silent expansion. The rest of the closed set still holds: no poll / table /
+> quote / divider / free-color. Also: **lists** in the Text toolbar are
+> deferred to a later pass — the Text editor ships **bold · italic · link · @**
+> for now (the Steps block already covers numbered lists).
+
 Block render CSS: `.post`, `.blk-p`, `.blk-teams/.team-card`, `.blk-video`,
 `.blk-steps/.step`, `.blk-callout` are in `explorations-board.jsx`;
 `.blk-crew`, `.blk-crewrow`, `.blk-photo` in `explorations-pinned.jsx`.

--- a/e2e/news.spec.ts
+++ b/e2e/news.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * News (the Trip Board) E2E — happy path for PR4.
+ *
+ * Covers the rich-text renderer (heading block + bold/link/mention segments)
+ * end-to-end in a real browser, and the composer's PR4 affordances (the
+ * rich-text toolbar + the Heading block). Authoring-level interactions
+ * (typing, execCommand bold, the @ dropdown) are intentionally NOT simulated
+ * here — contentEditable + execCommand are flaky under headless; that path is
+ * covered by the Vitest segment round-trip (src/server/routers/news.test.ts)
+ * and manual verification. This spec asserts the stable, high-value surface:
+ * the read renderer and the composer's controls.
+ */
+
+const MOCK_USER_ID = "user-test-001";
+const TRIP_ID = "news-e2e-trip-001";
+
+const MOCK_TRIP = {
+  id: TRIP_ID,
+  title: "Scotland Golf Adventure",
+  description: "Epic links golf trip",
+  location: "St Andrews, Scotland",
+  start_date: new Date(Date.now() + 30 * 86400000).toISOString(),
+  end_date: new Date(Date.now() + 37 * 86400000).toISOString(),
+  locked_destination_title: null,
+  locked_destination_location: null,
+  locked_destination_at: null,
+  event_id: null,
+  series_id: null,
+  cost_tier: null,
+  image_url: null,
+  accommodation: null,
+  notes: null,
+  activities: [],
+  golf_courses: [],
+  comparison_mode: false,
+  created_at: new Date().toISOString(),
+};
+
+const MOCK_MEMBERS = [
+  {
+    id: "member-001",
+    trip_id: TRIP_ID,
+    user_id: MOCK_USER_ID,
+    role: "Owner",
+    status: "in",
+    joined_at: new Date().toISOString(),
+    user: { id: MOCK_USER_ID, name: "Test User", nickname: null, email: "test@example.com", is_guest: false },
+    memberId: MOCK_USER_ID,
+    isGuest: false,
+    displayName: "Test User",
+  },
+  {
+    id: "member-002",
+    trip_id: TRIP_ID,
+    user_id: "user-002",
+    role: "Member",
+    status: "in",
+    joined_at: new Date().toISOString(),
+    user: { id: "user-002", name: "Jane Doe", nickname: null, email: "jane@example.com", is_guest: false },
+    memberId: "user-002",
+    isGuest: false,
+    displayName: "Jane Doe",
+  },
+];
+
+// A post exercising every PR4 capability: heading + bold run + link + mention.
+const NEWS_POST = {
+  id: "news-001",
+  tripId: TRIP_ID,
+  authorId: MOCK_USER_ID,
+  pinned: false,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  blocks: [
+    { type: "heading", text: "Saturday — Championship Day" },
+    {
+      type: "text",
+      segments: [
+        "Meet at the ",
+        { text: "first tee", bold: true },
+        " — details ",
+        { link: "https://buddytrip.app/tee", text: "here" },
+        " — nice work ",
+        { mention: { userId: "user-002", name: "Jane Doe", initials: "JD", color: null } },
+        "!",
+      ],
+    },
+  ],
+};
+
+const ROSTER = [
+  { userId: MOCK_USER_ID, name: "Test User", initials: "TU", color: null, avatarIcon: null, placeholder: false },
+  { userId: "user-002", name: "Jane Doe", initials: "JD", color: null, avatarIcon: null, placeholder: false },
+];
+
+function reply(data: unknown) {
+  return { status: 200, contentType: "application/json", body: JSON.stringify([{ result: { data } }]) };
+}
+
+async function setupMocks(page: import("@playwright/test").Page) {
+  await page.route("**/auth/v1/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/user")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: MOCK_USER_ID, email: "test@example.com", user_metadata: { name: "Test User" } }),
+      });
+    } else if (url.includes("/token") || url.includes("/session")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "mock-token", user: { id: MOCK_USER_ID, email: "test@example.com" } }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route("**/api/trpc/**", async (route) => {
+    const url = route.request().url();
+    const match = (name: string) => url.includes(name);
+
+    if (match("trips.getById")) return route.fulfill(reply(MOCK_TRIP));
+    if (match("tripMembers.list")) return route.fulfill(reply(MOCK_MEMBERS));
+    if (match("news.list")) return route.fulfill(reply([NEWS_POST]));
+    if (match("news.unreadCount")) return route.fulfill(reply(0));
+    if (match("news.readState")) return route.fulfill(reply({ lastReadAt: new Date().toISOString() }));
+    if (match("news.markRead")) return route.fulfill(reply({ lastReadAt: new Date().toISOString() }));
+    if (match("news.roster")) return route.fulfill(reply(ROSTER));
+    if (match("news.competitionDraw")) return route.fulfill(reply(null));
+    if (match("datePoll.get")) return route.fulfill(reply({ id: "poll-1", windows: [] }));
+    if (match("events.getByTrip")) return route.fulfill(reply(null));
+
+    // Any other list-style query the trip page pulls needs an array (it maps
+    // over the result); everything else can be null.
+    return route.fulfill(reply(match(".list") ? [] : null));
+  });
+}
+
+test.describe("News — rich-text rendering + composer (PR4)", () => {
+  test("renders a heading, bold run, link and mention in a post", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    // Open the News panel from the title-bar tool button.
+    await page.getByRole("button", { name: "News", exact: true }).click();
+
+    // Heading block → an <h3>.
+    await expect(
+      page.getByRole("heading", { name: "Saturday — Championship Day" }).first()
+    ).toBeVisible();
+
+    // Bold run renders as a 700-weight span.
+    const bold = page.getByText("first tee", { exact: true }).first();
+    await expect(bold).toBeVisible();
+    await expect(bold).toHaveCSS("font-weight", "700");
+
+    // Link segment renders as an anchor that keeps its href.
+    const link = page.getByRole("link", { name: "here" }).first();
+    await expect(link).toHaveAttribute("href", "https://buddytrip.app/tee");
+
+    // Mention renders as an inline pill carrying the person's name.
+    await expect(page.getByText("Jane Doe").first()).toBeVisible();
+  });
+
+  test("composer exposes the rich-text toolbar and the Heading block", async ({ page }) => {
+    await setupMocks(page);
+    await page.goto(`/trips/${TRIP_ID}`);
+
+    await page.getByRole("button", { name: "News", exact: true }).click();
+    await page.getByTestId("news-new-post").first().click();
+
+    // Rich-text toolbar (bold · italic · link · @) + the editable area.
+    await expect(page.getByRole("button", { name: "Bold" }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Italic" }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add link" }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Mention crew" }).first()).toBeVisible();
+    await expect(page.getByTestId("news-richtext").first()).toBeVisible();
+
+    // Heading is an addable block; adding it reveals the title input.
+    await page.getByRole("button", { name: "Heading" }).first().click();
+    await expect(page.getByPlaceholder("Section title…").first()).toBeVisible();
+  });
+});

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -45,15 +45,18 @@ function imageUrl(url: string | null | undefined): string | null {
 // Avatar (their Tabler icon, or initials) backed by their team color, plus
 // their plain name — no "@". The chip is tinted by the same color so a team
 // captain's pill reads as their team's.
-function Mention({ person }: { person: NewsPerson }) {
+// Exported so the composer's contentEditable can render the EXACT same chip
+// (via renderToStaticMarkup) — edit and preview stay byte-identical.
+export function Mention({ person }: { person: NewsPerson }) {
   // A color only when the member is actually on a competition team — otherwise
   // the standard avatar + a neutral chip (no fake team color).
   const team = person.color || null;
   return (
     <span
-      className="inline-flex items-center gap-1.5"
+      className="inline-flex items-center"
       style={{
-        padding: "2px 9px 2px 2px",
+        gap: 5,
+        padding: "1px 8px 1px 2px",
         borderRadius: 9999,
         background: team
           ? `color-mix(in srgb, ${team} 12%, var(--color-bt-card-raised))`
@@ -61,11 +64,14 @@ function Mention({ person }: { person: NewsPerson }) {
         border: team
           ? `1px solid color-mix(in srgb, ${team} 40%, var(--color-bt-border))`
           : "1px solid var(--color-bt-border)",
-        fontSize: 12.5,
+        fontSize: 13,
         fontWeight: 600,
+        lineHeight: 1.2,
         color: "var(--color-bt-text)",
-        lineHeight: 1,
-        verticalAlign: "-5px",
+        // `middle` centers the chip on the text line so the name no longer
+        // sits below the surrounding paragraph baseline.
+        verticalAlign: "middle",
+        whiteSpace: "nowrap",
       }}
     >
       <Avatar
@@ -73,7 +79,7 @@ function Mention({ person }: { person: NewsPerson }) {
         avatarIcon={person.avatarIcon ?? null}
         teamColor={team ?? undefined}
         muted={!!person.placeholder}
-        sizePx={18}
+        sizePx={16}
       />
       {person.name}
     </span>
@@ -209,7 +215,7 @@ export function NewsBlockView({ block }: { block: NewsBlock }) {
               >
                 {t.name}
               </div>
-              <div style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", marginTop: 3 }}>
+              <div style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", marginTop: 3 }}>
                 {t.players.join(" · ")}
               </div>
             </div>
@@ -246,7 +252,7 @@ export function NewsBlockView({ block }: { block: NewsBlock }) {
                 <figcaption
                   style={{
                     padding: "8px 12px",
-                    fontSize: 11.5,
+                    fontSize: 12.5,
                     color: "var(--color-bt-text-dim)",
                   }}
                 >
@@ -348,7 +354,7 @@ export function NewsBlockView({ block }: { block: NewsBlock }) {
                     <div style={{ fontSize: 13, fontWeight: 600, color: "#fff" }}>{block.title}</div>
                   )}
                   {block.meta && (
-                    <div style={{ fontSize: 11, color: "rgba(255,255,255,0.8)", marginTop: 2 }}>
+                    <div style={{ fontSize: 12, color: "rgba(255,255,255,0.85)", marginTop: 2 }}>
                       {block.meta}
                     </div>
                   )}
@@ -399,7 +405,7 @@ export function NewsBlockView({ block }: { block: NewsBlock }) {
               {block.title}
             </div>
             {block.meta && (
-              <div style={{ fontSize: 11, color: "var(--color-bt-text-dim)", marginTop: 2 }}>
+              <div style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 2 }}>
                 {block.meta}
               </div>
             )}

--- a/src/components/news/NewsBlock.tsx
+++ b/src/components/news/NewsBlock.tsx
@@ -80,17 +80,44 @@ function Mention({ person }: { person: NewsPerson }) {
   );
 }
 
-function RichText({ segments, dim }: { segments: NewsSegment[]; dim?: boolean }) {
+function Segment({ seg }: { seg: NewsSegment }) {
+  if (typeof seg === "string") return <span>{seg}</span>;
+  if ("mention" in seg) return <Mention person={seg.mention} />;
+  if ("link" in seg) {
+    return (
+      <a
+        href={seg.link}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: "var(--color-bt-accent)", textDecoration: "underline" }}
+      >
+        {seg.text}
+      </a>
+    );
+  }
+  // Formatted run — bold / italic.
   return (
-    <p style={paragraphStyle(dim)}>
-      {segments.map((seg, i) =>
-        typeof seg === "string" ? (
-          <span key={i}>{seg}</span>
-        ) : (
-          <Mention key={i} person={seg.mention} />
-        )
-      )}
-    </p>
+    <span
+      style={{
+        fontWeight: seg.bold ? 700 : undefined,
+        fontStyle: seg.italic ? "italic" : undefined,
+      }}
+    >
+      {seg.text}
+    </span>
+  );
+}
+
+function RichText({ segments, dim }: { segments: NewsSegment[]; dim?: boolean }) {
+  // A <div>, not a <p>: an inline mention renders the Avatar (a <div>), and a
+  // <div> inside <p> is invalid HTML (hydration error). The paragraph styling
+  // is applied inline, so a div reads identically.
+  return (
+    <div style={paragraphStyle(dim)}>
+      {segments.map((seg, i) => (
+        <Segment key={i} seg={seg} />
+      ))}
+    </div>
   );
 }
 
@@ -106,6 +133,21 @@ function paragraphStyle(dim?: boolean): React.CSSProperties {
 // ── One block ──────────────────────────────────────────────────────────────
 export function NewsBlockView({ block }: { block: NewsBlock }) {
   switch (block.type) {
+    case "heading":
+      return (
+        <h3
+          style={{
+            fontSize: 16.5,
+            fontWeight: 700,
+            lineHeight: 1.3,
+            color: "var(--color-bt-text)",
+            margin: 0,
+          }}
+        >
+          {block.text}
+        </h3>
+      );
+
     case "text":
       return block.segments ? (
         <RichText segments={block.segments} dim={block.dim} />

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -341,18 +341,18 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
                 className="inline-flex flex-shrink-0 items-center gap-1.5 rounded-[9px] transition-colors hover:bg-[var(--color-bt-accent-faint)]"
                 style={{
                   padding: "8px 11px",
-                  border: "1px dashed var(--color-bt-border)",
-                  background: "transparent",
+                  // Callout previews its amber surface; white icon + label on top.
+                  border:
+                    type === "callout"
+                      ? "1px solid var(--color-bt-warning-border)"
+                      : "1px dashed var(--color-bt-border)",
+                  background: type === "callout" ? "var(--color-bt-warning-faint)" : "transparent",
                   color: "var(--color-bt-text)",
                   fontSize: 12.5,
                   fontWeight: 500,
                 }}
               >
-                <Icon
-                  size={14}
-                  style={type === "callout" ? { color: "var(--color-bt-warning)" } : undefined}
-                />{" "}
-                {label}
+                <Icon size={14} /> {label}
               </button>
             ))}
           </div>
@@ -499,10 +499,10 @@ function BlockEditor({
     callout: Pin,
   };
   const Icon = kindIcon[block.type];
-  // Callout is the amber "panel" block — color its kind label amber so the
-  // block self-identifies instead of the label literally reading "(amber)".
+  // Callout is the amber "panel" block — give its editor card the amber
+  // surface (matching how it renders), with white icon + label on top, so it
+  // self-identifies instead of the label literally reading "(amber)".
   const isCallout = block.type === "callout";
-  const kindColor = isCallout ? "var(--color-bt-warning)" : "var(--color-bt-accent)";
 
   return (
     <div
@@ -526,9 +526,9 @@ function BlockEditor({
       }}
       style={{
         position: "relative",
-        border: "1px solid var(--color-bt-border)",
+        border: `1px solid ${isCallout ? "var(--color-bt-warning-border)" : "var(--color-bt-border)"}`,
         borderRadius: 11,
-        background: "var(--color-bt-card-raised)",
+        background: isCallout ? "var(--color-bt-warning-faint)" : "var(--color-bt-card-raised)",
         padding: "10px 12px 12px",
         opacity: dragging ? 0.4 : 1,
       }}
@@ -591,10 +591,10 @@ function BlockEditor({
             fontWeight: 700,
             letterSpacing: "0.08em",
             textTransform: "uppercase",
-            color: isCallout ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)",
+            color: isCallout ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
           }}
         >
-          <Icon size={11} style={{ color: kindColor }} />
+          <Icon size={11} style={{ color: isCallout ? "var(--color-bt-text)" : "var(--color-bt-accent)" }} />
           {kindLabel[block.type]}
         </span>
         <button

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -352,7 +352,11 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
                   fontWeight: 500,
                 }}
               >
-                <Icon size={14} /> {label}
+                <Icon
+                  size={14}
+                  style={type === "callout" ? { color: "var(--color-bt-warning)" } : undefined}
+                />{" "}
+                {label}
               </button>
             ))}
           </div>
@@ -594,7 +598,7 @@ function BlockEditor({
             color: isCallout ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
           }}
         >
-          <Icon size={11} style={{ color: isCallout ? "var(--color-bt-text)" : "var(--color-bt-accent)" }} />
+          <Icon size={11} style={{ color: isCallout ? "var(--color-bt-warning)" : "var(--color-bt-accent)" }} />
           {kindLabel[block.type]}
         </span>
         <button

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { Avatar } from "@/components/Avatar";
-import { NewsBlocks } from "@/components/news/NewsBlock";
+import { NewsBlocks, Mention } from "@/components/news/NewsBlock";
 import { RichTextEditor } from "@/components/news/RichTextEditor";
 import type { NewsBlock, NewsBlockType, NewsPerson, NewsPost } from "@/lib/news";
 
@@ -148,22 +148,40 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
   const addBlock = (type: NewsBlockType) => setBlocks((bs) => [...bs, blankBlock(type)]);
 
   // Drag-to-reorder (desktop, via the grip). Up/down arrows stay as the
-  // touch/keyboard fallback. dragFrom holds the picked-up block's index.
+  // touch/keyboard fallback.
+  //
   // `ins` is the insertion slot in the *original* array (0..length) — the gap
-  // the block should land in, derived from which edge of the hovered block the
-  // cursor is over. We compensate for removing `from` before splicing back.
-  const dragFrom = useRef<number | null>(null);
+  // the block should land in. Agenda-style: the indicator only appears once the
+  // cursor crosses the midpoint of a NEIGHBOURING block, and never on the
+  // dragged block's own two adjacent slots (which would be a no-op).
+  const [dragState, setDragState] = useState<{ from: number; ins: number | null } | null>(null);
+
   const reorderTo = (from: number, ins: number) =>
     setBlocks((bs) => {
       if (from < 0 || from >= bs.length) return bs;
-      // Dropping into the slot just before or after itself is a no-op.
-      if (ins === from || ins === from + 1) return bs;
+      if (ins === from || ins === from + 1) return bs; // own slot — no-op
       const copy = bs.slice();
       const [moved] = copy.splice(from, 1);
       const target = Math.max(0, Math.min(copy.length, ins > from ? ins - 1 : ins));
       copy.splice(target, 0, moved);
       return copy;
     });
+
+  const onBlockDragOver = (i: number, clientY: number, rect: DOMRect) =>
+    setDragState((s) => {
+      if (!s) return s;
+      const isTop = clientY < rect.top + rect.height / 2;
+      let ins: number | null = isTop ? i : i + 1;
+      // The two slots touching the dragged block are no-ops — hide the line so
+      // it can't bounce between them while you wiggle over your own tile.
+      if (ins === s.from || ins === s.from + 1) ins = null;
+      return s.ins === ins ? s : { ...s, ins };
+    });
+
+  const onBlockDrop = () => {
+    if (dragState && dragState.ins != null) reorderTo(dragState.from, dragState.ins);
+    setDragState(null);
+  };
 
   const submit = () => {
     if (!canSubmit) return;
@@ -285,15 +303,18 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
             onChange={(next) => setBlock(i, next)}
             onRemove={() => removeBlock(i)}
             onMove={(dir) => moveBlock(i, dir)}
-            onDragStartBlock={() => {
-              dragFrom.current = i;
-            }}
-            onDropBlock={(edge) => {
-              if (dragFrom.current !== null) {
-                reorderTo(dragFrom.current, edge === "top" ? i : i + 1);
-              }
-              dragFrom.current = null;
-            }}
+            dragging={dragState?.from === i}
+            dropIndicator={
+              dragState?.ins === i
+                ? "top"
+                : i === blocks.length - 1 && dragState?.ins === blocks.length
+                  ? "bottom"
+                  : null
+            }
+            onDragStartBlock={() => setDragState({ from: i, ins: null })}
+            onDragOverBlock={(clientY, rect) => onBlockDragOver(i, clientY, rect)}
+            onDropBlock={onBlockDrop}
+            onDragEndBlock={() => setDragState(null)}
           />
         ))}
 
@@ -308,15 +329,10 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
               marginBottom: 8,
             }}
           >
-            Add a block{variant === "mobile" ? " · swipe" : ""}
+            Add a block
           </div>
-          <div
-            className={
-              variant === "mobile"
-                ? "flex gap-1.5 overflow-x-auto pb-1"
-                : "flex flex-wrap gap-1.5"
-            }
-          >
+          {/* Wrap to multiple lines on every width — no horizontal swipe. */}
+          <div className="flex flex-wrap gap-1.5">
             {ADDABLE.map(({ type, label, icon: Icon }) => (
               <button
                 key={type}
@@ -433,8 +449,12 @@ function BlockEditor({
   onChange,
   onRemove,
   onMove,
+  dragging,
+  dropIndicator,
   onDragStartBlock,
+  onDragOverBlock,
   onDropBlock,
+  onDragEndBlock,
 }: {
   tripId: string;
   block: NewsBlock;
@@ -443,15 +463,18 @@ function BlockEditor({
   onChange: (b: NewsBlock) => void;
   onRemove: () => void;
   onMove: (dir: -1 | 1) => void;
+  /** This block is the one currently being dragged (dim it). */
+  dragging: boolean;
+  /** Where the insertion line sits relative to this block, if at all. */
+  dropIndicator: "top" | "bottom" | null;
   onDragStartBlock: () => void;
-  onDropBlock: (edge: "top" | "bottom") => void;
+  onDragOverBlock: (clientY: number, rect: DOMRect) => void;
+  onDropBlock: () => void;
+  onDragEndBlock: () => void;
 }) {
   // Drag is armed only while the grip is held, so dragging the block never
   // hijacks text selection inside its inputs.
   const [armed, setArmed] = useState(false);
-  // Which edge the dragged block would land on — drives a thin insertion line
-  // in the gap (above/below), so it reads as "lands here", not "drops inside".
-  const [dropEdge, setDropEdge] = useState<"top" | "bottom" | null>(null);
 
   const kindLabel: Record<NewsBlockType, string> = {
     heading: "Heading",
@@ -483,23 +506,15 @@ function BlockEditor({
       }}
       onDragEnd={() => {
         setArmed(false);
-        setDropEdge(null);
+        onDragEndBlock();
       }}
       onDragOver={(e) => {
         e.preventDefault();
-        // Top half → land above this block; bottom half → land below it.
-        const r = e.currentTarget.getBoundingClientRect();
-        setDropEdge(e.clientY < r.top + r.height / 2 ? "top" : "bottom");
-      }}
-      onDragLeave={(e) => {
-        // Ignore leaves into our own children (prevents line flicker).
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) setDropEdge(null);
+        onDragOverBlock(e.clientY, e.currentTarget.getBoundingClientRect());
       }}
       onDrop={(e) => {
         e.preventDefault();
-        const edge = dropEdge ?? "top";
-        setDropEdge(null);
-        onDropBlock(edge);
+        onDropBlock();
       }}
       style={{
         position: "relative",
@@ -507,16 +522,17 @@ function BlockEditor({
         borderRadius: 11,
         background: "var(--color-bt-card-raised)",
         padding: "10px 12px 12px",
+        opacity: dragging ? 0.4 : 1,
       }}
     >
-      {dropEdge && (
+      {dropIndicator && (
         <div
           aria-hidden="true"
           style={{
             position: "absolute",
             left: 2,
             right: 2,
-            [dropEdge === "top" ? "top" : "bottom"]: -6,
+            [dropIndicator === "top" ? "top" : "bottom"]: -6,
             height: 2,
             borderRadius: 2,
             background: "var(--color-bt-accent)",
@@ -840,27 +856,12 @@ function CrewFields({
       />
 
       {block.people.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">
           {block.people.map((p, i) => (
-            <span
-              key={i}
-              className="inline-flex items-center gap-1.5"
-              style={{
-                padding: "2px 5px 2px 2px",
-                borderRadius: 9999,
-                background: p.color
-                  ? `color-mix(in srgb, ${p.color} 12%, var(--color-bt-card-raised))`
-                  : "var(--color-bt-card-raised)",
-                border: p.color
-                  ? `1px solid color-mix(in srgb, ${p.color} 40%, var(--color-bt-border))`
-                  : "1px solid var(--color-bt-border)",
-                fontSize: 12,
-                fontWeight: 600,
-                color: "var(--color-bt-text)",
-              }}
-            >
-              <Avatar name={p.name} avatarIcon={p.avatarIcon ?? null} teamColor={p.color ?? undefined} muted={!!p.placeholder} sizePx={16} />
-              {p.name}
+            // The displayed chip is the exact same <Mention> the feed renders,
+            // so the edit view matches preview; the remove control sits beside it.
+            <span key={i} className="inline-flex items-center" style={{ gap: 3 }}>
+              <Mention person={p} />
               <button
                 type="button"
                 aria-label={`Remove ${p.name}`}

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -348,7 +348,11 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
                   fontWeight: 500,
                 }}
               >
-                <Icon size={14} /> {label}
+                <Icon
+                  size={14}
+                  style={type === "callout" ? { color: "var(--color-bt-warning)" } : undefined}
+                />{" "}
+                {label}
               </button>
             ))}
           </div>
@@ -483,7 +487,7 @@ function BlockEditor({
     teams: "Teams · from Competition",
     media: "Media",
     steps: "Steps",
-    callout: "Callout · panel (amber)",
+    callout: "Callout",
   };
   const kindIcon: Record<NewsBlockType, LucideIcon> = {
     heading: Heading,
@@ -495,6 +499,10 @@ function BlockEditor({
     callout: Pin,
   };
   const Icon = kindIcon[block.type];
+  // Callout is the amber "panel" block — color its kind label amber so the
+  // block self-identifies instead of the label literally reading "(amber)".
+  const isCallout = block.type === "callout";
+  const kindColor = isCallout ? "var(--color-bt-warning)" : "var(--color-bt-accent)";
 
   return (
     <div
@@ -583,10 +591,10 @@ function BlockEditor({
             fontWeight: 700,
             letterSpacing: "0.08em",
             textTransform: "uppercase",
-            color: "var(--color-bt-text-dim)",
+            color: isCallout ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)",
           }}
         >
-          <Icon size={11} style={{ color: "var(--color-bt-accent)" }} />
+          <Icon size={11} style={{ color: kindColor }} />
           {kindLabel[block.type]}
         </span>
         <button

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -346,7 +346,10 @@ export function NewsComposer({ tripId, variant, post, onDone }: NewsComposerProp
                     type === "callout"
                       ? "1px solid var(--color-bt-warning-border)"
                       : "1px dashed var(--color-bt-border)",
-                  background: type === "callout" ? "var(--color-bt-warning-faint)" : "transparent",
+                  background:
+                    type === "callout"
+                      ? "color-mix(in srgb, var(--color-bt-warning) 8%, var(--color-bt-card))"
+                      : "transparent",
                   color: "var(--color-bt-text)",
                   fontSize: 12.5,
                   fontWeight: 500,
@@ -532,7 +535,11 @@ function BlockEditor({
         position: "relative",
         border: `1px solid ${isCallout ? "var(--color-bt-warning-border)" : "var(--color-bt-border)"}`,
         borderRadius: 11,
-        background: isCallout ? "var(--color-bt-warning-faint)" : "var(--color-bt-card-raised)",
+        // Opaque equivalent of warning-faint (8% amber) over the post card, so
+        // it matches the rendered callout regardless of the lighter panel behind.
+        background: isCallout
+          ? "color-mix(in srgb, var(--color-bt-warning) 8%, var(--color-bt-card))"
+          : "var(--color-bt-card-raised)",
         padding: "10px 12px 12px",
         opacity: dragging ? 0.4 : 1,
       }}

--- a/src/components/news/NewsComposer.tsx
+++ b/src/components/news/NewsComposer.tsx
@@ -15,11 +15,13 @@ import {
   Users,
   Trophy,
   RefreshCw,
+  Heading,
   type LucideIcon,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { Avatar } from "@/components/Avatar";
 import { NewsBlocks } from "@/components/news/NewsBlock";
+import { RichTextEditor } from "@/components/news/RichTextEditor";
 import type { NewsBlock, NewsBlockType, NewsPerson, NewsPost } from "@/lib/news";
 
 // ── NewsComposer ────────────────────────────────────────────────────────────
@@ -36,6 +38,7 @@ import type { NewsBlock, NewsBlockType, NewsPerson, NewsPost } from "@/lib/news"
 
 // Block types the composer can ADD, in catalog order.
 const ADDABLE: { type: NewsBlockType; label: string; icon: LucideIcon }[] = [
+  { type: "heading", label: "Heading", icon: Heading },
   { type: "text", label: "Text", icon: Type },
   { type: "crew", label: "@Crew", icon: Users },
   { type: "teams", label: "Teams", icon: Trophy },
@@ -46,6 +49,8 @@ const ADDABLE: { type: NewsBlockType; label: string; icon: LucideIcon }[] = [
 
 function blankBlock(type: NewsBlockType): NewsBlock {
   switch (type) {
+    case "heading":
+      return { type: "heading", text: "" };
     case "text":
       return { type: "text", text: "" };
     case "crew":
@@ -68,7 +73,9 @@ function blankBlock(type: NewsBlockType): NewsBlock {
 function cleanBlocks(blocks: NewsBlock[]): NewsBlock[] {
   const out: NewsBlock[] = [];
   for (const b of blocks) {
-    if (b.type === "text") {
+    if (b.type === "heading") {
+      if (b.text.trim().length > 0) out.push({ type: "heading", text: b.text.trim() });
+    } else if (b.type === "text") {
       const hasText = (b.text ?? "").trim().length > 0;
       const hasSegments = (b.segments?.length ?? 0) > 0;
       if (hasText || hasSegments) out.push({ ...b, text: b.text?.trim() });
@@ -447,6 +454,7 @@ function BlockEditor({
   const [dropEdge, setDropEdge] = useState<"top" | "bottom" | null>(null);
 
   const kindLabel: Record<NewsBlockType, string> = {
+    heading: "Heading",
     text: "Text",
     crew: "@Crew · from the roster",
     teams: "Teams · from Competition",
@@ -455,6 +463,7 @@ function BlockEditor({
     callout: "Callout · panel (amber)",
   };
   const kindIcon: Record<NewsBlockType, LucideIcon> = {
+    heading: Heading,
     text: Type,
     crew: Users,
     teams: Trophy,
@@ -603,16 +612,18 @@ function BlockFields({
   onChange: (b: NewsBlock) => void;
 }) {
   switch (block.type) {
-    case "text":
+    case "heading":
       return (
-        <textarea
-          value={block.text ?? ""}
-          onChange={(e) => onChange({ type: "text", text: e.target.value, dim: block.dim })}
-          rows={3}
-          placeholder="Write something for the crew…"
-          style={{ ...inputStyle, resize: "vertical", lineHeight: 1.5 }}
+        <input
+          value={block.text}
+          onChange={(e) => onChange({ type: "heading", text: e.target.value })}
+          placeholder="Section title…"
+          style={{ ...inputStyle, fontSize: 16, fontWeight: 700 }}
         />
       );
+
+    case "text":
+      return <RichTextEditor tripId={tripId} block={block} onChange={onChange} />;
 
     case "callout":
       return (

--- a/src/components/news/NewsHelpModal.tsx
+++ b/src/components/news/NewsHelpModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   X,
+  Heading,
   Type,
   Users,
   Trophy,
@@ -32,10 +33,23 @@ interface CatalogEntry {
 
 const CATALOG: CatalogEntry[] = [
   {
+    name: "Heading",
+    icon: Heading,
+    desc: "A title line to break a longer post into sections.",
+    demo: { type: "heading", text: "Saturday — Championship Day" },
+  },
+  {
     name: "Text",
     icon: Type,
-    desc: "A paragraph — the everyday update. Plain text for now (rich formatting is coming).",
-    demo: { type: "text", text: "Tee times are tight — be at the first tee 10 minutes early." },
+    desc: "A paragraph — the everyday update. Bold, italic, links and @-mentions, all from the toolbar — no markdown.",
+    demo: {
+      type: "text",
+      segments: [
+        "Tee times are tight — ",
+        { text: "be at the first tee 10 minutes early", bold: true },
+        ".",
+      ],
+    },
   },
   {
     name: "@Crew",
@@ -158,7 +172,7 @@ export function NewsHelpModal({ open, onClose }: NewsHelpModalProps) {
           style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: "var(--color-bt-text-dim)" }}
         >
           A post is a stack of blocks. Add as many as you like, in any order, then drag to
-          reorder. These are the six block types:
+          reorder. These are the seven block types:
         </p>
 
         {/* Catalog */}

--- a/src/components/news/NewsHelpModal.tsx
+++ b/src/components/news/NewsHelpModal.tsx
@@ -175,8 +175,9 @@ export function NewsHelpModal({ open, onClose }: NewsHelpModalProps) {
           reorder. These are the seven block types:
         </p>
 
-        {/* Catalog */}
-        <div className="flex flex-col gap-3 overflow-y-auto px-[18px] py-3">
+        {/* Catalog — the flex-1 min-h-0 scroll region so the list scrolls
+            inside the capped modal height instead of overflowing off-screen. */}
+        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-[18px] py-3">
           {CATALOG.map(({ name, icon: Icon, desc, demo }) => (
             <div
               key={name}

--- a/src/components/news/RichTextEditor.tsx
+++ b/src/components/news/RichTextEditor.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { Bold, Italic, Link as LinkIcon, AtSign } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { Avatar } from "@/components/Avatar";
+import { Mention } from "@/components/news/NewsBlock";
 import type { NewsBlock, NewsPerson, NewsSegment } from "@/lib/news";
 
 // ── RichTextEditor ───────────────────────────────────────────────────────────
@@ -22,9 +24,10 @@ import type { NewsBlock, NewsPerson, NewsSegment } from "@/lib/news";
 // styleWithCSS off so the DOM uses <b>/<i> tags, which the serialiser reads.
 
 // ── Mention pill (raw DOM) ──────────────────────────────────────────────────
-// Inserted directly into the contentEditable, so it's built with the DOM API,
-// not React. A lightweight chip (initials dot + name); the rendered post and
-// the live Preview use the full Avatar-backed <Mention>.
+// Inserted directly into the contentEditable (so DOM API, not React), but the
+// VISIBLE chip is the very same <Mention> the feed/preview render — serialised
+// to static markup. That keeps the editor pill byte-identical to preview
+// (same avatar, same alignment). Identity for serialisation rides on data-*.
 function buildPill(person: NewsPerson): HTMLElement {
   const span = document.createElement("span");
   span.contentEditable = "false";
@@ -35,46 +38,8 @@ function buildPill(person: NewsPerson): HTMLElement {
   if (person.color) span.dataset.color = person.color;
   if (person.avatarIcon) span.dataset.avatarIcon = person.avatarIcon;
   if (person.placeholder) span.dataset.placeholder = "1";
-
-  const color = person.color || null;
-  span.style.cssText = [
-    "display:inline-flex",
-    "align-items:center",
-    "gap:5px",
-    "padding:1px 8px 1px 5px",
-    "border-radius:9999px",
-    "font-size:12.5px",
-    "font-weight:600",
-    "line-height:1.5",
-    "white-space:nowrap",
-    "user-select:all",
-    `color:var(--color-bt-text)`,
-    color
-      ? `background:color-mix(in srgb, ${color} 12%, var(--color-bt-card-raised))`
-      : "background:var(--color-bt-card-raised)",
-    color
-      ? `border:1px solid color-mix(in srgb, ${color} 40%, var(--color-bt-border))`
-      : "border:1px solid var(--color-bt-border)",
-  ].join(";");
-
-  const dot = document.createElement("span");
-  dot.textContent = person.initials;
-  dot.setAttribute("aria-hidden", "true");
-  dot.style.cssText = [
-    "display:inline-flex",
-    "align-items:center",
-    "justify-content:center",
-    "width:16px",
-    "height:16px",
-    "border-radius:50%",
-    "font-size:8px",
-    "font-weight:700",
-    "color:#fff",
-    `background:${color || "var(--color-bt-accent)"}`,
-  ].join(";");
-
-  span.appendChild(dot);
-  span.appendChild(document.createTextNode(person.name));
+  span.style.cssText = "display:inline-block;vertical-align:middle;user-select:all;";
+  span.innerHTML = renderToStaticMarkup(<Mention person={person} />);
   return span;
 }
 

--- a/src/components/news/RichTextEditor.tsx
+++ b/src/components/news/RichTextEditor.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Bold, Italic, Link as LinkIcon, AtSign } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { Avatar } from "@/components/Avatar";
+import type { NewsBlock, NewsPerson, NewsSegment } from "@/lib/news";
+
+// ── RichTextEditor ───────────────────────────────────────────────────────────
+//
+// The Text block editor: a contentEditable paragraph with a bold / italic /
+// link / @ toolbar that serialises to the NewsSegment model (no markdown, no
+// color — per SPEC-news.md). Lists are deferred to a later pass.
+//
+// contentEditable is uncontrolled: we set the DOM ONCE on mount from the block
+// being edited, then read it back on input. We never re-write innerHTML from
+// props (that would nuke the caret), so the parent's block state and this DOM
+// stay decoupled by design.
+//
+// Bold/italic use the (deprecated but universally supported) execCommand — by
+// far the least fragile way to toggle marks in contentEditable. We force
+// styleWithCSS off so the DOM uses <b>/<i> tags, which the serialiser reads.
+
+// ── Mention pill (raw DOM) ──────────────────────────────────────────────────
+// Inserted directly into the contentEditable, so it's built with the DOM API,
+// not React. A lightweight chip (initials dot + name); the rendered post and
+// the live Preview use the full Avatar-backed <Mention>.
+function buildPill(person: NewsPerson): HTMLElement {
+  const span = document.createElement("span");
+  span.contentEditable = "false";
+  span.dataset.mention = "1";
+  span.dataset.name = person.name;
+  span.dataset.initials = person.initials;
+  if (person.userId) span.dataset.userId = person.userId;
+  if (person.color) span.dataset.color = person.color;
+  if (person.avatarIcon) span.dataset.avatarIcon = person.avatarIcon;
+  if (person.placeholder) span.dataset.placeholder = "1";
+
+  const color = person.color || null;
+  span.style.cssText = [
+    "display:inline-flex",
+    "align-items:center",
+    "gap:5px",
+    "padding:1px 8px 1px 5px",
+    "border-radius:9999px",
+    "font-size:12.5px",
+    "font-weight:600",
+    "line-height:1.5",
+    "white-space:nowrap",
+    "user-select:all",
+    `color:var(--color-bt-text)`,
+    color
+      ? `background:color-mix(in srgb, ${color} 12%, var(--color-bt-card-raised))`
+      : "background:var(--color-bt-card-raised)",
+    color
+      ? `border:1px solid color-mix(in srgb, ${color} 40%, var(--color-bt-border))`
+      : "border:1px solid var(--color-bt-border)",
+  ].join(";");
+
+  const dot = document.createElement("span");
+  dot.textContent = person.initials;
+  dot.setAttribute("aria-hidden", "true");
+  dot.style.cssText = [
+    "display:inline-flex",
+    "align-items:center",
+    "justify-content:center",
+    "width:16px",
+    "height:16px",
+    "border-radius:50%",
+    "font-size:8px",
+    "font-weight:700",
+    "color:#fff",
+    `background:${color || "var(--color-bt-accent)"}`,
+  ].join(";");
+
+  span.appendChild(dot);
+  span.appendChild(document.createTextNode(person.name));
+  return span;
+}
+
+function pillToPerson(el: HTMLElement): NewsPerson {
+  return {
+    userId: el.dataset.userId ?? null,
+    name: el.dataset.name ?? "",
+    initials: el.dataset.initials ?? "?",
+    color: el.dataset.color ?? null,
+    avatarIcon: el.dataset.avatarIcon ?? null,
+    placeholder: el.dataset.placeholder === "1",
+  };
+}
+
+// ── Serialise: contentEditable DOM → NewsSegment[] ──────────────────────────
+function isBlockTag(tag: string): boolean {
+  return tag === "div" || tag === "p";
+}
+
+function serialize(root: HTMLElement): NewsSegment[] {
+  const out: NewsSegment[] = [];
+
+  const pushText = (text: string, bold: boolean, italic: boolean) => {
+    if (!text) return;
+    if (!bold && !italic) {
+      const last = out[out.length - 1];
+      if (typeof last === "string") out[out.length - 1] = last + text;
+      else out.push(text);
+    } else {
+      out.push({ text, ...(bold ? { bold: true } : {}), ...(italic ? { italic: true } : {}) });
+    }
+  };
+
+  const walk = (node: Node, bold: boolean, italic: boolean) => {
+    node.childNodes.forEach((child) => {
+      if (child.nodeType === Node.TEXT_NODE) {
+        pushText(child.textContent ?? "", bold, italic);
+        return;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) return;
+      const el = child as HTMLElement;
+
+      if (el.dataset.mention) {
+        out.push({ mention: pillToPerson(el) });
+        return;
+      }
+
+      const tag = el.tagName.toLowerCase();
+      if (tag === "a") {
+        const href = el.getAttribute("href") ?? "";
+        const text = el.textContent ?? "";
+        if (text && href) out.push({ link: href, text });
+        else pushText(text, bold, italic);
+        return;
+      }
+      if (tag === "br") {
+        pushText(" ", false, false);
+        return;
+      }
+
+      const fw = el.style.fontWeight;
+      const styledBold = fw === "bold" || (/^\d+$/.test(fw) && Number(fw) >= 600);
+      const nb = bold || tag === "b" || tag === "strong" || styledBold;
+      const ni = italic || tag === "i" || tag === "em" || el.style.fontStyle === "italic";
+
+      walk(el, nb, ni);
+      // Defensive: a stray block boundary becomes a space (Enter is blocked, so
+      // this is rare — pasted HTML can still introduce one).
+      if (isBlockTag(tag)) pushText(" ", false, false);
+    });
+  };
+
+  walk(root, false, false);
+  return out;
+}
+
+/** Collapse the segments into the stored block: a single plain run keeps the
+ *  simple `text` shape; anything richer stores `segments`. */
+function toTextBlock(segments: NewsSegment[], dim?: boolean): NewsBlock {
+  if (segments.length === 0) return { type: "text", text: "", dim };
+  if (segments.length === 1 && typeof segments[0] === "string") {
+    return { type: "text", text: segments[0], dim };
+  }
+  return { type: "text", segments, dim };
+}
+
+// ── Hydrate: block → initial contentEditable DOM (mount only) ────────────────
+function hydrate(root: HTMLElement, block: Extract<NewsBlock, { type: "text" }>) {
+  root.replaceChildren();
+  const append = (n: Node) => root.appendChild(n);
+
+  if (block.segments && block.segments.length > 0) {
+    for (const seg of block.segments) {
+      if (typeof seg === "string") {
+        append(document.createTextNode(seg));
+      } else if ("mention" in seg) {
+        append(buildPill(seg.mention));
+      } else if ("link" in seg) {
+        const a = document.createElement("a");
+        a.href = seg.link;
+        a.textContent = seg.text;
+        append(a);
+      } else {
+        let node: Node = document.createTextNode(seg.text);
+        if (seg.italic) {
+          const i = document.createElement("i");
+          i.appendChild(node);
+          node = i;
+        }
+        if (seg.bold) {
+          const b = document.createElement("b");
+          b.appendChild(node);
+          node = b;
+        }
+        append(node);
+      }
+    }
+  } else if (block.text) {
+    append(document.createTextNode(block.text));
+  }
+}
+
+function normalizeUrl(raw: string): string {
+  const u = raw.trim();
+  if (!u) return "";
+  if (/^https?:\/\//i.test(u) || /^mailto:/i.test(u)) return u;
+  return `https://${u}`;
+}
+
+interface RichTextEditorProps {
+  tripId: string;
+  block: Extract<NewsBlock, { type: "text" }>;
+  onChange: (b: NewsBlock) => void;
+}
+
+export function RichTextEditor({ tripId, block, onChange }: RichTextEditorProps) {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  // Capture the initial block once — hydrate must not re-run on prop changes.
+  const initialBlock = useRef(block);
+  const dimRef = useRef(block.dim);
+  const [isEmpty, setIsEmpty] = useState(
+    !((block.segments && block.segments.length) || (block.text && block.text.length))
+  );
+
+  const { data: roster = [] } = trpc.news.roster.useQuery({ tripId });
+
+  // ── @-mention dropdown state ──────────────────────────────────────────────
+  const [mention, setMention] = useState<
+    { query: string; top: number; left: number; index: number } | null
+  >(null);
+  // The text range [start, end) of the "@query" being replaced on select.
+  const mentionRange = useRef<{ node: Node; start: number; end: number } | null>(null);
+
+  // ── Link field state ──────────────────────────────────────────────────────
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const savedRange = useRef<Range | null>(null);
+
+  // Mount: paint the initial content.
+  useEffect(() => {
+    if (editorRef.current) hydrate(editorRef.current, initialBlock.current);
+  }, []);
+
+  const emit = useCallback(() => {
+    const el = editorRef.current;
+    if (!el) return;
+    const segments = serialize(el);
+    onChange(toTextBlock(segments, dimRef.current));
+    setIsEmpty((el.textContent ?? "").trim().length === 0 && !el.querySelector("[data-mention]"));
+  }, [onChange]);
+
+  // ── Detect an in-progress "@query" before the caret ───────────────────────
+  const detectMention = useCallback(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) {
+      setMention(null);
+      return;
+    }
+    const node = sel.focusNode;
+    if (!node || node.nodeType !== Node.TEXT_NODE) {
+      setMention(null);
+      return;
+    }
+    const offset = sel.focusOffset;
+    const before = (node.textContent ?? "").slice(0, offset);
+    const m = before.match(/@([^\s@]{0,40})$/);
+    if (!m) {
+      setMention(null);
+      return;
+    }
+    const start = offset - m[0].length;
+    mentionRange.current = { node, start, end: offset };
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    const wrapEl = wrapRef.current;
+    const wrap = wrapEl?.getBoundingClientRect();
+    // Clamp here (in the handler) so render never reads the ref.
+    const wrapW = wrapEl?.clientWidth ?? 280;
+    const rawLeft = rect.left - (wrap?.left ?? 0);
+    setMention({
+      query: m[1],
+      top: rect.bottom - (wrap?.top ?? 0) + 4,
+      left: Math.max(0, Math.min(rawLeft, wrapW - 220)),
+      index: 0,
+    });
+  }, []);
+
+  const onInput = useCallback(() => {
+    emit();
+    detectMention();
+  }, [emit, detectMention]);
+
+  // Single paragraph — Enter doesn't create new blocks/lines.
+  const onKeyDownEditor = (e: React.KeyboardEvent) => {
+    if (mention) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMention(null);
+        return;
+      }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setMention((m) =>
+          m ? { ...m, index: Math.max(0, Math.min(filtered.length - 1, m.index + (e.key === "ArrowDown" ? 1 : -1))) } : m
+        );
+        return;
+      }
+      if ((e.key === "Enter" || e.key === "Tab") && filtered.length > 0) {
+        e.preventDefault();
+        selectMention(filtered[mention.index] ?? filtered[0]);
+        return;
+      }
+    }
+    if (e.key === "Enter") e.preventDefault();
+  };
+
+  // ── Roster filtering (mirrors CrewFields word-start match, cap 6) ──────────
+  const q = (mention?.query ?? "").trim().toLowerCase();
+  const filtered = mention
+    ? roster
+        .filter((p) => (q ? p.name.toLowerCase().split(/\s+/).some((w) => w.startsWith(q)) : true))
+        .slice(0, 6)
+    : [];
+
+  const focusEditor = () => editorRef.current?.focus();
+
+  const selectMention = (person: NewsPerson) => {
+    const r = mentionRange.current;
+    const el = editorRef.current;
+    if (!r || !el) return;
+    const range = document.createRange();
+    try {
+      range.setStart(r.node, r.start);
+      range.setEnd(r.node, r.end);
+    } catch {
+      setMention(null);
+      return;
+    }
+    range.deleteContents();
+    const pill = buildPill(person);
+    range.insertNode(pill);
+    // Trailing space + caret after it.
+    const space = document.createTextNode(" ");
+    pill.after(space);
+    const after = document.createRange();
+    after.setStartAfter(space);
+    after.collapse(true);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(after);
+    setMention(null);
+    emit();
+  };
+
+  // ── Toolbar actions ───────────────────────────────────────────────────────
+  const exec = (cmd: "bold" | "italic") => {
+    focusEditor();
+    try {
+      document.execCommand("styleWithCSS", false, "false");
+      document.execCommand(cmd);
+    } catch {
+      /* no-op */
+    }
+    emit();
+  };
+
+  const openLink = () => {
+    const sel = window.getSelection();
+    savedRange.current = sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
+    setLinkUrl("");
+    setLinkOpen(true);
+  };
+
+  const applyLink = () => {
+    const href = normalizeUrl(linkUrl);
+    if (!href) {
+      setLinkOpen(false);
+      return;
+    }
+    focusEditor();
+    const sel = window.getSelection();
+    if (savedRange.current) {
+      sel?.removeAllRanges();
+      sel?.addRange(savedRange.current);
+    }
+    const collapsed = !sel || sel.isCollapsed;
+    if (collapsed) {
+      // No selection — insert the URL as its own linked text.
+      const a = document.createElement("a");
+      a.href = href;
+      a.textContent = linkUrl.trim();
+      const range = sel?.getRangeAt(0);
+      range?.insertNode(a);
+      if (range) {
+        range.setStartAfter(a);
+        range.collapse(true);
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      }
+    } else {
+      try {
+        document.execCommand("createLink", false, href);
+      } catch {
+        /* no-op */
+      }
+    }
+    setLinkOpen(false);
+    emit();
+  };
+
+  const insertAt = () => {
+    focusEditor();
+    try {
+      document.execCommand("insertText", false, "@");
+    } catch {
+      /* no-op */
+    }
+    onInput();
+  };
+
+  return (
+    <div ref={wrapRef} style={{ position: "relative" }}>
+      {/* Toolbar */}
+      <div className="mb-2 flex items-center gap-1">
+        <ToolbarButton label="Bold" onClick={() => exec("bold")}>
+          <Bold size={14} />
+        </ToolbarButton>
+        <ToolbarButton label="Italic" onClick={() => exec("italic")}>
+          <Italic size={14} />
+        </ToolbarButton>
+        <Divider />
+        <ToolbarButton label="Add link" onClick={openLink}>
+          <LinkIcon size={14} />
+        </ToolbarButton>
+        <Divider />
+        <ToolbarButton label="Mention crew" onClick={insertAt}>
+          <AtSign size={14} />
+        </ToolbarButton>
+      </div>
+
+      {/* Inline link field */}
+      {linkOpen && (
+        <div className="mb-2 flex items-center gap-1.5">
+          <input
+            autoFocus
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                applyLink();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                setLinkOpen(false);
+              }
+            }}
+            placeholder="Paste or type a URL…"
+            style={{
+              flex: 1,
+              boxSizing: "border-box",
+              background: "var(--color-bt-card)",
+              border: "1px solid var(--color-bt-border)",
+              borderRadius: 8,
+              padding: "7px 10px",
+              fontSize: 13,
+              color: "var(--color-bt-text)",
+              outline: "none",
+            }}
+          />
+          <button
+            type="button"
+            onClick={applyLink}
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "#0d1f1a",
+              border: "none",
+              borderRadius: 8,
+              padding: "7px 12px",
+              fontSize: 12.5,
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Add
+          </button>
+        </div>
+      )}
+
+      {/* Editable area */}
+      <div style={{ position: "relative" }}>
+        {isEmpty && !linkOpen && (
+          <span
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              top: 9,
+              left: 11,
+              fontSize: 14,
+              color: "var(--color-bt-text-dim)",
+              pointerEvents: "none",
+            }}
+          >
+            Write something… type @ to tag the crew.
+          </span>
+        )}
+        <div
+          ref={editorRef}
+          contentEditable
+          suppressContentEditableWarning
+          role="textbox"
+          aria-multiline="true"
+          data-testid="news-richtext"
+          onInput={onInput}
+          onKeyDown={onKeyDownEditor}
+          onBlur={emit}
+          style={{
+            minHeight: 64,
+            boxSizing: "border-box",
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+            borderRadius: 8,
+            padding: "9px 10px",
+            fontSize: 14,
+            lineHeight: 1.5,
+            color: "var(--color-bt-text)",
+            outline: "none",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+          }}
+        />
+      </div>
+
+      {/* @-mention dropdown */}
+      {mention && filtered.length > 0 && (
+        <div
+          className="absolute z-30 flex flex-col overflow-hidden"
+          style={{
+            top: mention.top,
+            left: mention.left,
+            width: 220,
+            background: "var(--color-bt-card-float)",
+            border: "1px solid var(--color-bt-border)",
+            borderRadius: 9,
+            boxShadow: "var(--shadow-floating)",
+          }}
+        >
+          {filtered.map((p, i) => (
+            <button
+              key={p.userId ?? p.name}
+              type="button"
+              // Use mousedown so the editor's selection isn't lost before we act.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                selectMention(p);
+              }}
+              className="flex items-center gap-2 px-2.5 py-2 text-left transition-colors hover:bg-[var(--color-bt-hover)]"
+              style={{
+                background: i === mention.index ? "var(--color-bt-hover)" : "transparent",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              <Avatar
+                name={p.name}
+                avatarIcon={p.avatarIcon ?? null}
+                teamColor={p.color ?? undefined}
+                muted={!!p.placeholder}
+                sizePx={20}
+              />
+              <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolbarButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      // mousedown + preventDefault so clicking the button doesn't blur the
+      // editor / drop its selection before the command runs.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="flex items-center justify-center rounded-md transition-colors hover:bg-[var(--color-bt-hover)]"
+      style={{
+        height: 28,
+        width: 28,
+        border: "1px solid var(--color-bt-border)",
+        background: "var(--color-bt-card-raised)",
+        color: "var(--color-bt-text)",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Divider() {
+  return <span aria-hidden="true" style={{ width: 1, height: 18, background: "var(--color-bt-border)", margin: "0 3px" }} />;
+}

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -43,13 +43,29 @@ export interface NewsStep {
   body: string;
 }
 
-/** A run of text: a plain string, or a mention pill inline. */
-export type NewsSegment = string | { mention: NewsPerson };
+/** A run of inline content inside a paragraph:
+ *  - `string` — a plain run (the back-compat fast path)
+ *  - `{ mention }` — an inline @Crew avatar pill
+ *  - `{ text, bold?, italic? }` — a formatted run
+ *  - `{ link, text }` — a hyperlink (`link` = href, `text` = visible label)
+ *  No color marks — formatting is bold/italic/link only (spec: no color). */
+export type NewsSegment =
+  | string
+  | { mention: NewsPerson }
+  | { text: string; bold?: boolean; italic?: boolean }
+  | { link: string; text: string };
 
-// ── The six blocks ──────────────────────────────────────────────────────
+// ── The blocks ────────────────────────────────────────────────────────────
 
-/** A paragraph. `segments` carries inline @Crew mentions; `text` is the
- *  plain-string fast path. `dim` renders it in the muted text color. */
+/** A title line above body content. Added post-handoff at the product owner's
+ *  request (see SPEC-news.md) — expands the original closed six. */
+export interface NewsHeadingBlock {
+  type: "heading";
+  text: string;
+}
+
+/** A paragraph. `segments` carries inline @Crew mentions + bold/italic/link
+ *  runs; `text` is the plain-string fast path. `dim` renders it muted. */
 export interface NewsTextBlock {
   type: "text";
   text?: string;
@@ -98,6 +114,7 @@ export interface NewsCalloutBlock {
 }
 
 export type NewsBlock =
+  | NewsHeadingBlock
   | NewsTextBlock
   | NewsCrewBlock
   | NewsTeamsBlock
@@ -118,8 +135,9 @@ export interface NewsPost {
   updatedAt: string;
 }
 
-/** The closed set, in composer/catalog order. */
+/** All block types, in composer/catalog order. */
 export const NEWS_BLOCK_TYPES: NewsBlockType[] = [
+  "heading",
   "text",
   "crew",
   "teams",
@@ -144,12 +162,27 @@ const personSchema = z.object({
   placeholder: z.boolean().optional(),
 });
 
+// `.strict()` on each object arm so the union discriminates by shape: without
+// it Zod strips unknown keys, so a `{ link, text }` segment would pass the
+// `{ text, … }` arm and silently lose its href. Strict forces the right arm.
 const segmentSchema = z.union([
   z.string(),
-  z.object({ mention: personSchema }),
+  z.object({ mention: personSchema }).strict(),
+  z.object({ link: z.string().min(1).max(2000), text: z.string().min(1).max(500) }).strict(),
+  z
+    .object({
+      text: z.string().max(5000),
+      bold: z.boolean().optional(),
+      italic: z.boolean().optional(),
+    })
+    .strict(),
 ]);
 
 export const newsBlockSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("heading"),
+    text: z.string().min(1).max(200),
+  }),
   z.object({
     type: z.literal("text"),
     text: z.string().max(5000).optional(),

--- a/src/server/routers/news.test.ts
+++ b/src/server/routers/news.test.ts
@@ -177,6 +177,50 @@ describe("news router", () => {
     ).rejects.toThrow();
   });
 
+  // ── heading block + rich-text segments (PR4) ──────────────────────────────
+
+  it("create — a heading block round-trips", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "heading", text: "Saturday — Championship Day" }],
+    });
+    expect(post.blocks[0]).toEqual({ type: "heading", text: "Saturday — Championship Day" });
+  });
+
+  it("create — rejects an empty-text heading", async () => {
+    await expect(
+      ctx.caller().news.create({ tripId, blocks: [{ type: "heading", text: "" }] })
+    ).rejects.toThrow();
+  });
+
+  it("create — rich-text segments (bold, link, mention) round-trip intact", async () => {
+    const blocks: NewsBlock[] = [
+      {
+        type: "text",
+        segments: [
+          "See ",
+          { text: "the leaderboard", bold: true },
+          " at ",
+          { link: "https://example.com/board", text: "this link" },
+          " — nice work ",
+          { mention: { userId: null, name: "Buddy", initials: "BB", color: null } },
+          "!",
+        ],
+      },
+    ];
+    const post = await ctx.caller().news.create({ tripId, blocks });
+    expect(post.blocks[0]).toEqual(blocks[0]);
+  });
+
+  it("create — a link segment keeps its href (not flattened to plain text)", async () => {
+    const post = await ctx.caller().news.create({
+      tripId,
+      blocks: [{ type: "text", segments: [{ link: "https://buddytrip.app", text: "site" }] }],
+    });
+    const block = post.blocks[0] as Extract<NewsBlock, { type: "text" }>;
+    expect(block.segments?.[0]).toEqual({ link: "https://buddytrip.app", text: "site" });
+  });
+
   // ── update / setPinned / delete ──────────────────────────────────────────
 
   it("update — owner edits blocks and pin state", async () => {


### PR DESCRIPTION
The final News refinement — a rich-text **Text** editor and a new **Heading** block.

## What's in it

**Rich-text Text editor** (`RichTextEditor.tsx`) — a contentEditable paragraph with a **bold · italic · link · @** toolbar:
- Inline **@Crew mention pills** while typing (reuses the roster autocomplete; word-start filter, arrow/enter nav).
- **Bold/italic** via `execCommand` (styleWithCSS off → `<b>`/`<i>`), an inline **link** field (bare domains normalized to `https://`).
- Serializes the DOM to the `NewsSegment` model and re-hydrates on edit.
- **Lists deferred** to a follow-up (Steps already covers numbered lists).

**Heading block** — a 7th block type (`{ type: "heading", text }`), a title line. The design spec explicitly excluded a heading block, so this was confirmed with the product owner and recorded as a deliberate exception in `SPEC-news.md` (the rest of the closed set holds).

## Model & rendering
- `NewsSegment` extended with `{ text, bold?, italic? }` and `{ link, text }` (keeps `string` + `{ mention }`). `segmentSchema` is a **strict** union so a link never silently collapses to plain text.
- Renderer handles the new segments (bold/italic spans, accent links) + the heading `<h3>`. `RichText` paragraph is a `<div>` (an inline mention renders an Avatar `<div>` — invalid inside `<p>`).
- Help modal: added the Heading entry, refreshed the Text copy, "six" → "seven".

## Tests
- **Vitest** (`news.test.ts`): heading + extended-segment round-trips, empty-heading rejection, and a guard that a link segment keeps its href. Full suite green locally.
- **Playwright** (`news.spec.ts`): a staged happy-path (heading + bold/link/mention render + composer affordances). The Playwright suite is repo-wide deferred in CI pending the auth-redirect/global-setup fix (see `ci.yml` / issue #29); this runs once that lands.

## Verification
- `tsc --noEmit` clean, lint clean, `vitest run` green.
- Verified live in preview: compose → bold/italic/link/@-mention → Heading block → Edit/Preview toggle → Post → feed render → edit re-hydration. No console/hydration errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)