### PR TITLE
feat(auth): real account deletion — users.deleteMe + cascade/anonymize FKs (migration 027)

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { ChevronRight } from "lucide-react";
@@ -1011,24 +1011,23 @@ function DeleteAccountSheet({ onClose }: { onClose: () => void }) {
   const [errorMsg, setErrorMsg] = useState("");
   const canDelete = confirmText === "DELETE" && status !== "loading";
 
-  // Deletion endpoint not built yet — we sign the user out so the danger
-  // action at least feels real, and surface a clear message about contact.
-  // When the proper deletion mutation lands, wire it here.
-  const deleteAccount = useMemo(() => async () => {
+  // Permanently delete the account: server deletes the auth user (cascading /
+  // anonymizing their rows per migrations 025+027), then we sign out locally
+  // and land on the marketing page.
+  const deleteMe = trpc.users.deleteMe.useMutation();
+  const deleteAccount = async () => {
     setStatus("loading");
     setErrorMsg("");
     try {
-      // TODO: Replace with trpc.users.deleteMe.mutate() when implemented.
-      // For now, sign out and direct the user to contact support so we
-      // don't ship a button that silently does nothing.
+      await deleteMe.mutateAsync();
       const supabase = createClient();
       await supabase.auth.signOut();
-      router.push("/?account-deleted=pending");
+      router.push("/?account-deleted=1");
     } catch (err) {
       setStatus("error");
-      setErrorMsg(err instanceof Error ? err.message : "Failed to start deletion.");
+      setErrorMsg(err instanceof Error ? err.message : "Failed to delete account.");
     }
-  }, [router]);
+  };
 
   return (
     <SheetShell title="Delete account" onClose={onClose}>

--- a/src/server/routers/users.test.ts
+++ b/src/server/routers/users.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { TestContext, createAnonCaller } from "../../__tests__/helpers/test-setup";
+import { createClient } from "@supabase/supabase-js";
+import {
+  TestContext,
+  createAnonCaller,
+  getAdminClient,
+} from "../../__tests__/helpers/test-setup";
+import { createCallerFactory, type TRPCContext } from "../trpc";
+import { appRouter } from "../router";
+
+const factory = createCallerFactory(appRouter);
 
 let ctx: TestContext;
 
@@ -131,6 +140,66 @@ describe("users router", () => {
       const memberMe = await ctx.callerAs("member").users.getMe();
       expect(ownerMe.avatar_icon).toBe("trophy");
       expect(memberMe.avatar_icon).toBe("star");
+    });
+  });
+
+  describe("deleteMe", () => {
+    it("permanently removes the caller's auth + public.users rows", async () => {
+      const admin = getAdminClient();
+      const email = `delete-test-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 6)}@example.com`;
+      const { data: created, error: createErr } =
+        await admin.auth.admin.createUser({
+          email,
+          email_confirm: true,
+          user_metadata: { name: "Delete Me" },
+        });
+      expect(createErr).toBeNull();
+      const tempId = created.user!.id;
+
+      try {
+        // handle_new_user mirrors the auth user into public.users on create.
+        const { data: before } = await admin
+          .from("users")
+          .select("id")
+          .eq("id", tempId)
+          .maybeSingle();
+        expect(before?.id).toBe(tempId);
+
+        // deleteMe uses only ctx.user.id + the service-role admin client, so a
+        // hand-built context for the temp user exercises the real path.
+        const callerCtx: TRPCContext = {
+          supabase: createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+          ),
+          user: { id: tempId, email },
+          membershipCache: new Map(),
+        };
+        const res = await factory(callerCtx).users.deleteMe();
+        expect(res).toEqual({ ok: true });
+
+        // auth.users row gone
+        const { data: after } = await admin.auth.admin.getUserById(tempId);
+        expect(after?.user ?? null).toBeNull();
+        // public.users row gone via the on_auth_user_deleted trigger (025)
+        const { data: pub } = await admin
+          .from("users")
+          .select("id")
+          .eq("id", tempId)
+          .maybeSingle();
+        expect(pub).toBeNull();
+      } finally {
+        // safety net if an assertion threw before deleteMe ran
+        await admin.auth.admin.deleteUser(tempId).catch(() => {});
+      }
+    });
+
+    it("is rejected for anonymous callers", async () => {
+      await expect(createAnonCaller().users.deleteMe()).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
     });
   });
 });

--- a/src/server/routers/users.ts
+++ b/src/server/routers/users.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
+import { createAdminClient } from "@/lib/supabase-admin";
 
 export const usersRouter = router({
   // -----------------------------------------------------------------------
@@ -115,5 +116,27 @@ export const usersRouter = router({
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR" });
       return data ?? [];
     }),
+
+  // -----------------------------------------------------------------------
+  // deleteMe — permanently delete the CALLER's own account.
+  //
+  // Deletes the auth.users row via the service-role admin client; the
+  // on_auth_user_deleted trigger (migration 025) removes the matching
+  // public.users row, and the FK behaviors set in migration 027 cascade /
+  // anonymize the rest (the user's expenses + transient rows go; trip content
+  // they authored survives with created_by nulled). Always self — it never
+  // accepts an id, so a caller can only ever delete their own account.
+  // -----------------------------------------------------------------------
+  deleteMe: authedProcedure.mutation(async ({ ctx }) => {
+    const admin = createAdminClient();
+    const { error } = await admin.auth.admin.deleteUser(ctx.user.id);
+    if (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `Failed to delete account: ${error.message}`,
+      });
+    }
+    return { ok: true };
+  }),
 
 });

