### PR TITLE
fix(db): default trips.thread_type to 'trip' (migration 026)

### DIFF
--- a/supabase/migrations/20260606150000_026_thread_type_default.sql
+++ b/supabase/migrations/20260606150000_026_thread_type_default.sql
@@ -1,0 +1,11 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- Migration 026 — Default trips.thread_type to 'trip'
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- thread_type was added (migration 024) as a plain nullable text anchor for the
+-- unified messaging model. Every existing row is a trip thread, so give the
+-- column a sensible default and backfill the nulls. Additive, zero-risk.
+-- (The closed set of thread_type values lands with the messaging refactor.)
+
+ALTER TABLE public.trips ALTER COLUMN thread_type SET DEFAULT 'trip';
+UPDATE public.trips SET thread_type = 'trip' WHERE thread_type IS NULL;


### PR DESCRIPTION
Tiny, zero-risk migration. `thread_type` (added in 024) was nullable with no default; every row is a trip thread, so:

```sql
ALTER TABLE public.trips ALTER COLUMN thread_type SET DEFAULT 'trip';
UPDATE public.trips SET thread_type = 'trip' WHERE thread_type IS NULL;
```

Per the agreed plan, **column enrichment of `circle_events`/`circle_courses` is deferred** to the competition build (option B) — documented in CLAUDE.md (#318), not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)