### PR TITLE
fix(auth): email-confirmed users land on dashboard, signed in

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,38 +1,65 @@
 import { NextResponse } from "next/server";
+import type {
+  AuthError,
+  EmailOtpType,
+  Session,
+  User,
+} from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase-server";
 
 /**
- * OAuth + magic-link callback.
+ * Auth callback — handles every email/OAuth flow that lands a user back in the
+ * app and needs a session established: email confirmation (signup), magic link,
+ * OAuth, and recovery. It supports BOTH link formats Supabase can send:
  *
- * After successfully exchanging the auth code, decide where to send
- * the user:
+ *   • `?code=…`                 → PKCE / OAuth → exchangeCodeForSession()
+ *   • `?token_hash=…&type=…`    → email OTP (signup confirm, recovery, etc.)
+ *                                 → verifyOtp({ token_hash, type })
  *
- *   1. `?next=` query param — explicit override, used by invite flows
- *      that need to land the user on a specific trip after the
- *      guest→member merge completes.
- *   2. New user (no trip memberships, no invite token) → /trips/new.
- *      Skip the empty state — the most useful next step on a trip
- *      planning app is creating a trip.
- *   3. Returning user → "/" — the smart-redirect logic on the home
- *      page picks their most relevant trip.
+ * Either way we end up with a session whose cookies are written onto the
+ * redirect response (route handlers allow cookie mutation), so the user is
+ * fully signed in when they arrive.
  *
- * If `?next=` is supplied we honor it without doing the trip-count
- * lookup, so invite redirects stay fast.
+ * Destination, in order:
+ *   1. `?next=` — explicit override (signup confirm passes `/dashboard`;
+ *      invite flows pass a specific trip after the guest→member merge).
+ *   2. New user (no trip memberships) → /trips/new — the most useful next step.
+ *   3. Returning user → "/" — the home-page smart redirect picks their trip.
+ *
+ * If `?next=` is supplied we honor it without the trip-count lookup, so signup
+ * and invite redirects stay fast.
  */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next");
 
-  if (!code) {
+  const supabase = await createClient();
+
+  // Establish the session from whichever flow Supabase sent.
+  let sessionData: { user: User | null; session: Session | null } | null = null;
+  let authError: AuthError | null = null;
+  if (tokenHash && type) {
+    // Email OTP flow (signup confirmation, recovery, email change, …).
+    const { data, error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash: tokenHash,
+    });
+    sessionData = data;
+    authError = error;
+  } else if (code) {
+    // PKCE / OAuth / magic-link code flow.
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    sessionData = data;
+    authError = error;
+  } else {
+    // Nothing to verify — bounce to login.
     return NextResponse.redirect(`${origin}/login`);
   }
 
-  const supabase = await createClient();
-  const { data: sessionData, error: exchangeError } =
-    await supabase.auth.exchangeCodeForSession(code);
-
-  if (exchangeError) {
+  if (authError) {
     return NextResponse.redirect(`${origin}/login`);
   }
 

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -148,10 +148,19 @@ export default function LoginClient({
     setError("");
     setLoading(true);
     try {
+      const origin = typeof window !== "undefined" ? window.location.origin : "";
       const { data, error: signUpError } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: { name } },
+        options: {
+          data: { name },
+          // Route the confirmation link through our auth callback so the token
+          // is exchanged for a session there (sets the cookie) and the user
+          // lands logged-in on the dashboard. Without this, redirect_to falls
+          // back to the Site URL (the marketing page), which never exchanges
+          // the token — the user appears signed out and has to log in manually.
+          emailRedirectTo: `${origin}/auth/callback?next=/dashboard`,
+        },
       });
       if (signUpError) throw signUpError;
 


### PR DESCRIPTION
## Bug
Sign up → click **Confirm my account** → lands on the **marketing page, still signed out**, and has to log in manually.

## Root cause
`supabase.auth.signUp()` was called **without `emailRedirectTo`** (unlike the magic-link and password-reset flows, which set it). So the confirmation link's `redirect_to` fell back to the Supabase **Site URL** (`https://bbmi.app` — the marketing root). That page never exchanges the auth token for a session, so **no session cookie was ever set** → the user appears logged out.

The `/auth/callback` route that *does* establish the session was being bypassed entirely.

## Fix (code)
1. **`LoginClient` →** `signUp` now sets `emailRedirectTo: ${origin}/auth/callback?next=/dashboard`, routing the confirmation through the callback and landing the verified user on the dashboard.
2. **`/auth/callback` →** now handles **both** link formats Supabase can send:
   - `?code=…` → `exchangeCodeForSession()` (PKCE / OAuth / magic link — existing)
   - `?token_hash=…&type=…` → `verifyOtp({ token_hash, type })` (email confirmation `signup`, recovery, email change — **new**)
   
   Either path establishes a session whose cookies are written onto the redirect response (route handlers permit cookie mutation), so the user arrives **fully authenticated**. `?next=/dashboard` is honored first, so confirmation lands straight on the app home.

## ⚠️ Requires one Supabase dashboard change (cannot be done from code)
Add **`https://bbmi.app/auth/callback`** (and `http://localhost:3000/auth/callback` for dev) to **Auth → URL Configuration → Redirect URLs**. Supabase validates `redirect_to` against this allowlist; if the callback URL isn't allowed, it silently falls back to the Site URL and the bug returns.

## Test (manual, after the dashboard change)
Sign up fresh → click the confirm link → should land on `/dashboard`, fully signed in, with no extra login step.

Verified: `tsc` clean, `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)