### PR TITLE
style(trip-header): clear the rounded-corner curve with px-4 padding

### DIFF
--- a/src/components/LocationHero.tsx
+++ b/src/components/LocationHero.tsx
@@ -81,14 +81,19 @@ export function LocationHero({
       style={isDark ? darkStyle : lightStyle}
       data-testid="location-hero"
     >
-      {/* Absolute top-right action slot — sits above all content, doesn't affect layout. */}
+      {/* Absolute top-right action slot — sits above all content, doesn't affect layout.
+          right-4 aligns the gear with the px-4 content padding below. */}
       {topRightAction && (
-        <div className="absolute right-3 top-3 z-20">
+        <div className="absolute right-4 top-3 z-20">
           {topRightAction}
         </div>
       )}
       <div className="relative z-10">
-        <div className="p-3">
+        {/* px-4 (16px) ≥ the card's rounded-2xl corner radius so the title /
+            location clear the corner curve instead of reading tight against it
+            (most visible on the non-owner view, no badge/gear buffer). py-3
+            keeps the hero vertically compact. */}
+        <div className="px-4 py-3">
         {/* Top block: title / location / dates. The state watermark is
             vertically centered within this block so it doesn't shift based on
             whether content (e.g. the countdown bar) is rendered below. */}

--- a/src/components/TripHeader.tsx
+++ b/src/components/TripHeader.tsx
@@ -299,7 +299,11 @@ const PlainHeader: FC<Omit<TripHeaderProps, "isLocked"> & { countdown: LabelledC
           fill all the way up to the meta strip without a hardcoded
           right-padding reservation. Title shrinks (truncate) first
           when the row is tight; meta+gear stays its natural size. */}
-      <div className="p-3">
+      {/* px-4 (16px) ≥ the card's rounded-2xl corner radius so the title /
+          location clear the corner curve instead of reading tight against it
+          (most visible on the non-owner view, which has no badge/gear buffer).
+          py-3 keeps the header vertically compact. */}
+      <div className="px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-2">
             {myRole && <RoleBadge role={myRole} />}


### PR DESCRIPTION
The trip-header card is `rounded-2xl` (**16px** corner radius) but its content padding was `p-3` (**12px**). Because padding < radius, the **title** (left) and **location** (right) sat *inside* the corner-curve zone and read tight against the edges — most visible on the **non-owner view**, which has no `OWNER` badge / settings gear to buffer the corners (the owner view's inset rounded elements hide it).

Fix: bump horizontal padding to `px-4` (16px ≥ the radius) so the text clears the curve, on both header variants:
- **`LocationHero`** (the gradient hero — what's in the screenshots) — `p-3` → `px-4 py-3`, and moved the gear `right-3` → `right-4` to stay aligned with the new padding.
- **`PlainHeader`** (`TripHeader`) — same `p-3` → `px-4 py-3`, for consistency.

`py-3` is kept so the header stays vertically compact (preserves the feel once dates/dock are added). Verified live at 490px — title + location now have clear breathing room from the corners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)