### PR TITLE
refactor(logistics): rename misnamed logistics_items columns

### DIFF
--- a/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
+++ b/src/app/trips/[tripId]/components/IdeaZonePanel.tsx
@@ -1431,9 +1431,9 @@ function SetDestinationSheet({
               createLogistics.mutateAsync({
                 tripId,
                 type: "lodging",
-                label: opt.name,
-                propertyName: opt.sleeps != null ? String(opt.sleeps) : undefined,
-                detail: opt.url ?? undefined,
+                title: opt.name,
+                sleeps: opt.sleeps != null ? String(opt.sleeps) : undefined,
+                link: opt.url ?? undefined,
                 transportType: opt.source ?? "other",
               })
             )

--- a/src/app/trips/[tripId]/components/LodgingPanel.tsx
+++ b/src/app/trips/[tripId]/components/LodgingPanel.tsx
@@ -50,14 +50,14 @@ function fmtDate(dateStr?: string | null): string {
 interface LodgingItemFull {
   id: string;
   type: "lodging" | "transport" | "general";
-  label: string;
-  detail?: string | null;
-  property_name?: string | null;   // sleeps count
+  title: string;
+  link?: string | null;
+  sleeps?: string | null;          // sleeps capacity, free text
   address?: string | null;
-  check_in_time?: string | null;
-  check_out_time?: string | null;
-  check_in_time_of_day?: string | null;
-  check_out_time_of_day?: string | null;
+  check_in_date?: string | null;
+  check_out_date?: string | null;
+  check_in_time?: string | null;   // clock time, HH:MM
+  check_out_time?: string | null;  // clock time, HH:MM
   transport_type?: string | null;  // platform
   total_price?: string | null;
   notes?: string | null;
@@ -84,13 +84,13 @@ function LodgingCard({
   onConfirmToggle: () => void;
 }) {
   const platform = getPlatform(item.transport_type);
-  const url = isHttpUrl(item.detail) ? item.detail! : null;
+  const url = isHttpUrl(item.link) ? item.link! : null;
   const domain = url ? extractDomainNullable(url) : null;
-  const nickname = item.label && item.label !== domain ? item.label : null;
+  const nickname = item.title && item.title !== domain ? item.title : null;
   const name = nickname ?? domain ?? "No name";
 
-  const checkIn = fmtDate(item.check_in_time);
-  const checkOut = fmtDate(item.check_out_time);
+  const checkIn = fmtDate(item.check_in_date);
+  const checkOut = fmtDate(item.check_out_date);
   const dateRange = checkIn && checkOut
     ? `${checkIn} – ${checkOut}`
     : checkIn || checkOut || null;
@@ -102,7 +102,7 @@ function LodgingCard({
   // but undated" is a dead end. Flag it so the user knows to add dates.
   // Dates needn't fall inside the trip range (pre/post-trip stays still
   // show up); they just have to exist.
-  const needsDates = confirmed && !item.check_in_time && !item.check_out_time;
+  const needsDates = confirmed && !item.check_in_date && !item.check_out_date;
 
   const price = item.total_price
     ? (/^[$€£¥]/.test(item.total_price) ? item.total_price : `$${item.total_price}`)
@@ -234,14 +234,14 @@ function LodgingCard({
             </button>
           ) : null}
         </div>
-        {(price || item.property_name) && (
+        {(price || item.sleeps) && (
           <div
             className="font-mono text-[11px]"
             style={{ color: "var(--color-bt-text-dim)" }}
           >
             {[
               price ? price : null,
-              item.property_name ? `sleeps ${item.property_name}` : null,
+              item.sleeps ? `sleeps ${item.sleeps}` : null,
             ]
               .filter(Boolean)
               .join(" · ")}
@@ -499,10 +499,10 @@ export function LodgingPanel({
   const lodgingItems = (items as LodgingItemFull[])
     .filter((i) => i.type === "lodging")
     .sort((a, b) => {
-      if (!a.check_in_time && !b.check_in_time) return 0;
-      if (!a.check_in_time) return 1;
-      if (!b.check_in_time) return -1;
-      return a.check_in_time < b.check_in_time ? -1 : 1;
+      if (!a.check_in_date && !b.check_in_date) return 0;
+      if (!a.check_in_date) return 1;
+      if (!b.check_in_date) return -1;
+      return a.check_in_date < b.check_in_date ? -1 : 1;
     });
 
   // ── Submit handlers ──────────────────────────────────────────────────
@@ -512,16 +512,16 @@ export function LodgingPanel({
     createItem.mutate({
       tripId,
       type: "lodging",
-      label: values.name.trim() || domain || "Property",
-      detail: values.url || undefined,
-      propertyName: values.sleeps.trim() || undefined,
+      title: values.name.trim() || domain || "Property",
+      link: values.url || undefined,
+      sleeps: values.sleeps.trim() || undefined,
       totalPrice: values.price.trim() || undefined,
       notes: values.notes.trim() || undefined,
       address: values.address.trim() || undefined,
-      checkInTime: values.checkIn || undefined,
-      checkOutTime: values.checkOut || undefined,
-      checkInTimeOfDay: values.checkInTimeOfDay || undefined,
-      checkOutTimeOfDay: values.checkOutTimeOfDay || undefined,
+      checkInDate: values.checkIn || undefined,
+      checkOutDate: values.checkOut || undefined,
+      checkInTime: values.checkInTimeOfDay || undefined,
+      checkOutTime: values.checkOutTimeOfDay || undefined,
       transportType: platform,
       imageUrls: values.imageUrls,
     });
@@ -534,16 +534,16 @@ export function LodgingPanel({
     updateItem.mutate({
       tripId,
       itemId: editingItem.id,
-      label: values.name.trim() || domain || "Property",
-      detail: values.url || null,
-      propertyName: values.sleeps.trim() || null,
+      title: values.name.trim() || domain || "Property",
+      link: values.url || null,
+      sleeps: values.sleeps.trim() || null,
       totalPrice: values.price.trim() || null,
       notes: values.notes.trim() || null,
       address: values.address.trim() || null,
-      checkInTime: values.checkIn || null,
-      checkOutTime: values.checkOut || null,
-      checkInTimeOfDay: values.checkInTimeOfDay || null,
-      checkOutTimeOfDay: values.checkOutTimeOfDay || null,
+      checkInDate: values.checkIn || null,
+      checkOutDate: values.checkOut || null,
+      checkInTime: values.checkInTimeOfDay || null,
+      checkOutTime: values.checkOutTimeOfDay || null,
       transportType: platform,
       imageUrls: values.imageUrls,
     });
@@ -554,7 +554,7 @@ export function LodgingPanel({
   // (the itinerary keys off dates). Confirmed-but-undated still counts as
   // an open action item, so it gates the nudge below.
   const confirmedDatedCount = lodgingItems.filter(
-    (i) => i.is_confirmed && (i.check_in_time || i.check_out_time)
+    (i) => i.is_confirmed && (i.check_in_date || i.check_out_date)
   ).length;
   const totalCount = lodgingItems.length;
 
@@ -566,8 +566,8 @@ export function LodgingPanel({
   const outOfRangeCount =
     tripStart && tripEnd
       ? lodgingItems.filter((i) => {
-          const checkIn = i.check_in_time?.slice(0, 10) ?? null;
-          const checkOut = i.check_out_time?.slice(0, 10) ?? null;
+          const checkIn = i.check_in_date?.slice(0, 10) ?? null;
+          const checkOut = i.check_out_date?.slice(0, 10) ?? null;
           if (checkIn && (checkIn < tripStart || checkIn > tripEnd)) return true;
           if (checkOut && (checkOut < tripStart || checkOut > tripEnd)) return true;
           return false;
@@ -862,19 +862,19 @@ export function LodgingPanel({
             isEditing
             showAddressAndDates
             initialValues={{
-              url: editingItem.detail?.startsWith("http") ? editingItem.detail : "",
+              url: editingItem.link?.startsWith("http") ? editingItem.link : "",
               name: (() => {
-                const domain = editingItem.detail?.startsWith("http") ? extractDomainNullable(editingItem.detail) : "";
-                return editingItem.label && editingItem.label !== domain ? editingItem.label : "";
+                const domain = editingItem.link?.startsWith("http") ? extractDomainNullable(editingItem.link) : "";
+                return editingItem.title && editingItem.title !== domain ? editingItem.title : "";
               })(),
-              sleeps: editingItem.property_name ?? "",
+              sleeps: editingItem.sleeps ?? "",
               price: editingItem.total_price ?? "",
               notes: editingItem.notes ?? "",
               address: editingItem.address ?? "",
-              checkIn: editingItem.check_in_time ?? "",
-              checkOut: editingItem.check_out_time ?? "",
-              checkInTimeOfDay: editingItem.check_in_time_of_day ?? "",
-              checkOutTimeOfDay: editingItem.check_out_time_of_day ?? "",
+              checkIn: editingItem.check_in_date ?? "",
+              checkOut: editingItem.check_out_date ?? "",
+              checkInTimeOfDay: editingItem.check_in_time ?? "",
+              checkOutTimeOfDay: editingItem.check_out_time ?? "",
               imageUrls: editingItem.image_urls?.length
                 ? editingItem.image_urls
                 : editingItem.image_url
@@ -1023,19 +1023,19 @@ export function LodgingPanel({
           isEditing
           showAddressAndDates
           initialValues={{
-            url: editingItem.detail?.startsWith("http") ? editingItem.detail : "",
+            url: editingItem.link?.startsWith("http") ? editingItem.link : "",
             name: (() => {
-              const domain = editingItem.detail?.startsWith("http") ? extractDomainNullable(editingItem.detail) : "";
-              return editingItem.label && editingItem.label !== domain ? editingItem.label : "";
+              const domain = editingItem.link?.startsWith("http") ? extractDomainNullable(editingItem.link) : "";
+              return editingItem.title && editingItem.title !== domain ? editingItem.title : "";
             })(),
-            sleeps: editingItem.property_name ?? "",
+            sleeps: editingItem.sleeps ?? "",
             price: editingItem.total_price ?? "",
             notes: editingItem.notes ?? "",
             address: editingItem.address ?? "",
-            checkIn: editingItem.check_in_time ?? "",
-            checkOut: editingItem.check_out_time ?? "",
-            checkInTimeOfDay: editingItem.check_in_time_of_day ?? "",
-            checkOutTimeOfDay: editingItem.check_out_time_of_day ?? "",
+            checkIn: editingItem.check_in_date ?? "",
+            checkOut: editingItem.check_out_date ?? "",
+            checkInTimeOfDay: editingItem.check_in_time ?? "",
+            checkOutTimeOfDay: editingItem.check_out_time ?? "",
             imageUrls: editingItem.image_urls?.length
               ? editingItem.image_urls
               : editingItem.image_url

--- a/src/app/trips/[tripId]/components/itinerary.test.ts
+++ b/src/app/trips/[tripId]/components/itinerary.test.ts
@@ -39,11 +39,11 @@ function lodgingItem(
   return {
     id: "l1",
     type: "lodging",
-    label: "Beach House",
-    property_name: "Sleeps 8",
+    title: "Beach House",
+    sleeps: "Sleeps 8",
     address: "1 Ocean Dr",
-    check_in_time: "2026-06-15",
-    check_out_time: "2026-06-18",
+    check_in_date: "2026-06-15",
+    check_out_date: "2026-06-18",
     is_confirmed: true,
     ...overrides,
   };
@@ -263,7 +263,7 @@ describe("buildItinerary — lodging", () => {
   it("skips check-in event when check_in_time is missing without throwing", () => {
     const events = buildItinerary({
       scheduleItems: [],
-      logisticsItems: [lodgingItem({ check_in_time: null })],
+      logisticsItems: [lodgingItem({ check_in_date: null })],
       members: [],
     });
     expect(events).toHaveLength(1);
@@ -273,7 +273,7 @@ describe("buildItinerary — lodging", () => {
   it("skips check-out event when check_out_time is missing", () => {
     const events = buildItinerary({
       scheduleItems: [],
-      logisticsItems: [lodgingItem({ check_out_time: null })],
+      logisticsItems: [lodgingItem({ check_out_date: null })],
       members: [],
     });
     expect(events).toHaveLength(1);
@@ -305,8 +305,8 @@ describe("buildItinerary — sorting", () => {
       logisticsItems: [
         lodgingItem({
           id: "l1",
-          check_in_time: "2026-06-15",
-          check_out_time: "2026-06-15",
+          check_in_date: "2026-06-15",
+          check_out_date: "2026-06-15",
         }),
       ],
       members: [
@@ -440,16 +440,16 @@ describe("dayNumber", () => {
 
 describe("summarizeLodging", () => {
   // Column semantics (see LodgingPanel): `label` = property NAME,
-  // `property_name` = SLEEPS capacity (repurposed column).
-  it("maps name from label and sleeps from property_name, with computed nights", () => {
+  // name comes from `title`, capacity from `sleeps`.
+  it("maps name from title and sleeps from the sleeps column, with computed nights", () => {
     const stays = summarizeLodging([
       lodgingItem({
         id: "l1",
-        label: "Beach House",
-        property_name: "8", // sleeps count, NOT the name
+        title: "Beach House",
+        sleeps: "8", // sleeps count, NOT the name
         address: "1 Ocean Dr",
-        check_in_time: "2026-06-17",
-        check_out_time: "2026-06-19",
+        check_in_date: "2026-06-17",
+        check_out_date: "2026-06-19",
       }),
     ]);
     expect(stays).toEqual([
@@ -467,41 +467,41 @@ describe("summarizeLodging", () => {
 
   it("orders multiple properties by check-in date (handles mid-trip moves)", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "cabin", label: "Lake Cabin", check_in_time: "2026-06-19", check_out_time: "2026-06-21" }),
-      lodgingItem({ id: "beach", label: "Beach House", check_in_time: "2026-06-17", check_out_time: "2026-06-19" }),
+      lodgingItem({ id: "cabin", title: "Lake Cabin", check_in_date: "2026-06-19", check_out_date: "2026-06-21" }),
+      lodgingItem({ id: "beach", title: "Beach House", check_in_date: "2026-06-17", check_out_date: "2026-06-19" }),
     ]);
     expect(stays.map((s) => s.id)).toEqual(["beach", "cabin"]);
   });
 
   it("returns null nights when there's no check-out date", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "l1", label: "Beach House", check_out_time: null }),
+      lodgingItem({ id: "l1", title: "Beach House", check_out_date: null }),
     ]);
     expect(stays[0].checkOut).toBeNull();
     expect(stays[0].nights).toBeNull();
   });
 
-  it("sleeps is null when property_name is empty/unset", () => {
+  it("sleeps is null when the sleeps column is empty/unset", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "l1", label: "Beach House", property_name: null }),
+      lodgingItem({ id: "l1", title: "Beach House", sleeps: null }),
     ]);
     expect(stays[0].sleeps).toBeNull();
   });
 
   it("skips non-lodging, unconfirmed, and check-in-less items", () => {
     const stays = summarizeLodging([
-      lodgingItem({ id: "ok", label: "Keep" }),
+      lodgingItem({ id: "ok", title: "Keep" }),
       lodgingItem({ id: "unconf", is_confirmed: false }),
-      lodgingItem({ id: "nodate", check_in_time: null }),
+      lodgingItem({ id: "nodate", check_in_date: null }),
       lodgingItem({ id: "transport", type: "transport" }),
     ]);
     expect(stays.map((s) => s.id)).toEqual(["ok"]);
   });
 
-  it("falls back name to 'Lodging' when label is empty (never uses property_name as the name)", () => {
+  it("falls back name to 'Lodging' when title is empty (never uses sleeps as the name)", () => {
     const [a, b] = summarizeLodging([
-      lodgingItem({ id: "a", label: "Named", property_name: "6" }),
-      lodgingItem({ id: "b", label: "", property_name: "6" }),
+      lodgingItem({ id: "a", title: "Named", sleeps: "6" }),
+      lodgingItem({ id: "b", title: "", sleeps: "6" }),
     ]);
     expect(a.name).toBe("Named");
     expect(b.name).toBe("Lodging"); // NOT "6"

--- a/src/app/trips/[tripId]/components/itinerary.ts
+++ b/src/app/trips/[tripId]/components/itinerary.ts
@@ -29,17 +29,16 @@ export interface ItineraryLogisticsItem {
   id: string;
   type: "lodging" | "transport" | "general";
   /** The property NAME (e.g. "Beach House"). */
-  label: string;
-  /** Repurposed/mis-named column: actually stores the SLEEPS capacity (free
-   *  text, e.g. "8"), NOT the property name. See LodgingPanel/AddPropertySheet. */
-  property_name?: string | null;
+  title: string;
+  /** Sleeps capacity, free text (e.g. "8"). */
+  sleeps?: string | null;
   address?: string | null;
-  /** Stored as text; treated as YYYY-MM-DD by the rest of the app. */
+  /** Check-in / check-out dates, stored as text, treated as YYYY-MM-DD. */
+  check_in_date?: string | null;
+  check_out_date?: string | null;
+  /** Optional clock time in HH:MM (24h) — surfaced on the itinerary. */
   check_in_time?: string | null;
   check_out_time?: string | null;
-  /** Optional clock time in HH:MM (24h) — surfaced on the itinerary. */
-  check_in_time_of_day?: string | null;
-  check_out_time_of_day?: string | null;
   is_confirmed?: boolean | null;
 }
 
@@ -205,27 +204,27 @@ export function buildItinerary(input: {
     if (item.type !== "lodging") continue;
     if (!item.is_confirmed) continue;
 
-    const name = item.property_name ?? item.label ?? "Lodging";
+    const name = item.title || "Lodging";
     const subtitle = item.address ?? null;
 
-    if (isDateString(item.check_in_time)) {
+    if (isDateString(item.check_in_date)) {
       events.push({
         kind: "lodging-checkin",
         id: `${item.id}-checkin`,
-        date: item.check_in_time.slice(0, 10),
-        time: normalizeTimeOfDay(item.check_in_time_of_day),
-        title: `Check in: ${item.label || name}`,
+        date: item.check_in_date.slice(0, 10),
+        time: normalizeTimeOfDay(item.check_in_time),
+        title: `Check in: ${name}`,
         subtitle,
         address: item.address ?? null,
       });
     }
-    if (isDateString(item.check_out_time)) {
+    if (isDateString(item.check_out_date)) {
       events.push({
         kind: "lodging-checkout",
         id: `${item.id}-checkout`,
-        date: item.check_out_time.slice(0, 10),
-        time: normalizeTimeOfDay(item.check_out_time_of_day),
-        title: `Check out: ${item.label || name}`,
+        date: item.check_out_date.slice(0, 10),
+        time: normalizeTimeOfDay(item.check_out_time),
+        title: `Check out: ${name}`,
         // Check-out shows just the time + name — no location/address line
         // (and no Map link; you're leaving, not navigating there).
         subtitle: null,
@@ -286,9 +285,9 @@ export function buildItinerary(input: {
 
 export interface LodgingStay {
   id: string;
-  /** Property name — comes from `label` (see note on the input shape). */
+  /** Property name — comes from `title`. */
   name: string;
-  /** Sleeps capacity, free text (e.g. "8") — comes from `property_name`. null when unset. */
+  /** Sleeps capacity, free text (e.g. "8") — comes from `sleeps`. null when unset. */
   sleeps: string | null;
   address: string | null;
   /** YYYY-MM-DD */
@@ -315,21 +314,18 @@ export function summarizeLodging(
   for (const item of items) {
     if (item.type !== "lodging") continue;
     if (!item.is_confirmed) continue;
-    if (!isDateString(item.check_in_time)) continue;
+    if (!isDateString(item.check_in_date)) continue;
 
-    const checkIn = item.check_in_time.slice(0, 10);
-    const checkOut = isDateString(item.check_out_time)
-      ? item.check_out_time.slice(0, 10)
+    const checkIn = item.check_in_date.slice(0, 10);
+    const checkOut = isDateString(item.check_out_date)
+      ? item.check_out_date.slice(0, 10)
       : null;
 
     stays.push({
       id: item.id,
-      // The property NAME lives in `label`. NOTE: `property_name` is a
-      // repurposed/mis-named column that actually stores the sleeps capacity
-      // (see LodgingPanel + AddPropertySheet) — it is NOT the name. `||` (not
-      // `??`) so an empty-string label falls through to "Lodging".
-      name: item.label || "Lodging",
-      sleeps: item.property_name?.trim() || null,
+      // `||` (not `??`) so an empty-string title falls through to "Lodging".
+      name: item.title || "Lodging",
+      sleeps: item.sleeps?.trim() || null,
       address: item.address ?? null,
       checkIn,
       checkOut,

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -71,7 +71,7 @@ export function FreshTripGuide({
   //
   // Crew:    counts non-owner members. "3 added" type label.
   // Lodging: first lodging entry sorted by check-in date; CTA shows
-  //          its property_name. Trips can have multiple properties
+  //          its title. Trips can have multiple properties
   //          (lake house → resort), so we surface the earliest one
   //          since that's the trip's opening lodging.
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
@@ -89,13 +89,12 @@ export function FreshTripGuide({
   const firstLodging = useMemo(() => {
     const lodgings = (logistics as Array<{
       type?: string | null;
-      label?: string | null;
-      property_name?: string | null;
-      check_in_time?: string | null;
+      title?: string | null;
+      check_in_date?: string | null;
     }>).filter((l) => l.type === "lodging");
     lodgings.sort((a, b) => {
-      const ax = a.check_in_time ?? "";
-      const bx = b.check_in_time ?? "";
+      const ax = a.check_in_date ?? "";
+      const bx = b.check_in_date ?? "";
       if (!ax && !bx) return 0;
       if (!ax) return 1;
       if (!bx) return -1;
@@ -104,13 +103,8 @@ export function FreshTripGuide({
     return lodgings[0];
   }, [logistics]);
   const lodgingDone = !!firstLodging;
-  // Read from `label` — AddPropertySheet stores the user-typed title in
-  // the `label` column. `property_name` is misnamed: LodgingPanel writes
-  // the "sleeps" capacity number into it (see LodgingPanel.handleCreate).
-  // Worth a follow-up rename in the schema, but for now `label` is the
-  // right field for "the property's title."
-  const lodgingDoneCta =
-    firstLodging?.label ?? firstLodging?.property_name ?? "Lodging added";
+  // The property title lives in the `title` column.
+  const lodgingDoneCta = firstLodging?.title ?? "Lodging added";
 
   // Commit gate: dates + at least one of lodging/agenda is "enough to go" —
   // surface a commit bar that makes the itinerary the default Home.

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -285,8 +285,8 @@ export default function TripDetailPage() {
   const lodgingItems = (prefetchedLogistics as Array<{
     type?: string | null;
     is_confirmed?: boolean | null;
-    check_in_time?: string | null;
-    check_out_time?: string | null;
+    check_in_date?: string | null;
+    check_out_date?: string | null;
   }>).filter((i) => i.type === "lodging");
   const tripStart = (trip as { start_date?: string | null }).start_date ?? null;
   const tripEnd   = (trip as { end_date?: string | null }).end_date ?? null;
@@ -294,8 +294,8 @@ export default function TripDetailPage() {
     effectiveCanEdit &&
     tripStart && tripEnd &&
     lodgingItems.some((i) => {
-      const ci = i.check_in_time?.slice(0, 10) ?? null;
-      const co = i.check_out_time?.slice(0, 10) ?? null;
+      const ci = i.check_in_date?.slice(0, 10) ?? null;
+      const co = i.check_out_date?.slice(0, 10) ?? null;
       return (ci && (ci < tripStart || ci > tripEnd)) ||
              (co && (co < tripStart || co > tripEnd));
     });
@@ -309,7 +309,7 @@ export default function TripDetailPage() {
   const lodgingUnconfirmed =
     effectiveCanEdit &&
     lodgingItems.length > 0 &&
-    !lodgingItems.some((i) => i.is_confirmed && (i.check_in_time || i.check_out_time));
+    !lodgingItems.some((i) => i.is_confirmed && (i.check_in_date || i.check_out_date));
   const scheduleOutOfRange =
     effectiveCanEdit &&
     tripStart && tripEnd &&

--- a/src/server/routers/logistics.test.ts
+++ b/src/server/routers/logistics.test.ts
@@ -26,15 +26,21 @@ describe("logistics router", () => {
     const item = await caller.logistics.create({
       tripId,
       type: "lodging",
-      label: "Beach House",
-      propertyName: "Oceanfront Villa",
+      title: "Beach House",
+      sleeps: "8",
       address: "123 Beach Rd",
-      checkInTime: "3:00 PM",
-      checkOutTime: "11:00 AM",
+      checkInDate: "2026-09-09",
+      checkOutDate: "2026-09-13",
+      checkInTime: "15:00",
+      checkOutTime: "11:00",
     });
     lodgingId = item.id;
     expect(item.type).toBe("lodging");
-    expect(item.property_name).toBe("Oceanfront Villa");
+    expect(item.title).toBe("Beach House");
+    expect(item.sleeps).toBe("8");
+    // The date/time split: dates land in *_date, clock time in *_time.
+    expect(item.check_in_date).toBe("2026-09-09");
+    expect(item.check_in_time).toBe("15:00");
   });
 
   it("create — planner can create a transport item", async () => {
@@ -42,7 +48,7 @@ describe("logistics router", () => {
     const item = await caller.logistics.create({
       tripId,
       type: "transport",
-      label: "Airport Shuttle",
+      title: "Airport Shuttle",
       transportType: "shuttle",
       pickupLocation: "Terminal B",
       pickupTime: "2:30 PM",
@@ -57,12 +63,12 @@ describe("logistics router", () => {
     const item = await caller.logistics.create({
       tripId,
       type: "general",
-      label: "Grocery Run",
-      detail: "Costco on Friday afternoon",
+      title: "Grocery Run",
+      link: "Costco on Friday afternoon",
     });
     generalId = item.id;
     expect(item.type).toBe("general");
-    expect(item.detail).toBe("Costco on Friday afternoon");
+    expect(item.link).toBe("Costco on Friday afternoon");
   });
 
   it("create — member cannot create", async () => {
@@ -71,7 +77,7 @@ describe("logistics router", () => {
       caller.logistics.create({
         tripId,
           type: "general",
-        label: "Sneaky item",
+        title: "Sneaky item",
       })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
@@ -104,7 +110,7 @@ describe("logistics router", () => {
       caller.logistics.update({
         tripId,
         itemId: lodgingId,
-        label: "Hacked",
+        title: "Hacked",
       })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });

--- a/src/server/routers/logistics.ts
+++ b/src/server/routers/logistics.ts
@@ -15,7 +15,7 @@ export const logisticsRouter = router({
     .query(async ({ ctx }) => {
       // `select("*")` is intentional here: logistics_items is a narrow table
       // (~22 columns) and the lodging/transport UI consumes essentially all of
-      // them — label, detail, property_name, address, check_in/out_time(_of_day),
+      // them — title, link, sleeps, address, check_in/out_date, check_in/out_time,
       // transport_type, pickup_location/time, is_confirmed, total_price, notes,
       // and the image_url/image_urls cover photos. An explicit column list would
       // enumerate nearly the whole table for no payload saving while risking a
@@ -45,15 +45,15 @@ export const logisticsRouter = router({
       z.object({
         tripId: z.string(),
         type: logisticsType,
-        label: z.string().min(1).max(200),
-        detail: z.string().max(1000).optional(),
+        title: z.string().min(1).max(200),
+        link: z.string().max(1000).optional(),
         // Lodging fields
-        propertyName: z.string().max(200).optional(),
+        sleeps: z.string().max(200).optional(),
         address: z.string().max(500).optional(),
-        checkInTime: z.string().max(50).optional(),
-        checkOutTime: z.string().max(50).optional(),
-        checkInTimeOfDay: z.string().max(20).optional(),
-        checkOutTimeOfDay: z.string().max(20).optional(),
+        checkInDate: z.string().max(50).optional(),
+        checkOutDate: z.string().max(50).optional(),
+        checkInTime: z.string().max(20).optional(),
+        checkOutTime: z.string().max(20).optional(),
         totalPrice: z.string().max(100).optional(),
         notes: z.string().max(1000).optional(),
         // Transport fields
@@ -77,14 +77,14 @@ export const logisticsRouter = router({
         .insert({
           trip_id: ctx.tripId,
           type: input.type,
-          label: input.label,
-          detail: input.detail ?? null,
-          property_name: input.propertyName ?? null,
+          title: input.title,
+          link: input.link ?? null,
+          sleeps: input.sleeps ?? null,
           address: input.address ?? null,
+          check_in_date: input.checkInDate ?? null,
+          check_out_date: input.checkOutDate ?? null,
           check_in_time: input.checkInTime ?? null,
           check_out_time: input.checkOutTime ?? null,
-          check_in_time_of_day: input.checkInTimeOfDay ?? null,
-          check_out_time_of_day: input.checkOutTimeOfDay ?? null,
           total_price: input.totalPrice ?? null,
           notes: input.notes ?? null,
           transport_type: input.transportType ?? null,
@@ -120,14 +120,14 @@ export const logisticsRouter = router({
         tripId: z.string(),
         itemId: z.string(),
         type: logisticsType.optional(),
-        label: z.string().min(1).max(200).optional(),
-        detail: z.string().max(1000).nullable().optional(),
-        propertyName: z.string().max(200).nullable().optional(),
+        title: z.string().min(1).max(200).optional(),
+        link: z.string().max(1000).nullable().optional(),
+        sleeps: z.string().max(200).nullable().optional(),
         address: z.string().max(500).nullable().optional(),
-        checkInTime: z.string().max(50).nullable().optional(),
-        checkOutTime: z.string().max(50).nullable().optional(),
-        checkInTimeOfDay: z.string().max(20).nullable().optional(),
-        checkOutTimeOfDay: z.string().max(20).nullable().optional(),
+        checkInDate: z.string().max(50).nullable().optional(),
+        checkOutDate: z.string().max(50).nullable().optional(),
+        checkInTime: z.string().max(20).nullable().optional(),
+        checkOutTime: z.string().max(20).nullable().optional(),
         totalPrice: z.string().max(100).nullable().optional(),
         notes: z.string().max(1000).nullable().optional(),
         transportType: z.string().max(100).nullable().optional(),
@@ -142,14 +142,14 @@ export const logisticsRouter = router({
     .mutation(async ({ ctx, input }) => {
       const update: Record<string, unknown> = {};
       if (input.type !== undefined) update.type = input.type;
-      if (input.label !== undefined) update.label = input.label;
-      if (input.detail !== undefined) update.detail = input.detail;
-      if (input.propertyName !== undefined) update.property_name = input.propertyName;
+      if (input.title !== undefined) update.title = input.title;
+      if (input.link !== undefined) update.link = input.link;
+      if (input.sleeps !== undefined) update.sleeps = input.sleeps;
       if (input.address !== undefined) update.address = input.address;
+      if (input.checkInDate !== undefined) update.check_in_date = input.checkInDate;
+      if (input.checkOutDate !== undefined) update.check_out_date = input.checkOutDate;
       if (input.checkInTime !== undefined) update.check_in_time = input.checkInTime;
       if (input.checkOutTime !== undefined) update.check_out_time = input.checkOutTime;
-      if (input.checkInTimeOfDay !== undefined) update.check_in_time_of_day = input.checkInTimeOfDay;
-      if (input.checkOutTimeOfDay !== undefined) update.check_out_time_of_day = input.checkOutTimeOfDay;
       if (input.totalPrice !== undefined) update.total_price = input.totalPrice;
       if (input.notes !== undefined) update.notes = input.notes;
       if (input.transportType !== undefined) update.transport_type = input.transportType;

--- a/supabase/migrations/20260607170000_028_logistics_items_column_refactor.sql
+++ b/supabase/migrations/20260607170000_028_logistics_items_column_refactor.sql
@@ -1,0 +1,67 @@
+-- 028 — logistics_items column refactor
+--
+-- The lodging columns were historically misnamed. Live data confirmed the
+-- real semantics before this migration:
+--   label                 → the property TITLE      ("Killer Beach House")
+--   detail                → the booking LINK         (VRBO/Airbnb URL)
+--   property_name         → the SLEEPS capacity      ("30")
+--   check_in_time         → the check-in DATE        ("2026-09-09")
+--   check_out_time        → the check-out DATE       ("2026-09-13")
+--   check_in_time_of_day  → the check-in clock TIME  ("16:00")
+--   check_out_time_of_day → the check-out clock TIME ("09:00")
+--
+-- This renames them to honest names and repurposes check_in_time/check_out_time
+-- to hold the real clock time (the date moves to new *_date columns):
+--   title         (was label)
+--   link          (was detail)
+--   sleeps        (was property_name)
+--   check_in_date / check_out_date   (new — hold the dates)
+--   check_in_time / check_out_time   (now hold the clock time, was *_of_day)
+--
+-- All columns stay `text` — this is a pure rename/repurpose, no retyping.
+-- Done pre-launch while the table holds only test data, but written to be
+-- safe on real rows too: new columns are added + backfilled before any drop,
+-- and the date/time shuffle is a single UPDATE so every SET expression reads
+-- the pre-update row values (Postgres semantics) — no ordering hazard.
+
+-- 1. New / renamed columns (additive first).
+ALTER TABLE public.logistics_items ADD COLUMN IF NOT EXISTS title          text;
+ALTER TABLE public.logistics_items ADD COLUMN IF NOT EXISTS link           text;
+ALTER TABLE public.logistics_items ADD COLUMN IF NOT EXISTS sleeps         text;
+ALTER TABLE public.logistics_items ADD COLUMN IF NOT EXISTS check_in_date  text;
+ALTER TABLE public.logistics_items ADD COLUMN IF NOT EXISTS check_out_date text;
+
+-- 2. Backfill the straight renames.
+UPDATE public.logistics_items
+SET title  = COALESCE(title, label),
+    link   = COALESCE(link, detail),
+    sleeps = COALESCE(sleeps, property_name);
+
+-- 3. Move the dates to the new *_date columns AND repurpose check_in_time /
+--    check_out_time to hold the clock time. Single statement: every RHS reads
+--    the OLD row, so reading check_in_time (old=date) into check_in_date and
+--    writing check_in_time = check_in_time_of_day (old=clock) is race-free.
+UPDATE public.logistics_items
+SET check_in_date  = check_in_time,
+    check_out_date = check_out_time,
+    check_in_time  = check_in_time_of_day,
+    check_out_time = check_out_time_of_day;
+
+-- 4. title carries the old NOT NULL guarantee from label.
+ALTER TABLE public.logistics_items ALTER COLUMN title SET NOT NULL;
+
+-- 5. Drop the now-migrated legacy columns.
+ALTER TABLE public.logistics_items DROP COLUMN IF EXISTS label;
+ALTER TABLE public.logistics_items DROP COLUMN IF EXISTS detail;
+ALTER TABLE public.logistics_items DROP COLUMN IF EXISTS property_name;
+ALTER TABLE public.logistics_items DROP COLUMN IF EXISTS check_in_time_of_day;
+ALTER TABLE public.logistics_items DROP COLUMN IF EXISTS check_out_time_of_day;
+
+-- 6. Document the honest semantics for the next reader.
+COMMENT ON COLUMN public.logistics_items.title          IS 'Display title (lodging property name / transport label).';
+COMMENT ON COLUMN public.logistics_items.link           IS 'Booking / reference URL (e.g. VRBO, Airbnb).';
+COMMENT ON COLUMN public.logistics_items.sleeps         IS 'Lodging sleeps capacity, free text (e.g. "8").';
+COMMENT ON COLUMN public.logistics_items.check_in_date  IS 'Lodging check-in date, YYYY-MM-DD.';
+COMMENT ON COLUMN public.logistics_items.check_out_date IS 'Lodging check-out date, YYYY-MM-DD.';
+COMMENT ON COLUMN public.logistics_items.check_in_time  IS 'Lodging check-in clock time, HH:MM (24h).';
+COMMENT ON COLUMN public.logistics_items.check_out_time IS 'Lodging check-out clock time, HH:MM (24h).';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -124,16 +124,16 @@ ON CONFLICT (id) DO NOTHING;
 -- ═══════════════════════════════════════════════════════════════
 
 INSERT INTO logistics_items (
-  id, trip_id, type, label, detail, property_name, address,
-  check_in_time, check_out_time, sort_order, is_confirmed,
-  created_by, created_at
+  id, trip_id, type, title, link, sleeps, address,
+  check_in_date, check_out_date, check_in_time, check_out_time,
+  sort_order, is_confirmed, created_by, created_at
 ) VALUES
-  (gen_random_uuid(), 'seed-trip-bbmi-2027', 'lodging', 'Lily Pond Cottage', 'Cozy 4-bedroom on-property',
-    'Bandon Dunes Resort — Lily Pond', '57744 Round Lake Dr, Bandon, OR 97411',
-    '15:00', '11:00', 0, true,  :owner_id, now()),
-  (gen_random_uuid(), 'seed-trip-bbmi-2027', 'lodging', 'Inn at Bandon Dunes', 'Backup if Lily Pond falls through',
-    'Bandon Dunes Inn',               '57744 Round Lake Dr, Bandon, OR 97411',
-    '15:00', '11:00', 1, false, :owner_id, now())
+  (gen_random_uuid(), 'seed-trip-bbmi-2027', 'lodging', 'Lily Pond Cottage',
+    'https://www.bandondunesgolf.com/stay', '8', '57744 Round Lake Dr, Bandon, OR 97411',
+    '2027-09-15', '2027-09-19', '15:00', '11:00', 0, true,  :owner_id, now()),
+  (gen_random_uuid(), 'seed-trip-bbmi-2027', 'lodging', 'Inn at Bandon Dunes',
+    'https://www.bandondunesgolf.com/stay', '6', '57744 Round Lake Dr, Bandon, OR 97411',
+    '2027-09-15', '2027-09-19', '15:00', '11:00', 1, false, :owner_id, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
**#3** — fix the misnamed `logistics_items` lodging columns before users join.

Live data confirmed every mapping; migration **028** renames/repurposes (all stay `text`):

| Old column | Held | New column |
|---|---|---|
| `label` | property title | `title` |
| `detail` | booking URL | `link` |
| `property_name` | sleeps capacity | `sleeps` |
| `check_in_time` | check-in **date** | `check_in_date` |
| `check_out_time` | check-out **date** | `check_out_date` |
| `check_in_time_of_day` | check-in **clock time** | `check_in_time` |
| `check_out_time_of_day` | check-out **clock time** | `check_out_time` |

The migration adds new columns → backfills → shuffles date→`*_date` and clock-time→`*_time` in a **single race-free UPDATE** (Postgres reads pre-update row values for every SET) → drops the legacy columns. Verified no view/function/trigger referenced the dropped columns.

### Coordinated code sweep
`logistics.list` does `select("*")`, so raw columns reach every consumer. Renamed the router's API input fields and all readers in lockstep:
- `logistics.ts` (create/update input + mappings)
- `itinerary.ts`, `LodgingPanel.tsx`, `FreshTripGuide.tsx`, `page.tsx`, `IdeaZonePanel.tsx`
- `logistics.test.ts`, `itinerary.test.ts`, `seed.sql`

Also fixed a latent **"sleeps-as-name"** fallback in `buildItinerary`/`FreshTripGuide` (it previously could surface the sleeps count as the property name).

### ⚠️ Migration/deploy coupling — merge promptly
CI runs `supabase db push` on **this PR's run**, applying 028 to the shared remote DB. Until this PR merges and Vercel redeploys the new code, the **live (main) app reads the now-renamed columns and its lodging/itinerary will error.** Acceptable here only because we're pre-launch with no real users (near-empty DB) — but please merge + let it redeploy without a long gap.

### Verification
- `tsc --noEmit` clean, `next lint` clean
- 41 `itinerary` unit tests pass locally
- `logistics` router test exercises the new date/time split — runs in CI **after** db push applies 028

🤖 Generated with [Claude Code](https://claude.com/claude-code)