### PR TITLE
feat(engine): GolfCard score styling (Slice C §1–§4)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -261,3 +261,18 @@ summary,
 @media (prefers-reduced-motion: reduce) {
   .ts-slide-right, .ts-slide-left { animation: none; }
 }
+
+/* GolfCard eagle/birdie celebration (Slice C §3) — a halo ring pulses outward
+   from the chip + a brief pop. One-shot on commit; reduced-motion disables it. */
+@keyframes golfHalo {
+  0%   { transform: scale(0.72); opacity: 0.5; }
+  70%  { opacity: 0; }
+  100% { transform: scale(1.75); opacity: 0; }
+}
+@keyframes golfPop {
+  0%, 100% { transform: scale(1); }
+  34%      { transform: scale(1.18); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [style*="golfHalo"], [style*="golfPop"] { animation: none !important; }
+}

--- a/src/components/games/GolfChip.tsx
+++ b/src/components/games/GolfChip.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { golfResult, GOLF_STYLE } from "./golfScore";
+
+/**
+ * GolfChip — a committed score shown with the Traditional par-relative shape +
+ * color (Slice C §1). Circle (under par) / rounded square (over par) / bare
+ * number (par). Single ring = a 1.5px border; DOUBLE ring = a concentric INNER
+ * border inset within `size` (never a box-shadow — a shadow paints outside the
+ * chip and collides with neighbors in the tight grid cells).
+ *
+ * `celebrate` plays a one-shot halo+pop for eagle/birdie (gated on
+ * prefers-reduced-motion in globals.css). The number is ringed, never on a
+ * solid-filled cell, so it can't read as a button.
+ */
+interface GolfChipProps {
+  value: number;
+  par: number;
+  size: number;
+  fontSize?: number;
+  celebrate?: boolean;
+}
+
+export function GolfChip({ value, par, size, fontSize, celebrate }: GolfChipProps) {
+  const result = golfResult(value, par)!; // caller passes a real value
+  const s = GOLF_STYLE[result];
+  const radius = s.shape === "circle" ? "50%" : s.shape === "square" ? 5 : 0;
+  const ring = s.ring !== "none" ? `1.5px solid ${s.fg}` : "none";
+  const showHalo = celebrate && (result === "eagle" || result === "birdie");
+
+  return (
+    <span
+      className="relative inline-flex items-center justify-center"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: radius,
+        background: s.bg,
+        border: ring,
+        color: s.fg,
+        fontSize: fontSize ?? Math.round(size * 0.5),
+        fontWeight: 700,
+        boxSizing: "border-box",
+        animation: showHalo ? "golfPop 0.5s ease-out" : undefined,
+      }}
+    >
+      {/* Double ring — concentric inner border, contained within `size`. */}
+      {s.ring === "double" && (
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            inset: 3,
+            borderRadius: s.shape === "circle" ? "50%" : 3,
+            border: `1.5px solid ${s.fg}`,
+          }}
+        />
+      )}
+      {/* Eagle/birdie halo — one-shot, pulses outward (reduced-motion safe). */}
+      {showHalo && (
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            inset: -2,
+            borderRadius: s.shape === "circle" ? "50%" : 6,
+            border: `2px solid ${s.fg}`,
+            animation: "golfHalo 0.7s ease-out",
+          }}
+        />
+      )}
+      {value}
+    </span>
+  );
+}

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -7,6 +7,8 @@ import { StrokeKeypad } from "./StrokeKeypad";
 import { MatchCard } from "./MatchCard";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
 import { Avatar } from "@/components/Avatar";
