### PR TITLE
PR2: fix launch-blocking guest→signup merge + DB cleanup (migration 023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,26 @@ These patterns have been established through prior work. Follow them exactly —
 5. **Middleware auth** — `requireAuth` before any `requireTripMember`/`requireTripRole`
 6. **Test isolation** — 4 shared persistent users (`test-owner`, `test-planner`, `test-member`, `test-outsider`), unique trips per test
 
+## Guest → real-user conversion (auth)
+
+Placeholders/invited crew are `users` rows with `is_guest = true`. When a real
+account signs up, the DB does the conversion — there is no app-code path:
+
+- `on_auth_user_created` (trigger on `auth.users`) → `handle_new_user()`.
+- If a guest row matches the new email, `handle_new_user` nulls the guest's
+  email, inserts the real `users` row, and calls
+  `merge_guest_to_real_user(ghost_id, real_id)` to reassign the guest's rows
+  (trip_members, team_assignments, idea_votes, date_poll_votes, expense_splits,
+  messages, expenses.paid_by, quick_info_tiles.created_by, series.owner_id,
+  users.created_by, invites.created_by) and delete the guest row. It then marks
+  matching `invites` accepted.
+- Brand-new emails (no matching guest) skip the merge entirely.
+
+**Keep `merge_guest_to_real_user` in lockstep with the schema** — it runs inside
+the signup trigger, so a reference to a dropped table/column makes the whole
+signup fail (this exact bug was fixed in migration 023). When you drop a table
+or a `user_id`/`created_by` column, update this function in the same migration.
+
 ## Migration Workflow
 
 Migrations are committed as files in `supabase/migrations/` and applied to the remote DB by CI's `supabase db push` step. The CLI compares the `supabase_migrations.schema_migrations` history table against local filenames and **fails when they don't match exactly**.

--- a/src/app/trips/[tripId]/tabs/types.ts
+++ b/src/app/trips/[tripId]/tabs/types.ts
@@ -22,7 +22,6 @@ export interface TripData {
   about_message?: string | null;
   /** Panel activation flag — owner taps the invitation card to flip this on. */
   itinerary_enabled?: boolean | null;
-  travel_plans_crew_visible?: boolean | null;
   series_id?: string | null;
   created_at?: string | null;
 }

--- a/supabase/migrations/20260606120000_023_fix_guest_merge_and_db_cleanup.sql
+++ b/supabase/migrations/20260606120000_023_fix_guest_merge_and_db_cleanup.sql
@@ -1,0 +1,57 @@
+-- 023 — Fix the guest→real-user merge (launch-blocking) + pre-launch DB cleanup
+--
+-- All statements are idempotent and transaction-safe (no CONCURRENTLY), so
+-- `supabase db push` applies this cleanly. Index work here is on tiny tables
+-- (and the DB is reset before launch), so a plain CREATE INDEX is instantaneous;
+-- larger/live indexes in the competition build will be applied CONCURRENTLY
+-- out-of-band (CONCURRENTLY can't run inside the transaction db push wraps each
+-- migration in).
+
+-- ── 1. CRITICAL: fix merge_guest_to_real_user ──────────────────────────────
+-- This runs from handle_new_user() (the on_auth_user_created signup trigger)
+-- whenever someone signs up with an email that matches an existing guest
+-- (placeholder) row. The previous body referenced six tables dropped in the
+-- squash/refactors (players, player_hole_scores, idea_comments, rounds,
+-- scoreboard_shares, group_results) and a non-existent trips.owner_id column,
+-- so the conversion raised "relation does not exist" and the entire signup
+-- rolled back. Rewritten to reassign only the guest-owned rows that exist in
+-- the current schema. Ownership lives in trip_members (role='Owner'), not a
+-- trips.owner_id column, so that line is gone.
+CREATE OR REPLACE FUNCTION public.merge_guest_to_real_user(p_ghost_id text, p_real_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $function$
+BEGIN
+  UPDATE public.trip_members     SET user_id         = p_real_id WHERE user_id         = p_ghost_id;
+  UPDATE public.team_assignments SET user_id         = p_real_id WHERE user_id         = p_ghost_id;
+  UPDATE public.idea_votes       SET user_id         = p_real_id WHERE user_id         = p_ghost_id;
+  UPDATE public.date_poll_votes  SET user_id         = p_real_id WHERE user_id         = p_ghost_id;
+  UPDATE public.expense_splits   SET user_id         = p_real_id WHERE user_id         = p_ghost_id;
+  UPDATE public.messages         SET user_id         = p_real_id WHERE user_id         = p_ghost_id;
+  UPDATE public.expenses         SET paid_by_user_id = p_real_id WHERE paid_by_user_id = p_ghost_id;
+  UPDATE public.quick_info_tiles SET created_by      = p_real_id WHERE created_by      = p_ghost_id;
+  UPDATE public.series           SET owner_id        = p_real_id WHERE owner_id        = p_ghost_id;
+  UPDATE public.users            SET created_by      = p_real_id WHERE created_by      = p_ghost_id;
+  UPDATE public.invites          SET created_by      = p_real_id WHERE created_by      = p_ghost_id;
+  DELETE FROM public.users WHERE id = p_ghost_id AND is_guest = true;
+END;
+$function$;
+
+-- ── 2. Drop duplicate indexes (redundant with the UNIQUE-constraint index) ──
+DROP INDEX IF EXISTS public.invites_token_idx;       -- dup of invites_token_key (unique)
+DROP INDEX IF EXISTS public.idx_users_email;         -- dup of users_email_key (unique)
+DROP INDEX IF EXISTS public.idx_golf_courses_place_id; -- dup of golf_courses_place_id_key (unique)
+
+-- ── 3. Index the messages.user_id foreign key (unindexed, grows fastest) ────
+CREATE INDEX IF NOT EXISTS idx_messages_user_id ON public.messages (user_id);
+
+-- ── 4. Drop verified-dead columns ──────────────────────────────────────────
+-- travel_plans_crew_visible: only ever declared in a TS type, never read/written.
+-- events.modifiers: never selected, inserted, or read anywhere in the app.
+-- (NB: trips.comparison_mode and trips.itinerary_enabled are NOT dropped —
+--  comparison_mode is read in page.tsx/TripCard; itinerary_enabled is read by
+--  HomeTab→ItineraryPanel. Both are still live reads.)
+ALTER TABLE public.trips  DROP COLUMN IF EXISTS travel_plans_crew_visible;
+ALTER TABLE public.events DROP COLUMN IF EXISTS modifiers;


### PR DESCRIPTION
Second pre-launch cleanup PR (DB). One idempotent, transaction-safe migration (`023`). CI's `supabase db push` applies it.

## 🚨 Critical fix (answers your three questions)
**Q1 — the working guest→real conversion path:** `on_auth_user_created` (trigger on `auth.users`) → `handle_new_user()`. If a guest (`is_guest=true`) row matches the new email, it nulls the guest's email, inserts the real `users` row, calls `merge_guest_to_real_user(ghost, real)` to reassign the guest's rows, then marks `invites` accepted. New emails skip the merge. **There is no app-code path — it's all in this trigger.**

**Q2 — is `merge_guest_to_real_user` triggered?** **Yes** — `handle_new_user` calls it on every signup that matches a guest. It is *not* dead.

**Q3 — what happens when a guest signs up with the same email?** It was supposed to migrate their data. But the function still `UPDATE`d six tables dropped in the squash (`players`, `player_hole_scores`, `idea_comments`, `rounds`, `scoreboard_shares`, `group_results`) + a non-existent `trips.owner_id`, so it raised `relation does not exist` → **the entire signup rolled back**. Any placeholder/invited crew member signing up with their email currently fails. (Your earlier signup test used a brand-new email, so it only hit the Resend issue.)

→ **Fixed**, not removed (removing would orphan converted users from their trips). Rewrote the function to reassign only rows that exist in the current schema. Documented the path + a "keep in lockstep with the schema" rule in `CLAUDE.md`.

## Also in migration 023
- **Drop 3 duplicate indexes** — `invites_token_idx`, `idx_users_email`, `idx_golf_courses_place_id` (each redundant with its UNIQUE-constraint index).
- **Add `idx_messages_user_id`** — the unindexed FK that grows fastest. Plain `CREATE INDEX` (not CONCURRENTLY): Supabase wraps each migration in a transaction so CONCURRENTLY can't run, and the table is tiny / about to be reset, so the lock is sub-ms. Larger live indexes in the competition build get CONCURRENTLY out-of-band.
- **Drop verified-dead columns** `trips.travel_plans_crew_visible` (only a stale TS type) and `events.modifiers` (no app reference); removed the dead type field.

## Corrections from the audit (NOT dropped — both are live reads)
- `trips.comparison_mode` — read in `page.tsx` + `TripCard` (exploration trips). **Kept.**
- `trips.itinerary_enabled` — read by `HomeTab → ItineraryPanel`. **Kept** (flagged in PR1).

## Verification
`tsc` clean · `next lint` zero warnings · **430/430 Vitest tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)