### PR TITLE
chore(email): make Resend sender env-driven (RESEND_FROM) — landed off #313

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,20 @@ GOLF_API_KEY=
 # Format: postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
 # SUPABASE_DB_URL=postgresql://...
 
-# --- Feedback channel ---
+# --- Email (Resend) ---
+
+# Resend API key (SECRET — server-only). Sends trip invites + beta feedback.
+RESEND_API_KEY=re_...
+
+# Sender identity for app emails. MUST be an address on a domain verified in
+# Resend, or sends fail / land in spam. Leave unset and it falls back to
+# Resend's sandbox sender (onboarding@resend.dev), which only delivers to the
+# Resend account owner. Prod value once bbmi.app is verified:
+RESEND_FROM=BuddyTrip <noreply@bbmi.app>
+
+# Dev-only override: in development, redirect ALL app email to this address so
+# you never email real users while testing. Ignored in production.
+RESEND_DEV_TO_EMAIL=
 
 # Destination address for in-app beta feedback. When set, feedback.send routes
 # reports here via Resend. Omit in CI (no send needed); set in production and

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,8 +2,11 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-// Swap to noreply@buddytrip.app once domain is purchased and verified
-const FROM = "BuddyTrip <onboarding@resend.dev>";
+// Sender identity. Set RESEND_FROM in prod once bbmi.app is verified in Resend
+// (e.g. "BuddyTrip <noreply@bbmi.app>"). Until then it falls back to Resend's
+// shared sandbox sender, which ONLY delivers to the Resend account owner —
+// so unset in prod = invites silently reach no one but you.
+const FROM = process.env.RESEND_FROM ?? "BuddyTrip <onboarding@resend.dev>";
 
 const DEV_TO_EMAIL = process.env.RESEND_DEV_TO_EMAIL;
 


### PR DESCRIPTION
Re-lands the `RESEND_FROM` change that was committed to #313's branch *after* #313 had already been merged, so it never reached `main` (main still hardcoded `onboarding@resend.dev`).

- `email.ts`: `FROM` now reads `RESEND_FROM`, falling back to Resend's sandbox sender when unset.
- `.env.example`: documents the Resend email vars + the `noreply@bbmi.app` prod value.

Does **not** change behavior until `RESEND_FROM` is set in Vercel **and** `bbmi.app` is verified in Resend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)