### PR TITLE
fix(auth): cascade auth-user deletion into public.users (migration 025)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,11 @@ account signs up, the DB does the conversion — there is no app-code path:
   invites.created_by) and delete the guest row. It then marks matching
   `invites` accepted.
 - Brand-new emails (no matching guest) skip the merge entirely.
+- Deleting a user is also DB-side: `on_auth_user_deleted` (trigger on
+  `auth.users`) → `handle_user_delete()` deletes the matching `public.users`
+  row (`id = OLD.id::text`); FKs into `public.users` cascade the rest. Added in
+  migration 025 — without it, the Supabase dashboard "Delete user" left an
+  orphaned `public.users` row and the email stayed blocked by `users_email_key`.
 
 **Keep `merge_guest_to_real_user` in lockstep with the schema** — it runs inside
 the signup trigger, so a reference to a dropped table/column makes the whole

--- a/supabase/migrations/20260606140000_025_handle_user_delete.sql
+++ b/supabase/migrations/20260606140000_025_handle_user_delete.sql
@@ -1,0 +1,37 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- Migration 025 — Cascade auth-user deletion into public.users
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- Problem: deleting a user in the Supabase dashboard (or via the admin API)
+-- removes the `auth.users` row but leaves its `public.users` mirror row behind.
+-- The two can't be linked by a foreign key (auth.users.id is uuid, our
+-- public.users.id is text), and we only had an INSERT-side trigger
+-- (handle_new_user) — nothing on DELETE. Result: the app still sees the user,
+-- and because public.users.email is UNIQUE, that email can't be re-registered
+-- (a fresh signup collides on users_email_key and the signup trigger rolls back).
+--
+-- Fix: mirror handle_new_user with a delete-side trigger that removes the
+-- public.users row when its auth.users row is deleted. FKs into public.users
+-- (trip_members, team_assignments, idea_votes, date_poll_votes, expense_splits,
+-- messages, expenses.paid_by_user_id, quick_info_tiles.created_by, invites, …)
+-- are ON DELETE CASCADE, so the rest of that user's rows clean up automatically.
+--
+-- Idempotent (CREATE OR REPLACE + DROP TRIGGER IF EXISTS) and safe to re-apply.
+
+CREATE OR REPLACE FUNCTION public.handle_user_delete()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $function$
+BEGIN
+  -- public.users.id stores the auth uuid as text.
+  DELETE FROM public.users WHERE id = OLD.id::text;
+  RETURN OLD;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS on_auth_user_deleted ON auth.users;
+CREATE TRIGGER on_auth_user_deleted
+  AFTER DELETE ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_user_delete();


### PR DESCRIPTION
## Bug
Deleting a user in the Supabase dashboard "doesn't work — the user remains."

## Root cause
- `public.users.id` is **`text`**, `auth.users.id` is **`uuid`** → they **can't be FK-linked**, so there's no `ON DELETE CASCADE`.
- We only had an **INSERT**-side trigger (`handle_new_user`) — **nothing on DELETE**.
- `public.users.email` has a **`users_email_key` UNIQUE** constraint.

So deleting the `auth.users` row leaves the `public.users` row **orphaned**: the app still sees the user, and the email stays occupied — a fresh signup with it collides on `users_email_key` and the signup trigger rolls back.

## Fix — migration 025
Adds a delete-side trigger mirroring `handle_new_user`:
```sql
on_auth_user_deleted (AFTER DELETE ON auth.users) → handle_user_delete()
  → DELETE FROM public.users WHERE id = OLD.id::text;
```
FKs into `public.users` (`trip_members`, `team_assignments`, `idea_votes`, `date_poll_votes`, `expense_splits`, `messages`, `expenses.paid_by_user_id`, `quick_info_tiles.created_by`, `invites`, …) are `ON DELETE CASCADE`, so the user's remaining rows clean up automatically. Idempotent. Documented in `CLAUDE.md`.

## After merge
Dashboard "Delete user" fully removes the user (auth + public). Re-signup with that email then works. *(Any `public.users` rows orphaned by deletes done **before** this trigger existed should be cleaned up once — I can do that on request.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)