### PR TITLE
refactor(rls): tighten policies to match tRPC Owner-only intent

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -252,15 +252,17 @@ Owner split-edit; Owner idea-create / Organizer idea-edit; Organizer logistics /
 schedule / news / tiles / competition; Owner competition+team delete; member
 votes/reads).
 
-**4 spots where RLS is *looser* than the tRPC intent** — harmless today (tRPC is
-the only write path) but worth tightening for defense-in-depth:
+Spots where RLS was *looser* than the tRPC intent — harmless today (tRPC is the
+only write path) but tightened in **migration 030** so RLS is a true backstop:
 
-| Table / cmd | RLS allows | tRPC intent |
-|-------------|-----------|-------------|
-| `trip_members` INSERT/UPDATE | self **or** Owner+Organizer | roster mgmt is **Owner-only** (self-row writes OK) |
-| `trips` UPDATE | Owner+Organizer (any column) | `lockDestination` + owner fields are **Owner-only** |
-| `invites` INSERT | any trip member | `inviteByEmail` is **Owner-only** |
-| `date_poll_votes` (vote for others) | Owner+Organizer | `castVoteForMember` is **Owner-only** |
+| Table / cmd | Was | Now (migration 030) |
+|-------------|-----|---------------------|
+| `trip_members` INSERT/UPDATE | self **or** Owner+Organizer | self **or** Owner — matches Owner-only roster mgmt |
+| `invites` INSERT | any trip member | Owner — matches `inviteByEmail` |
+| `date_poll_votes` "_ghost" (vote for a guest) | Owner+Organizer | Owner — matches `castVoteForMember` |
 
-**Recommendation:** optional follow-up migration to tighten those four to
-Owner-only (so RLS is true defense-in-depth). Low urgency — flag if you want it.
+**`trips` UPDATE left as Owner+Organizer (intentional).** Organizers
+legitimately update most trip columns (rename, about, dates, change
+destination); only `lockDestination` / `transferOwnership` are Owner-only, and
+those are **column-level** distinctions row-level RLS can't express without a
+trigger. tRPC enforces them — not worth a trigger for defense-in-depth here.

--- a/supabase/migrations/20260607190000_030_tighten_rls_to_match_trpc.sql
+++ b/supabase/migrations/20260607190000_030_tighten_rls_to_match_trpc.sql
@@ -1,0 +1,59 @@
+-- 030 — tighten RLS to match the tRPC permission intent (defense-in-depth)
+--
+-- The 2026-06-07 RLS parity audit found a handful of write-policies that were
+-- LOOSER than the tRPC gates (they allowed Organizers where tRPC reserves the
+-- action to the Owner). No active hole — all writes go through tRPC — but RLS
+-- should mirror the API so it's a real backstop. This pulls those to Owner-only.
+--
+-- NOT changed: `trips` UPDATE stays Owner+Organizer. Organizers legitimately
+-- update most trip columns (rename, about message, dates, change destination);
+-- only lockDestination / transferOwnership are Owner-only, and those are
+-- *column-level* distinctions that row-level RLS can't express without a
+-- trigger. tRPC enforces them. Idempotent.
+
+-- 1. trip_members — roster writes are Owner-only (members may still write their
+--    OWN row: join, travel, status). Drop 'Organizer' from the non-self arm.
+DROP POLICY IF EXISTS trip_members_insert ON public.trip_members;
+CREATE POLICY trip_members_insert ON public.trip_members
+  AS PERMISSIVE FOR INSERT TO authenticated
+  WITH CHECK ((user_id = (auth.uid())::text) OR has_trip_role(trip_id, ARRAY['Owner'::text]));
+
+DROP POLICY IF EXISTS trip_members_update ON public.trip_members;
+CREATE POLICY trip_members_update ON public.trip_members
+  AS PERMISSIVE FOR UPDATE TO authenticated
+  USING ((user_id = (auth.uid())::text) OR has_trip_role(trip_id, ARRAY['Owner'::text]));
+
+-- 2. invites — creating an invite is Owner-only (tRPC inviteByEmail /
+--    sendInvitationBlast). Also renames the now-inaccurate policy
+--    ("planners and owners …") to reflect Owner-only.
+DROP POLICY IF EXISTS "planners and owners can create invites" ON public.invites;
+DROP POLICY IF EXISTS "owners can create invites" ON public.invites;
+CREATE POLICY "owners can create invites" ON public.invites
+  AS PERMISSIVE FOR INSERT TO public
+  WITH CHECK (has_trip_role(trip_id, ARRAY['Owner'::text]));
+
+-- 3. date_poll_votes — voting on behalf of someone else is Owner-only
+--    (tRPC castVoteForMember). The "_ghost" policies (vote for a guest crew
+--    row) allowed Organizers; pull to Owner. Self-vote + the existing
+--    "_owner_any" policies are unchanged.
+DROP POLICY IF EXISTS date_poll_votes_insert_ghost ON public.date_poll_votes;
+CREATE POLICY date_poll_votes_insert_ghost ON public.date_poll_votes
+  AS PERMISSIVE FOR INSERT TO authenticated
+  WITH CHECK (
+    (EXISTS (SELECT 1 FROM public.users u
+       WHERE u.id = date_poll_votes.user_id AND u.is_guest = true))
+    AND (EXISTS (SELECT 1 FROM public.date_windows dw
+       WHERE dw.id = date_poll_votes.window_id
+         AND has_trip_role(dw.trip_id, ARRAY['Owner'::text])))
+  );
+
+DROP POLICY IF EXISTS date_poll_votes_update_ghost ON public.date_poll_votes;
+CREATE POLICY date_poll_votes_update_ghost ON public.date_poll_votes
+  AS PERMISSIVE FOR UPDATE TO authenticated
+  USING (
+    (EXISTS (SELECT 1 FROM public.users u
+       WHERE u.id = date_poll_votes.user_id AND u.is_guest = true))
+    AND (EXISTS (SELECT 1 FROM public.date_windows dw
+       WHERE dw.id = date_poll_votes.window_id
+         AND has_trip_role(dw.trip_id, ARRAY['Owner'::text])))
+  );


### PR DESCRIPTION
Follow-up to the RLS parity audit (#340) — tightens the write-policies that were **looser than the tRPC gates** so RLS is a genuine backstop, not just tRPC.

| Table / cmd | Was | Now |
|---|---|---|
| `trip_members` INSERT/UPDATE | self **or** Owner+Organizer | self **or** Owner (matches Owner-only roster; members still write their own row) |
| `invites` INSERT | any member | Owner (matches `inviteByEmail`) |
| `date_poll_votes` `_ghost` (vote for a guest) | Owner+Organizer | Owner (matches `castVoteForMember`) |

**`trips` UPDATE intentionally left Owner+Organizer** — Organizers legitimately update most trip columns (rename / about / dates / change destination); only `lockDestination` + `transferOwnership` are Owner-only, and those are *column-level* distinctions row-level RLS can't express without a trigger (tRPC enforces them). Not worth a trigger for defense-in-depth here. Documented in PERMISSIONS.md.

No tRPC operation is newly blocked (tRPC already gates these at Owner; an Organizer never reaches them via the API). Idempotent migration. **Merge promptly** — like 029, CI applies it to the shared DB on this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)