### PR TITLE
style(itinerary): drop full card outlines, keep left accent stripe

### DIFF
--- a/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
+++ b/src/app/trips/[tripId]/tabs/components/ItineraryView.tsx
@@ -497,7 +497,7 @@ function ArrivalsGroup({ arrivals }: { arrivals: ArrivalEvent[] }) {
       className="rounded-xl px-4 py-3"
       style={{
         background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
+        // Match EventCard — left stripe only, no full outline.
         borderLeft: "3px solid var(--color-bt-accent)",
       }}
     >
@@ -644,7 +644,6 @@ function LodgingBlock({ stays }: { stays: LodgingStay[] }) {
             flex: "1 1 240px",
             minWidth: 0,
             background: "var(--color-bt-card)",
-            border: "1px solid var(--color-bt-border)",
           }}
         >
           <span
@@ -727,7 +726,7 @@ function FilterPill({
           : {
               background: "var(--color-bt-card-raised)",
               color: "var(--color-bt-text-dim)",
-              border: "1px solid var(--color-bt-border)",
+              border: "1px solid var(--color-bt-subtle-border)",
             }
       }
     >
@@ -1143,7 +1142,8 @@ function EventCard({ event, compact = false }: { event: ItineraryEvent; compact?
       className={`flex items-center gap-3.5 rounded-xl px-4 ${compact ? "py-2" : "py-3"}`}
       style={{
         background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
+        // No full outline — the 3px colored left stripe alone marks the
+        // category; the card reads as a flat row on the page surface.
         borderLeft: `3px solid ${stripeColor}`,
       }}
     >


### PR DESCRIPTION
Follow-up to the "left accent stripe" refactor (`9994cee`), which swapped each itinerary card's tinted full background + tinted border for a neutral card bg + neutral grey border + a colored left stripe. The leftover grey `1px` border then read as a heavy box around every row (the border wasn't new — it just stopped being camouflaged by the matching tint).

Changes (all in `ItineraryView.tsx`):
- **EventCard** — removed the full `border`, kept the 3px colored left stripe. Cards read as flat rows on the page surface.
- **ArrivalsGroup** — same (it's a peer timeline card).
- **LodgingBlock** (the top summary cards) — removed the outline.
- **FilterPill** — softened the *inactive* border `--color-bt-border` → `--color-bt-subtle-border` (active pills keep their colored selection border + dot).

Collapsed run bands ("Days N–M · open", "Earlier") are intentionally left with their muted dashed treatment.

Verified live (screenshot): timeline cards now show only the colored left stripe, lodging cards are borderless, filters softened. `tsc` + `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)