### PR TITLE
chore: canonicalize on bbmi.app (NEXT_PUBLIC_SITE_URL) + fold in auth-callback fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # BuddyTrip — Environment Variables
 # Copy to .env.local and fill in your values.
 
+# Canonical public site origin (no trailing slash). Drives email invite/trip
+# links, the tRPC server base URL, and metadataBase for OG tags. In local dev
+# set to http://localhost:3000; in prod/preview set to the real domain.
+NEXT_PUBLIC_SITE_URL=https://bbmi.app
+
 # Supabase project URL (public, safe for client)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **BuddyTrip** — mobile-first group trip planning and competition scoring app
 - Repo: github.com/zgrether/buddytrip
-- Deployed: buddytrip-app.vercel.app
+- Deployed: bbmi.app
 
 ## Stack
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -36,7 +36,7 @@ leaderboard, in-app notifications.
 | Styling | `--color-bt-*` CSS token system, light/dark mode |
 
 **Repo:** github.com/zgrether/buddytrip (private)
-**Deployed:** buddytrip-app.vercel.app
+**Deployed:** bbmi.app
 **Key files:** `CLAUDE.md` (enforced patterns), `STYLE_GUIDE.md` (design
 system), `PERMISSIONS.md` (role matrix), `DEFERRED.md` (backlog)
 

--- a/design/README.md
+++ b/design/README.md
@@ -20,7 +20,7 @@ the repo, plus a few core components — `TripHeader`, `TripCard`,
 ## Product context
 
 **BuddyTrip** is a Next.js 15 / Tailwind v4 / Supabase app, deployed at
-`buddytrip-app.vercel.app`. One product, two distinct visual surfaces:
+`bbmi.app`. One product, two distinct visual surfaces:
 
 | Surface | Files | What it is |
 |---|---|---|

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,38 +1,65 @@
 import { NextResponse } from "next/server";
+import type {
+  AuthError,
+  EmailOtpType,
+  Session,
+  User,
+} from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase-server";
 
 /**
- * OAuth + magic-link callback.
+ * Auth callback — handles every email/OAuth flow that lands a user back in the
+ * app and needs a session established: email confirmation (signup), magic link,
+ * OAuth, and recovery. It supports BOTH link formats Supabase can send:
  *
- * After successfully exchanging the auth code, decide where to send
- * the user:
+ *   • `?code=…`                 → PKCE / OAuth → exchangeCodeForSession()
+ *   • `?token_hash=…&type=…`    → email OTP (signup confirm, recovery, etc.)
+ *                                 → verifyOtp({ token_hash, type })
  *
- *   1. `?next=` query param — explicit override, used by invite flows
- *      that need to land the user on a specific trip after the
- *      guest→member merge completes.
- *   2. New user (no trip memberships, no invite token) → /trips/new.
- *      Skip the empty state — the most useful next step on a trip
- *      planning app is creating a trip.
- *   3. Returning user → "/" — the smart-redirect logic on the home
- *      page picks their most relevant trip.
+ * Either way we end up with a session whose cookies are written onto the
+ * redirect response (route handlers allow cookie mutation), so the user is
+ * fully signed in when they arrive.
  *
- * If `?next=` is supplied we honor it without doing the trip-count
- * lookup, so invite redirects stay fast.
+ * Destination, in order:
+ *   1. `?next=` — explicit override (signup confirm passes `/dashboard`;
+ *      invite flows pass a specific trip after the guest→member merge).
+ *   2. New user (no trip memberships) → /trips/new — the most useful next step.
+ *   3. Returning user → "/" — the home-page smart redirect picks their trip.
+ *
+ * If `?next=` is supplied we honor it without the trip-count lookup, so signup
+ * and invite redirects stay fast.
  */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next");
 
-  if (!code) {
+  const supabase = await createClient();
+
+  // Establish the session from whichever flow Supabase sent.
+  let sessionData: { user: User | null; session: Session | null } | null = null;
+  let authError: AuthError | null = null;
+  if (tokenHash && type) {
+    // Email OTP flow (signup confirmation, recovery, email change, …).
+    const { data, error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash: tokenHash,
+    });
+    sessionData = data;
+    authError = error;
+  } else if (code) {
+    // PKCE / OAuth / magic-link code flow.
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+    sessionData = data;
+    authError = error;
+  } else {
+    // Nothing to verify — bounce to login.
     return NextResponse.redirect(`${origin}/login`);
   }
 