+import { GolfChip } from "./GolfChip";
+import { golfWord } from "./golfScore";
 import type { ScoreUnit, Participant, ScoreValues } from "./types";
 
 /**
@@ -118,6 +120,8 @@ export function MatchEntryView({
 
   // Active player (keypad target) — DERIVED, hole-scoped override (Slice A pattern).
   const [override, setOverride] = useState<{ hole: number; pid: string } | null>(null);
+  // The cell just committed — gets the one-shot eagle/birdie celebration.
+  const [lastCommit, setLastCommit] = useState<{ hole: number; pid: string } | null>(null);
   const interactiveHere = allParticipants.filter((p) => isInteractive(p.id, hole));
   const activePid =
     override && override.hole === hole && interactiveHere.some((p) => p.id === override.pid)
@@ -147,9 +151,11 @@ export function MatchEntryView({
   const allMatchesOver = groups.every((g) => g.st.over);
   const canFinish = allMatchesOver || allHolesComplete;
 
+  const par = unit?.par;
   const commit = (v: number) => {
     if (!activePid) return;
     onChange(activePid, label, v);
+    setLastCommit({ hole, pid: activePid });
     setOverride({ hole, pid: activePid }); // pin — no auto-advance (waits for ✓)
   };
   const confirmAdvance = () => {
@@ -257,6 +263,11 @@ export function MatchEntryView({
           <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--color-bt-text)" }}>
             Hole {label}
           </div>
+          {par != null && (
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
+              Par {par}
+            </div>
+          )}
           <HoleProgress count={units.length} currentHole={hole} completed={completedHoleNumbers} />
         </div>
         <NavArrow dir="next" disabled={hole >= units.length} onClick={() => goHole(hole + 1)} />
@@ -280,6 +291,8 @@ export function MatchEntryView({
                 valueFor={valueFor}
                 onTap={() => setOverride({ hole, pid: m.a.id })}
                 isMe={!!meId && m.a.id === meId}
+                par={par}
+                celebrate={lastCommit?.pid === m.a.id && lastCommit?.hole === hole}
               />
               <PlayerRow
                 group={g}
@@ -292,6 +305,8 @@ export function MatchEntryView({
                 valueFor={valueFor}
                 onTap={() => setOverride({ hole, pid: m.b.id })}
                 isMe={!!meId && m.b.id === meId}
+                par={par}
+                celebrate={lastCommit?.pid === m.b.id && lastCommit?.hole === hole}
                 last
               />
             </div>
@@ -344,6 +359,8 @@ function PlayerRow({
   valueFor,
   onTap,
   isMe,
+  par,
+  celebrate,
   last,
 }: {
   group: { st: ReturnType<typeof matchState>; strokeHolesA: Set<number>; strokeHolesB: Set<number> };
@@ -356,14 +373,29 @@ function PlayerRow({
   valueFor: (pid: string, l: string) => number | undefined;
   onTap: () => void;
   isMe?: boolean;
+  par?: number;
+  celebrate?: boolean;
   last?: boolean;
 }) {
   const v = valueFor(player.id, label);
   const stroked = (isA ? group.strokeHolesA : group.strokeHolesB).has(hole);
 
   // Score entry only cares about THIS hole — never the match state. Awaiting a
-  // score until one is entered; then the gross/net (stroke holes only).
-  const subtitle = v == null ? "Awaiting score" : stroked ? `Gross ${v} · net ${v - 1}` : "";
+  // score until one is entered; then the golf word for the GROSS, and on a
+  // stroke hole the bold NET word (what counts): "Bogey · net Par".
+  let subtitle: React.ReactNode = "Awaiting score";
+  if (v != null && par != null) {
+    const gw = golfWord(v, par);
+    subtitle = stroked ? (
+      <>
+        {gw} · net <span style={{ fontWeight: 700, color: "var(--color-bt-text)" }}>{golfWord(v - 1, par)}</span>
+      </>
+    ) : (
+      gw
+    );
+  } else if (v != null) {
+    subtitle = stroked ? `Gross ${v} · net ${v - 1}` : "";
+  }
 
   return (
     <button
@@ -388,12 +420,24 @@ function PlayerRow({
         </span>
         <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
       </div>
-      <MatchScoreCell value={v} active={active} stroked={stroked} />
+      <MatchScoreCell value={v} active={active} stroked={stroked} par={par} celebrate={celebrate} />
     </button>
   );
 }
 
-function MatchScoreCell({ value, active, stroked }: { value: number | undefined; active: boolean; stroked: boolean }) {
+function MatchScoreCell({
+  value,
+  active,
+  stroked,
+  par,
+  celebrate,
+}: {
+  value: number | undefined;
+  active: boolean;
+  stroked: boolean;
+  par?: number;
+  celebrate?: boolean;
+}) {
   const base: React.CSSProperties = {
     position: "relative",
     width: 52,
@@ -402,6 +446,16 @@ function MatchScoreCell({ value, active, stroked }: { value: number | undefined;
     flexShrink: 0,
   };
   const pip = stroked ? <StrokePip /> : null;
+  // Committed (not being edited) + par known → color the GROSS with the golf
+  // shape; the stroke pip stays in the corner (net is stated in the subtitle).
+  if (!active && value != null && par != null) {
+    return (
+      <span className="flex items-center justify-center" style={{ ...base }}>
+        <GolfChip value={value} par={par} size={42} fontSize={22} celebrate={celebrate} />
+        {pip}
+      </span>
+    );
+  }
   if (active && value == null) {
     return (
       <span

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -5,6 +5,8 @@ import { ChevronLeft, Grid3x3 } from "lucide-react";
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import { StrokeKeypad } from "./StrokeKeypad";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
+import { GolfChip } from "./GolfChip";
+import { golfWord, golfResult, GOLF_STYLE } from "./golfScore";
 import type { ScoreUnit, Participant, ScoreValues, ScoreDirection } from "./types";
 
 /**
@@ -75,6 +77,9 @@ export function ScoreEntryView({
   // `currentHole` (e.g. tapping a cell in the review grid) — with no
   // render-phase setState to reset it.
   const [override, setOverride] = useState<{ hole: number; pid: string } | null>(null);
+  // The cell just committed — gets the one-shot eagle/birdie celebration.
+  const [lastCommit, setLastCommit] = useState<{ hole: number; pid: string } | null>(null);
+  const par = unit?.par;
   const activePid =
     override && override.hole === hole && participants.some((p) => p.id === override.pid)
       ? override.pid
@@ -103,6 +108,7 @@ export function ScoreEntryView({
   const commit = (v: number) => {
     if (!activePid) return;
     onChange(activePid, label, v);
+    setLastCommit({ hole, pid: activePid });
     // Pin this player as active so a committed score does NOT auto-advance.
     // Advancing waits for ✓ (confirmAdvance) — lets the user validate/edit the
     // number first. Applies equally to a new entry and an edit.
@@ -220,6 +226,11 @@ export function ScoreEntryView({
           <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--color-bt-text)" }}>
             Hole {label}
           </div>
+          {par != null && (
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
+              Par {par}
+            </div>
+          )}
           <HoleProgress count={units.length} currentHole={hole} completed={completedHoleNumbers} />
         </div>
         <NavArrow dir="next" disabled={hole >= units.length} onClick={() => goHole(hole + 1)} />
@@ -286,13 +297,25 @@ export function ScoreEntryView({
                   <div
                     style={{
                       fontSize: 13,
-                      color: lead ? "var(--color-bt-place-1-text)" : "var(--color-bt-text-dim)",
+                      fontWeight: par != null && v != null ? 600 : 400,
+                      color:
+                        par != null && v != null
+                          ? GOLF_STYLE[golfResult(v, par)!].fg
+                          : lead
+                            ? "var(--color-bt-place-1-text)"
+                            : "var(--color-bt-text-dim)",
                     }}
                   >
-                    {total === 0 ? "No scores yet" : lead ? `${total} total · Leading` : `${total} total`}
+                    {par != null && v != null
+                      ? golfWord(v, par)
+                      : total === 0
+                        ? "No scores yet"
+                        : lead
+                          ? `${total} total · Leading`
+                          : `${total} total`}
                   </div>
                 </div>
-                <ScoreCell value={v} active={active} />
+                <ScoreCell value={v} active={active} par={par} celebrate={lastCommit?.pid === p.id && lastCommit?.hole === hole} />
               </button>
               {active && isCorrection && (
                 <div
@@ -333,7 +356,25 @@ export function ScoreEntryView({
   );
 }
 
-function ScoreCell({ value, active }: { value: number | undefined; active: boolean }) {
+function ScoreCell({
+  value,
+  active,
+  par,
+  celebrate,
+}: {
+  value: number | undefined;
+  active: boolean;
+  par?: number;
+  celebrate?: boolean;
+}) {
+  // Committed (not being edited) + par known → the golf shape IS the cell.
+  if (!active && value != null && par != null) {
+    return (
+      <span className="flex items-center justify-center" style={{ width: 52, height: 46, flexShrink: 0 }}>
+        <GolfChip value={value} par={par} size={42} fontSize={22} celebrate={celebrate} />
+      </span>
+    );
+  }
   if (active && value == null) {
     return (
       <span

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -111,22 +111,22 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
           <div
             className="flex"
             style={{
-              height: 36,
+              height: 38,
               position: "sticky",
               top: 0,
               zIndex: 2,
-              background: "var(--color-bt-card)",
+              background: "var(--color-bt-card-raised)",
               borderBottom: "1px solid var(--color-bt-border)",
             }}
           >
-            <div className="flex items-center" style={{ ...nameCell, padding: "0 10px" }}>
-              <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+            <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-card-raised)", padding: "0 10px" }}>
+              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
                 Hole
               </span>
             </div>
             {units.map((u) => (
               <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
-                <span style={{ fontSize: 11, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>{u.label}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>{u.label}</span>
               </div>
             ))}
             {/* Out / In subtotals + Total as trailing columns. */}
