### PR TITLE
feat(dashboard): helper panel with feature cards for new members

### DIFF
--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -3,6 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { HelperCards } from "@/components/HelperCards";
+import { FeaturesSection } from "@/components/marketing/FeaturesSection";
+import { MARKETING_CSS } from "@/components/marketing/MarketingPage";
 import { trpc } from "@/lib/trpc-client";
 import { TopNav } from "@/components/TopNav";
 import { TripCard } from "@/components/TripCard";
@@ -79,6 +83,8 @@ export default function DashboardClient() {
   }
 
   const hasAnyTrips = trips.length > 0;
+  const showHelperCards =
+    trips.length <= 3 && !(trips as TripRow[]).some((t) => t.myRole === "Owner");
 
   return (
     <div
@@ -180,6 +186,40 @@ export default function DashboardClient() {
               </div>
             )}
           </div>
+        )}
+
+        {/* Helper panel — always rendered in a min-viewport-height wrapper
+            so the FeaturesSection below always starts off-screen. The link
+            smooth-scrolls down to it, matching the empty-state behaviour. */}
+        {hasAnyTrips && (
+          <div
+            className="mt-10"
+            style={{ minHeight: "calc(100vh - 56px)" }}
+          >
+            {showHelperCards && <HelperCards />}
+            <div className={`text-center ${showHelperCards ? "mt-6" : "mt-2"}`}>
+              <Link
+                href="#how-it-works"
+                className="text-[13px]"
+                style={{ color: "var(--color-bt-accent)" }}
+              >
+                See how BuddyTrip works →
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {/* How-it-works section — always in the DOM so the anchor resolves.
+            Starts off-screen due to the min-height wrapper above. */}
+        {hasAnyTrips && (
+          <>
+            <style>{MARKETING_CSS}</style>
+            <div className="bt-mkt-root" style={{ minHeight: 0 }}>
+              <div className="bt-mkt-main">
+                <FeaturesSection />
+              </div>
+            </div>
+          </>
         )}
       </main>
 

--- a/src/components/AuthenticatedEmptyState.tsx
+++ b/src/components/AuthenticatedEmptyState.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { Plane } from "lucide-react";
+import { HelperCards } from "@/components/HelperCards";
 import { FeaturesSection } from "@/components/marketing/FeaturesSection";
 import { MARKETING_CSS } from "@/components/marketing/MarketingPage";
 
@@ -69,16 +70,19 @@ export function AuthenticatedEmptyState() {
           >
             New trip
           </Link>
+        </div>
 
-          {/* Ghost link — smooth-scrolls down to the FeaturesSection
-              rendered below (matches the in-page anchor). */}
-          <div className="mt-4">
+        {/* Helper cards — always shown on the empty state (0 trips
+            counts as ≤3 with no ownership). */}
+        <div className="mt-10 w-full max-w-[642px]">
+          <HelperCards />
+          <div className="mt-6 text-center">
             <Link
               href="#how-it-works"
               className="text-[13px]"
               style={{ color: "var(--color-bt-accent)" }}
             >
-              Not sure where to start? See how BuddyTrip works →
+              See how BuddyTrip works →
             </Link>
           </div>
         </div>

--- a/src/components/HelperCards.tsx
+++ b/src/components/HelperCards.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { MapPin, CalendarDays, DollarSign, Trophy } from "lucide-react";
+import Link from "next/link";
+
+const HELPER_FEATURES = [
+  {
+    icon: MapPin,
+    iconBg: "rgba(99,102,241,0.15)",
+    iconColor: "#818cf8",
+    title: "Plan together",
+    body: "Vote on where to go, agree on dates. Everyone weighs in; the owner locks it.",
+  },
+  {
+    icon: CalendarDays,
+    iconBg: "rgba(45,212,191,0.12)",
+    iconColor: "var(--color-bt-accent)",
+    title: "One itinerary",
+    body: "Lodging, tee times, dinners — all in one place. Everyone sees the same thing.",
+  },
+  {
+    icon: DollarSign,
+    iconBg: "rgba(251,146,60,0.13)",
+    iconColor: "#fb923c",
+    title: "Split fairly",
+    body: "Log who paid, split however makes sense. No spreadsheet, no awkward follow-up.",
+  },
+  {
+    icon: Trophy,
+    iconBg: "rgba(251,191,36,0.12)",
+    iconColor: "#fbbf24",
+    title: "Compete",
+    body: "Teams, events, live scoring. Weight the last round heavier so it stays interesting.",
+  },
+] as const;
+
+export function HelperCards() {
+  return (
+    <div className="mx-auto w-full max-w-[642px]">
+      <p
+        className="mb-3 text-center text-[11px] font-semibold uppercase tracking-widest"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Here&rsquo;s what BuddyTrip does
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        {HELPER_FEATURES.map(({ icon: Icon, iconBg, iconColor, title, body }) => (
+          <div
+            key={title}
+            className="h-[143px] rounded-2xl p-4 text-left"
+            style={{ background: "var(--color-bt-card)" }}
+          >
+            <div
+              className="mb-3 flex h-9 w-9 items-center justify-center rounded-xl"
+              style={{ background: iconBg }}
+            >
+              <Icon size={18} strokeWidth={1.75} style={{ color: iconColor }} />
+            </div>
+            <div
+              className="mb-1 text-[13px] font-semibold"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {title}
+            </div>
+            <div
+              className="text-[12px] leading-[1.55]"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              {body}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function HelperCardsWithLink({ showCards }: { showCards: boolean }) {
+  return (
+    <div className="mt-10">
+      {showCards && <HelperCards />}
+      <div className={`text-center ${showCards ? "mt-6" : "mt-2"}`}>
+        <Link
+          href="/#how-it-works"
+          className="text-[13px]"
+          style={{ color: "var(--color-bt-accent)" }}
+        >
+          See how BuddyTrip works →
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a 4-card **"Here's what BuddyTrip does"** panel (Plan together, One itinerary, Split fairly, Compete) to both the empty dashboard and the non-empty dashboard
- Cards are **315×143 px** fixed on desktop, responsive below that
- Panel is **gated**: visible only when the user has ≤3 trips and owns none of them — hides automatically once the user is an established member
- A **"See how BuddyTrip works →"** link always shows once trips exist and smooth-scrolls to the full `FeaturesSection` rendered off-screen below the fold, matching the existing empty-state behavior exactly
- Extracted shared `HelperCards` component used by both `AuthenticatedEmptyState` and `DashboardClient`

## Test plan

- [ ] Sign in as a brand-new account (0 trips) — verify 4 cards appear below the "New trip" CTA with left-aligned text and correct header
- [ ] Sign in as a member account with 1–3 trips where you own none — verify cards appear below the trip list, link scrolls to FeaturesSection
- [ ] Sign in as an owner account with any trips — verify cards are hidden, only the link shows
- [ ] Sign in as any account with 4+ trips — verify cards are hidden, only the link shows
- [ ] Click "See how BuddyTrip works →" — verify smooth scroll to FeaturesSection off-screen
- [ ] Resize to mobile — verify cards shrink responsively in 2-column layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)