### PR TITLE
fix(auth): middleware validates session with getUser(), not getSession()

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,12 +25,15 @@ export async function middleware(request: NextRequest) {
     }
   );
 
-  // getSession() verifies JWT locally (no network roundtrip).
-  // Actual auth is enforced by RLS on every tRPC query.
+  // Validate the session against the auth server. getUser() re-verifies the JWT
+  // (and refreshes it, writing fresh cookies via setAll above) rather than
+  // trusting whatever the cookie decodes to. getSession() only reads the cookie
+  // locally — so an orphaned/expired auth cookie read as "logged in" and
+  // bounced users off /login into a redirect dead-end. Supabase also flags
+  // server-side getSession() as insecure for exactly this reason.
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user ?? null;
+    data: { user },
+  } = await supabase.auth.getUser();
 
   // Redirect unauthenticated users to /login (except for public routes).
   // The root route `/` serves the marketing page for unauthenticated visitors


### PR DESCRIPTION
**Bug (the "Sign in button does nothing" / stranded-out-of-login report):** the middleware decided the `/login → /` away-redirect from `getSession()`, which only **decodes the auth cookie locally** without validating it. A stale/expired cookie (e.g. lingering after a logout that didn't fully clear it) therefore read as *logged in*:
- `/login` → redirected to `/`
- `/` validated properly → session dead → rendered the marketing page
- Net: "Sign in" bounced to marketing and looked dead; a user whose session expired/corrupted could be **stranded out of re-authenticating**.

**Fix:** use `getUser()`, which re-verifies the JWT against the auth server (and refreshes it, writing fresh cookies). An invalid cookie now correctly reads as logged-out → the login form shows. The protective guard and the `/login` away-redirect both stay — they're just driven by a *validated* user now.

This is also Supabase's documented secure pattern; **server-side `getSession()` is explicitly flagged insecure**. Per the standing "do it the right way / comments can be challenged" guidance, I dropped the prior `// no network roundtrip` rationale — that local-only shortcut *was* the bug.

**Scope:** middleware only. The other two `getSession()` calls (`auth-context.tsx`, `invite/page.tsx`) are **client-side** — not a trust boundary, server enforces — so they're correct as-is.

**Note:** `getUser()` adds one auth-server roundtrip per matched request (the canonical SSR cost). If that latency ever matters, `getClaims()` (local JWT verification via the project's JWKS) is a follow-up option once asymmetric signing keys are enabled.

`tsc` + `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)