-  const supabase = await createClient();
-  const { data: sessionData, error: exchangeError } =
-    await supabase.auth.exchangeCodeForSession(code);
-
-  if (exchangeError) {
+  if (authError) {
     return NextResponse.redirect(`${origin}/login`);
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,11 @@ import { Providers } from "@/lib/providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  // Resolves relative/OG URLs against the canonical domain (https://bbmi.app)
+  // in prod; falls back to localhost in dev.
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+  ),
   title: "BuddyTrip",
   description: "Group trip planning and competition app",
   icons: {

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -148,10 +148,19 @@ export default function LoginClient({
     setError("");
     setLoading(true);
     try {
+      const origin = typeof window !== "undefined" ? window.location.origin : "";
       const { data, error: signUpError } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: { name } },
+        options: {
+          data: { name },
+          // Route the confirmation link through our auth callback so the token
+          // is exchanged for a session there (sets the cookie) and the user
+          // lands logged-in on the dashboard. Without this, redirect_to falls
+          // back to the Site URL (the marketing page), which never exchanges
+          // the token — the user appears signed out and has to log in manually.
+          emailRedirectTo: `${origin}/auth/callback?next=/dashboard`,
+        },
       });
       if (signUpError) throw signUpError;
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -7,10 +7,10 @@ const FROM = "BuddyTrip <onboarding@resend.dev>";
 
 const DEV_TO_EMAIL = process.env.RESEND_DEV_TO_EMAIL;
 
-const BASE_URL =
-  process.env.NEXT_PUBLIC_VERCEL_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-    : "http://localhost:3000";
+// Canonical site origin (https://bbmi.app in prod). Drives invite/trip links in
+// emails — must be the real public domain, not the ephemeral per-deployment
+// VERCEL_URL (which previously left these links pointing at localhost in prod).
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 
 function resolveRecipient(toEmail: string): string {
   if (process.env.NODE_ENV === "development" && DEV_TO_EMAIL) {

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -10,6 +10,9 @@ import { AuthProvider } from "@/lib/auth-context";
 
 function getBaseUrl() {
   if (typeof window !== "undefined") return "";
+  // Canonical production origin wins; VERCEL_URL stays as the fallback so
+  // preview deployments still resolve to their own host.
+  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   return "http://localhost:3000";
 }

--- a/src/lib/trpc.ts
+++ b/src/lib/trpc.ts
@@ -4,6 +4,9 @@ import superjson from "superjson";
 
 function getBaseUrl() {
   if (typeof window !== "undefined") return "";
+  // Canonical production origin wins; VERCEL_URL stays as the fallback so
+  // preview deployments still resolve to their own host.
+  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   return "http://localhost:3000";
 }


### PR DESCRIPTION
Domain migration to **bbmi.app**. Introduces one canonical origin env var (`NEXT_PUBLIC_SITE_URL`) and routes every base-URL consumer through it, plus folds in the unmerged auth-callback fix (#312) so it all ships together.

## Changes
1. **`NEXT_PUBLIC_SITE_URL`** documented in `.env.example` (= `https://bbmi.app`). Set locally to `http://localhost:3000`.
2. **`email.ts`** — `BASE_URL` now uses `NEXT_PUBLIC_SITE_URL`. 🔴 **Fixes the real bug:** invite/trip links used `NEXT_PUBLIC_VERCEL_URL`, which Vercel never sets, so in prod they fell back to `http://localhost:3000` (dead links).
3. **`providers.tsx` + `trpc.ts`** — prefer `NEXT_PUBLIC_SITE_URL`; keep `VERCEL_URL` as the fallback so preview deployments still resolve to their own host.
4. **`layout.tsx`** — `metadataBase: new URL(NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000")` so OG/relative URLs resolve to the canonical domain.
5. **Auth callback fix (cherry-picked from #312)** — `signUp` sets `emailRedirectTo: ${origin}/auth/callback?next=/dashboard`, and the callback handles both the `code` and `token_hash`/`type` flows via `verifyOtp`, so email-confirmed users land on `/dashboard` already signed in. **Supersedes #312.**
6. **Docs** — `buddytrip-app.vercel.app` → `bbmi.app` in `CLAUDE.md`, `PROJECT_STATUS.md`, `design/README.md`.

Verified: no `NEXT_PUBLIC_VERCEL_URL` or `buddytrip-app.vercel.app` references remain in `src/`; `tsc` clean; `next lint` clean.

## ⚠️ After merge — manual dashboard steps (cannot be done from code)
- **Supabase → Auth → URL Configuration → Redirect URLs:** add `https://bbmi.app/auth/callback` and `http://localhost:3000/auth/callback`.
- **Vercel → Env:** set `NEXT_PUBLIC_SITE_URL=https://bbmi.app` (production **and** preview).
- (Still parked) **Resend:** verify the sending domain + swap `email.ts` `FROM` off `onboarding@resend.dev` so confirmation/invite emails actually deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)