--- a/supabase/migrations/20260606160000_027_user_delete_fk_behaviors.sql
+++ b/supabase/migrations/20260606160000_027_user_delete_fk_behaviors.sql
@@ -1,0 +1,60 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- Migration 027 — Make user deletion cascade/anonymize cleanly
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- Account deletion policy (option A — "we're a glorified spreadsheet, not a
+-- bank"): a deleted user's TRIP CONTENT survives with authorship anonymized,
+-- and their TRANSIENT / personal rows are removed. Today several FKs into
+-- public.users are RESTRICT or NO ACTION, which BLOCK the delete entirely
+-- (the on_auth_user_deleted trigger from migration 025 deletes the
+-- public.users row, and any blocking FK rolls the whole auth-user delete back).
+--
+-- This migration re-points those FKs so deletion just works — for both the
+-- in-app "Delete account" flow (users.deleteMe) and the Supabase dashboard.
+--
+-- SET NULL (keep the row, anonymize the author — requires the col be nullable):
+--   schedule_items.created_by, schedule_items.confirmed_by,
+--   logistics_items.created_by, idea_lodging_options.created_by
+-- CASCADE (delete the user's own transient/financial rows):
+--   invites.created_by, expenses.paid_by_user_id, expense_splits.user_id
+--   (expense_splits already cascades off expenses, so a deleted payer's
+--    expenses take their splits with them.)
+--
+-- NOTE: the SET NULL columns become nullable — any code reading `created_by`
+-- must tolerate a null author (a member who has since deleted their account).
+-- Idempotent: DROP CONSTRAINT IF EXISTS + re-ADD; DROP NOT NULL is a no-op if
+-- already dropped.
+
+-- ── SET NULL: trip content survives, author anonymized ─────────────────────
+ALTER TABLE public.schedule_items      ALTER COLUMN created_by   DROP NOT NULL;
+ALTER TABLE public.logistics_items     ALTER COLUMN created_by   DROP NOT NULL;
+ALTER TABLE public.idea_lodging_options ALTER COLUMN created_by  DROP NOT NULL;
+
+ALTER TABLE public.schedule_items DROP CONSTRAINT IF EXISTS schedule_items_created_by_fkey;
+ALTER TABLE public.schedule_items ADD  CONSTRAINT schedule_items_created_by_fkey
+  FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+ALTER TABLE public.schedule_items DROP CONSTRAINT IF EXISTS schedule_items_confirmed_by_fkey;
+ALTER TABLE public.schedule_items ADD  CONSTRAINT schedule_items_confirmed_by_fkey
+  FOREIGN KEY (confirmed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+ALTER TABLE public.logistics_items DROP CONSTRAINT IF EXISTS logistics_items_created_by_fkey;
+ALTER TABLE public.logistics_items ADD  CONSTRAINT logistics_items_created_by_fkey
+  FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+ALTER TABLE public.idea_lodging_options DROP CONSTRAINT IF EXISTS idea_lodging_options_created_by_fkey;
+ALTER TABLE public.idea_lodging_options ADD  CONSTRAINT idea_lodging_options_created_by_fkey
+  FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+-- ── CASCADE: the user's own transient / financial rows go with them ────────
+ALTER TABLE public.invites DROP CONSTRAINT IF EXISTS invites_created_by_fkey;
+ALTER TABLE public.invites ADD  CONSTRAINT invites_created_by_fkey
+  FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.expenses DROP CONSTRAINT IF EXISTS expenses_paid_by_user_id_fkey;
+ALTER TABLE public.expenses ADD  CONSTRAINT expenses_paid_by_user_id_fkey
+  FOREIGN KEY (paid_by_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+ALTER TABLE public.expense_splits DROP CONSTRAINT IF EXISTS expense_splits_user_id_fkey;
+ALTER TABLE public.expense_splits ADD  CONSTRAINT expense_splits_user_id_fkey
+  FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Bug
The in-app **"Delete account"** button never deleted anything — it just called `supabase.auth.signOut()` (with an explicit `// TODO`), so the account survived and the user could log right back in (e.g. `zgrethphoto@gmail.com`).

## Fix — option A ("anonymize, don't block"; we're a glorified spreadsheet, not a bank)

**Migration 027** re-points the FKs into `public.users` that were `RESTRICT`/`NO ACTION` and would otherwise *block* a delete (rolling back via the 025 trigger):
| FK | New behavior | Effect |
|---|---|---|
| `schedule_items.created_by` / `.confirmed_by` | SET NULL | trip content survives, author anonymized |
| `logistics_items.created_by` | SET NULL | "" |
| `idea_lodging_options.created_by` | SET NULL | "" |
| `invites.created_by` | CASCADE | pending invites (transient) removed |
| `expenses.paid_by_user_id` | CASCADE | their receipts removed (splits cascade off expenses) |
| `expense_splits.user_id` | CASCADE | their shares removed |

(The four `SET NULL` columns were `NOT NULL`; 027 drops that so authorship can be nulled.)

**`users.deleteMe`** — authed tRPC mutation that deletes the **caller's own** auth user via the service-role admin client (never accepts an id, so you can only delete yourself). The `on_auth_user_deleted` trigger (025) clears `public.users`; 027's FKs handle the rest.

**Profile** — `DeleteAccountSheet` now calls `deleteMe` → `signOut` → redirect (was the signOut-only stub).

## Tests
`users.deleteMe` round-trip (disposable auth user created → deleted → both `auth.users` + `public.users` rows confirmed gone) + anon-rejection. Full suite green locally (`tsc`, lint clean).

## ⚠️ Heads-up
`schedule_items.created_by`, `logistics_items.created_by`, `idea_lodging_options.created_by` are now **nullable** — any UI reading them must tolerate a null author (a member who deleted their account). Also: deleting a trip's sole Owner leaves the trip ownerless (pre-existing edge case, not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)