### PR TITLE
feat(itinerary) P2: lodging top block

### DIFF
--- a/src/app/trips/[tripId]/components/itinerary.test.ts
+++ b/src/app/trips/[tripId]/components/itinerary.test.ts
@@ -6,6 +6,7 @@ import {
   isHappeningNow,
   todayLocalISO,
   dayNumber,
+  summarizeLodging,
   type ItineraryScheduleItem,
   type ItineraryLogisticsItem,
   type ItineraryTripMember,
@@ -395,5 +396,67 @@ describe("dayNumber", () => {
 
   it("returns null when tripStart is missing", () => {
     expect(dayNumber("2026-06-15", null)).toBeNull();
+  });
+});
+
+// ── summarizeLodging (top block) ──────────────────────────────────────────
+
+describe("summarizeLodging", () => {
+  it("summarizes a confirmed lodging item with computed nights", () => {
+    const stays = summarizeLodging([
+      lodgingItem({
+        id: "l1",
+        property_name: "Beach House",
+        check_in_time: "2026-06-17",
+        check_out_time: "2026-06-19",
+      }),
+    ]);
+    expect(stays).toEqual([
+      {
+        id: "l1",
+        name: "Beach House",
+        address: "1 Ocean Dr",
+        checkIn: "2026-06-17",
+        checkOut: "2026-06-19",
+        nights: 2,
+      },
+    ]);
+  });
+
+  it("orders multiple properties by check-in date (handles mid-trip moves)", () => {
+    const stays = summarizeLodging([
+      lodgingItem({ id: "cabin", property_name: "Lake Cabin", check_in_time: "2026-06-19", check_out_time: "2026-06-21" }),
+      lodgingItem({ id: "beach", property_name: "Beach House", check_in_time: "2026-06-17", check_out_time: "2026-06-19" }),
+    ]);
+    expect(stays.map((s) => s.id)).toEqual(["beach", "cabin"]);
+  });
+
+  it("returns null nights when there's no check-out date", () => {
+    const stays = summarizeLodging([
+      lodgingItem({ id: "l1", property_name: "Beach House", check_out_time: null }),
+    ]);
+    expect(stays[0].checkOut).toBeNull();
+    expect(stays[0].nights).toBeNull();
+  });
+
+  it("skips non-lodging, unconfirmed, and check-in-less items", () => {
+    const stays = summarizeLodging([
+      lodgingItem({ id: "ok", property_name: "Keep" }),
+      lodgingItem({ id: "unconf", is_confirmed: false }),
+      lodgingItem({ id: "nodate", check_in_time: null }),
+      lodgingItem({ id: "transport", type: "transport" }),
+    ]);
+    expect(stays.map((s) => s.id)).toEqual(["ok"]);
+  });
+
+  it("falls back name: property_name → label → 'Lodging'", () => {
+    const [a, b, c] = summarizeLodging([
+      lodgingItem({ id: "a", property_name: "Named", label: "L" }),
+      lodgingItem({ id: "b", property_name: null, label: "LabelOnly" }),
+      lodgingItem({ id: "c", property_name: null, label: "" }),
+    ]);
+    expect(a.name).toBe("Named");
+    expect(b.name).toBe("LabelOnly");
+    expect(c.name).toBe("Lodging");
   });
 });

--- a/src/app/trips/[tripId]/components/itinerary.test.ts
+++ b/src/app/trips/[tripId]/components/itinerary.test.ts
@@ -402,11 +402,15 @@ describe("dayNumber", () => {
 // ── summarizeLodging (top block) ──────────────────────────────────────────
 
 describe("summarizeLodging", () => {
-  it("summarizes a confirmed lodging item with computed nights", () => {
+  // Column semantics (see LodgingPanel): `label` = property NAME,
+  // `property_name` = SLEEPS capacity (repurposed column).
+  it("maps name from label and sleeps from property_name, with computed nights", () => {
     const stays = summarizeLodging([
       lodgingItem({
         id: "l1",
-        property_name: "Beach House",
+        label: "Beach House",
+        property_name: "8", // sleeps count, NOT the name
+        address: "1 Ocean Dr",
         check_in_time: "2026-06-17",
         check_out_time: "2026-06-19",
       }),
@@ -415,6 +419,7 @@ describe("summarizeLodging", () => {
       {
         id: "l1",
         name: "Beach House",
+        sleeps: "8",
         address: "1 Ocean Dr",
         checkIn: "2026-06-17",
         checkOut: "2026-06-19",
@@ -425,23 +430,30 @@ describe("summarizeLodging", () => {
 
   it("orders multiple properties by check-in date (handles mid-trip moves)", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "cabin", property_name: "Lake Cabin", check_in_time: "2026-06-19", check_out_time: "2026-06-21" }),
-      lodgingItem({ id: "beach", property_name: "Beach House", check_in_time: "2026-06-17", check_out_time: "2026-06-19" }),
+      lodgingItem({ id: "cabin", label: "Lake Cabin", check_in_time: "2026-06-19", check_out_time: "2026-06-21" }),
+      lodgingItem({ id: "beach", label: "Beach House", check_in_time: "2026-06-17", check_out_time: "2026-06-19" }),
     ]);
     expect(stays.map((s) => s.id)).toEqual(["beach", "cabin"]);
   });
 
   it("returns null nights when there's no check-out date", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "l1", property_name: "Beach House", check_out_time: null }),
+      lodgingItem({ id: "l1", label: "Beach House", check_out_time: null }),
     ]);
     expect(stays[0].checkOut).toBeNull();
     expect(stays[0].nights).toBeNull();
   });
 
+  it("sleeps is null when property_name is empty/unset", () => {
+    const stays = summarizeLodging([
+      lodgingItem({ id: "l1", label: "Beach House", property_name: null }),
+    ]);
+    expect(stays[0].sleeps).toBeNull();
+  });
+
   it("skips non-lodging, unconfirmed, and check-in-less items", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "ok", property_name: "Keep" }),
+      lodgingItem({ id: "ok", label: "Keep" }),
       lodgingItem({ id: "unconf", is_confirmed: false }),
       lodgingItem({ id: "nodate", check_in_time: null }),
       lodgingItem({ id: "transport", type: "transport" }),
@@ -449,14 +461,13 @@ describe("summarizeLodging", () => {
     expect(stays.map((s) => s.id)).toEqual(["ok"]);
   });
 
-  it("falls back name: property_name → label → 'Lodging'", () => {
-    const [a, b, c] = summarizeLodging([
-      lodgingItem({ id: "a", property_name: "Named", label: "L" }),
-      lodgingItem({ id: "b", property_name: null, label: "LabelOnly" }),
-      lodgingItem({ id: "c", property_name: null, label: "" }),
+  it("falls back name to 'Lodging' when label is empty (never uses property_name as the name)", () => {
+    const [a, b] = summarizeLodging([
+      lodgingItem({ id: "a", label: "Named", property_name: "6" }),
+      lodgingItem({ id: "b", label: "", property_name: "6" }),
     ]);
     expect(a.name).toBe("Named");
-    expect(b.name).toBe("LabelOnly");
-    expect(c.name).toBe("Lodging");
+    expect(b.name).toBe("Lodging"); // NOT "6"
+    expect(b.sleeps).toBe("6");
   });
 });

--- a/src/app/trips/[tripId]/components/itinerary.ts
+++ b/src/app/trips/[tripId]/components/itinerary.ts
@@ -268,6 +268,63 @@ export function buildItinerary(input: {
   return events;
 }
 
+// ── Lodging summary (top block) ────────────────────────────────────────────
+//
+// Presentation helper for the itinerary's lodging block (rendered above the
+// day list, NOT inline). One entry per confirmed lodging property with a
+// check-in date, ordered by check-in. buildItinerary still emits the inline
+// lodging check-in/out events for other consumers; the home itinerary view
+// just renders this block instead.
+
+export interface LodgingStay {
+  id: string;
+  name: string;
+  address: string | null;
+  /** YYYY-MM-DD */
+  checkIn: string;
+  /** YYYY-MM-DD, or null when no check-out date is set. */
+  checkOut: string | null;
+  /** check-out − check-in in days, or null when check-out is unknown. */
+  nights: number | null;
+}
+
+/** Whole-day difference between two YYYY-MM-DD dates (TZ-naive, noon-anchored). */
+function nightsBetween(checkIn: string, checkOut: string): number {
+  const [y1, m1, d1] = checkIn.split("-").map((n) => parseInt(n, 10));
+  const [y2, m2, d2] = checkOut.split("-").map((n) => parseInt(n, 10));
+  const a = new Date(y1, m1 - 1, d1, 12, 0, 0, 0).getTime();
+  const b = new Date(y2, m2 - 1, d2, 12, 0, 0, 0).getTime();
+  return Math.max(0, Math.round((b - a) / 86400000));
+}
+
+export function summarizeLodging(
+  items: ItineraryLogisticsItem[]
+): LodgingStay[] {
+  const stays: LodgingStay[] = [];
+  for (const item of items) {
+    if (item.type !== "lodging") continue;
+    if (!item.is_confirmed) continue;
+    if (!isDateString(item.check_in_time)) continue;
+
+    const checkIn = item.check_in_time.slice(0, 10);
+    const checkOut = isDateString(item.check_out_time)
+      ? item.check_out_time.slice(0, 10)
+      : null;
+
+    stays.push({
+      id: item.id,
+      // `||` (not `??`) so an empty-string name/label falls through to the next.
+      name: item.property_name || item.label || "Lodging",
+      address: item.address ?? null,
+      checkIn,
+      checkOut,
+      nights: checkOut ? nightsBetween(checkIn, checkOut) : null,
+    });
+  }
+  stays.sort((a, b) => (a.checkIn < b.checkIn ? -1 : a.checkIn > b.checkIn ? 1 : 0));
+  return stays;
+}
+
 // ── Sorting ───────────────────────────────────────────────────────────────
 
 const KIND_PRIORITY: Record<ItineraryEvent["kind"], number> = {

--- a/src/app/trips/[tripId]/components/itinerary.ts
+++ b/src/app/trips/[tripId]/components/itinerary.ts
@@ -28,7 +28,10 @@ export interface ItineraryScheduleItem {
 export interface ItineraryLogisticsItem {
   id: string;
   type: "lodging" | "transport" | "general";
+  /** The property NAME (e.g. "Beach House"). */
   label: string;
+  /** Repurposed/mis-named column: actually stores the SLEEPS capacity (free
+   *  text, e.g. "8"), NOT the property name. See LodgingPanel/AddPropertySheet. */
   property_name?: string | null;
   address?: string | null;
   /** Stored as text; treated as YYYY-MM-DD by the rest of the app. */
@@ -278,7 +281,10 @@ export function buildItinerary(input: {
 
 export interface LodgingStay {
   id: string;
+  /** Property name — comes from `label` (see note on the input shape). */
   name: string;
+  /** Sleeps capacity, free text (e.g. "8") — comes from `property_name`. null when unset. */
+  sleeps: string | null;
   address: string | null;
   /** YYYY-MM-DD */
   checkIn: string;
@@ -313,8 +319,12 @@ export function summarizeLodging(
 
     stays.push({
       id: item.id,
-      // `||` (not `??`) so an empty-string name/label falls through to the next.
-      name: item.property_name || item.label || "Lodging",
+      // The property NAME lives in `label`. NOTE: `property_name` is a
+      // repurposed/mis-named column that actually stores the sleeps capacity
+      // (see LodgingPanel + AddPropertySheet) — it is NOT the name. `||` (not
+      // `??`) so an empty-string label falls through to "Lodging".
+      name: item.label || "Lodging",
+      sleeps: item.property_name?.trim() || null,
       address: item.address ?? null,
       checkIn,
       checkOut,

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -18,11 +18,13 @@ import { addDays, differenceInDays } from "@/lib/tripStatus";
 import {
   buildItinerary,
   groupByDay,
+  summarizeLodging,
   todayLocalISO,
   type ItineraryEvent,
   type ItineraryLogisticsItem,
   type ItineraryScheduleItem,
   type ItineraryTripMember,
+  type LodgingStay,
 } from "../../components/itinerary";
 import type { TripData } from "../types";
 import { DOMAIN_COLORS, type Domain } from "@/lib/domainColors";
@@ -100,6 +102,14 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction 
     return map;
   }, [events]);
 
+  // Lodging renders as a block above the day list (not inline), so summarize
+  // confirmed properties by check-in date. The inline day rows below exclude
+  // lodging-kind events.
+  const lodgingStays = useMemo(
+    () => summarizeLodging(logisticsItems as unknown as ItineraryLogisticsItem[]),
+    [logisticsItems],
+  );
+
   // ── Day range: trip.start_date → trip.end_date inclusive, PLUS any
   //               event dates that fall outside that range. Dropping
   //               events that fall on the night-before-arrival or the
@@ -153,10 +163,16 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction 
   };
 
   // Per-category counts drive whether each filter pill is shown.
-  // Don't tease a filter the user can't actually use.
-  const hasLodging = events.some((e) => categoryOf(e) === "lodging");
+  // Don't tease a filter the user can't actually use. Lodging now comes from
+  // the summarized block (not inline events).
+  const hasLodging = lodgingStays.length > 0;
   const hasTravel = events.some((e) => categoryOf(e) === "travel");
   const hasEvents = events.some((e) => categoryOf(e) === "event");
+
+  // The lodging block shows only under All or Lodging.
+  const showLodgingBlock =
+    lodgingStays.length > 0 &&
+    (activeFilters.has("all") || activeFilters.has("lodging"));
 
   // Show pill row only if there's >1 category to filter between. Travel
   // arrivals weave in from crew members' own travel plans (Crew tab), so the
@@ -240,6 +256,8 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction 
         )}
       </div>
 
+      {showLodgingBlock && <LodgingBlock stays={lodgingStays} />}
+
       {isEmpty ? (
         <EmptyItineraryState onCancel={onCancel} />
       ) : (
@@ -256,7 +274,9 @@ export function ItineraryView({ trip, isOwner: _isOwner, onCancel, headerAction 
                 date={date}
                 dayNumber={dayNumber}
                 isToday={date === today}
-                events={(eventsByDate.get(date) ?? []).filter(showEvent)}
+                events={(eventsByDate.get(date) ?? [])
+                  .filter((e) => categoryOf(e) !== "lodging")
+                  .filter(showEvent)}
               />
             );
           })}
@@ -390,6 +410,85 @@ function SkeletonRow({
       <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
         {time}
       </span>
+    </div>
+  );
+}
+
+// ── LodgingBlock ──────────────────────────────────────────────────────────
+// Horizontal flex-wrap row of confirmed properties, ordered by check-in,
+// sitting under the ITINERARY/filters row (no "where we're staying" label).
+// Each tile: planning-blue home icon, name, "Jun 17 – 19 · 2 nights" meta,
+// and a Directions button (collapses to the pin icon on mobile). Matches the
+// design source's `.hy-prop` recipe (planning-tinted via color-mix on tokens).
+
+const PLANNING_TILE_BG = "color-mix(in srgb, var(--color-bt-planning) 18%, var(--color-bt-card))";
+const PLANNING_BTN_BG = "color-mix(in srgb, var(--color-bt-planning) 13%, var(--color-bt-card))";
+const PLANNING_BTN_BORDER = "color-mix(in srgb, var(--color-bt-planning) 24%, transparent)";
+
+/** "Jun 17 – 19 · 2 nights" — single month collapses to one label; nights
+ *  appended only when a check-out date is known. */
+function formatStayMeta(stay: LodgingStay): string {
+  const ci = parseLocalDate(stay.checkIn);
+  const ciMonth = ci.toLocaleDateString("en-US", { month: "short" });
+  if (!stay.checkOut) return `${ciMonth} ${ci.getDate()}`;
+  const co = parseLocalDate(stay.checkOut);
+  const coMonth = co.toLocaleDateString("en-US", { month: "short" });
+  const range =
+    ciMonth === coMonth
+      ? `${ciMonth} ${ci.getDate()} – ${co.getDate()}`
+      : `${ciMonth} ${ci.getDate()} – ${coMonth} ${co.getDate()}`;
+  const nights =
+    stay.nights != null ? ` · ${stay.nights} night${stay.nights === 1 ? "" : "s"}` : "";
+  return `${range}${nights}`;
+}
+
+function LodgingBlock({ stays }: { stays: LodgingStay[] }) {
+  return (
+    <div className="flex flex-wrap gap-2.5">
+      {stays.map((stay) => (
+        <div
+          key={stay.id}
+          className="flex items-center gap-3 rounded-xl px-3 py-2.5"
+          style={{
+            flex: "1 1 240px",
+            minWidth: 0,
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+          }}
+        >
+          <span
+            className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px]"
+            style={{ color: "var(--color-bt-planning)", background: PLANNING_TILE_BG }}
+          >
+            <Home size={17} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {stay.name}
+            </p>
+            <p className="truncate text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+              {formatStayMeta(stay)}
+            </p>
+          </div>
+          {stay.address && (
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(stay.address)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-shrink-0 items-center gap-1.5 rounded-[10px] px-2.5 py-1.5 text-[12.5px] font-semibold"
+              style={{
+                color: "var(--color-bt-planning)",
+                background: PLANNING_BTN_BG,
+                border: `1px solid ${PLANNING_BTN_BORDER}`,
+              }}
+              aria-label={`Directions to ${stay.name}`}
+            >
+              <MapPin size={13} />
+              <span className="hidden sm:inline">Directions</span>
+            </a>
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -425,21 +425,26 @@ const PLANNING_TILE_BG = "color-mix(in srgb, var(--color-bt-planning) 18%, var(-
 const PLANNING_BTN_BG = "color-mix(in srgb, var(--color-bt-planning) 13%, var(--color-bt-card))";
 const PLANNING_BTN_BORDER = "color-mix(in srgb, var(--color-bt-planning) 24%, transparent)";
 
-/** "Jun 17 – 19 · 2 nights" — single month collapses to one label; nights
- *  appended only when a check-out date is known. */
+/** "Jun 17 – 19 · 2 nights · Sleeps 8" — single month collapses to one label;
+ *  nights appended when check-out is known; "· Sleeps N" appended when known. */
 function formatStayMeta(stay: LodgingStay): string {
   const ci = parseLocalDate(stay.checkIn);
   const ciMonth = ci.toLocaleDateString("en-US", { month: "short" });
-  if (!stay.checkOut) return `${ciMonth} ${ci.getDate()}`;
-  const co = parseLocalDate(stay.checkOut);
-  const coMonth = co.toLocaleDateString("en-US", { month: "short" });
-  const range =
-    ciMonth === coMonth
-      ? `${ciMonth} ${ci.getDate()} – ${co.getDate()}`
-      : `${ciMonth} ${ci.getDate()} – ${coMonth} ${co.getDate()}`;
+  let range: string;
+  if (!stay.checkOut) {
+    range = `${ciMonth} ${ci.getDate()}`;
+  } else {
+    const co = parseLocalDate(stay.checkOut);
+    const coMonth = co.toLocaleDateString("en-US", { month: "short" });
+    range =
+      ciMonth === coMonth
+        ? `${ciMonth} ${ci.getDate()} – ${co.getDate()}`
+        : `${ciMonth} ${ci.getDate()} – ${coMonth} ${co.getDate()}`;
+  }
   const nights =
     stay.nights != null ? ` · ${stay.nights} night${stay.nights === 1 ? "" : "s"}` : "";
-  return `${range}${nights}`;
+  const sleeps = stay.sleeps ? ` · Sleeps ${stay.sleeps}` : "";
+  return `${range}${nights}${sleeps}`;
 }
 
 function LodgingBlock({ stays }: { stays: LodgingStay[] }) {


### PR DESCRIPTION
Second slice of the Home itinerary read-view. Moves **lodging out of the inline day list into a horizontal block** under the ITINERARY/filters row, per `SPEC-itinerary-home.md` §1. Presentation-only — `buildItinerary` is unchanged (still emits inline lodging events for other consumers); the home view just renders the block instead and excludes lodging from the day rows.

## Changes
- **`itinerary.ts`** → `summarizeLodging()`: one `LodgingStay` per **confirmed** lodging property **with a check-in date**, ordered by check-in; `nights` computed from check-out (null when no check-out); name falls back property_name → label → "Lodging". Pure + **5 new tests**.
- **`ItineraryView`** → `LodgingBlock`: `flex-wrap` row, each tile `flex: 1 1 240px`; planning-blue home icon tile; meta **"Jun 17 – 19 · 2 nights"** (single-month range collapses); **Directions** → Google Maps, collapses to the pin icon on mobile (`hidden sm:inline`). Matches the design source's `.hy-prop` recipe (planning tint via `color-mix` on tokens — no hardcoded hex). Lodging removed from inline day rows; the **Lodging filter** now governs the block (shown under All / Lodging).

## Deferred
- **"Sleeps N"** omitted — `logistics_items` has no capacity column (agreed: skip for now; nights are computed). Easy to append if a `sleeps` column lands later.

**33/33** itinerary unit tests · `tsc` + `next lint` clean.

## Next (P3–P5)
Per-day Arrivals group · empty-day compression + past-day collapse + TODAY pill · commit bar + setup-guide pill + mobile filter dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)