### PR TITLE
fix(calendar): vertically center day numbers over the range ribbon

### DIFF
--- a/src/app/trips/[tripId]/components/DatesSheet.tsx
+++ b/src/app/trips/[tripId]/components/DatesSheet.tsx
@@ -577,7 +577,11 @@ function FullRangeCalendar({
           const isToday = isSameDay(day, today);
           const showFill = between || (isStart && hasEnd) || isEnd;
           return (
-            <div key={idx} className="relative" style={{ height: FULL_ROW_H }}>
+            <div
+              key={idx}
+              className="relative flex items-center justify-center"
+              style={{ height: FULL_ROW_H }}
+            >
               {showFill && (
                 <div
                   className="absolute inset-y-1"

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -845,7 +845,11 @@ function InlineRangeCalendar({
           // (start with an end set, or end itself).
           const showFill = between || (isStart && hasEnd) || isEnd;
           return (
-            <div key={idx} className="relative" style={{ height: ROW_H }}>
+            <div
+              key={idx}
+              className="relative flex items-center justify-center"
+              style={{ height: ROW_H }}
+            >
               {showFill && (
                 <div
                   className="absolute inset-y-1"

--- a/src/app/trips/[tripId]/tabs/components/DatePollStackedCards.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollStackedCards.tsx
@@ -1214,7 +1214,11 @@ function InlineAddOption({
           const isToday = isSameDay(day, today);
           const showFill = between || (isStart && hasEnd) || isEnd;
           return (
-            <div key={idx} className="relative" style={{ height: 30 }}>
+            <div
+              key={idx}
+              className="relative flex items-center justify-center"
+              style={{ height: 30 }}
+            >
               {showFill && (
                 <div
                   className="absolute inset-y-1"

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -427,7 +427,10 @@ export function DatePicker(props: DatePickerProps) {
               const showFill = between || (isStart && hasEnd) || isEnd;
 
               return (
-                <div key={day.getTime()} className="relative h-9">
+                <div
+                  key={day.getTime()}
+                  className="relative flex h-9 items-center justify-center"
+                >
                   {showFill && (
                     <div
                       className="absolute inset-y-1"


### PR DESCRIPTION
**#8** — the date-range ribbon read slightly lower than the day numbers in every row.

Cause: in each day cell the in-range fill bar is `absolute inset-y-1` (vertically centered in the row), but the day-number **button was top-aligned** (the cell was just `relative`, no vertical centering). So the number sat above the ribbon's center.

Fix: center the button (`flex items-center justify-center`) in the cell — applied to all three calendars that share this recipe: **DatesSheet** (the "Set your dates" modal in the screenshot), **DatePicker** (lodging), and **SetDatesFlipCard** (the home flip card).

`tsc` + `next lint` clean.

> Note: the "right-click paste" item is **not** in this PR — I found no code-level cause (standard `<input>`s, no `onContextMenu`/`onPaste`/`user-select:none`/right-click-dismiss). Need a repro to pin it (see PR thread / chat).