### PR TITLE
fix(expenses): gate inline Add-receipt button on title + amount

### DIFF
--- a/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
+++ b/src/app/trips/[tripId]/tabs/ExpensesSection.tsx
@@ -494,8 +494,8 @@ function AddReceiptFullComposer({
       <button
         type="button"
         onClick={handleSubmit}
-        disabled={create.isPending}
-        className="mt-1 rounded-lg py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 disabled:opacity-60"
+        disabled={!canSubmit}
+        className="mt-1 rounded-lg py-2.5 text-sm font-semibold transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
         style={{
           background: "var(--color-bt-accent)",
           color: "var(--color-bt-on-accent)",


### PR DESCRIPTION
**Item 1.** On the "Add your first receipt" composer, the **Add receipt** button was enabled by default — it was only `disabled` while the create mutation was pending, so it looked clickable with an empty form (clicking just no-opped via `handleSubmit`'s `!canSubmit` early-return).

Now `disabled={!canSubmit}` — the button stays disabled until there's a **title + a positive amount + a paid-by** (the existing `canSubmit` condition). Also bumped the disabled affordance (`opacity-40` + `cursor-not-allowed`) so it reads clearly inactive.

`tsc` + `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)