@@ -135,17 +135,17 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
             <HeaderSub label="Total" wide />
           </div>
 
-          {/* Par row — same surface as the Hole header (card). */}
+          {/* Par row — same surface as the Hole header. */}
           {hasPar && (
-            <div className="flex" style={{ height: 28, background: "var(--color-bt-card)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-              <div className="flex items-center" style={{ ...nameCell, padding: "0 10px" }}>
-                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+            <div className="flex" style={{ height: 30, background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+              <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-card-raised)", padding: "0 10px" }}>
+                <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
                   Par
                 </span>
               </div>
               {units.map((u) => (
                 <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
-                  <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{u.par}</span>
+                  <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{u.par}</span>
                 </div>
               ))}
               {hasSections && <ParSub value={parSum(front)} />}
@@ -156,15 +156,15 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
 
           {/* Stroke-index row — no surface (sits on base), smaller + dimmer. */}
           {hasIndex && (
-            <div className="flex" style={{ height: 24, background: "var(--color-bt-base)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+            <div className="flex" style={{ height: 26, background: "var(--color-bt-base)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
               <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-base)", padding: "0 10px" }}>
-                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+                <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
                   Index
                 </span>
               </div>
               {units.map((u) => (
                 <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
-                  <span style={{ fontSize: 10, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.strokeIndex}</span>
+                  <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.strokeIndex}</span>
                 </div>
               ))}
               {hasSections && <IndexSub />}
@@ -186,7 +186,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
                   >
                     {p.initials}
                   </span>
-                  <span style={{ fontSize: 12, fontWeight: 500, color: "var(--color-bt-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  <span style={{ fontSize: 16, fontWeight: 700, color: "var(--color-bt-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {p.name}
                   </span>
                 </div>

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
+import { GolfChip } from "./GolfChip";
 import type { ScoreUnit, Participant, ScoreValues, ScoreDirection } from "./types";
 
 /**
@@ -48,6 +49,16 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
   const sumOf = (pid: string, list: ScoreUnit[]) =>
     list.reduce((a, u) => a + (valOf(pid, u.label) ?? 0), 0);
   const totalOf = (pid: string) => sumOf(pid, units);
+
+  // GolfCard: par-relative coloring + a Par row + ±-vs-par subtotals, when the
+  // units carry par (always for stroke play; real course par lands with the
+  // picker). ±-vs-par is over the holes a player has actually scored.
+  const hasPar = units.length > 0 && units.every((u) => u.par != null);
+  const parSum = (list: ScoreUnit[]) => list.reduce((a, u) => a + (u.par ?? 0), 0);
+  const vsParOf = (pid: string, list: ScoreUnit[]): number => {
+    const scored = list.filter((u) => valOf(pid, u.label) != null);
+    return scored.reduce((a, u) => a + (valOf(pid, u.label)! - (u.par ?? 0)), 0);
+  };
 
   // Leader (low total among participants who have any score).
   const scoredIds = participants
@@ -122,6 +133,25 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
             <HeaderSub label="Total" wide />
           </div>
 
+          {/* Par row */}
+          {hasPar && (
+            <div className="flex" style={{ height: 28, borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+              <div className="flex items-center" style={{ ...nameCell, padding: "0 10px" }}>
+                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+                  Par
+                </span>
+              </div>
+              {units.map((u) => (
+                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                  <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{u.par}</span>
+                </div>
+              ))}
+              {hasSections && <ParSub value={parSum(front)} />}
+              {hasSections && <ParSub value={parSum(back)} />}
+              <ParSub value={parSum(units)} wide />
+            </div>
+          )}
+
           {/* Rows */}
           {participants.map((p) => {
             const isLeader = leaderIds.has(p.id);
@@ -141,6 +171,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
                 {units.map((u) => {
                   const v = valOf(p.id, u.label);
                   const hasPip = pips?.[p.id]?.has(u.label);
+                  const colored = v != null && hasPar && u.par != null;
                   return (
                     <button
                       key={u.label}
@@ -148,17 +179,18 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
                       className="relative flex items-center justify-center"
                       style={{ ...cellBase, height: 44, ...divider(u.label), fontSize: 13, fontWeight: 500, color: v != null ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}
                     >
-                      {v ?? "—"}
+                      {colored ? <GolfChip value={v!} par={u.par!} size={26} fontSize={13} /> : (v ?? "—")}
                       {hasPip && <StrokePip />}
                     </button>
                   );
                 })}
-                {hasSections && <SubCell value={sumOf(p.id, front)} />}
-                {hasSections && <SubCell value={sumOf(p.id, back)} />}
-                <SubCell value={totalOf(p.id)} wide bold leader={isLeader} />
+                {hasSections && <SubCell value={sumOf(p.id, front)} vsPar={hasPar ? vsParOf(p.id, front) : undefined} />}
+                {hasSections && <SubCell value={sumOf(p.id, back)} vsPar={hasPar ? vsParOf(p.id, back) : undefined} />}
+                <SubCell value={totalOf(p.id)} vsPar={hasPar ? vsParOf(p.id, units) : undefined} wide bold leader={isLeader} />
               </div>
             );
           })}
+          {hasPar && <Legend />}
         </div>
       </div>
       {/* Right-edge fade signalling more columns */}
@@ -166,6 +198,27 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
         className="pointer-events-none absolute right-0 top-0 h-full"
         style={{ width: 24, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
       />
+    </div>
+  );
+}
+
+/** Eagle / birdie / par / bogey / dbl+ chips with labels (Slice C §2). */
+function Legend() {
+  const items: { label: string; gross: number; par: number }[] = [
+    { label: "Eagle", gross: 3, par: 5 },
+    { label: "Birdie", gross: 3, par: 4 },
+    { label: "Par", gross: 4, par: 4 },
+    { label: "Bogey", gross: 5, par: 4 },
+    { label: "Dbl+", gross: 6, par: 4 },
+  ];
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2" style={{ padding: "12px 12px 14px" }}>
+      {items.map((it) => (
+        <span key={it.label} className="flex items-center gap-1.5">
+          <GolfChip value={it.gross} par={it.par} size={22} fontSize={11} />
+          <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{it.label}</span>
+        </span>
+      ))}
     </div>
   );
 }
@@ -206,22 +259,56 @@ function HeaderSub({ label, wide }: { label: string; wide?: boolean }) {
   );
 }
 
-function SubCell({ value, wide, bold, leader }: { value: number; wide?: boolean; bold?: boolean; leader?: boolean }) {
+function SubCell({
+  value,
+  vsPar,
+  wide,
+  bold,
+  leader,
+}: {
+  value: number;
+  vsPar?: number;
+  wide?: boolean;
+  bold?: boolean;
+  leader?: boolean;
+}) {
   return (
     <div
-      className="flex items-center justify-center"
+      className="flex flex-col items-center justify-center"
       style={{
         width: wide ? TOTAL_W : SUB_W,
         minWidth: wide ? TOTAL_W : SUB_W,
         height: 44,
         flexShrink: 0,
         background: wide ? "rgba(45,212,191,0.07)" : "rgba(255,255,255,0.025)",
-        fontSize: bold ? 14 : 13,
-        fontWeight: bold ? 700 : 600,
         color: leader ? "var(--color-bt-place-1-text)" : bold ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
       }}
     >
-      {value}
+      <span style={{ fontSize: bold ? 14 : 13, fontWeight: bold ? 700 : 600 }}>{value}</span>
+      {vsPar != null && <VsPar diff={vsPar} />}
+    </div>
+  );
+}
+
+/** ±-vs-par line: over = blue, under = red, even = dim "E" (Slice C §2). */
+function VsPar({ diff }: { diff: number }) {
+  const text = diff > 0 ? `+${diff}` : diff < 0 ? `−${Math.abs(diff)}` : "E";
+  const color = diff > 0 ? "#93c5fd" : diff < 0 ? "#fca5a5" : "var(--color-bt-text-dim)";
+  return <span style={{ fontSize: 10, fontWeight: 600, color, fontVariantNumeric: "tabular-nums" }}>{text}</span>;
+}
+
+function ParSub({ value, wide }: { value: number; wide?: boolean }) {
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={{
+        width: wide ? TOTAL_W : SUB_W,
+        minWidth: wide ? TOTAL_W : SUB_W,
+        flexShrink: 0,
+        background: wide ? "rgba(45,212,191,0.07)" : "rgba(255,255,255,0.025)",
+      }}
+    >
+      <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{value}</span>
     </div>
   );
 }

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -102,9 +102,9 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
   };
 
   return (
-    <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
-      <div className="relative min-h-0 flex-1">
-        <div className="h-full overflow-x-auto">
+    <div className="h-full" style={{ background: "var(--color-bt-base)" }}>
+      <div className="relative">
+        <div className="overflow-x-auto">
           <div style={{ minWidth: "max-content" }}>
           {/* Header */}
           <div

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -104,7 +104,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
   return (
     <div className="h-full" style={{ background: "var(--color-bt-base)" }}>
       <div className="relative">
-        <div className="overflow-x-auto">
+        <div className="no-scrollbar overflow-x-auto">
           <div style={{ minWidth: "max-content" }}>
           {/* Header */}
           <div
@@ -288,10 +288,11 @@ function SubCell({
         height: 44,
         flexShrink: 0,
         background: wide ? "rgba(45,212,191,0.07)" : "rgba(255,255,255,0.025)",
-        color: leader ? "var(--color-bt-place-1-text)" : bold ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+        // Totals are white; only the leader/winner goes green.
+        color: leader ? "var(--color-bt-place-1-text)" : "var(--color-bt-text)",
       }}
     >
-      <span style={{ fontSize: bold ? 14 : 13, fontWeight: bold ? 700 : 600 }}>{value}</span>
+      <span style={{ fontSize: bold ? 17 : 16, fontWeight: bold ? 700 : 600 }}>{value}</span>
       {vsPar != null && <VsPar diff={vsPar} />}
     </div>
   );

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -54,6 +54,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
   // units carry par (always for stroke play; real course par lands with the
   // picker). ±-vs-par is over the holes a player has actually scored.
   const hasPar = units.length > 0 && units.every((u) => u.par != null);
+  const hasIndex = units.length > 0 && units.every((u) => u.strokeIndex != null);
   const parSum = (list: ScoreUnit[]) => list.reduce((a, u) => a + (u.par ?? 0), 0);
   const vsParOf = (pid: string, list: ScoreUnit[]): number => {
     const scored = list.filter((u) => valOf(pid, u.label) != null);
@@ -134,9 +135,9 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
             <HeaderSub label="Total" wide />
           </div>
 
-          {/* Par row */}
+          {/* Par row — same surface as the Hole header (card). */}
           {hasPar && (
-            <div className="flex" style={{ height: 28, borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+            <div className="flex" style={{ height: 28, background: "var(--color-bt-card)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
               <div className="flex items-center" style={{ ...nameCell, padding: "0 10px" }}>
                 <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
                   Par
@@ -153,12 +154,32 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
             </div>
           )}
 
+          {/* Stroke-index row — no surface (sits on base), smaller + dimmer. */}
+          {hasIndex && (
+            <div className="flex" style={{ height: 24, background: "var(--color-bt-base)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+              <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-base)", padding: "0 10px" }}>
+                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+                  Index
+                </span>
+              </div>
+              {units.map((u) => (
+                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                  <span style={{ fontSize: 10, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.strokeIndex}</span>
+                </div>
+              ))}
+              {hasSections && <IndexSub />}
+              {hasSections && <IndexSub />}
+              <IndexSub wide />
+            </div>
+          )}
+
           {/* Rows */}
-          {participants.map((p) => {
+          {participants.map((p, i) => {
             const isLeader = leaderIds.has(p.id);
+            const rowBg = i % 2 === 0 ? "var(--color-bt-card)" : "var(--color-bt-base)";
             return (
-              <div key={p.id} className="flex" style={{ height: 44, borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-                <div className="flex items-center gap-1.5" style={{ ...nameCell, padding: "0 10px" }}>
+              <div key={p.id} className="flex" style={{ height: 44, background: rowBg, borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+                <div className="flex items-center gap-1.5" style={{ ...nameCell, background: rowBg, padding: "0 10px" }}>
                   <span
                     className="flex items-center justify-center"
                     style={{ width: 18, height: 18, borderRadius: "50%", background: `${p.color}22`, color: p.color, fontSize: 8, fontWeight: 700, flexShrink: 0 }}
@@ -303,6 +324,21 @@ function VsPar({ diff }: { diff: number }) {
   const text = diff > 0 ? `+${diff}` : diff < 0 ? `−${Math.abs(diff)}` : "E";
   const color = diff > 0 ? "#93c5fd" : diff < 0 ? "#fca5a5" : "var(--color-bt-text-dim)";
   return <span style={{ fontSize: 10, fontWeight: 600, color, fontVariantNumeric: "tabular-nums" }}>{text}</span>;
+}
+
+/** Blank subtotal cell for the index row — keeps the Out/In/Total tint columns
+ *  continuous without showing a meaningless index sum. */
+function IndexSub({ wide }: { wide?: boolean }) {
+  return (
+    <div
+      style={{
+        width: wide ? TOTAL_W : SUB_W,
+        minWidth: wide ? TOTAL_W : SUB_W,
+        flexShrink: 0,
+        background: wide ? "rgba(45,212,191,0.07)" : "rgba(255,255,255,0.025)",
+      }}
+    />
+  );
 }
 
 function ParSub({ value, wide }: { value: number; wide?: boolean }) {

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -102,9 +102,10 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
   };
 
   return (
-    <div className="relative h-full" style={{ background: "var(--color-bt-base)" }}>
-      <div className="h-full overflow-x-auto">
-        <div style={{ minWidth: "max-content" }}>
+    <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <div className="relative min-h-0 flex-1">
+        <div className="h-full overflow-x-auto">
+          <div style={{ minWidth: "max-content" }}>
           {/* Header */}
           <div
             className="flex"
@@ -190,14 +191,20 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
               </div>
             );
           })}
-          {hasPar && <Legend />}
+          </div>
         </div>
+        {/* Right-edge fade signalling more columns */}
+        <div
+          className="pointer-events-none absolute right-0 top-0 h-full"
+          style={{ width: 24, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
+        />
       </div>
-      {/* Right-edge fade signalling more columns */}
-      <div
-        className="pointer-events-none absolute right-0 top-0 h-full"
-        style={{ width: 24, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
-      />
+      {/* Legend is pinned below the scroller — it does NOT scroll with the grid. */}
+      {hasPar && (
+        <div className="shrink-0" style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}>
+          <Legend />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/games/golfScore.test.ts
+++ b/src/components/games/golfScore.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { golfResult, golfWord } from "./golfScore";
+
+describe("golfResult", () => {
+  it("classifies relative to par", () => {
+    expect(golfResult(3, 5)).toBe("eagle"); // −2
+    expect(golfResult(2, 5)).toBe("eagle"); // −3 (better than eagle still 'eagle')
+    expect(golfResult(3, 4)).toBe("birdie"); // −1
+    expect(golfResult(4, 4)).toBe("par"); // 0
+    expect(golfResult(5, 4)).toBe("bogey"); // +1
+    expect(golfResult(6, 4)).toBe("double"); // +2
+    expect(golfResult(8, 4)).toBe("double"); // triple+ folds into 'double'
+  });
+
+  it("returns null for an unscored hole", () => {
+    expect(golfResult(null, 4)).toBeNull();
+    expect(golfResult(undefined, 4)).toBeNull();
+  });
+
+  it("golfWord maps the result to a label", () => {
+    expect(golfWord(3, 4)).toBe("Birdie");
+    expect(golfWord(4, 4)).toBe("Par");
+    expect(golfWord(7, 4)).toBe("Double");
+    expect(golfWord(null, 4)).toBeNull();
+  });
+});

--- a/src/components/games/golfScore.ts
+++ b/src/components/games/golfScore.ts
@@ -1,0 +1,57 @@
+/**
+ * GolfCard score-color system (Slice C §1). Pure — classifies a gross score
+ * relative to par and supplies the Traditional palette (LOCKED).
+ *
+ * Under par = warm, over par = cool, par = neutral. Par stays neutral on purpose
+ * — green is reserved for leading/winning (place-1), and par is the most common
+ * result, so a green par would make the whole card glow. These score colors live
+ * OUTSIDE the button-token system (like team/vote colors) and must never read as
+ * interactive — the number is RINGED, never on a solid-filled cell. Teal
+ * (`--color-bt-accent`) is reserved for controls; never a score.
+ */
+
+export type GolfResult = "eagle" | "birdie" | "par" | "bogey" | "double";
+
+/** 'double' covers +2 or worse (triple+ too). */
+export function golfResult(gross: number | null | undefined, par: number): GolfResult | null {
+  if (gross == null) return null;
+  const d = gross - par;
+  if (d <= -2) return "eagle";
+  if (d === -1) return "birdie";
+  if (d === 0) return "par";
+  if (d === 1) return "bogey";
+  return "double";
+}
+
+export interface GolfStyle {
+  shape: "circle" | "square" | "none";
+  ring: "double" | "single" | "none";
+  fg: string; // number + ring
+  bg: string; // cell tint
+}
+
+export const GOLF_STYLE: Record<GolfResult, GolfStyle> = {
+  eagle: { shape: "circle", ring: "double", fg: "#fcd34d", bg: "rgba(251,191,36,0.22)" },
+  birdie: { shape: "circle", ring: "single", fg: "#fca5a5", bg: "rgba(248,113,113,0.18)" },
+  par: { shape: "none", ring: "none", fg: "var(--color-bt-text)", bg: "transparent" },
+  bogey: { shape: "square", ring: "single", fg: "#93c5fd", bg: "rgba(96,165,250,0.16)" },
+  double: { shape: "square", ring: "double", fg: "#c4b5fd", bg: "rgba(139,92,246,0.20)" },
+};
+
+const WORDS: Record<GolfResult, string> = {
+  eagle: "Eagle",
+  birdie: "Birdie",
+  par: "Par",
+  bogey: "Bogey",
+  double: "Double",
+};
+
+/** Golf word for a gross score vs par (e.g. "Birdie"). null when unscored. */
+export function golfWord(gross: number | null | undefined, par: number): string | null {
+  const r = golfResult(gross, par);
+  return r ? WORDS[r] : null;
+}
+
+export function golfWordFor(result: GolfResult): string {
+  return WORDS[result];
+}

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -13,6 +13,9 @@ export interface ScoreUnit {
   section?: "front" | "back";
   /** Par for this hole — drives GolfCard par-relative coloring (Slice C). */
   par?: number;
+  /** Stroke (handicap) index, 1 = hardest. From `metadata.handicap_index[]`;
+   *  shown in the GolfCard INDEX row and (with a course) allocates strokes. */
+  strokeIndex?: number;
 }
 
 export interface Participant {

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -11,6 +11,8 @@ export interface ScoreUnit {
   label: string;
   /** Section bucket from `scorecard_schema.scoring.sections` (front/back-9). */
   section?: "front" | "back";
+  /** Par for this hole — drives GolfCard par-relative coloring (Slice C). */
+  par?: number;
 }
 
 export interface Participant {

--- a/src/lib/strokePlayConfig.ts
+++ b/src/lib/strokePlayConfig.ts
@@ -9,14 +9,18 @@ import type { ScoreUnit } from "@/components/games/types";
  * template, so it uses this known stroke-play shape. The scorecard components
  * stay schema-driven (they take `units` as a prop) — this is just the data.
  */
-// Default par-72 layout (matches the template `scorecard_schema.metadata.par`).
-// Real per-hole par replaces this once a course is attached (Slice C picker).
+// Default par-72 layout + handicap index (matches the template
+// `scorecard_schema.metadata.{par,handicap_index}`). Real per-hole values replace
+// these once a course is attached (Slice C picker). The index follows the common
+// odd-front / even-back convention (1 = hardest).
 const DEFAULT_PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4];
+const DEFAULT_INDEX = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
 
 export const STROKE_PLAY_UNITS: ScoreUnit[] = Array.from({ length: 18 }, (_, i) => ({
   label: String(i + 1),
   section: i < 9 ? "front" : "back",
   par: DEFAULT_PAR[i],
+  strokeIndex: DEFAULT_INDEX[i],
 }));
 
 // Player identity palette (identity colors, not theme tokens — sanctioned like

--- a/src/lib/strokePlayConfig.ts
+++ b/src/lib/strokePlayConfig.ts
@@ -9,9 +9,14 @@ import type { ScoreUnit } from "@/components/games/types";
  * template, so it uses this known stroke-play shape. The scorecard components
  * stay schema-driven (they take `units` as a prop) — this is just the data.
  */
+// Default par-72 layout (matches the template `scorecard_schema.metadata.par`).
+// Real per-hole par replaces this once a course is attached (Slice C picker).
+const DEFAULT_PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4];
+
 export const STROKE_PLAY_UNITS: ScoreUnit[] = Array.from({ length: 18 }, (_, i) => ({
   label: String(i + 1),
   section: i < 9 ? "front" : "back",
+  par: DEFAULT_PAR[i],
 }));
 
 // Player identity palette (identity colors, not theme tokens — sanctioned like

--- a/supabase/migrations/20260610120000_038_template_handicap_index.sql
+++ b/supabase/migrations/20260610120000_038_template_handicap_index.sql
@@ -1,0 +1,17 @@
+-- 038 — add metadata.handicap_index to the scorecard templates (Slice C)
+--
+-- The GolfCard review grid renders an INDEX row (stroke/handicap index, 1 =
+-- hardest) alongside PAR, sourced from `scorecard_schema.units.metadata
+-- .handicap_index[]`. The templates carried `par` but not the index, so this
+-- adds a par-72 default (odd-front / even-back convention). A real course
+-- overrides per-hole values once the Course Picker lands. Idempotent.
+
+UPDATE public.game_type_templates
+SET scorecard_schema = jsonb_set(
+  scorecard_schema,
+  '{units,metadata,handicap_index}',
+  '[7,3,15,1,11,5,17,9,13,8,4,16,2,12,6,18,10,14]'::jsonb,
+  true
+)
+WHERE scorecard_schema #> '{units,metadata,par}' IS NOT NULL
+  AND scorecard_schema #> '{units,metadata,handicap_index}' IS NULL;


### PR DESCRIPTION
GolfCard **score styling** — the par-relative color system layered onto the Slice A grid + entry views. The Course Picker (§5) and the real stroke-index row (§6) are a distinct follow-up (they need course-data plumbing); this uses the par already in the scorecard schema.

## What's in
- **`golfScore.ts`** (pure, unit-tested) — `golfResult(gross, par)` → eagle/birdie/par/bogey/double (double folds triple+), the **LOCKED Traditional palette**, and `golfWord`.
- **`GolfChip`** — circle (under) / rounded square (over) / bare number (par). Single ring = border; **double ring = a concentric inner border within `size`** (never a box-shadow → no ring collisions in the 30px grid cells). Ringed, never solid-filled (can't read as a button). Eagle/birdie **one-shot halo + pop**, `prefers-reduced-motion` gated.
- **`ScoreUnit.par`** + `STROKE_PLAY_UNITS` par-72 default (real course par replaces it with the picker).
- **`StandardGrid`** — Par row + **±-vs-par** subtotals (over=blue, under=red, even=`E`) + colored cells + legend, reusing the Slice A grid (sticky names, Out/In/Total, hole-10 split intact).
- **`ScoreEntryView` + `MatchEntryView`** — committed cell *is* the colored shape; `Par N` hole line; golf-word subtitle. Match entry colors the **gross** and states the bold **net** word on stroke holes (`Bogey · net Par`) — coexists with the Slice B board (runs on net) without re-tinting it.

## Deferred (next chunk)
Course Picker (search / confirm-with-tees / add-manually / per-hole stepper / edit-hole sheet), the real stroke-index row + yardage, the in-memory course library, and retiring the Slice B sequential SI fallback once a course is attached.

## Verification
`tsc` + lint clean; `golfScore` unit tests green; verified live on Quick Game (birdie red circle, double indigo double-square, par row, ±-vs-par, legend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)