### PR TITLE
fix(calendar): optically center day numbers over the ribbon (leading-none)

### DIFF
--- a/src/app/trips/[tripId]/components/DatesSheet.tsx
+++ b/src/app/trips/[tripId]/components/DatesSheet.tsx
@@ -597,7 +597,7 @@ function FullRangeCalendar({
                 onClick={() => handleDayClick(day)}
                 onMouseEnter={() => setHovered(day)}
                 onMouseLeave={() => setHovered(null)}
-                className="relative mx-auto flex items-center justify-center rounded-full text-[13px] transition-colors"
+                className="relative mx-auto flex items-center justify-center rounded-full text-[13px] leading-none transition-colors"
                 style={{
                   width: FULL_CAP_PX,
                   height: FULL_CAP_PX,

--- a/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/SetDatesFlipCard.tsx
@@ -865,7 +865,7 @@ function InlineRangeCalendar({
                 onClick={() => handleDayClick(day)}
                 onMouseEnter={() => setHovered(day)}
                 onMouseLeave={() => setHovered(null)}
-                className="relative mx-auto flex items-center justify-center rounded-full text-[11px] transition-colors"
+                className="relative mx-auto flex items-center justify-center rounded-full text-[11px] leading-none transition-colors"
                 style={{
                   width: CAP_PX,
                   height: CAP_PX,

--- a/src/app/trips/[tripId]/tabs/components/DatePollStackedCards.tsx
+++ b/src/app/trips/[tripId]/tabs/components/DatePollStackedCards.tsx
@@ -1234,7 +1234,7 @@ function InlineAddOption({
                 onClick={() => handleDayClick(day)}
                 onMouseEnter={() => setHovered(day)}
                 onMouseLeave={() => setHovered(null)}
-                className="relative mx-auto flex items-center justify-center rounded-full text-[11px] transition-colors"
+                className="relative mx-auto flex items-center justify-center rounded-full text-[11px] leading-none transition-colors"
                 style={{
                   width: 26,
                   height: 26,

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -447,7 +447,7 @@ export function DatePicker(props: DatePickerProps) {
                     onClick={() => handleDayClick(day)}
                     onMouseEnter={() => setHovered(day)}
                     onMouseLeave={() => setHovered(null)}
-                    className="relative mx-auto flex h-9 w-9 items-center justify-center rounded-full text-[13px] disabled:cursor-not-allowed"
+                    className="relative mx-auto flex h-9 w-9 items-center justify-center rounded-full text-[13px] leading-none disabled:cursor-not-allowed"
                     style={{
                       background: isCap ? accent : "transparent",
                       color: isCap


### PR DESCRIPTION
Follow-up to #327. That PR centered the day-number **button box** over the range ribbon, but the **digit glyph** still sat high inside its line box, so the ribbon read as slightly low — most visible on the small 11px date-poll **"Add a date option"** calendar.

Measured live in the preview:
- Before: glyph center sat **0.75px** above the ribbon center (poll calendar)
- After `leading-none`: **0px** — digit dead-centered on the ribbon

Applied `leading-none` to the day-number buttons in all four calendars: DatePollStackedCards, SetDatesFlipCard, DatesSheet, DatePicker.

`tsc` + `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)