### PR TITLE
PR4: pre-launch data reset — wipe test data, recreate real accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 /test-results
 /playwright-report
 
+# local DB backups / snapshots (may contain test PII — never commit)
+/backups
+
 # next.js
 /.next/
 /out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,13 @@
 - Mock/test data lives only in `supabase/seed.sql` — never in migration files
 - Migration files are production-safe — schema, views, functions, triggers, RLS policies only
 - `seed.sql` is never run automatically — manual development use only
-- Before launch: `TRUNCATE TABLE users CASCADE` wipes all test data
+- Pre-launch reset (done 2026-06-06): truncated all user/trip-scoped data tables.
+  `TRUNCATE users CASCADE` alone is NOT enough — `trips` and its child rows have
+  no FK to `users`, so they'd orphan; truncate the full data set and keep the
+  reference tables (`catalog_ideas`/`golf_courses`/`game_type_templates`). The 6
+  real auth-backed `public.users` rows (Zach ×2 + the 4 shared CI test users) are
+  recreated after, matching their `auth.users` UUIDs, so the test suite keeps
+  working. A pre-reset JSON snapshot lives in `/backups` (gitignored).
 
 ## Document Authority
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,5 +1,15 @@
 -- BuddyTrip — Local dev seed
 --
+-- This file is for LOCAL development only (supabase start) — it is never run
+-- against prod. It uses \set placeholders for the two local auth UUIDs.
+--
+-- Prod was reset on 2026-06-06 (final pre-launch wipe): all user/trip-scoped
+-- data tables truncated, reference tables kept (catalog_ideas, golf_courses,
+-- game_type_templates), and the 6 real auth-backed users recreated — Zach's two
+-- accounts (zgrether@gmail.com, zgrethphoto@gmail.com) + the 4 shared CI test
+-- users (test-owner/planner/member/outsider@buddytrip.app). No BBMI trip data
+-- has been seeded yet — that's a deliberate later step.
+--
 -- Rewritten 2026-05-17 during pre-launch cleanup. The previous seed
 -- referenced 30+ CC-generated test users and was tied to the old
 -- pre-reset database. After the post-cleanup reset, the only real auth


### PR DESCRIPTION
Final pre-launch PR. The substance is an **operational data wipe already run against prod (2026-06-06)**; this PR carries the doc/ignore changes that record it. **No schema or migration changes.**

## What ran on prod (live SQL — DML, not a migration)
- **Truncated all 25 user/trip-scoped data tables** + the 4 empty `circle_*` stubs.
  - ⚠️ Correction to the original plan: `TRUNCATE users CASCADE` *alone* is insufficient — `trips` and its children (`ideas`, `schedule_items`, …) have no FK to `users`, so they'd be left orphaned. Truncated the full data set instead.
- **Kept reference tables:** `catalog_ideas` (20), `golf_courses` (15), `game_type_templates` (4).
- **Recreated the 6 real auth-backed `public.users` rows** — Zach ×2 (`zgrether@gmail.com`, `zgrethphoto@gmail.com`) + the 4 shared CI test users — matching their `auth.users` UUIDs, so the test suite keeps working. (`handle_new_user` only fires on auth *creation*, not sign-in, so these mirror rows had to be recreated explicitly.)
- **Backup:** the free Supabase plan has no restorable backup, so I took a **151 KB JSON snapshot** of all pre-reset data into `/backups` (gitignored) as the restore point.

## Verified after reset
| | |
|---|---|
| `users` | 6 (0 guests) — the 6 real accounts only |
| `trips` / `trip_members` / `messages` / `competitions` / `news_posts` | 0 |
| reference tables | preserved (20 / 15 / 4) |
| `auth.users` | untouched (logins work) |
| **Vitest** | **430/430 pass against the reset DB** |

**No BBMI trip data seeded yet** — that's a deliberate later step once the real roster is gathered.

## Repo changes (the only committed diff)
- `.gitignore` — ignore `/backups`
- `CLAUDE.md` — corrected the seed-reset rule (full truncate, not `users CASCADE` alone)
- `supabase/seed.sql` — header records the 2026-06-06 reset + the 6 canonical accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)