### PR TITLE
feat(engine): Course Selector / Builder (Slice C part 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,11 +208,21 @@ cascade — see the auth section.
 
 `circle_events` and `circle_courses` (migration 024) are intentionally **thin
 anchor stubs** — `id, circle_id, name, created_at` only. Their full columns
-(e.g. `thread_id`, `year`, `recap_text`, `video_url`; course `holes`,
-`par_values`, `tee_sets`) are deferred to the competition/history build, when
-the real shapes are known. When those land, `thread_id` and every other FK
-column must be `text` (e.g. `thread_id text REFERENCES trips(id)`), per the rule
-above — never `uuid`.
+(e.g. `thread_id`, `year`, `recap_text`, `video_url`) are deferred to the
+competition/history build, when the real shapes are known. When those land,
+`thread_id` and every other FK column must be `text` (e.g.
+`thread_id text REFERENCES trips(id)`), per the rule above — never `uuid`.
+
+**Course data is global, NOT circle-scoped** (revised in Slice C part 2). A
+course's par, stroke index, and per-tee yards are global facts (Pebble Creek's
+index is the same for everyone), so they live in a standalone global **`courses`**
+table (migration 039) reached via **`CourseService`** (`src/lib/courseService.ts`)
+— *not* `circle_courses`, and *not* the dead `golf_course_details` (archived only).
+`circle_courses` stays the thin stub, now reserved for a later **Circle-Era join**
+(`circle_id` → `course_id` into the global `courses`), never the course-data home.
+Applying a course to a game **snapshots** its `par[]` + `handicap_index[]` into
+`games.scorecard_schema.units.metadata` (the shape `strokeHoles` reads); the
+snapshot freezes once scores exist, and `games.course_id` is kept as provenance.
 
 ## What "Done" Means for Any Task
 

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -12,9 +12,10 @@ import { StandardGrid } from "@/components/games/StandardGrid";
 import { RelHandicapControl } from "@/components/games/RelHandicapControl";
 import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
+import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
-import { STROKE_PLAY_UNITS, PLAYER_COLORS, initialsOf } from "@/lib/strokePlayConfig";
+import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf } from "@/lib/strokePlayConfig";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
 /** "07:40" → "7:40 AM". Empty/invalid → "". */
@@ -74,12 +75,18 @@ export default function NewMatchGamePage() {
   const [view, setView] = useState<"entry" | "grid">("entry");
   const [currentHole, setCurrentHole] = useState(1);
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
+  // Course (Slice C): picked on the new-game screen, applied to the game once
+  // it's created. id null until chosen.
+  const [courseId, setCourseId] = useState<string | null>(null);
+  const [courseName, setCourseName] = useState<string | null>(null);
+  const [coursePickerOpen, setCoursePickerOpen] = useState(false);
 
   const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
   const matchesQ = trpc.matches.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
 
   const createGame = trpc.games.create.useMutation();
+  const applyCourse = trpc.games.applyCourse.useMutation();
   const setPairings = trpc.matches.setPairings.useMutation();
   const setHandicap = trpc.matches.setHandicap.useMutation();
   const activate = trpc.matches.activate.useMutation();
@@ -157,19 +164,28 @@ export default function NewMatchGamePage() {
   // without waiting on a refetch.
   const mergedFor = (pid: string) => ({ ...(loadedValues[pid] ?? {}), ...(values[pid] ?? {}) });
 
+  // Effective scorecard: the game's course snapshot (Slice C) or the template
+  // default. Drives par + stroke index for the grid, pips, and decided holes —
+  // the SAME index the server scores on (no sequential fallback once set).
+  const scUnits = useMemo(
+    () => unitsFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof unitsFromSchema>[0]),
+    [gameQ.data]
+  );
+  const scIndex = useMemo(() => strokeIndexOf(scUnits), [scUnits]);
+
   // Decided holes (A's perspective) for an overview strip — the shared builder.
   const decidedFor = (g: MatchGroupData) =>
-    buildDecided(mergedFor(g.a.id), mergedFor(g.b.id), g.strokesA, g.strokesB);
+    buildDecided(mergedFor(g.a.id), mergedFor(g.b.id), g.strokesA, g.strokesB, scIndex, scUnits.length);
 
   // A match's current hole = the first hole either player hasn't scored yet, so
   // opening a match drops you where it's at (not the hole you left from).
   const currentHoleFor = (g: MatchGroupData) => {
     const va = mergedFor(g.a.id);
     const vb = mergedFor(g.b.id);
-    for (let h = 1; h <= STROKE_PLAY_UNITS.length; h++) {
+    for (let h = 1; h <= scUnits.length; h++) {
       if (va[String(h)] == null || vb[String(h)] == null) return h;
     }
-    return STROKE_PLAY_UNITS.length;
+    return scUnits.length;
   };
 
   // Derive the screen from server state; manual transitions take precedence.
@@ -219,6 +235,14 @@ export default function NewMatchGamePage() {
       teeTime: teeTime || null,
     });
     setGameId(g.id);
+    // Snapshot the chosen course's par+index onto the new game (the §0 contract).
+    if (courseId) {
+      try {
+        await applyCourse.mutateAsync({ tripId, gameId: g.id, courseId });
+      } catch {
+        // Non-fatal: the game still works on the template default par/index.
+      }
+    }
     const count = Math.min(Math.max(1, matchCount), maxMatches);
     setDraft(Array.from({ length: count }, (_, i) => ({ matchNumber: i + 1, a: null, b: null, handicap: 0 })));
     go("setup");
@@ -325,11 +349,11 @@ export default function NewMatchGamePage() {
   const entryPips = useMemo(() => {
     const m: Record<string, Set<string>> = {};
     if (selectedGroup) {
-      m[selectedGroup.a.id] = new Set([...strokeHoles(selectedGroup.strokesA)].map(String));
-      m[selectedGroup.b.id] = new Set([...strokeHoles(selectedGroup.strokesB)].map(String));
+      m[selectedGroup.a.id] = new Set([...strokeHoles(selectedGroup.strokesA, scIndex)].map(String));
+      m[selectedGroup.b.id] = new Set([...strokeHoles(selectedGroup.strokesB, scIndex)].map(String));
     }
     return m;
-  }, [selectedGroup]);
+  }, [selectedGroup, scIndex]);
 
   // ── Loading ──
   if (!tripId || roleLoading || (gameId && (gameQ.isLoading || matchesQ.isLoading))) {
@@ -352,7 +376,7 @@ export default function NewMatchGamePage() {
             </div>
             <div className="min-h-0 flex-1">
               <StandardGrid
-                units={STROKE_PLAY_UNITS}
+                units={scUnits}
                 participants={entryParticipants}
                 values={values}
                 direction="low_wins"
@@ -368,7 +392,7 @@ export default function NewMatchGamePage() {
           <MatchEntryView
             gameName={`${selectedGroup.a.name} v ${selectedGroup.b.name}`}
             subtitle="Singles match · 1v1"
-            units={STROKE_PLAY_UNITS}
+            units={scUnits}
             matches={[selectedGroup]}
             values={values}
             currentHole={currentHole}
@@ -413,9 +437,22 @@ export default function NewMatchGamePage() {
           crewCount={crewCount}
           teeTime={teeTime}
           setTeeTime={setTeeTime}
+          courseName={courseName}
+          onPickCourse={() => setCoursePickerOpen(true)}
           onCreate={handleCreate}
-          pending={createGame.isPending}
+          pending={createGame.isPending || applyCourse.isPending}
           canEdit={canEdit}
+        />
+      )}
+
+      {coursePickerOpen && (
+        <CoursePicker
+          onClose={() => setCoursePickerOpen(false)}
+          onApply={({ id, name }) => {
+            setCourseId(id);
+            setCourseName(name);
+            setCoursePickerOpen(false);
+          }}
         />
       )}
 
@@ -553,6 +590,8 @@ function NewGame({
   crewCount,
   teeTime,
   setTeeTime,
+  courseName,
+  onPickCourse,
   onCreate,
   pending,
   canEdit,
@@ -563,6 +602,8 @@ function NewGame({
   crewCount: number;
   teeTime: string;
   setTeeTime: (t: string) => void;
+  courseName: string | null;
+  onPickCourse: () => void;
   onCreate: () => void;
   pending: boolean;
   canEdit: boolean;
@@ -574,11 +615,13 @@ function NewGame({
   return (
     <div>
       <div className="flex flex-col gap-3.5">
-        {/* Course — stub picker (Slice C); same field style as the tee time. */}
+        {/* Course — opens the Course Selector (Slice C); same field style as the tee time. */}
         <div>
           <FieldLabel>Course</FieldLabel>
-          <button type="button" className="flex w-full items-center justify-between rounded-xl border px-3 py-2.5 text-left text-sm" style={pillStyle}>
-            <span style={{ color: "var(--color-bt-text-dim)" }}>Select a course</span>
+          <button type="button" onClick={onPickCourse} className="flex w-full items-center justify-between rounded-xl border px-3 py-2.5 text-left text-sm" style={pillStyle}>
+            <span style={{ color: courseName ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>
+              {courseName ?? "Select a course"}
+            </span>
             <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />
           </button>
         </div>

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -355,9 +355,17 @@ function SearchScreen({
           <div className="mt-5">
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Recent courses</p>
             <div className="flex flex-col gap-2">
-              {recent.map((c) => (
-                <CourseRow key={c.id} name={c.name} sub={[c.location, `${c.hole_count} holes`].filter(Boolean).join(" · ")} onClick={() => onPickRecent(c)} />
-              ))}
+              {recent.map((c) => {
+                const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
+                return (
+                  <CourseRow
+                    key={c.id}
+                    name={c.name}
+                    sub={[c.location, par ? `Par ${par}` : "", `${c.hole_count} holes`].filter(Boolean).join(" · ")}
+                    onClick={() => onPickRecent(c)}
+                  />
+                );
+              })}
             </div>
           </div>
         )
@@ -413,16 +421,23 @@ function ConfirmScreen({
   onUse: () => void;
 }) {
   const tee = draft.teeSets[activeTee];
+  const totalPar = draft.par.reduce<number>((a, p) => a + p, 0);
+  const totalYards = (tee?.yards ?? []).reduce<number>((a, y) => a + (y ?? 0), 0);
   return (
     <>
       <div className="flex-1 overflow-y-auto" style={{ padding: "16px 16px 8px" }}>
         <div style={{ fontSize: 18, fontWeight: 700, color: "var(--color-bt-text)" }}>{draft.name}</div>
-        {draft.location && (
-          <div className="flex items-center gap-1" style={{ marginTop: 2 }}>
-            <MapPin size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-            <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{draft.location}</span>
-          </div>
-        )}
+        <div className="flex flex-wrap items-center gap-x-2" style={{ marginTop: 2 }}>
+          {draft.location && (
+            <span className="flex items-center gap-1">
+              <MapPin size={13} style={{ color: "var(--color-bt-text-dim)" }} />
+              <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{draft.location}</span>
+            </span>
+          )}
+          <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+            {draft.location ? "· " : ""}Par {totalPar}{totalYards > 0 ? ` · ${totalYards.toLocaleString()} yds` : ""}
+          </span>
+        </div>
 
         {draft.teeSets.length > 0 && (
           <div className="no-scrollbar mt-3 flex gap-2 overflow-x-auto">
@@ -453,7 +468,7 @@ function ConfirmScreen({
                 className="flex w-full items-center text-left"
                 style={{ height: 38, background: i % 2 === 0 ? "var(--color-bt-card)" : "var(--color-bt-base)", borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}
               >
-                <Cell bold>{h}</Cell>
+                <Cell bold left>{h}</Cell>
                 <Cell>
                   {tee?.yards[i] != null ? (
                     <span style={{ color: "var(--color-bt-text-dim)" }}>{tee.yards[i]}</span>
@@ -469,6 +484,14 @@ function ConfirmScreen({
               </button>
             );
           })}
+          {/* Course totals — par is course-level; yards is the active tee. */}
+          <div className="flex items-center" style={{ height: 36, background: "var(--color-bt-card-raised)", borderTop: "1px solid var(--color-bt-border)" }}>
+            <Cell bold left>Total</Cell>
+            <Cell dim>{totalYards > 0 ? totalYards.toLocaleString() : "—"}</Cell>
+            <Cell bold>{totalPar}</Cell>
+            {draft.hasStrokeIndex && <Cell> </Cell>}
+            <span style={{ width: ICON_COL, flexShrink: 0 }} />
+          </div>
         </div>
       </div>
       <Footer label={indexComplete ? "Use this course" : `${missingCount} holes need a valid index`} disabled={!indexComplete || saving} onClick={onUse} />
@@ -841,7 +864,7 @@ const ICON_COL = 32;
 function HoleHeader({ hasIndex }: { hasIndex: boolean }) {
   return (
     <div className="flex items-center" style={{ height: 30, background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-border)" }}>
-      <HCell>Hole</HCell>
+      <HCell left>Hole</HCell>
       <HCell>Yds</HCell>
       <HCell>Par</HCell>
       {hasIndex && <HCell>Index</HCell>}
@@ -849,12 +872,12 @@ function HoleHeader({ hasIndex }: { hasIndex: boolean }) {
     </div>
   );
 }
-function HCell({ children }: { children: React.ReactNode }) {
-  return <span style={{ flex: 1, minWidth: 0, textAlign: "center", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--color-bt-text-dim)" }}>{children}</span>;
+function HCell({ children, left }: { children: React.ReactNode; left?: boolean }) {
+  return <span style={{ flex: 1, minWidth: 0, textAlign: left ? "left" : "center", paddingLeft: left ? 12 : 0, fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--color-bt-text-dim)" }}>{children}</span>;
 }
-function Cell({ children, bold, warn }: { children: React.ReactNode; bold?: boolean; warn?: boolean }) {
+function Cell({ children, bold, warn, left, dim }: { children: React.ReactNode; bold?: boolean; warn?: boolean; left?: boolean; dim?: boolean }) {
   return (
-    <span style={{ flex: 1, minWidth: 0, textAlign: "center", fontSize: 14, fontWeight: bold || warn ? 700 : 500, color: warn ? "var(--color-bt-warning)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+    <span style={{ flex: 1, minWidth: 0, textAlign: left ? "left" : "center", paddingLeft: left ? 12 : 0, fontSize: 14, fontWeight: bold || warn ? 700 : 500, color: warn ? "var(--color-bt-warning)" : dim ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
       {children}
     </span>
   );

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -453,18 +453,19 @@ function ConfirmScreen({
                 className="flex w-full items-center text-left"
                 style={{ height: 38, background: i % 2 === 0 ? "var(--color-bt-card)" : "var(--color-bt-base)", borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}
               >
-                <Cell w={48} bold>{h}</Cell>
-                <Cell w={72} dim>{tee?.yards[i] ?? "—"}</Cell>
-                <Cell w={56}>{p}</Cell>
-                {draft.hasStrokeIndex && (
-                  <span className="flex flex-1 items-center justify-between pr-3">
-                    <span style={{ flex: 1, textAlign: "center", fontSize: 14, fontWeight: bad ? 700 : 500, color: bad ? "var(--color-bt-warning)" : "var(--color-bt-text)" }}>
-                      {draft.index[i] ?? "—"}
-                    </span>
-                    <PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-                  </span>
-                )}
-                {!draft.hasStrokeIndex && <span className="flex flex-1 justify-end pr-3"><PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} /></span>}
+                <Cell bold>{h}</Cell>
+                <Cell>
+                  {tee?.yards[i] != null ? (
+                    <span style={{ color: "var(--color-bt-text-dim)" }}>{tee.yards[i]}</span>
+                  ) : (
+                    <span style={{ color: "var(--color-bt-text-dim)", opacity: 0.4 }}>000</span>
+                  )}
+                </Cell>
+                <Cell>{p}</Cell>
+                {draft.hasStrokeIndex && <Cell warn={bad}>{draft.index[i] ?? "—"}</Cell>}
+                <IconCol>
+                  <PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} />
+                </IconCol>
               </button>
             );
           })}
@@ -833,26 +834,33 @@ function Switch({ on }: { on: boolean }) {
   );
 }
 
+// Data columns share the width equally (flex:1); the trailing icon column is
+// just wide enough for the edit pencil.
+const ICON_COL = 32;
+
 function HoleHeader({ hasIndex }: { hasIndex: boolean }) {
   return (
     <div className="flex items-center" style={{ height: 30, background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-border)" }}>
-      <HCell w={48}>Hole</HCell>
-      <HCell w={72}>Yds</HCell>
-      <HCell w={56}>Par</HCell>
-      {hasIndex && <span className="flex-1 pr-3 text-center text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Index</span>}
-      {!hasIndex && <span className="flex-1" />}
+      <HCell>Hole</HCell>
+      <HCell>Yds</HCell>
+      <HCell>Par</HCell>
+      {hasIndex && <HCell>Index</HCell>}
+      <span style={{ width: ICON_COL, flexShrink: 0 }} />
     </div>
   );
 }
-function HCell({ w, children }: { w: number; children: React.ReactNode }) {
-  return <span style={{ width: w, textAlign: "center", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--color-bt-text-dim)" }}>{children}</span>;
+function HCell({ children }: { children: React.ReactNode }) {
+  return <span style={{ flex: 1, minWidth: 0, textAlign: "center", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--color-bt-text-dim)" }}>{children}</span>;
 }
-function Cell({ w, children, bold, dim }: { w: number; children: React.ReactNode; bold?: boolean; dim?: boolean }) {
+function Cell({ children, bold, warn }: { children: React.ReactNode; bold?: boolean; warn?: boolean }) {
   return (
-    <span style={{ width: w, textAlign: "center", fontSize: 14, fontWeight: bold ? 700 : 500, color: dim ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+    <span style={{ flex: 1, minWidth: 0, textAlign: "center", fontSize: 14, fontWeight: bold || warn ? 700 : 500, color: warn ? "var(--color-bt-warning)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
       {children}
     </span>
   );
+}
+function IconCol({ children }: { children: React.ReactNode }) {
+  return <span className="flex items-center justify-center" style={{ width: ICON_COL, flexShrink: 0 }}>{children}</span>;
 }
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -40,6 +40,8 @@ interface Draft {
   teeSets: TeeSet[];
   source: "manual" | "golfapi";
   providerId?: string;
+  /** Set when reviewing an existing library course; applied as-is unless edited. */
+  existingId?: string;
 }
 
 type Screen = "search" | "confirm" | "new" | "entry";
@@ -75,6 +77,9 @@ export function CoursePicker({
   const [hole, setHole] = useState(1);
   const [editingHole, setEditingHole] = useState<number | null>(null);
   const [pulling, setPulling] = useState(false);
+  // True once any hole is edited — a reviewed library course is applied as-is
+  // when untouched, or saved as a new course (a copy) when edited.
+  const [edited, setEdited] = useState(false);
 
   const recent = trpc.courses.list.useQuery({ limit: 8 });
   const createCourse = trpc.courses.create.useMutation();
@@ -113,19 +118,26 @@ export function CoursePicker({
     [validation, draft.hasStrokeIndex]
   );
 
-  const setPar = (h: number, value: number) =>
+  const setPar = (h: number, value: number) => {
+    setEdited(true);
     setDraft((d) => ({ ...d, par: d.par.map((p, i) => (i === h - 1 ? value : p)) }));
-  const setIndex = (h: number, value: number) =>
+  };
+  const setIndex = (h: number, value: number) => {
+    setEdited(true);
     setDraft((d) => ({ ...d, index: applyStrokeIndexSwap(d.index, h - 1, value) }));
-  const setYards = (h: number, value: number | null) =>
+  };
+  const setYards = (h: number, value: number | null) => {
+    setEdited(true);
     setDraft((d) => ({
       ...d,
       teeSets: d.teeSets.map((t, ti) =>
         ti === activeTee ? { ...t, yards: t.yards.map((y, i) => (i === h - 1 ? value : y)) } : t
       ),
     }));
+  };
 
   async function pull(summary: CourseSummary) {
+    setEdited(false);
     setPulling(true);
     const detail = await getCourseDetail(summary.id);
     setPulling(false);
@@ -153,8 +165,32 @@ export function CoursePicker({
     setScreen("confirm");
   }
 
+  // Review a saved library course on the Confirm screen before applying (eyeball
+  // / fix-a-hole). Untouched → applied as-is; edited → saved as a copy.
+  function reviewRecent(c: RecentCourse) {
+    setEdited(false);
+    setDraft({
+      name: c.name,
+      location: c.location ?? "",
+      holeCount: c.hole_count,
+      par: c.par,
+      index: c.has_stroke_index ? c.handicap_index : Array(c.hole_count).fill(null),
+      hasStrokeIndex: c.has_stroke_index,
+      teeSets: c.tee_sets?.length ? c.tee_sets : [blankTee(c.hole_count, "White")],
+      source: "manual",
+      existingId: c.id,
+    });
+    setActiveTee(0);
+    setScreen("confirm");
+  }
+
   async function save() {
     if (!indexComplete || !draft.name.trim()) return;
+    // Reviewing an existing library course, unedited → apply it directly.
+    if (draft.existingId && !edited) {
+      onApply({ id: draft.existingId, name: draft.name.trim() });
+      return;
+    }
     const course = await createCourse.mutateAsync({
       name: draft.name.trim(),
       location: draft.location.trim() || undefined,
@@ -214,8 +250,9 @@ export function CoursePicker({
           recent={(recent.data as RecentCourse[]) ?? []}
           pulling={pulling}
           onPick={pull}
-          onPickRecent={(c) => onApply({ id: c.id, name: c.name })}
+          onPickRecent={reviewRecent}
           onManual={() => {
+            setEdited(false);
             setDraft(blankDraft(18));
             setActiveTee(0);
             setScreen("new");
@@ -259,7 +296,11 @@ interface RecentCourse {
   id: string;
   name: string;
   location: string | null;
-  hole_count: number;
+  hole_count: 9 | 18;
+  par: number[];
+  handicap_index: number[];
+  has_stroke_index: boolean;
+  tee_sets: TeeSet[];
 }
 
 // ── Search ──────────────────────────────────────────────────────────────────

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -1,0 +1,732 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, Search, Plus, X, AlertTriangle, MapPin, PencilLine } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { HoleEditor } from "./HoleEditor";
+import {
+  searchCourses,
+  getCourseDetail,
+  parFromDetail,
+  indexFromDetail,
+  teeSetsFromDetail,
+  type CourseSummary,
+} from "@/lib/courseService";
+import { validateStrokeIndex, applyStrokeIndexSwap, type IndexEntry } from "@/lib/courseIndex";
+import { NavArrow, HoleProgress } from "../entryChrome";
+
+/**
+ * CoursePicker — the Course Selector/Builder flow (Slice C part 2). A full-screen
+ * overlay launched from the new-game "Select a course" field. Two paths, one
+ * editor: lookup (search → results → confirm) and manual (new course → stepped
+ * per-hole entry), both producing a saved global `courses` row; on apply it
+ * hands the parent { id, name } to snapshot onto the game (games.applyCourse).
+ *
+ * The stroke index is enforced as a valid 1..N permutation via swap-on-edit, and
+ * `Use this course` / `Save` is blocked until complete — including dirty lookup
+ * data, where golfapi's missing hcp lands as null and is flagged here.
+ */
+
+type TeeSet = { name: string; yards: (number | null)[] };
+interface Draft {
+  name: string;
+  location: string;
+  holeCount: 9 | 18;
+  par: number[];
+  index: IndexEntry[];
+  teeSets: TeeSet[];
+  source: "manual" | "golfapi";
+  providerId?: string;
+}
+
+type Screen = "search" | "confirm" | "new" | "entry";
+
+const blankTee = (n: number, name: string): TeeSet => ({ name, yards: Array(n).fill(null) });
+
+function blankDraft(holeCount: 9 | 18): Draft {
+  return {
+    name: "",
+    location: "",
+    holeCount,
+    par: Array(holeCount).fill(4),
+    index: Array(holeCount).fill(null),
+    teeSets: [blankTee(holeCount, "White")],
+    source: "manual",
+  };
+}
+
+export function CoursePicker({
+  onApply,
+  onClose,
+}: {
+  onApply: (course: { id: string; name: string }) => void;
+  onClose: () => void;
+}) {
+  const [screen, setScreen] = useState<Screen>("search");
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<CourseSummary[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [draft, setDraft] = useState<Draft>(() => blankDraft(18));
+  const [activeTee, setActiveTee] = useState(0);
+  const [hole, setHole] = useState(1); // 1-based, entry screen
+  const [editingHole, setEditingHole] = useState<number | null>(null); // confirm-edit, 1-based
+  const [pulling, setPulling] = useState(false);
+
+  const recent = trpc.courses.list.useQuery({ limit: 8 });
+  const createCourse = trpc.courses.create.useMutation();
+
+  // Debounced provider search. All setState runs inside the timeout/async
+  // callback (never synchronously in the effect body); stale results for a
+  // too-short query are hidden by `showResults` in the render, not cleared here.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) return;
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      setSearching(true);
+      const r = await searchCourses(q);
+      if (!cancelled) {
+        setResults(r);
+        setSearching(false);
+      }
+    }, 350);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [query]);
+
+  const validation = useMemo(
+    () => validateStrokeIndex(draft.index, draft.holeCount),
+    [draft.index, draft.holeCount]
+  );
+  const flagged = useMemo(
+    () => new Set([...validation.unsetHoles, ...validation.duplicateHoles, ...validation.outOfRangeHoles]),
+    [validation]
+  );
+
+  // ── Draft mutators ────────────────────────────────────────────────────
+  const setPar = (h: number, value: number) =>
+    setDraft((d) => ({ ...d, par: d.par.map((p, i) => (i === h - 1 ? value : p)) }));
+  const setIndex = (h: number, value: number) =>
+    setDraft((d) => ({ ...d, index: applyStrokeIndexSwap(d.index, h - 1, value) }));
+  const setYards = (h: number, value: number | null) =>
+    setDraft((d) => ({
+      ...d,
+      teeSets: d.teeSets.map((t, ti) =>
+        ti === activeTee ? { ...t, yards: t.yards.map((y, i) => (i === h - 1 ? value : y)) } : t
+      ),
+    }));
+
+  // ── Pull a lookup result → confirm ──────────────────────────────────────
+  async function pull(summary: CourseSummary) {
+    setPulling(true);
+    const detail = await getCourseDetail(summary.id);
+    setPulling(false);
+    if (!detail || detail.holes.length === 0) {
+      // No usable scorecard — fall back to manual, prefilled with what we know.
+      const d = blankDraft(18);
+      setDraft({ ...d, name: summary.name, location: summary.location });
+      setActiveTee(0);
+      setHole(1);
+      setScreen("new");
+      return;
+    }
+    const holeCount = (detail.holes.length >= 18 ? 18 : 9) as 9 | 18;
+    const tees = teeSetsFromDetail(detail);
+    setDraft({
+      name: detail.name,
+      location: detail.location,
+      holeCount,
+      par: parFromDetail(detail).slice(0, holeCount),
+      index: indexFromDetail(detail).slice(0, holeCount),
+      teeSets: tees.length ? tees.map((t) => ({ ...t, yards: t.yards.slice(0, holeCount) })) : [blankTee(holeCount, "White")],
+      source: "golfapi",
+      providerId: detail.externalId,
+    });
+    setActiveTee(0);
+    setScreen("confirm");
+  }
+
+  // ── Save (shared by confirm + manual entry) ──────────────────────────────
+  async function save() {
+    if (!validation.valid || !draft.name.trim()) return;
+    const course = await createCourse.mutateAsync({
+      name: draft.name.trim(),
+      location: draft.location.trim() || undefined,
+      holeCount: draft.holeCount,
+      par: draft.par,
+      handicapIndex: draft.index as number[], // valid ⇒ all numbers
+      teeSets: draft.teeSets,
+      source: draft.source,
+      providerId: draft.providerId,
+    });
+    onApply({ id: course.id as string, name: course.name as string });
+  }
+
+  const headerTitle =
+    screen === "search" ? "Add a course" : screen === "confirm" ? "Confirm course" : screen === "new" ? "New course" : "Enter holes";
+  const back = () => {
+    if (editingHole != null) return setEditingHole(null);
+    if (screen === "confirm" || screen === "new") return setScreen("search");
+    if (screen === "entry") return setScreen("new");
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <header
+        className="flex shrink-0 items-center justify-between"
+        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        <button onClick={back} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{headerTitle}</div>
+        <button onClick={onClose} aria-label="Close" className="flex h-9 w-9 items-center justify-center">
+          <X size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+        </button>
+      </header>
+
+      {editingHole != null ? (
+        <HoleEditScreen
+          draft={draft}
+          hole={editingHole}
+          activeTee={activeTee}
+          flagged={flagged}
+          setPar={setPar}
+          setIndex={setIndex}
+          setYards={setYards}
+          onDone={() => setEditingHole(null)}
+        />
+      ) : screen === "search" ? (
+        <SearchScreen
+          query={query}
+          setQuery={setQuery}
+          searching={searching}
+          results={results}
+          recent={(recent.data as RecentCourse[]) ?? []}
+          pulling={pulling}
+          onPick={pull}
+          onPickRecent={(c) => onApply({ id: c.id, name: c.name })}
+          onManual={() => {
+            setDraft(blankDraft(18));
+            setActiveTee(0);
+            setScreen("new");
+          }}
+        />
+      ) : screen === "confirm" ? (
+        <ConfirmScreen
+          draft={draft}
+          activeTee={activeTee}
+          setActiveTee={setActiveTee}
+          validation={validation}
+          flagged={flagged}
+          saving={createCourse.isPending}
+          onEditHole={(h) => setEditingHole(h)}
+          onUse={save}
+        />
+      ) : screen === "new" ? (
+        <NewCourseScreen draft={draft} setDraft={setDraft} onStart={() => { setHole(1); setScreen("entry"); }} />
+      ) : (
+        <EntryScreen
+          draft={draft}
+          hole={hole}
+          setHole={setHole}
+          activeTee={activeTee}
+          setActiveTee={setActiveTee}
+          validation={validation}
+          flagged={flagged}
+          saving={createCourse.isPending}
+          setPar={setPar}
+          setIndex={setIndex}
+          setYards={setYards}
+          onSave={save}
+        />
+      )}
+    </div>
+  );
+}
+
+interface RecentCourse {
+  id: string;
+  name: string;
+  location: string | null;
+  hole_count: number;
+  par: number[];
+}
+
+// ── Search ──────────────────────────────────────────────────────────────────
+function SearchScreen({
+  query,
+  setQuery,
+  searching,
+  results,
+  recent,
+  pulling,
+  onPick,
+  onPickRecent,
+  onManual,
+}: {
+  query: string;
+  setQuery: (q: string) => void;
+  searching: boolean;
+  results: CourseSummary[];
+  recent: RecentCourse[];
+  pulling: boolean;
+  onPick: (c: CourseSummary) => void;
+  onPickRecent: (c: RecentCourse) => void;
+  onManual: () => void;
+}) {
+  const showResults = query.trim().length >= 2;
+  return (
+    <div className="flex-1 overflow-y-auto" style={{ padding: "16px" }}>
+      <div className="flex items-center gap-2 rounded-xl border px-3" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
+        <Search size={16} style={{ color: "var(--color-bt-text-dim)" }} />
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search courses"
+          className="w-full bg-transparent py-2.5 text-sm outline-none"
+          style={{ color: "var(--color-bt-text)" }}
+        />
+      </div>
+
+      {pulling && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 14 }}>Pulling scorecard…</p>}
+
+      {showResults ? (
+        <div className="mt-4 flex flex-col gap-2">
+          {searching && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>Searching…</p>}
+          {!searching && results.length === 0 && (
+            <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches.</p>
+          )}
+          {results.map((c) => (
+            <button
+              key={c.id}
+              onClick={() => onPick(c)}
+              className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left"
+              style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
+            >
+              <span className="min-w-0">
+                <span className="block truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{c.name}</span>
+                {c.location && <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{c.location}</span>}
+              </span>
+              <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+            </button>
+          ))}
+        </div>
+      ) : (
+        recent.length > 0 && (
+          <div className="mt-5">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Recent courses</p>
+            <div className="flex flex-col gap-2">
+              {recent.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => onPickRecent(c)}
+                  className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left"
+                  style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{c.name}</span>
+                    <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
+                      {[c.location, `${c.hole_count} holes`].filter(Boolean).join(" · ")}
+                    </span>
+                  </span>
+                  <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+                </button>
+              ))}
+            </div>
+          </div>
+        )
+      )}
+
+      {/* Manual entry — first-class, always present (not an error state). */}
+      <button
+        onClick={onManual}
+        className="mt-5 flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3"
+        style={{ borderColor: "var(--color-bt-accent-border)", borderStyle: "dashed", color: "var(--color-bt-accent)", background: "transparent" }}
+      >
+        <PencilLine size={16} />
+        <span style={{ fontSize: 14, fontWeight: 600 }}>Add course manually</span>
+      </button>
+      <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8, textAlign: "center" }}>
+        No course found, or no signal? Enter par + index by hand.
+      </p>
+    </div>
+  );
+}
+
+// ── Confirm (lookup) ──────────────────────────────────────────────────────────
+function ConfirmScreen({
+  draft,
+  activeTee,
+  setActiveTee,
+  validation,
+  flagged,
+  saving,
+  onEditHole,
+  onUse,
+}: {
+  draft: Draft;
+  activeTee: number;
+  setActiveTee: (i: number) => void;
+  validation: ReturnType<typeof validateStrokeIndex>;
+  flagged: Set<number>;
+  saving: boolean;
+  onEditHole: (h: number) => void;
+  onUse: () => void;
+}) {
+  const tee = draft.teeSets[activeTee];
+  return (
+    <>
+      <div className="flex-1 overflow-y-auto" style={{ padding: "16px 16px 8px" }}>
+        <div style={{ fontSize: 18, fontWeight: 700, color: "var(--color-bt-text)" }}>{draft.name}</div>
+        {draft.location && (
+          <div className="flex items-center gap-1" style={{ marginTop: 2 }}>
+            <MapPin size={13} style={{ color: "var(--color-bt-text-dim)" }} />
+            <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{draft.location}</span>
+          </div>
+        )}
+
+        {/* Tee chips */}
+        {draft.teeSets.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {draft.teeSets.map((t, i) => (
+              <button
+                key={t.name + i}
+                onClick={() => setActiveTee(i)}
+                style={{
+                  padding: "5px 12px",
+                  borderRadius: 9999,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  border: `1px solid ${i === activeTee ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+                  background: i === activeTee ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+                  color: i === activeTee ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                }}
+              >
+                {t.name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {!validation.valid && (
+          <div className="mt-3 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}>
+            <AlertTriangle size={15} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
+            <span style={{ fontSize: 12.5, color: "var(--color-bt-warning)" }}>
+              This course&apos;s stroke index is incomplete — a wrong index mis-allocates handicap strokes. Tap the flagged holes to fix before using.
+            </span>
+          </div>
+        )}
+
+        {/* Per-hole rows */}
+        <div className="mt-3 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
+          <HoleHeader />
+          {draft.par.map((p, i) => {
+            const h = i + 1;
+            const bad = flagged.has(h);
+            return (
+              <button
+                key={h}
+                onClick={() => onEditHole(h)}
+                className="flex w-full items-center text-left"
+                style={{ height: 38, background: i % 2 === 0 ? "var(--color-bt-card)" : "var(--color-bt-base)", borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}
+              >
+                <Cell w={48} bold>{h}</Cell>
+                <Cell w={72} dim>{tee?.yards[i] ?? "—"}</Cell>
+                <Cell w={56}>{p}</Cell>
+                <span className="flex flex-1 items-center justify-between pr-3">
+                  <span style={{ flex: 1, textAlign: "center", fontSize: 14, fontWeight: bad ? 700 : 500, color: bad ? "var(--color-bt-warning)" : "var(--color-bt-text)" }}>
+                    {draft.index[i] ?? "—"}
+                  </span>
+                  <PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} />
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <Footer
+        label={validation.valid ? "Use this course" : `${validation.unsetHoles.length + validation.duplicateHoles.length + validation.outOfRangeHoles.length} holes need a valid index`}
+        disabled={!validation.valid || saving}
+        onClick={onUse}
+      />
+    </>
+  );
+}
+
+// ── New course (manual setup) ─────────────────────────────────────────────────
+function NewCourseScreen({
+  draft,
+  setDraft,
+  onStart,
+}: {
+  draft: Draft;
+  setDraft: React.Dispatch<React.SetStateAction<Draft>>;
+  onStart: () => void;
+}) {
+  const setHoleCount = (n: 9 | 18) =>
+    setDraft((d) => ({
+      ...d,
+      holeCount: n,
+      par: Array(n).fill(4),
+      index: Array(n).fill(null),
+      teeSets: d.teeSets.map((t) => ({ ...t, yards: Array(n).fill(null) })),
+    }));
+  const addTee = () => setDraft((d) => ({ ...d, teeSets: [...d.teeSets, blankTee(d.holeCount, "")] }));
+  const setTeeName = (i: number, name: string) =>
+    setDraft((d) => ({ ...d, teeSets: d.teeSets.map((t, ti) => (ti === i ? { ...t, name } : t)) }));
+  const removeTee = (i: number) => setDraft((d) => ({ ...d, teeSets: d.teeSets.filter((_, ti) => ti !== i) }));
+
+  return (
+    <>
+      <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
+        <div className="flex flex-col gap-3.5">
+          <Field label="Course name">
+            <input value={draft.name} onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))} placeholder="e.g. Pebble Creek" className="w-full rounded-xl border px-3 py-2.5 text-sm" style={inputStyle} />
+          </Field>
+          <Field label="Location">
+            <input value={draft.location} onChange={(e) => setDraft((d) => ({ ...d, location: e.target.value }))} placeholder="Optional" className="w-full rounded-xl border px-3 py-2.5 text-sm" style={inputStyle} />
+          </Field>
+          <Field label="Holes">
+            <div className="flex gap-2">
+              {([18, 9] as const).map((n) => (
+                <button
+                  key={n}
+                  onClick={() => setHoleCount(n)}
+                  className="flex-1 rounded-xl border py-2.5 text-sm font-semibold"
+                  style={{
+                    background: draft.holeCount === n ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+                    borderColor: draft.holeCount === n ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
+                    color: draft.holeCount === n ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                  }}
+                >
+                  {n} holes
+                </button>
+              ))}
+            </div>
+          </Field>
+          <Field label="Tee sets">
+            <div className="flex flex-col gap-2">
+              {draft.teeSets.map((t, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <input
+                    value={t.name}
+                    onChange={(e) => setTeeName(i, e.target.value)}
+                    placeholder="Name them anything (White, Member…)"
+                    className="w-full rounded-xl border px-3 py-2.5 text-sm"
+                    style={inputStyle}
+                  />
+                  {draft.teeSets.length > 1 && (
+                    <button onClick={() => removeTee(i)} aria-label="Remove tee" className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg" style={{ border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}>
+                      <X size={15} />
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button onClick={addTee} className="flex items-center justify-center gap-1.5 rounded-xl border py-2" style={{ borderStyle: "dashed", borderColor: "var(--color-bt-accent-border)", color: "var(--color-bt-accent)" }}>
+                <Plus size={15} />
+                <span style={{ fontSize: 13, fontWeight: 600 }}>Add tee set</span>
+              </button>
+            </div>
+          </Field>
+        </div>
+      </div>
+      <Footer label="Start entering holes" disabled={!draft.name.trim() || draft.teeSets.every((t) => !t.name.trim())} onClick={onStart} />
+    </>
+  );
+}
+
+// ── Stepped per-hole entry (manual) ───────────────────────────────────────────
+function EntryScreen({
+  draft,
+  hole,
+  setHole,
+  activeTee,
+  setActiveTee,
+  validation,
+  flagged,
+  saving,
+  setPar,
+  setIndex,
+  setYards,
+  onSave,
+}: {
+  draft: Draft;
+  hole: number;
+  setHole: (h: number) => void;
+  activeTee: number;
+  setActiveTee: (i: number) => void;
+  validation: ReturnType<typeof validateStrokeIndex>;
+  flagged: Set<number>;
+  saving: boolean;
+  setPar: (h: number, v: number) => void;
+  setIndex: (h: number, v: number) => void;
+  setYards: (h: number, v: number | null) => void;
+  onSave: () => void;
+}) {
+  const n = draft.holeCount;
+  const completed = draft.index.map((v, i) => (v != null ? i + 1 : 0)).filter(Boolean);
+  return (
+    <>
+      <div className="flex shrink-0 items-center justify-between" style={{ padding: "12px 16px" }}>
+        <NavArrow dir="prev" disabled={hole <= 1} onClick={() => setHole(hole - 1)} />
+        <div className="flex flex-col items-center" style={{ gap: 10, flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 22, fontWeight: 700, color: "var(--color-bt-text)" }}>Hole {hole}</div>
+          <HoleProgress count={n} currentHole={hole} completed={completed} />
+        </div>
+        <NavArrow dir="next" disabled={hole >= n} onClick={() => setHole(hole + 1)} />
+      </div>
+
+      <div className="flex-1 overflow-y-auto" style={{ padding: "4px 16px 8px" }}>
+        <TeeChips draft={draft} activeTee={activeTee} setActiveTee={setActiveTee} />
+        <div style={{ marginTop: 14 }}>
+          <HoleEditor
+            holeNumber={hole}
+            holeCount={n}
+            par={draft.par[hole - 1]}
+            index={draft.index[hole - 1] ?? null}
+            teeName={draft.teeSets[activeTee]?.name || null}
+            yards={draft.teeSets[activeTee]?.yards[hole - 1] ?? null}
+            swapHint="Reusing an index swaps it with the hole that currently has it."
+            onPar={(v) => setPar(hole, v)}
+            onIndex={(v) => setIndex(hole, v)}
+            onYards={(v) => setYards(hole, v)}
+          />
+        </div>
+      </div>
+
+      {hole < n ? (
+        <Footer label={`Next · Hole ${hole + 1}`} onClick={() => setHole(hole + 1)} />
+      ) : (
+        <Footer
+          label={validation.valid ? "Save course" : `${flagged.size} holes need a valid index`}
+          disabled={!validation.valid || saving}
+          onClick={onSave}
+        />
+      )}
+    </>
+  );
+}
+
+// ── Single-hole edit (from confirm) ───────────────────────────────────────────
+function HoleEditScreen({
+  draft,
+  hole,
+  activeTee,
+  flagged,
+  setPar,
+  setIndex,
+  setYards,
+  onDone,
+}: {
+  draft: Draft;
+  hole: number;
+  activeTee: number;
+  flagged: Set<number>;
+  setPar: (h: number, v: number) => void;
+  setIndex: (h: number, v: number) => void;
+  setYards: (h: number, v: number | null) => void;
+  onDone: () => void;
+}) {
+  return (
+    <>
+      <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
+        <HoleEditor
+          holeNumber={hole}
+          holeCount={draft.holeCount}
+          par={draft.par[hole - 1]}
+          index={draft.index[hole - 1] ?? null}
+          teeName={draft.teeSets[activeTee]?.name || null}
+          yards={draft.teeSets[activeTee]?.yards[hole - 1] ?? null}
+          swapHint="Reusing an index swaps it with the hole that currently has it."
+          onPar={(v) => setPar(hole, v)}
+          onIndex={(v) => setIndex(hole, v)}
+          onYards={(v) => setYards(hole, v)}
+        />
+      </div>
+      <Footer label="Done" disabled={flagged.has(hole)} onClick={onDone} />
+    </>
+  );
+}
+
+// ── Shared bits ───────────────────────────────────────────────────────────────
+
+const inputStyle: React.CSSProperties = {
+  background: "var(--color-bt-card-raised)",
+  borderColor: "var(--color-bt-border)",
+  color: "var(--color-bt-text)",
+};
+
+function TeeChips({ draft, activeTee, setActiveTee }: { draft: Draft; activeTee: number; setActiveTee: (i: number) => void }) {
+  if (draft.teeSets.length <= 1) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {draft.teeSets.map((t, i) => (
+        <button
+          key={t.name + i}
+          onClick={() => setActiveTee(i)}
+          style={{
+            padding: "4px 11px",
+            borderRadius: 9999,
+            fontSize: 12.5,
+            fontWeight: 600,
+            border: `1px solid ${i === activeTee ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+            background: i === activeTee ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+            color: i === activeTee ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+          }}
+        >
+          {t.name || `Tee ${i + 1}`}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function HoleHeader() {
+  return (
+    <div className="flex items-center" style={{ height: 30, background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-border)" }}>
+      <HCell w={48}>Hole</HCell>
+      <HCell w={72}>Yds</HCell>
+      <HCell w={56}>Par</HCell>
+      <span className="flex-1 pr-3 text-center text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Index</span>
+    </div>
+  );
+}
+function HCell({ w, children }: { w: number; children: React.ReactNode }) {
+  return <span style={{ width: w, textAlign: "center", fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--color-bt-text-dim)" }}>{children}</span>;
+}
+function Cell({ w, children, bold, dim }: { w: number; children: React.ReactNode; bold?: boolean; dim?: boolean }) {
+  return (
+    <span style={{ width: w, textAlign: "center", fontSize: 14, fontWeight: bold ? 700 : 500, color: dim ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+      {children}
+    </span>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function Footer({ label, disabled, onClick }: { label: string; disabled?: boolean; onClick: () => void }) {
+  return (
+    <div className="shrink-0" style={{ padding: 16, borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-base)" }}>
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        className="w-full disabled:opacity-40"
+        style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -1,30 +1,32 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { ChevronLeft, ChevronRight, Search, Plus, X, AlertTriangle, MapPin, PencilLine } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, Search, Plus, X, AlertTriangle, MapPin, PencilLine, GripVertical } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { HoleEditor } from "./HoleEditor";
+import { HoleEditor, Keypad } from "./HoleEditor";
 import {
   searchCourses,
   getCourseDetail,
   parFromDetail,
   indexFromDetail,
   teeSetsFromDetail,
+  teeColor,
   type CourseSummary,
 } from "@/lib/courseService";
 import { validateStrokeIndex, applyStrokeIndexSwap, type IndexEntry } from "@/lib/courseIndex";
 import { NavArrow, HoleProgress } from "../entryChrome";
 
 /**
- * CoursePicker — the Course Selector/Builder flow (Slice C part 2). A full-screen
- * overlay launched from the new-game "Select a course" field. Two paths, one
- * editor: lookup (search → results → confirm) and manual (new course → stepped
- * per-hole entry), both producing a saved global `courses` row; on apply it
- * hands the parent { id, name } to snapshot onto the game (games.applyCourse).
+ * CoursePicker — the Course Selector/Builder flow (Slice C + addendum C-1). A
+ * full-screen overlay launched from the new-game "Select a course" field. Two
+ * paths, one editor: lookup (search → results → confirm) and manual (new course
+ * → stepped per-hole entry), both producing a saved global `courses` row; on
+ * apply it hands the parent { id, name } to snapshot onto the game.
  *
- * The stroke index is enforced as a valid 1..N permutation via swap-on-edit, and
- * `Use this course` / `Save` is blocked until complete — including dirty lookup
- * data, where golfapi's missing hcp lands as null and is flagged here.
+ * Stroke index is optional (a creation toggle); when on it's enforced as a valid
+ * 1..N permutation via the 18-cell grid's swap-on-pick, and Use/Save is blocked
+ * until complete. Per-hole controls are tap-first: par segmented, yards keypad,
+ * index grid — no ± steppers.
  */
 
 type TeeSet = { name: string; yards: (number | null)[] };
@@ -34,6 +36,7 @@ interface Draft {
   holeCount: 9 | 18;
   par: number[];
   index: IndexEntry[];
+  hasStrokeIndex: boolean;
   teeSets: TeeSet[];
   source: "manual" | "golfapi";
   providerId?: string;
@@ -50,6 +53,7 @@ function blankDraft(holeCount: 9 | 18): Draft {
     holeCount,
     par: Array(holeCount).fill(4),
     index: Array(holeCount).fill(null),
+    hasStrokeIndex: true,
     teeSets: [blankTee(holeCount, "White")],
     source: "manual",
   };
@@ -68,16 +72,13 @@ export function CoursePicker({
   const [searching, setSearching] = useState(false);
   const [draft, setDraft] = useState<Draft>(() => blankDraft(18));
   const [activeTee, setActiveTee] = useState(0);
-  const [hole, setHole] = useState(1); // 1-based, entry screen
-  const [editingHole, setEditingHole] = useState<number | null>(null); // confirm-edit, 1-based
+  const [hole, setHole] = useState(1);
+  const [editingHole, setEditingHole] = useState<number | null>(null);
   const [pulling, setPulling] = useState(false);
 
   const recent = trpc.courses.list.useQuery({ limit: 8 });
   const createCourse = trpc.courses.create.useMutation();
 
-  // Debounced provider search. All setState runs inside the timeout/async
-  // callback (never synchronously in the effect body); stale results for a
-  // too-short query are hidden by `showResults` in the render, not cleared here.
   useEffect(() => {
     const q = query.trim();
     if (q.length < 2) return;
@@ -100,12 +101,18 @@ export function CoursePicker({
     () => validateStrokeIndex(draft.index, draft.holeCount),
     [draft.index, draft.holeCount]
   );
+  const indexComplete = !draft.hasStrokeIndex || validation.valid;
+  const missingCount = draft.hasStrokeIndex
+    ? validation.unsetHoles.length + validation.duplicateHoles.length + validation.outOfRangeHoles.length
+    : 0;
   const flagged = useMemo(
-    () => new Set([...validation.unsetHoles, ...validation.duplicateHoles, ...validation.outOfRangeHoles]),
-    [validation]
+    () =>
+      draft.hasStrokeIndex
+        ? new Set([...validation.unsetHoles, ...validation.duplicateHoles, ...validation.outOfRangeHoles])
+        : new Set<number>(),
+    [validation, draft.hasStrokeIndex]
   );
 
-  // ── Draft mutators ────────────────────────────────────────────────────
   const setPar = (h: number, value: number) =>
     setDraft((d) => ({ ...d, par: d.par.map((p, i) => (i === h - 1 ? value : p)) }));
   const setIndex = (h: number, value: number) =>
@@ -118,15 +125,12 @@ export function CoursePicker({
       ),
     }));
 
-  // ── Pull a lookup result → confirm ──────────────────────────────────────
   async function pull(summary: CourseSummary) {
     setPulling(true);
     const detail = await getCourseDetail(summary.id);
     setPulling(false);
     if (!detail || detail.holes.length === 0) {
-      // No usable scorecard — fall back to manual, prefilled with what we know.
-      const d = blankDraft(18);
-      setDraft({ ...d, name: summary.name, location: summary.location });
+      setDraft({ ...blankDraft(18), name: summary.name, location: summary.location });
       setActiveTee(0);
       setHole(1);
       setScreen("new");
@@ -140,6 +144,7 @@ export function CoursePicker({
       holeCount,
       par: parFromDetail(detail).slice(0, holeCount),
       index: indexFromDetail(detail).slice(0, holeCount),
+      hasStrokeIndex: true,
       teeSets: tees.length ? tees.map((t) => ({ ...t, yards: t.yards.slice(0, holeCount) })) : [blankTee(holeCount, "White")],
       source: "golfapi",
       providerId: detail.externalId,
@@ -148,15 +153,15 @@ export function CoursePicker({
     setScreen("confirm");
   }
 
-  // ── Save (shared by confirm + manual entry) ──────────────────────────────
   async function save() {
-    if (!validation.valid || !draft.name.trim()) return;
+    if (!indexComplete || !draft.name.trim()) return;
     const course = await createCourse.mutateAsync({
       name: draft.name.trim(),
       location: draft.location.trim() || undefined,
       holeCount: draft.holeCount,
       par: draft.par,
-      handicapIndex: draft.index as number[], // valid ⇒ all numbers
+      handicapIndex: draft.hasStrokeIndex ? (draft.index as number[]) : undefined,
+      hasStrokeIndex: draft.hasStrokeIndex,
       teeSets: draft.teeSets,
       source: draft.source,
       providerId: draft.providerId,
@@ -193,6 +198,7 @@ export function CoursePicker({
           draft={draft}
           hole={editingHole}
           activeTee={activeTee}
+          setActiveTee={setActiveTee}
           flagged={flagged}
           setPar={setPar}
           setIndex={setIndex}
@@ -220,7 +226,8 @@ export function CoursePicker({
           draft={draft}
           activeTee={activeTee}
           setActiveTee={setActiveTee}
-          validation={validation}
+          indexComplete={indexComplete}
+          missingCount={missingCount}
           flagged={flagged}
           saving={createCourse.isPending}
           onEditHole={(h) => setEditingHole(h)}
@@ -235,8 +242,8 @@ export function CoursePicker({
           setHole={setHole}
           activeTee={activeTee}
           setActiveTee={setActiveTee}
-          validation={validation}
-          flagged={flagged}
+          indexComplete={indexComplete}
+          missingCount={missingCount}
           saving={createCourse.isPending}
           setPar={setPar}
           setIndex={setIndex}
@@ -253,7 +260,6 @@ interface RecentCourse {
   name: string;
   location: string | null;
   hole_count: number;
-  par: number[];
 }
 
 // ── Search ──────────────────────────────────────────────────────────────────
@@ -280,7 +286,7 @@ function SearchScreen({
 }) {
   const showResults = query.trim().length >= 2;
   return (
-    <div className="flex-1 overflow-y-auto" style={{ padding: "16px" }}>
+    <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
       <div className="flex items-center gap-2 rounded-xl border px-3" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
         <Search size={16} style={{ color: "var(--color-bt-text-dim)" }} />
         <input
@@ -298,22 +304,9 @@ function SearchScreen({
       {showResults ? (
         <div className="mt-4 flex flex-col gap-2">
           {searching && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>Searching…</p>}
-          {!searching && results.length === 0 && (
-            <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches.</p>
-          )}
+          {!searching && results.length === 0 && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches.</p>}
           {results.map((c) => (
-            <button
-              key={c.id}
-              onClick={() => onPick(c)}
-              className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left"
-              style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
-            >
-              <span className="min-w-0">
-                <span className="block truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{c.name}</span>
-                {c.location && <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{c.location}</span>}
-              </span>
-              <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
-            </button>
+            <CourseRow key={c.id} name={c.name} sub={c.location} onClick={() => onPick(c)} />
           ))}
         </div>
       ) : (
@@ -322,27 +315,13 @@ function SearchScreen({
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Recent courses</p>
             <div className="flex flex-col gap-2">
               {recent.map((c) => (
-                <button
-                  key={c.id}
-                  onClick={() => onPickRecent(c)}
-                  className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left"
-                  style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{c.name}</span>
-                    <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
-                      {[c.location, `${c.hole_count} holes`].filter(Boolean).join(" · ")}
-                    </span>
-                  </span>
-                  <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
-                </button>
+                <CourseRow key={c.id} name={c.name} sub={[c.location, `${c.hole_count} holes`].filter(Boolean).join(" · ")} onClick={() => onPickRecent(c)} />
               ))}
             </div>
           </div>
         )
       )}
 
-      {/* Manual entry — first-class, always present (not an error state). */}
       <button
         onClick={onManual}
         className="mt-5 flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3"
@@ -358,12 +337,25 @@ function SearchScreen({
   );
 }
 
+function CourseRow({ name, sub, onClick }: { name: string; sub?: string | null; onClick: () => void }) {
+  return (
+    <button onClick={onClick} className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left" style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}>
+      <span className="min-w-0">
+        <span className="block truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{name}</span>
+        {sub && <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{sub}</span>}
+      </span>
+      <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+    </button>
+  );
+}
+
 // ── Confirm (lookup) ──────────────────────────────────────────────────────────
 function ConfirmScreen({
   draft,
   activeTee,
   setActiveTee,
-  validation,
+  indexComplete,
+  missingCount,
   flagged,
   saving,
   onEditHole,
@@ -372,7 +364,8 @@ function ConfirmScreen({
   draft: Draft;
   activeTee: number;
   setActiveTee: (i: number) => void;
-  validation: ReturnType<typeof validateStrokeIndex>;
+  indexComplete: boolean;
+  missingCount: number;
   flagged: Set<number>;
   saving: boolean;
   onEditHole: (h: number) => void;
@@ -390,30 +383,15 @@ function ConfirmScreen({
           </div>
         )}
 
-        {/* Tee chips */}
         {draft.teeSets.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-2">
+          <div className="no-scrollbar mt-3 flex gap-2 overflow-x-auto">
             {draft.teeSets.map((t, i) => (
-              <button
-                key={t.name + i}
-                onClick={() => setActiveTee(i)}
-                style={{
-                  padding: "5px 12px",
-                  borderRadius: 9999,
-                  fontSize: 13,
-                  fontWeight: 600,
-                  border: `1px solid ${i === activeTee ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
-                  background: i === activeTee ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
-                  color: i === activeTee ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-                }}
-              >
-                {t.name}
-              </button>
+              <TeeChip key={i} name={t.name || `Tee ${i + 1}`} on={i === activeTee} onClick={() => setActiveTee(i)} />
             ))}
           </div>
         )}
 
-        {!validation.valid && (
+        {draft.hasStrokeIndex && !indexComplete && (
           <div className="mt-3 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}>
             <AlertTriangle size={15} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
             <span style={{ fontSize: 12.5, color: "var(--color-bt-warning)" }}>
@@ -422,9 +400,8 @@ function ConfirmScreen({
           </div>
         )}
 
-        {/* Per-hole rows */}
         <div className="mt-3 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
-          <HoleHeader />
+          <HoleHeader hasIndex={draft.hasStrokeIndex} />
           {draft.par.map((p, i) => {
             const h = i + 1;
             const bad = flagged.has(h);
@@ -438,22 +415,21 @@ function ConfirmScreen({
                 <Cell w={48} bold>{h}</Cell>
                 <Cell w={72} dim>{tee?.yards[i] ?? "—"}</Cell>
                 <Cell w={56}>{p}</Cell>
-                <span className="flex flex-1 items-center justify-between pr-3">
-                  <span style={{ flex: 1, textAlign: "center", fontSize: 14, fontWeight: bad ? 700 : 500, color: bad ? "var(--color-bt-warning)" : "var(--color-bt-text)" }}>
-                    {draft.index[i] ?? "—"}
+                {draft.hasStrokeIndex && (
+                  <span className="flex flex-1 items-center justify-between pr-3">
+                    <span style={{ flex: 1, textAlign: "center", fontSize: 14, fontWeight: bad ? 700 : 500, color: bad ? "var(--color-bt-warning)" : "var(--color-bt-text)" }}>
+                      {draft.index[i] ?? "—"}
+                    </span>
+                    <PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} />
                   </span>
-                  <PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-                </span>
+                )}
+                {!draft.hasStrokeIndex && <span className="flex flex-1 justify-end pr-3"><PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} /></span>}
               </button>
             );
           })}
         </div>
       </div>
-      <Footer
-        label={validation.valid ? "Use this course" : `${validation.unsetHoles.length + validation.duplicateHoles.length + validation.outOfRangeHoles.length} holes need a valid index`}
-        disabled={!validation.valid || saving}
-        onClick={onUse}
-      />
+      <Footer label={indexComplete ? "Use this course" : `${missingCount} holes need a valid index`} disabled={!indexComplete || saving} onClick={onUse} />
     </>
   );
 }
@@ -477,9 +453,16 @@ function NewCourseScreen({
       teeSets: d.teeSets.map((t) => ({ ...t, yards: Array(n).fill(null) })),
     }));
   const addTee = () => setDraft((d) => ({ ...d, teeSets: [...d.teeSets, blankTee(d.holeCount, "")] }));
-  const setTeeName = (i: number, name: string) =>
-    setDraft((d) => ({ ...d, teeSets: d.teeSets.map((t, ti) => (ti === i ? { ...t, name } : t)) }));
+  const setTeeName = (i: number, name: string) => setDraft((d) => ({ ...d, teeSets: d.teeSets.map((t, ti) => (ti === i ? { ...t, name } : t)) }));
   const removeTee = (i: number) => setDraft((d) => ({ ...d, teeSets: d.teeSets.filter((_, ti) => ti !== i) }));
+  const reorderTee = (from: number, to: number) =>
+    setDraft((d) => {
+      if (from === to) return d;
+      const next = [...d.teeSets];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return { ...d, teeSets: next };
+    });
 
   return (
     <>
@@ -509,34 +492,112 @@ function NewCourseScreen({
               ))}
             </div>
           </Field>
+
+          {/* Stroke index toggle. */}
+          <button
+            onClick={() => setDraft((d) => ({ ...d, hasStrokeIndex: !d.hasStrokeIndex }))}
+            className="flex items-center justify-between gap-3 rounded-xl border px-3 py-2.5 text-left"
+            style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}
+          >
+            <span className="min-w-0">
+              <span style={{ display: "block", fontSize: 14, fontWeight: 600, color: "var(--color-bt-text)" }}>Add stroke indices</span>
+              <span style={{ display: "block", fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 2 }}>
+                The course&apos;s 1–{draft.holeCount} difficulty ranking. Needed for net play — skip if you don&apos;t have it.
+              </span>
+            </span>
+            <Switch on={draft.hasStrokeIndex} />
+          </button>
+
           <Field label="Tee sets">
-            <div className="flex flex-col gap-2">
-              {draft.teeSets.map((t, i) => (
-                <div key={i} className="flex items-center gap-2">
-                  <input
-                    value={t.name}
-                    onChange={(e) => setTeeName(i, e.target.value)}
-                    placeholder="Name them anything (White, Member…)"
-                    className="w-full rounded-xl border px-3 py-2.5 text-sm"
-                    style={inputStyle}
-                  />
-                  {draft.teeSets.length > 1 && (
-                    <button onClick={() => removeTee(i)} aria-label="Remove tee" className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg" style={{ border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}>
-                      <X size={15} />
-                    </button>
-                  )}
-                </div>
-              ))}
-              <button onClick={addTee} className="flex items-center justify-center gap-1.5 rounded-xl border py-2" style={{ borderStyle: "dashed", borderColor: "var(--color-bt-accent-border)", color: "var(--color-bt-accent)" }}>
-                <Plus size={15} />
-                <span style={{ fontSize: 13, fontWeight: 600 }}>Add tee set</span>
-              </button>
-            </div>
+            <TeeList tees={draft.teeSets} onName={setTeeName} onRemove={removeTee} onReorder={reorderTee} />
+            <button onClick={addTee} className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-xl border py-2" style={{ borderStyle: "dashed", borderColor: "var(--color-bt-accent-border)", color: "var(--color-bt-accent)" }}>
+              <Plus size={15} />
+              <span style={{ fontSize: 13, fontWeight: 600 }}>Add tee set</span>
+            </button>
+            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 6 }}>Drag to order · longest first.</p>
           </Field>
         </div>
       </div>
       <Footer label="Start entering holes" disabled={!draft.name.trim() || draft.teeSets.every((t) => !t.name.trim())} onClick={onStart} />
     </>
+  );
+}
+
+/** Pointer-drag reorderable tee list (works on touch + mouse). */
+function TeeList({
+  tees,
+  onName,
+  onRemove,
+  onReorder,
+}: {
+  tees: TeeSet[];
+  onName: (i: number, name: string) => void;
+  onRemove: (i: number) => void;
+  onReorder: (from: number, to: number) => void;
+}) {
+  const ROW = 52;
+  const [drag, setDrag] = useState<{ from: number; dy: number } | null>(null);
+  const startY = useRef(0);
+
+  const total = (t: TeeSet) => t.yards.reduce<number>((a, y) => a + (y ?? 0), 0);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {tees.map((t, i) => {
+        const dragging = drag?.from === i;
+        return (
+          <div
+            key={i}
+            className="flex items-center gap-2 rounded-xl border px-2"
+            style={{
+              height: 44,
+              background: "var(--color-bt-card-raised)",
+              borderColor: dragging ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
+              transform: dragging ? `translateY(${drag!.dy}px)` : undefined,
+              zIndex: dragging ? 2 : undefined,
+              position: dragging ? "relative" : undefined,
+              touchAction: "none",
+            }}
+          >
+            <span
+              onPointerDown={(e) => {
+                (e.target as HTMLElement).setPointerCapture(e.pointerId);
+                startY.current = e.clientY;
+                setDrag({ from: i, dy: 0 });
+              }}
+              onPointerMove={(e) => {
+                if (drag?.from === i) setDrag({ from: i, dy: e.clientY - startY.current });
+              }}
+              onPointerUp={() => {
+                if (drag?.from === i) {
+                  const to = Math.max(0, Math.min(tees.length - 1, i + Math.round(drag.dy / ROW)));
+                  onReorder(i, to);
+                  setDrag(null);
+                }
+              }}
+              className="flex h-9 w-7 cursor-grab items-center justify-center"
+              style={{ color: "var(--color-bt-text-dim)", touchAction: "none" }}
+            >
+              <GripVertical size={16} />
+            </span>
+            <span style={{ width: 10, height: 10, borderRadius: "50%", background: teeColor(t.name || `Tee ${i + 1}`), flexShrink: 0 }} />
+            <input
+              value={t.name}
+              onChange={(e) => onName(i, e.target.value)}
+              placeholder="Name them anything (White, Member…)"
+              className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+              style={{ color: "var(--color-bt-text)" }}
+            />
+            <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{total(t) > 0 ? `${total(t)} yds` : ""}</span>
+            {tees.length > 1 && (
+              <button onClick={() => onRemove(i)} aria-label="Remove tee" className="flex h-8 w-8 shrink-0 items-center justify-center" style={{ color: "var(--color-bt-text-dim)" }}>
+                <X size={15} />
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -547,8 +608,8 @@ function EntryScreen({
   setHole,
   activeTee,
   setActiveTee,
-  validation,
-  flagged,
+  indexComplete,
+  missingCount,
   saving,
   setPar,
   setIndex,
@@ -560,8 +621,8 @@ function EntryScreen({
   setHole: (h: number) => void;
   activeTee: number;
   setActiveTee: (i: number) => void;
-  validation: ReturnType<typeof validateStrokeIndex>;
-  flagged: Set<number>;
+  indexComplete: boolean;
+  missingCount: number;
   saving: boolean;
   setPar: (h: number, v: number) => void;
   setIndex: (h: number, v: number) => void;
@@ -570,6 +631,21 @@ function EntryScreen({
 }) {
   const n = draft.holeCount;
   const completed = draft.index.map((v, i) => (v != null ? i + 1 : 0)).filter(Boolean);
+  const yardsOf = () => draft.teeSets[activeTee]?.yards[hole - 1] ?? null;
+  const pushDigit = (d: number) => {
+    const cur = yardsOf();
+    if (cur == null && d === 0) return; // no leading zero
+    const next = (cur ?? 0) * 10 + d;
+    if (next > 999) return;
+    setYards(hole, next);
+  };
+  const backspace = () => {
+    const cur = yardsOf();
+    setYards(hole, cur == null || cur < 10 ? null : Math.floor(cur / 10));
+  };
+  const lastHole = hole >= n;
+  const onNext = () => (lastHole ? onSave() : setHole(hole + 1));
+
   return (
     <>
       <div className="flex shrink-0 items-center justify-between" style={{ padding: "12px 16px" }}>
@@ -582,32 +658,32 @@ function EntryScreen({
       </div>
 
       <div className="flex-1 overflow-y-auto" style={{ padding: "4px 16px 8px" }}>
-        <TeeChips draft={draft} activeTee={activeTee} setActiveTee={setActiveTee} />
-        <div style={{ marginTop: 14 }}>
-          <HoleEditor
-            holeNumber={hole}
-            holeCount={n}
-            par={draft.par[hole - 1]}
-            index={draft.index[hole - 1] ?? null}
-            teeName={draft.teeSets[activeTee]?.name || null}
-            yards={draft.teeSets[activeTee]?.yards[hole - 1] ?? null}
-            swapHint="Reusing an index swaps it with the hole that currently has it."
-            onPar={(v) => setPar(hole, v)}
-            onIndex={(v) => setIndex(hole, v)}
-            onYards={(v) => setYards(hole, v)}
-          />
-        </div>
+        <HoleEditor
+          holeNumber={hole}
+          holeCount={n}
+          par={draft.par[hole - 1]}
+          onPar={(v) => setPar(hole, v)}
+          hasStrokeIndex={draft.hasStrokeIndex}
+          index={draft.index}
+          onIndexPick={(v) => setIndex(hole, v)}
+          tees={draft.teeSets}
+          activeTee={activeTee}
+          onTee={setActiveTee}
+          yards={yardsOf()}
+          yardsActive
+          onYardsTap={() => {}}
+        />
+        {lastHole && !indexComplete && (
+          <p style={{ fontSize: 12.5, color: "var(--color-bt-warning)", marginTop: 12 }}>{missingCount} holes still need a stroke index.</p>
+        )}
       </div>
 
-      {hole < n ? (
-        <Footer label={`Next · Hole ${hole + 1}`} onClick={() => setHole(hole + 1)} />
-      ) : (
-        <Footer
-          label={validation.valid ? "Save course" : `${flagged.size} holes need a valid index`}
-          disabled={!validation.valid || saving}
-          onClick={onSave}
-        />
-      )}
+      <Keypad
+        onDigit={pushDigit}
+        onBackspace={backspace}
+        onNext={onNext}
+        nextLabel={lastHole ? (saving ? "Saving…" : "Save ›") : `Hole ${hole + 1} ›`}
+      />
     </>
   );
 }
@@ -617,6 +693,7 @@ function HoleEditScreen({
   draft,
   hole,
   activeTee,
+  setActiveTee,
   flagged,
   setPar,
   setIndex,
@@ -626,12 +703,27 @@ function HoleEditScreen({
   draft: Draft;
   hole: number;
   activeTee: number;
+  setActiveTee: (i: number) => void;
   flagged: Set<number>;
   setPar: (h: number, v: number) => void;
   setIndex: (h: number, v: number) => void;
   setYards: (h: number, v: number | null) => void;
   onDone: () => void;
 }) {
+  const [yardsActive, setYardsActive] = useState(false);
+  const yardsOf = () => draft.teeSets[activeTee]?.yards[hole - 1] ?? null;
+  const pushDigit = (d: number) => {
+    const cur = yardsOf();
+    if (cur == null && d === 0) return;
+    const next = (cur ?? 0) * 10 + d;
+    if (next > 999) return;
+    setYards(hole, next);
+  };
+  const backspace = () => {
+    const cur = yardsOf();
+    setYards(hole, cur == null || cur < 10 ? null : Math.floor(cur / 10));
+  };
+
   return (
     <>
       <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
@@ -639,60 +731,75 @@ function HoleEditScreen({
           holeNumber={hole}
           holeCount={draft.holeCount}
           par={draft.par[hole - 1]}
-          index={draft.index[hole - 1] ?? null}
-          teeName={draft.teeSets[activeTee]?.name || null}
-          yards={draft.teeSets[activeTee]?.yards[hole - 1] ?? null}
-          swapHint="Reusing an index swaps it with the hole that currently has it."
           onPar={(v) => setPar(hole, v)}
-          onIndex={(v) => setIndex(hole, v)}
-          onYards={(v) => setYards(hole, v)}
+          hasStrokeIndex={draft.hasStrokeIndex}
+          index={draft.index}
+          onIndexPick={(v) => setIndex(hole, v)}
+          tees={draft.teeSets}
+          activeTee={activeTee}
+          onTee={setActiveTee}
+          yards={yardsOf()}
+          yardsActive={yardsActive}
+          onYardsTap={() => setYardsActive(true)}
+          showSwapWarning
         />
       </div>
-      <Footer label="Done" disabled={flagged.has(hole)} onClick={onDone} />
+      {yardsActive ? (
+        <Keypad onDigit={pushDigit} onBackspace={backspace} onNext={() => setYardsActive(false)} nextLabel="Done ✓" />
+      ) : (
+        <Footer label="Done" disabled={flagged.has(hole)} onClick={onDone} />
+      )}
     </>
   );
 }
 
 // ── Shared bits ───────────────────────────────────────────────────────────────
-
 const inputStyle: React.CSSProperties = {
   background: "var(--color-bt-card-raised)",
   borderColor: "var(--color-bt-border)",
   color: "var(--color-bt-text)",
 };
 
-function TeeChips({ draft, activeTee, setActiveTee }: { draft: Draft; activeTee: number; setActiveTee: (i: number) => void }) {
-  if (draft.teeSets.length <= 1) return null;
+function TeeChip({ name, on, onClick }: { name: string; on: boolean; onClick: () => void }) {
   return (
-    <div className="flex flex-wrap gap-2">
-      {draft.teeSets.map((t, i) => (
-        <button
-          key={t.name + i}
-          onClick={() => setActiveTee(i)}
-          style={{
-            padding: "4px 11px",
-            borderRadius: 9999,
-            fontSize: 12.5,
-            fontWeight: 600,
-            border: `1px solid ${i === activeTee ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
-            background: i === activeTee ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
-            color: i === activeTee ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-          }}
-        >
-          {t.name || `Tee ${i + 1}`}
-        </button>
-      ))}
-    </div>
+    <button
+      onClick={onClick}
+      className="flex shrink-0 items-center gap-1.5"
+      style={{
+        padding: "5px 12px",
+        borderRadius: 9999,
+        fontSize: 13,
+        fontWeight: 600,
+        border: `1px solid ${on ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+        background: on ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+        color: on ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+      }}
+    >
+      <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(name), flexShrink: 0 }} />
+      {name}
+    </button>
   );
 }
 
-function HoleHeader() {
+function Switch({ on }: { on: boolean }) {
+  return (
+    <span
+      className="relative shrink-0"
+      style={{ width: 40, height: 24, borderRadius: 9999, background: on ? "var(--color-bt-accent)" : "var(--color-bt-border)", transition: "background 0.15s" }}
+    >
+      <span style={{ position: "absolute", top: 2, left: on ? 18 : 2, width: 20, height: 20, borderRadius: "50%", background: "#fff", transition: "left 0.15s" }} />
+    </span>
+  );
+}
+
+function HoleHeader({ hasIndex }: { hasIndex: boolean }) {
   return (
     <div className="flex items-center" style={{ height: 30, background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-border)" }}>
       <HCell w={48}>Hole</HCell>
       <HCell w={72}>Yds</HCell>
       <HCell w={56}>Par</HCell>
-      <span className="flex-1 pr-3 text-center text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Index</span>
+      {hasIndex && <span className="flex-1 pr-3 text-center text-[10px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Index</span>}
+      {!hasIndex && <span className="flex-1" />}
     </div>
   );
 }
@@ -710,7 +817,7 @@ function Cell({ w, children, bold, dim }: { w: number; children: React.ReactNode
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</label>
+      <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</label>
       {children}
     </div>
   );
@@ -719,12 +826,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 function Footer({ label, disabled, onClick }: { label: string; disabled?: boolean; onClick: () => void }) {
   return (
     <div className="shrink-0" style={{ padding: 16, borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-base)" }}>
-      <button
-        onClick={onClick}
-        disabled={disabled}
-        className="w-full disabled:opacity-40"
-        style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
-      >
+      <button onClick={onClick} disabled={disabled} className="w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
         {label}
       </button>
     </div>

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Plus, Minus } from "lucide-react";
+
+/**
+ * HoleEditor — the SHARED per-hole editor (Slice C part 2, §1/§5). One component,
+ * two callers: manual entry steps it 1→N, and confirm-edit opens it for a single
+ * hole. Presentational only — yds · par · index steppers in, changes out via
+ * callbacks. Swap-on-edit lives in the parent (it owns the full index array);
+ * this just reports the requested new index and renders the swap hint.
+ *
+ * Yards are per active tee and OPTIONAL (display only); par 3–6; stroke index
+ * 1..holeCount (1 = hardest).
+ */
+interface HoleEditorProps {
+  holeNumber: number;
+  holeCount: number;
+  par: number;
+  /** Current stroke index for this hole, or null when unset. */
+  index: number | null;
+  /** Active tee name (null = no tees defined → yards row hidden). */
+  teeName: string | null;
+  /** This hole's yards on the active tee, or null. */
+  yards: number | null;
+  /** Hint shown when the chosen index currently sits on another hole. */
+  swapHint?: string | null;
+  onPar: (value: number) => void;
+  onIndex: (value: number) => void;
+  onYards: (value: number | null) => void;
+}
+
+const MIN_PAR = 3;
+const MAX_PAR = 6;
+
+export function HoleEditor({
+  holeNumber,
+  holeCount,
+  par,
+  index,
+  teeName,
+  yards,
+  swapHint,
+  onPar,
+  onIndex,
+  onYards,
+}: HoleEditorProps) {
+  const idxCurrent = index ?? 0;
+  return (
+    <div className="flex flex-col" style={{ gap: 14 }}>
+      {/* Par */}
+      <StepRow
+        label="Par"
+        value={String(par)}
+        onDec={() => onPar(Math.max(MIN_PAR, par - 1))}
+        onInc={() => onPar(Math.min(MAX_PAR, par + 1))}
+        decDisabled={par <= MIN_PAR}
+        incDisabled={par >= MAX_PAR}
+      />
+
+      {/* Stroke index */}
+      <div>
+        <StepRow
+          label="Stroke index"
+          value={index == null ? "—" : String(index)}
+          hint="1 = hardest"
+          onDec={() => onIndex(Math.max(1, (idxCurrent || 1) - 1))}
+          onInc={() => onIndex(Math.min(holeCount, (idxCurrent || 0) + 1))}
+          decDisabled={idxCurrent <= 1}
+          incDisabled={idxCurrent >= holeCount}
+        />
+        {swapHint && (
+          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 6, paddingLeft: 2 }}>
+            {swapHint}
+          </p>
+        )}
+      </div>
+
+      {/* Yards (optional, per active tee) */}
+      {teeName && (
+        <div>
+          <FieldLabel>{`Yards · ${teeName}`}</FieldLabel>
+          <input
+            inputMode="numeric"
+            value={yards == null ? "" : String(yards)}
+            placeholder="Optional"
+            onChange={(e) => {
+              const digits = e.target.value.replace(/[^0-9]/g, "");
+              onYards(digits === "" ? null : Math.min(999, parseInt(digits, 10)));
+            }}
+            className="w-full rounded-xl border px-3 py-2.5 text-sm"
+            style={{
+              background: "var(--color-bt-card-raised)",
+              borderColor: "var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          />
+        </div>
+      )}
+      <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", paddingLeft: 2 }}>
+        Hole {holeNumber} of {holeCount}
+      </p>
+    </div>
+  );
+}
+
+function StepRow({
+  label,
+  value,
+  hint,
+  onDec,
+  onInc,
+  decDisabled,
+  incDisabled,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  onDec: () => void;
+  onInc: () => void;
+  decDisabled: boolean;
+  incDisabled: boolean;
+}) {
+  return (
+    <div>
+      <FieldLabel>{label}</FieldLabel>
+      <div
+        className="flex w-full items-center justify-between rounded-xl border px-3 py-2.5"
+        style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}
+      >
+        <span style={{ fontSize: 18, fontWeight: 700, color: "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+          {value}
+          {hint && <span style={{ fontSize: 12, fontWeight: 400, color: "var(--color-bt-text-dim)", marginLeft: 8 }}>{hint}</span>}
+        </span>
+        <div className="flex items-center gap-2">
+          <Step dir="dec" disabled={decDisabled} onClick={onDec} />
+          <Step dir="inc" disabled={incDisabled} onClick={onInc} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Step({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="flex items-center justify-center disabled:opacity-30"
+      style={{ width: 32, height: 32, borderRadius: 8, background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
+    >
+      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
+    </button>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+      {children}
+    </label>
+  );
+}

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -1,161 +1,255 @@
 "use client";
 
-import { Plus, Minus } from "lucide-react";
+import { Check, Delete } from "lucide-react";
+import { teeColor } from "@/lib/courseService";
+import type { IndexEntry } from "@/lib/courseIndex";
 
 /**
- * HoleEditor — the SHARED per-hole editor (Slice C part 2, §1/§5). One component,
+ * HoleEditor — the SHARED per-hole editor (Slice C, addendum C-1). One component,
  * two callers: manual entry steps it 1→N, and confirm-edit opens it for a single
- * hole. Presentational only — yds · par · index steppers in, changes out via
- * callbacks. Swap-on-edit lives in the parent (it owns the full index array);
- * this just reports the requested new index and renders the swap hint.
- *
- * Yards are per active tee and OPTIONAL (display only); par 3–6; stroke index
- * 1..holeCount (1 = hardest).
+ * hole. Controls are tap-first (no ± steppers): par is a 3·4·5·6 segmented, yards
+ * is a tappable numeric field driven by the docked Keypad (rendered by the
+ * screen), and stroke index is an 18-cell grid where used ranks dim with a ✓ and
+ * tapping swaps (the permutation can't be broken). The index block hides entirely
+ * when the course has no stroke index (net play unavailable).
  */
 interface HoleEditorProps {
-  holeNumber: number;
+  holeNumber: number; // 1-based
   holeCount: number;
   par: number;
-  /** Current stroke index for this hole, or null when unset. */
-  index: number | null;
-  /** Active tee name (null = no tees defined → yards row hidden). */
-  teeName: string | null;
-  /** This hole's yards on the active tee, or null. */
-  yards: number | null;
-  /** Hint shown when the chosen index currently sits on another hole. */
-  swapHint?: string | null;
   onPar: (value: number) => void;
-  onIndex: (value: number) => void;
-  onYards: (value: number | null) => void;
+  hasStrokeIndex: boolean;
+  /** Full index array (for grid selection / used-elsewhere ✓ / swap). */
+  index: IndexEntry[];
+  onIndexPick: (rank: number) => void;
+  tees: { name: string }[];
+  activeTee: number;
+  onTee: (i: number) => void;
+  yards: number | null;
+  yardsActive: boolean;
+  onYardsTap: () => void;
+  /** Edit-hole sheet shows the swap warning above the grid. */
+  showSwapWarning?: boolean;
 }
 
-const MIN_PAR = 3;
-const MAX_PAR = 6;
+const PAR_SEGMENTS = [3, 4, 5, 6];
 
 export function HoleEditor({
   holeNumber,
   holeCount,
   par,
-  index,
-  teeName,
-  yards,
-  swapHint,
   onPar,
-  onIndex,
-  onYards,
+  hasStrokeIndex,
+  index,
+  onIndexPick,
+  tees,
+  activeTee,
+  onTee,
+  yards,
+  yardsActive,
+  onYardsTap,
+  showSwapWarning,
 }: HoleEditorProps) {
-  const idxCurrent = index ?? 0;
+  const teeName = tees[activeTee]?.name?.trim() || `Tee ${activeTee + 1}`;
   return (
-    <div className="flex flex-col" style={{ gap: 14 }}>
-      {/* Par */}
-      <StepRow
-        label="Par"
-        value={String(par)}
-        onDec={() => onPar(Math.max(MIN_PAR, par - 1))}
-        onInc={() => onPar(Math.min(MAX_PAR, par + 1))}
-        decDisabled={par <= MIN_PAR}
-        incDisabled={par >= MAX_PAR}
-      />
-
-      {/* Stroke index */}
-      <div>
-        <StepRow
-          label="Stroke index"
-          value={index == null ? "—" : String(index)}
-          hint="1 = hardest"
-          onDec={() => onIndex(Math.max(1, (idxCurrent || 1) - 1))}
-          onInc={() => onIndex(Math.min(holeCount, (idxCurrent || 0) + 1))}
-          decDisabled={idxCurrent <= 1}
-          incDisabled={idxCurrent >= holeCount}
-        />
-        {swapHint && (
-          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 6, paddingLeft: 2 }}>
-            {swapHint}
-          </p>
-        )}
-      </div>
-
-      {/* Yards (optional, per active tee) */}
-      {teeName && (
+    <div className="flex flex-col" style={{ gap: 16 }}>
+      {/* Tee tabs — which tee's yardage you're filling. */}
+      {tees.length > 0 && (
         <div>
-          <FieldLabel>{`Yards · ${teeName}`}</FieldLabel>
-          <input
-            inputMode="numeric"
-            value={yards == null ? "" : String(yards)}
-            placeholder="Optional"
-            onChange={(e) => {
-              const digits = e.target.value.replace(/[^0-9]/g, "");
-              onYards(digits === "" ? null : Math.min(999, parseInt(digits, 10)));
-            }}
-            className="w-full rounded-xl border px-3 py-2.5 text-sm"
-            style={{
-              background: "var(--color-bt-card-raised)",
-              borderColor: "var(--color-bt-border)",
-              color: "var(--color-bt-text)",
-            }}
-          />
+          <FieldLabel>Tee · yardage for</FieldLabel>
+          <div className="no-scrollbar flex gap-2 overflow-x-auto">
+            {tees.map((t, i) => {
+              const name = t.name?.trim() || `Tee ${i + 1}`;
+              const on = i === activeTee;
+              return (
+                <button
+                  key={i}
+                  onClick={() => onTee(i)}
+                  className="flex shrink-0 items-center gap-1.5"
+                  style={{
+                    padding: "5px 11px",
+                    borderRadius: 9999,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    border: `1px solid ${on ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+                    background: on ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+                    color: on ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                  }}
+                >
+                  <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(name), flexShrink: 0 }} />
+                  {name}
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
-      <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", paddingLeft: 2 }}>
+
+      {/* Par — segmented. */}
+      <div>
+        <FieldLabel>Par</FieldLabel>
+        <div className="flex gap-2">
+          {PAR_SEGMENTS.map((p) => {
+            const on = p === par;
+            return (
+              <button
+                key={p}
+                onClick={() => onPar(p)}
+                className="flex-1"
+                style={{
+                  height: 44,
+                  borderRadius: 10,
+                  fontSize: 17,
+                  fontWeight: 700,
+                  border: `1px solid ${on ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
+                  background: on ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                  color: on ? "#0d1f1a" : "var(--color-bt-text)",
+                }}
+              >
+                {p}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Yards — tappable numeric field; the keypad (screen) fills it. */}
+      <div>
+        <FieldLabel>{`Yards · ${teeName}`}</FieldLabel>
+        <button
+          onClick={onYardsTap}
+          className="flex w-full items-center justify-between rounded-xl border px-3"
+          style={{
+            height: 48,
+            background: "var(--color-bt-card-raised)",
+            borderColor: yardsActive ? "var(--color-bt-accent)" : "var(--color-bt-border)",
+            boxShadow: yardsActive ? "0 0 0 3px rgba(45,212,191,0.12)" : undefined,
+          }}
+        >
+          <span style={{ fontSize: 22, fontWeight: 700, color: yards == null ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+            {yards == null ? "—" : yards}
+            {yardsActive && <span style={{ color: "var(--color-bt-accent)", fontWeight: 400 }}>|</span>}
+          </span>
+          <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>yds · optional</span>
+        </button>
+      </div>
+
+      {/* Stroke index — 18-cell grid, or the off-line. */}
+      {hasStrokeIndex ? (
+        <div>
+          <FieldLabel>Stroke index · 1 = hardest</FieldLabel>
+          {showSwapWarning && (
+            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginBottom: 8 }}>
+              Reassigning an index swaps it with the hole that currently holds it.
+            </p>
+          )}
+          <div className="grid gap-1.5" style={{ gridTemplateColumns: "repeat(6, 1fr)" }}>
+            {Array.from({ length: holeCount }, (_, i) => i + 1).map((rank) => {
+              const owner = index.findIndex((v) => v === rank);
+              const selected = owner === holeNumber - 1;
+              const usedElsewhere = owner >= 0 && owner !== holeNumber - 1;
+              return (
+                <button
+                  key={rank}
+                  onClick={() => onIndexPick(rank)}
+                  className="relative flex items-center justify-center"
+                  style={{
+                    height: 40,
+                    borderRadius: 8,
+                    fontSize: 14,
+                    fontWeight: 700,
+                    fontVariantNumeric: "tabular-nums",
+                    border: `1px solid ${selected ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
+                    background: selected ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+                    color: selected ? "#0d1f1a" : "var(--color-bt-text)",
+                    opacity: usedElsewhere ? 0.4 : 1,
+                  }}
+                >
+                  {rank}
+                  {usedElsewhere && (
+                    <Check size={10} style={{ position: "absolute", top: 3, right: 3, color: "var(--color-bt-text-dim)" }} />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8 }}>
+            Read it off the course&apos;s scorecard. Each rank 1–{holeCount} is used once; ✓ = already assigned.
+          </p>
+        </div>
+      ) : (
+        <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.5 }}>
+          Stroke indices are off for this course — net play is unavailable. Add them in course settings.
+        </p>
+      )}
+
+      <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
         Hole {holeNumber} of {holeCount}
       </p>
     </div>
   );
 }
 
-function StepRow({
-  label,
-  value,
-  hint,
-  onDec,
-  onInc,
-  decDisabled,
-  incDisabled,
+/** Docked 3-column numeric keypad that fills the active yards field.
+ *  `1–9`, then `⌫ · 0 · Next ›` (accent Next commits + advances). */
+export function Keypad({
+  onDigit,
+  onBackspace,
+  onNext,
+  nextLabel,
 }: {
-  label: string;
-  value: string;
-  hint?: string;
-  onDec: () => void;
-  onInc: () => void;
-  decDisabled: boolean;
-  incDisabled: boolean;
+  onDigit: (d: number) => void;
+  onBackspace: () => void;
+  onNext: () => void;
+  nextLabel: string;
 }) {
   return (
-    <div>
-      <FieldLabel>{label}</FieldLabel>
-      <div
-        className="flex w-full items-center justify-between rounded-xl border px-3 py-2.5"
-        style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}
-      >
-        <span style={{ fontSize: 18, fontWeight: 700, color: "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
-          {value}
-          {hint && <span style={{ fontSize: 12, fontWeight: 400, color: "var(--color-bt-text-dim)", marginLeft: 8 }}>{hint}</span>}
-        </span>
-        <div className="flex items-center gap-2">
-          <Step dir="dec" disabled={decDisabled} onClick={onDec} />
-          <Step dir="inc" disabled={incDisabled} onClick={onInc} />
-        </div>
+    <div
+      className="shrink-0"
+      style={{ padding: 10, borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)" }}
+    >
+      <div className="grid gap-2" style={{ gridTemplateColumns: "repeat(3, 1fr)" }}>
+        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((d) => (
+          <Key key={d} onClick={() => onDigit(d)}>
+            {d}
+          </Key>
+        ))}
+        <Key onClick={onBackspace} aria-label="Backspace">
+          <Delete size={20} style={{ color: "var(--color-bt-text)" }} />
+        </Key>
+        <Key onClick={() => onDigit(0)}>0</Key>
+        <Key onClick={onNext} accent>
+          {nextLabel}
+        </Key>
       </div>
     </div>
   );
 }
 
-function Step({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled: boolean; onClick: () => void }) {
+function Key({ children, onClick, accent, ...rest }: { children: React.ReactNode; onClick: () => void; accent?: boolean } & React.HTMLAttributes<HTMLButtonElement>) {
   return (
     <button
       onClick={onClick}
-      disabled={disabled}
-      className="flex items-center justify-center disabled:opacity-30"
-      style={{ width: 32, height: 32, borderRadius: 8, background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
+      {...rest}
+      className="flex items-center justify-center"
+      style={{
+        height: 48,
+        borderRadius: 10,
+        fontSize: accent ? 15 : 20,
+        fontWeight: accent ? 600 : 600,
+        background: accent ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
+        color: accent ? "#0d1f1a" : "var(--color-bt-text)",
+        border: accent ? "none" : "1px solid var(--color-bt-border)",
+      }}
     >
-      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
+      {children}
     </button>
   );
 }
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
-    <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+    <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
       {children}
     </label>
   );

--- a/src/lib/courseIndex.test.ts
+++ b/src/lib/courseIndex.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateStrokeIndex,
+  applyStrokeIndexSwap,
+  buildScorecardSchema,
+  type ScorecardSchema,
+  type IndexEntry,
+} from "./courseIndex";
+
+describe("validateStrokeIndex", () => {
+  it("accepts a complete permutation of 1..N", () => {
+    const idx = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
+    expect(validateStrokeIndex(idx, 18).valid).toBe(true);
+  });
+
+  it("flags unset holes", () => {
+    const idx = [1, 2, null, 4];
+    const r = validateStrokeIndex(idx, 4);
+    expect(r.valid).toBe(false);
+    expect(r.unsetHoles).toEqual([3]);
+  });
+
+  it("flags duplicates (both holes that share the value)", () => {
+    const idx = [1, 2, 2, 4]; // 3 missing, 2 duped
+    const r = validateStrokeIndex(idx, 4);
+    expect(r.valid).toBe(false);
+    expect(r.duplicateHoles).toEqual([2, 3]);
+    expect(r.unsetHoles).toEqual([]);
+  });
+
+  it("flags out-of-range values", () => {
+    const idx = [1, 2, 3, 9];
+    const r = validateStrokeIndex(idx, 4);
+    expect(r.valid).toBe(false);
+    expect(r.outOfRangeHoles).toEqual([4]);
+  });
+
+  it("validates a 9-hole permutation of 1..9", () => {
+    expect(validateStrokeIndex([1, 2, 3, 4, 5, 6, 7, 8, 9], 9).valid).toBe(true);
+    expect(validateStrokeIndex([1, 2, 3, 4, 5, 6, 7, 8, 8], 9).valid).toBe(false);
+  });
+});
+
+describe("applyStrokeIndexSwap", () => {
+  it("swaps with the hole that currently holds the value", () => {
+    // Hole 4 (idx 3) has index 1; set hole 1 (idx 0, currently 7) to 1.
+    const idx = [7, 3, 15, 1];
+    const next = applyStrokeIndexSwap(idx, 0, 1);
+    expect(next[0]).toBe(1); // hole 1 now 1
+    expect(next[3]).toBe(7); // hole 4 took hole 1's old value
+    expect(idx[0]).toBe(7); // input not mutated
+  });
+
+  it("swaps null in when the edited hole was unset", () => {
+    const idx = [null, 3, 15, 1];
+    const next = applyStrokeIndexSwap(idx, 0, 1);
+    expect(next[0]).toBe(1);
+    expect(next[3]).toBeNull(); // hole 4 took hole 1's (null) previous value
+  });
+
+  it("plain-sets when no hole holds the value yet", () => {
+    const idx = [null, null, null, null];
+    const next = applyStrokeIndexSwap(idx, 2, 3);
+    expect(next).toEqual([null, null, 3, null]);
+  });
+
+  it("a sequence of swaps keeps the set a permutation", () => {
+    let idx: IndexEntry[] = [1, 2, 3, 4];
+    idx = applyStrokeIndexSwap(idx, 0, 4); // [4,2,3,1]
+    idx = applyStrokeIndexSwap(idx, 1, 3); // [4,3,2,1]
+    expect(validateStrokeIndex(idx, 4).valid).toBe(true);
+    expect([...idx].sort((a, b) => (a! - b!))).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("buildScorecardSchema", () => {
+  const template: ScorecardSchema = {
+    units: {
+      type: "holes",
+      count: 18,
+      labels: Array.from({ length: 18 }, (_, i) => String(i + 1)),
+      metadata: { par: Array(18).fill(4), handicap_index: Array(18).fill(1) },
+    },
+    scoring: {
+      strategy: "stroke_total",
+      direction: "low_wins",
+      sections: [
+        { name: "Front 9", units: ["1"] },
+        { name: "Back 9", units: ["10"] },
+      ],
+    },
+  };
+
+  it("snapshots par + handicap_index into units.metadata (18 holes)", () => {
+    const par = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4];
+    const idx = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
+    const s = buildScorecardSchema(template, par, idx, 18);
+    expect(s.units.metadata?.par).toEqual(par);
+    expect(s.units.metadata?.handicap_index).toEqual(idx);
+    expect(s.units.count).toBe(18);
+    expect(s.units.labels).toHaveLength(18);
+    expect(s.scoring?.sections).toEqual([
+      { name: "Front 9", units: ["1", "2", "3", "4", "5", "6", "7", "8", "9"] },
+      { name: "Back 9", units: ["10", "11", "12", "13", "14", "15", "16", "17", "18"] },
+    ]);
+  });
+
+  it("produces a single Front section for a 9-hole course", () => {
+    const par = [4, 5, 3, 4, 4, 3, 5, 4, 4];
+    const idx = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const s = buildScorecardSchema(template, par, idx, 9);
+    expect(s.units.count).toBe(9);
+    expect(s.units.labels).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9"]);
+    expect(s.scoring?.sections).toHaveLength(1);
+    expect(s.scoring?.sections?.[0].units).toHaveLength(9);
+  });
+
+  it("does not mutate the template", () => {
+    buildScorecardSchema(template, Array(18).fill(3), Array.from({ length: 18 }, (_, i) => i + 1), 18);
+    expect(template.units.metadata?.par).toEqual(Array(18).fill(4));
+  });
+});

--- a/src/lib/courseIndex.test.ts
+++ b/src/lib/courseIndex.test.ts
@@ -115,6 +115,14 @@ describe("buildScorecardSchema", () => {
     expect(s.scoring?.sections?.[0].units).toHaveLength(9);
   });
 
+  it("fills a sequential index when none is provided (stroke index off)", () => {
+    const par = Array(18).fill(4);
+    const s = buildScorecardSchema(template, par, [], 18);
+    expect(s.units.metadata?.handicap_index).toEqual(Array.from({ length: 18 }, (_, i) => i + 1));
+    const s9 = buildScorecardSchema(template, Array(9).fill(4), undefined, 9);
+    expect(s9.units.metadata?.handicap_index).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
   it("does not mutate the template", () => {
     buildScorecardSchema(template, Array(18).fill(3), Array.from({ length: 18 }, (_, i) => i + 1), 18);
     expect(template.units.metadata?.par).toEqual(Array(18).fill(4));

--- a/src/lib/courseIndex.ts
+++ b/src/lib/courseIndex.ts
@@ -1,0 +1,142 @@
+/**
+ * Course stroke-index correctness core (Slice C part 2, §3) — PURE, client-safe.
+ *
+ * Stroke index must be a valid permutation of 1..N (N = holes): each value used
+ * exactly once, no gaps, no dupes. `strokeHoles` allocates handicap strokes to
+ * the lowest-index holes, so a dup/gap silently mis-allocates EVERY stroke — the
+ * highest-stakes correctness rule in the picker. These helpers (a) validate a
+ * set and (b) implement swap-on-edit so an invalid set is impossible to enter.
+ *
+ * Used by the picker UI (swap + gate) and the server (re-validate on apply); no
+ * DB / provider deps so both sides share the same rules and can't diverge.
+ */
+
+export type IndexEntry = number | null | undefined;
+
+export interface IndexValidation {
+  /** A complete, valid permutation of 1..N. */
+  valid: boolean;
+  /** 1-based hole numbers with no index set. */
+  unsetHoles: number[];
+  /** 1-based holes whose value duplicates another hole's. */
+  duplicateHoles: number[];
+  /** 1-based holes whose value is < 1 or > N. */
+  outOfRangeHoles: number[];
+}
+
+/** Validate a stroke-index set against a permutation of 1..n. */
+export function validateStrokeIndex(index: IndexEntry[], n: number): IndexValidation {
+  const unsetHoles: number[] = [];
+  const outOfRangeHoles: number[] = [];
+  const holesByValue = new Map<number, number[]>();
+
+  for (let i = 0; i < n; i++) {
+    const v = index[i];
+    if (v == null) {
+      unsetHoles.push(i + 1);
+      continue;
+    }
+    if (!Number.isInteger(v) || v < 1 || v > n) {
+      outOfRangeHoles.push(i + 1);
+      continue;
+    }
+    const holes = holesByValue.get(v) ?? [];
+    holes.push(i + 1);
+    holesByValue.set(v, holes);
+  }
+
+  const duplicateHoles: number[] = [];
+  for (const holes of holesByValue.values()) {
+    if (holes.length > 1) duplicateHoles.push(...holes);
+  }
+  duplicateHoles.sort((a, b) => a - b);
+
+  const valid =
+    unsetHoles.length === 0 && outOfRangeHoles.length === 0 && duplicateHoles.length === 0;
+  return { valid, unsetHoles, duplicateHoles, outOfRangeHoles };
+}
+
+/**
+ * Swap-on-edit (§3). Set hole `holeIdx` (0-based) to `newValue`; whichever hole
+ * currently holds `newValue` takes this hole's previous index (which may be
+ * null — still a clean swap). If no hole holds `newValue` yet, it's a plain
+ * set. Never mutates the input — returns a fresh array.
+ */
+export function applyStrokeIndexSwap(
+  index: IndexEntry[],
+  holeIdx: number,
+  newValue: number
+): IndexEntry[] {
+  const next = [...index];
+  const prev = next[holeIdx] ?? null;
+  const otherIdx = next.findIndex((v, i) => i !== holeIdx && v === newValue);
+  next[holeIdx] = newValue;
+  if (otherIdx !== -1) next[otherIdx] = prev;
+  return next;
+}
+
+// ── Scorecard-schema contract (§0) ─────────────────────────────────────────
+// Minimal shape of game_type_templates.scorecard_schema we read/patch. We patch
+// units.metadata.{par,handicap_index} + labels/count/sections to the course's
+// hole layout; everything else on the template is preserved verbatim.
+
+export interface ScorecardUnits {
+  type?: string;
+  count?: number;
+  ordered?: boolean;
+  labels?: string[];
+  metadata?: { par?: number[]; handicap_index?: number[]; [k: string]: unknown };
+}
+export interface ScorecardScoring {
+  strategy?: string;
+  direction?: string;
+  sections?: { name: string; units: string[] }[];
+}
+export interface ScorecardSchema {
+  units: ScorecardUnits;
+  scoring?: ScorecardScoring;
+  [k: string]: unknown;
+}
+
+const range = (from: number, to: number): string[] =>
+  Array.from({ length: to - from + 1 }, (_, i) => String(from + i));
+
+/**
+ * Build the per-game scorecard_schema snapshot (§0 contract): clone the template
+ * and overwrite the hole layout (count/labels/sections) + metadata.par +
+ * metadata.handicap_index with the applied course's data. Front/back sections
+ * follow the 1..9 / 10..N split; a 9-hole course has a single Front section.
+ */
+export function buildScorecardSchema(
+  template: ScorecardSchema,
+  par: number[],
+  handicapIndex: number[],
+  holeCount: number
+): ScorecardSchema {
+  const next = JSON.parse(JSON.stringify(template)) as ScorecardSchema;
+  const labels = range(1, holeCount);
+
+  next.units = {
+    ...next.units,
+    count: holeCount,
+    labels,
+    metadata: { ...(next.units.metadata ?? {}), par, handicap_index: handicapIndex },
+  };
+
+  if (next.scoring) {
+    const frontName = next.scoring.sections?.[0]?.name ?? "Front 9";
+    const backName = next.scoring.sections?.[1]?.name ?? "Back 9";
+    next.scoring = {
+      ...next.scoring,
+      sections:
+        holeCount > 9
+          ? [
+              { name: frontName, units: range(1, 9) },
+              { name: backName, units: range(10, holeCount) },
+            ]
+          : [{ name: frontName, units: labels }],
+    };
+  }
+
+  return next;
+}

--- a/src/lib/courseIndex.ts
+++ b/src/lib/courseIndex.ts
@@ -110,17 +110,21 @@ const range = (from: number, to: number): string[] =>
 export function buildScorecardSchema(
   template: ScorecardSchema,
   par: number[],
-  handicapIndex: number[],
+  handicapIndex: number[] | null | undefined,
   holeCount: number
 ): ScorecardSchema {
   const next = JSON.parse(JSON.stringify(template)) as ScorecardSchema;
   const labels = range(1, holeCount);
+  // A course without a real index (stroke index off) snapshots a sequential
+  // 1..N index of the right length — net falls back to hole order; it never
+  // leaves a stale 18-long template index on a 9-hole game.
+  const index = handicapIndex?.length ? handicapIndex : Array.from({ length: holeCount }, (_, i) => i + 1);
 
   next.units = {
     ...next.units,
     count: holeCount,
     labels,
-    metadata: { ...(next.units.metadata ?? {}), par, handicap_index: handicapIndex },
+    metadata: { ...(next.units.metadata ?? {}), par, handicap_index: index },
   };
 
   if (next.scoring) {

--- a/src/lib/courseService.ts
+++ b/src/lib/courseService.ts
@@ -42,6 +42,26 @@ export interface CourseDetail {
   holes: CourseHole[];
 }
 
+// Well-known tee names → a display color dot. Arbitrary/free-text names fall
+// back to the neutral dim token (safe lookup — never throws on unknown names).
+const TEE_DOT: Record<string, string> = {
+  black: "#1f2937",
+  blue: "#3b82f6",
+  white: "#e5e7eb",
+  gold: "#f59e0b",
+  yellow: "#eab308",
+  red: "#ef4444",
+  green: "#22c55e",
+  silver: "#cbd5e1",
+  member: "#a855f7",
+  championship: "#1f2937",
+};
+export function teeColor(name: string): string {
+  const key = name.trim().toLowerCase();
+  for (const k of Object.keys(TEE_DOT)) if (key.includes(k)) return TEE_DOT[k];
+  return "var(--color-bt-text-dim)";
+}
+
 /** Search the provider for courses. Returns [] on any failure (→ manual entry). */
 export async function searchCourses(
   query: string,

--- a/src/lib/courseService.ts
+++ b/src/lib/courseService.ts
@@ -1,0 +1,107 @@
+/**
+ * CourseService — the provider abstraction (Slice C part 2, §5). The picker UI
+ * talks to THIS, never to golfapi.io directly; the provider lives behind the
+ * `/api/golf-courses/*` routes and is swappable without touching any caller.
+ *
+ * Every call fails soft: a search returns `[]` and a detail returns `null` on
+ * any error / rate-limit / missing key, so the UI gracefully falls back to
+ * manual entry rather than surfacing a failure.
+ */
+
+export interface CourseSummary {
+  id: string;
+  name: string;
+  location: string;
+  city: string;
+  state: string;
+  country: string;
+  courseCount: number;
+}
+
+export interface CourseTeeBox {
+  name: string;
+  color: string;
+  rating: number;
+  slope: number;
+  totalYardage: number;
+}
+
+export interface CourseHole {
+  number: number;
+  par: number;
+  handicapIndex: number;
+  tees: { [teeBoxName: string]: { yardage: number } };
+}
+
+export interface CourseDetail {
+  externalId: string;
+  name: string;
+  clubName: string;
+  location: string;
+  teeBoxes: CourseTeeBox[];
+  holes: CourseHole[];
+}
+
+/** Search the provider for courses. Returns [] on any failure (→ manual entry). */
+export async function searchCourses(
+  query: string,
+  opts?: { country?: string; state?: string }
+): Promise<CourseSummary[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+  const params = new URLSearchParams({ q });
+  if (opts?.country) params.set("country", opts.country);
+  if (opts?.state) params.set("state", opts.state);
+  try {
+    const res = await fetch(`/api/golf-courses/search?${params}`);
+    if (!res.ok) return [];
+    return (await res.json()) as CourseSummary[];
+  } catch {
+    return [];
+  }
+}
+
+/** Pull full scorecard detail for a course. Returns null on any failure. */
+export async function getCourseDetail(id: string): Promise<CourseDetail | null> {
+  if (!id) return null;
+  try {
+    const res = await fetch(`/api/golf-courses/${encodeURIComponent(id)}`);
+    if (!res.ok) return null;
+    return (await res.json()) as CourseDetail;
+  } catch {
+    return null;
+  }
+}
+
+// ── Provider detail → picker shape ─────────────────────────────────────────
+
+/** Course-level par[] from a pulled detail, ordered by hole. */
+export function parFromDetail(detail: CourseDetail): number[] {
+  return [...detail.holes].sort((a, b) => a.number - b.number).map((h) => h.par || 0);
+}
+
+/**
+ * Course-level handicap_index[] from a pulled detail, ordered by hole. golfapi
+ * frequently returns 0 / missing for a hole's hcp — those become `null` (unset)
+ * so the confirm screen's validation flags them instead of silently accepting a
+ * broken index (§3, dirty lookup data).
+ */
+export function indexFromDetail(detail: CourseDetail): (number | null)[] {
+  return [...detail.holes]
+    .sort((a, b) => a.number - b.number)
+    .map((h) => (h.handicapIndex >= 1 ? h.handicapIndex : null));
+}
+
+/** Tee sets ({ name, yards[] }) from a pulled detail, ordered by hole. */
+export function teeSetsFromDetail(
+  detail: CourseDetail
+): { name: string; yards: (number | null)[] }[] {
+  const holes = [...detail.holes].sort((a, b) => a.number - b.number);
+  return detail.teeBoxes.map((tee) => ({
+    name: tee.name,
+    yards: holes.map((h) => {
+      const y = h.tees[tee.name]?.yardage;
+      return y && y > 0 ? y : null;
+    }),
+  }));
+}

--- a/src/lib/strokePlayConfig.ts
+++ b/src/lib/strokePlayConfig.ts
@@ -9,12 +9,13 @@ import type { ScoreUnit } from "@/components/games/types";
  * template, so it uses this known stroke-play shape. The scorecard components
  * stay schema-driven (they take `units` as a prop) — this is just the data.
  */
-// Default par-72 layout + handicap index (matches the template
-// `scorecard_schema.metadata.{par,handicap_index}`). Real per-hole values replace
-// these once a course is attached (Slice C picker). The index follows the common
-// odd-front / even-back convention (1 = hardest).
+// Default par-72 layout. No-course games have no real stroke index, so the
+// default index is SEQUENTIAL (1..18) — the honest "strokes go in hole order"
+// fallback that `strokeHoles` allocates on (and that the Slice B match tests
+// assert). A real, non-sequential index arrives only when a course is applied
+// (Slice C), at which point the game's snapshot drives par + index everywhere.
 const DEFAULT_PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4];
-const DEFAULT_INDEX = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
+const DEFAULT_INDEX = Array.from({ length: 18 }, (_, i) => i + 1);
 
 export const STROKE_PLAY_UNITS: ScoreUnit[] = Array.from({ length: 18 }, (_, i) => ({
   label: String(i + 1),
@@ -22,6 +23,32 @@ export const STROKE_PLAY_UNITS: ScoreUnit[] = Array.from({ length: 18 }, (_, i) 
   par: DEFAULT_PAR[i],
   strokeIndex: DEFAULT_INDEX[i],
 }));
+
+/**
+ * Derive scorecard units from a game's effective `scorecard_schema` (its course
+ * snapshot when applied — Slice C — else the game-type template's default).
+ * Falls back to STROKE_PLAY_UNITS when a schema is absent or malformed, so the
+ * grid/entry/pips read the SAME par + index the server scores on.
+ */
+interface SchemaLike {
+  units?: { labels?: string[]; metadata?: { par?: number[]; handicap_index?: number[] } };
+}
+export function unitsFromSchema(schema?: SchemaLike | null): ScoreUnit[] {
+  const meta = schema?.units?.metadata;
+  const labels = schema?.units?.labels;
+  if (!labels?.length || !meta?.par || !meta?.handicap_index) return STROKE_PLAY_UNITS;
+  return labels.map((label, i) => ({
+    label,
+    section: i < 9 ? "front" : "back",
+    par: meta.par![i],
+    strokeIndex: meta.handicap_index![i],
+  }));
+}
+
+/** The stroke-index array (handicap index per hole) for `strokeHoles`/`buildDecided`. */
+export function strokeIndexOf(units: ScoreUnit[]): number[] {
+  return units.map((u) => u.strokeIndex ?? 0);
+}
 
 // Player identity palette (identity colors, not theme tokens — sanctioned like
 // team colors per STYLE_GUIDE §7).

--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -14,9 +14,11 @@ import { buildDecided, matchState } from "@/lib/matchPlay";
  * - Idempotent: a recompute updates the match rows in place and replaces the
  *   game's `game_results`.
  *
- * Stroke index: course metadata when a course is attached; the course is stubbed
- * in Slice B, so the sequential fallback in `buildDecided` is the normal path
- * until the Slice C course picker lands (replaces it with no change here).
+ * Stroke index: a game's own `scorecard_schema` snapshot (written when a course
+ * is applied — Slice C) drives `buildDecided`. A no-course game has no snapshot,
+ * so it falls through to `strokeHoles`'s sequential allocation — the documented
+ * Slice B fallback, kept as the no-course path (NOT the template default, which
+ * is only a display placeholder).
  */
 
 interface SideRef {
@@ -55,6 +57,10 @@ export async function computeMatchPlayResults(
     .from("game_matches")
     .select("id, side_a, side_b, status")
     .eq("game_id", gameId);
+
+  // Stroke index: the game's course snapshot if one is applied, else undefined
+  // → `buildDecided` uses the sequential fallback (the no-course path).
+  const { strokeIndex, holeCount } = await loadStrokeIndex(supabase, gameId);
 
   // user_id → handicap strokes (null = 0).
   const { data: parts } = await supabase
@@ -98,7 +104,9 @@ export async function computeMatchPlayResults(
       gross.get(a.id) ?? {},
       gross.get(b.id) ?? {},
       hcap.get(a.id) ?? 0,
-      hcap.get(b.id) ?? 0
+      hcap.get(b.id) ?? 0,
+      strokeIndex,
+      holeCount
     );
     const st = matchState(decided);
 
@@ -144,6 +152,25 @@ export async function computeMatchPlayResults(
   }
 
   return outcomes;
+}
+
+interface SchemaShape {
+  units?: { count?: number; metadata?: { handicap_index?: number[] } };
+}
+
+/** The game's snapshot stroke index + hole count, if a course has been applied.
+ *  No snapshot → undefined → caller uses the sequential fallback. */
+async function loadStrokeIndex(
+  supabase: SupabaseClient,
+  gameId: string
+): Promise<{ strokeIndex?: number[]; holeCount?: number }> {
+  const { data: game } = await supabase
+    .from("games")
+    .select("scorecard_schema")
+    .eq("id", gameId)
+    .maybeSingle();
+  const schema = game?.scorecard_schema as SchemaShape | null;
+  return { strokeIndex: schema?.units?.metadata?.handicap_index, holeCount: schema?.units?.count };
 }
 
 function mkResult(gameId: string, entityId: string, position: number): GameResultRow {

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -15,6 +15,7 @@ import { teamAssignmentsRouter } from "./routers/teamAssignments";
 import { logisticsRouter } from "./routers/logistics";
 import { scheduleRouter } from "./routers/schedule";
 import { golfCoursesRouter } from "./routers/golfCourses";
+import { coursesRouter } from "./routers/courses";
 import { ideaLodgingRouter } from "./routers/ideaLodging";
 import { archivedIdeasRouter } from "./routers/archivedIdeas";
 import { feedbackRouter } from "./routers/feedback";
@@ -40,6 +41,7 @@ export const appRouter = router({
   logistics: logisticsRouter,
   schedule: scheduleRouter,
   golfCourses: golfCoursesRouter,
+  courses: coursesRouter,
   ideaLodging: ideaLodgingRouter,
   archivedIdeas: archivedIdeasRouter,
   feedback: feedbackRouter,

--- a/src/server/routers/courses.test.ts
+++ b/src/server/routers/courses.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+const MATCH_PLAY = "gtt_match_play_singles";
+const PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4];
+const IDX = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
+
+let ctx: TestContext;
+let tripId: string;
+const courseIds: string[] = [];
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Course Picker Trip");
+});
+
+afterAll(async () => {
+  // Courses are global (not trip-scoped) — clean them up explicitly.
+  for (const id of courseIds) await ctx.admin.from("courses").delete().eq("id", id);
+  await ctx.cleanup();
+});
+
+describe("courses router — global library", () => {
+  it("create saves a course with par + a valid stroke-index permutation", async () => {
+    const course = await ctx.caller().courses.create({
+      name: "Pebble Creek",
+      location: "Bend, OR",
+      holeCount: 18,
+      par: PAR,
+      handicapIndex: IDX,
+      teeSets: [{ name: "White", yards: Array(18).fill(350) }],
+      source: "manual",
+    });
+    courseIds.push(course.id as string);
+    expect(course.par).toEqual(PAR);
+    expect(course.handicap_index).toEqual(IDX);
+    expect(course.source).toBe("manual");
+    expect(course.hole_count).toBe(18);
+  });
+
+  it("create rejects a duplicated stroke index (broken permutation)", async () => {
+    const bad = [...IDX];
+    bad[1] = bad[0]; // duplicate
+    await expect(
+      ctx.caller().courses.create({ name: "Bad Idx", holeCount: 18, par: PAR, handicapIndex: bad })
+    ).rejects.toThrow(/permutation/i);
+  });
+
+  it("create rejects a par/index length mismatch", async () => {
+    await expect(
+      ctx.caller().courses.create({ name: "Short", holeCount: 18, par: PAR.slice(0, 17), handicapIndex: IDX })
+    ).rejects.toThrow(/18 entries/i);
+  });
+
+  it("list + getById surface a saved course", async () => {
+    const list = await ctx.caller().courses.list({ limit: 50 });
+    expect(list.some((c: { id: string }) => c.id === courseIds[0])).toBe(true);
+    const one = await ctx.caller().courses.getById({ courseId: courseIds[0] });
+    expect(one.name).toBe("Pebble Creek");
+  });
+});
+
+describe("games.applyCourse — the contract snapshot", () => {
+  it("snapshots par + handicap_index into the game's scorecard_schema + keeps course_id", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Singles" });
+    const course = await ctx.caller().courses.create({
+      name: "Snapshot GC",
+      holeCount: 18,
+      par: PAR,
+      handicapIndex: IDX,
+    });
+    courseIds.push(course.id as string);
+
+    const updated = await ctx.caller().games.applyCourse({
+      tripId,
+      gameId: game.id as string,
+      courseId: course.id as string,
+    });
+    const schema = updated!.scorecard_schema as {
+      units: { metadata: { par: number[]; handicap_index: number[] }; count: number };
+    };
+    expect(schema.units.metadata.par).toEqual(PAR);
+    expect(schema.units.metadata.handicap_index).toEqual(IDX);
+    expect(schema.units.count).toBe(18);
+    expect(updated!.course_id).toBe(course.id);
+  });
+
+  it("is frozen once a score exists (re-apply blocked)", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Frozen" });
+    const course = await ctx.caller().courses.create({
+      name: "Frozen GC",
+      holeCount: 18,
+      par: PAR,
+      handicapIndex: IDX,
+    });
+    courseIds.push(course.id as string);
+
+    await ctx.caller().games.applyCourse({ tripId, gameId: game.id as string, courseId: course.id as string });
+
+    // A score lands → the par/index it's played on is frozen.
+    await ctx.admin.from("score_entries").insert({
+      id: crypto.randomUUID(),
+      game_id: game.id,
+      participant_id: ctx.user.id,
+      participant_type: "user",
+      unit_label: "1",
+      value: 4,
+    });
+
+    await expect(
+      ctx.caller().games.applyCourse({ tripId, gameId: game.id as string, courseId: course.id as string })
+    ).rejects.toThrow(/already entered|can't be changed/i);
+  });
+});

--- a/src/server/routers/courses.test.ts
+++ b/src/server/routers/courses.test.ts
@@ -52,6 +52,25 @@ describe("courses router — global library", () => {
     ).rejects.toThrow(/18 entries/i);
   });
 
+  it("saves an index-off course (no handicapIndex) and applies a sequential snapshot", async () => {
+    const course = await ctx.caller().courses.create({
+      name: "Gross Only GC",
+      holeCount: 18,
+      par: PAR,
+      hasStrokeIndex: false,
+    });
+    courseIds.push(course.id as string);
+    expect(course.has_stroke_index).toBe(false);
+    expect(course.handicap_index).toEqual([]);
+
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Gross" });
+    const updated = await ctx.caller().games.applyCourse({ tripId, gameId: game.id as string, courseId: course.id as string });
+    const schema = updated!.scorecard_schema as { units: { metadata: { par: number[]; handicap_index: number[] } } };
+    expect(schema.units.metadata.par).toEqual(PAR);
+    // No real index → sequential 1..18 snapshot (net falls back to hole order).
+    expect(schema.units.metadata.handicap_index).toEqual(Array.from({ length: 18 }, (_, i) => i + 1));
+  });
+
   it("list + getById surface a saved course", async () => {
     const list = await ctx.caller().courses.list({ limit: 50 });
     expect(list.some((c: { id: string }) => c.id === courseIds[0])).toBe(true);

--- a/src/server/routers/courses.ts
+++ b/src/server/routers/courses.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, authedProcedure } from "../trpc";
+import { validateStrokeIndex } from "@/lib/courseIndex";
+
+/**
+ * courses — the GLOBAL course library (Slice C part 2, §5). Course par + stroke
+ * index + per-tee yards are global facts (not circle-scoped), so any member can
+ * read the whole library and add to it. Looked-up and hand-built courses persist
+ * identically here; applying a course to a game is `games.applyCourse` (the
+ * snapshot write — separate, because it mutates a trip-scoped game).
+ *
+ * The stroke index is re-validated server-side as a complete permutation of
+ * 1..holeCount — the client enforces it via swap-on-edit, but a course can never
+ * be saved with a broken index regardless of the caller (§3).
+ */
+
+const teeSetSchema = z.object({
+  name: z.string().trim().min(1).max(60),
+  yards: z.array(z.number().int().positive().nullable()).optional(),
+});
+
+export const coursesRouter = router({
+  // create — save a looked-up or hand-built course to the global library.
+  create: authedProcedure
+    .input(
+      z.object({
+        name: z.string().trim().min(1).max(200),
+        location: z.string().trim().max(200).optional(),
+        holeCount: z.union([z.literal(9), z.literal(18)]),
+        par: z.array(z.number().int().min(3).max(7)),
+        handicapIndex: z.array(z.number().int().min(1)),
+        teeSets: z.array(teeSetSchema).max(12).optional(),
+        source: z.enum(["manual", "golfapi"]).optional(),
+        providerId: z.string().max(120).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const n = input.holeCount;
+      if (input.par.length !== n || input.handicapIndex.length !== n) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `par and handicapIndex must each have ${n} entries`,
+        });
+      }
+      // Permutation gate — never persist a course with a broken index.
+      const check = validateStrokeIndex(input.handicapIndex, n);
+      if (!check.valid) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Stroke index must be a complete permutation of 1..N (no gaps or duplicates)",
+        });
+      }
+
+      const id = crypto.randomUUID();
+      const { error: insertErr } = await ctx.supabase.from("courses").insert({
+        id,
+        name: input.name,
+        location: input.location ?? null,
+        hole_count: n,
+        par: input.par,
+        handicap_index: input.handicapIndex,
+        tee_sets: input.teeSets ?? [],
+        source: input.source ?? "manual",
+        provider_id: input.providerId ?? null,
+        created_by: ctx.user!.id,
+      });
+      if (insertErr) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to save course: ${insertErr.message}`,
+        });
+      }
+
+      const { data, error } = await ctx.supabase
+        .from("courses")
+        .select("*")
+        .eq("id", id)
+        .single();
+      if (error || !data) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to read saved course: ${error?.message}`,
+        });
+      }
+      return data;
+    }),
+
+  // list — recent courses for the empty-search "Recent courses" list (§2/§5).
+  // Global most-recent, not per-circle.
+  list: authedProcedure
+    .input(z.object({ limit: z.number().int().min(1).max(50).optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      const { data, error } = await ctx.supabase
+        .from("courses")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .limit(input?.limit ?? 20);
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to list courses: ${error.message}`,
+        });
+      }
+      return data ?? [];
+    }),
+
+  // getById — fetch a single library course.
+  getById: authedProcedure
+    .input(z.object({ courseId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const { data, error } = await ctx.supabase
+        .from("courses")
+        .select("*")
+        .eq("id", input.courseId)
+        .maybeSingle();
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to fetch course: ${error.message}`,
+        });
+      }
+      if (!data) throw new TRPCError({ code: "NOT_FOUND", message: "Course not found" });
+      return data;
+    }),
+});

--- a/src/server/routers/courses.ts
+++ b/src/server/routers/courses.ts
@@ -29,7 +29,8 @@ export const coursesRouter = router({
         location: z.string().trim().max(200).optional(),
         holeCount: z.union([z.literal(9), z.literal(18)]),
         par: z.array(z.number().int().min(3).max(7)),
-        handicapIndex: z.array(z.number().int().min(1)),
+        handicapIndex: z.array(z.number().int().min(1)).optional(),
+        hasStrokeIndex: z.boolean().optional(),
         teeSets: z.array(teeSetSchema).max(12).optional(),
         source: z.enum(["manual", "golfapi"]).optional(),
         providerId: z.string().max(120).optional(),
@@ -37,19 +38,22 @@ export const coursesRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const n = input.holeCount;
-      if (input.par.length !== n || input.handicapIndex.length !== n) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `par and handicapIndex must each have ${n} entries`,
-        });
+      const hasIndex = input.hasStrokeIndex ?? true;
+      if (input.par.length !== n) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: `par must have ${n} entries` });
       }
-      // Permutation gate — never persist a course with a broken index.
-      const check = validateStrokeIndex(input.handicapIndex, n);
-      if (!check.valid) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Stroke index must be a complete permutation of 1..N (no gaps or duplicates)",
-        });
+      // Permutation gate — only when the course HAS an index; never persist a
+      // broken one. Index-off courses store an empty index (net unavailable).
+      if (hasIndex) {
+        if ((input.handicapIndex ?? []).length !== n) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: `handicapIndex must have ${n} entries` });
+        }
+        if (!validateStrokeIndex(input.handicapIndex!, n).valid) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Stroke index must be a complete permutation of 1..N (no gaps or duplicates)",
+          });
+        }
       }
 
       const id = crypto.randomUUID();
@@ -59,7 +63,8 @@ export const coursesRouter = router({
         location: input.location ?? null,
         hole_count: n,
         par: input.par,
-        handicap_index: input.handicapIndex,
+        handicap_index: hasIndex ? input.handicapIndex : [],
+        has_stroke_index: hasIndex,
         tee_sets: input.teeSets ?? [],
         source: input.source ?? "manual",
         provider_id: input.providerId ?? null,

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -4,6 +4,7 @@ import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
 import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
+import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema } from "@/lib/courseIndex";
 
 /**
  * games — the competition-engine spine (Slice A: individual stroke play).
@@ -155,6 +156,84 @@ export const gamesRouter = router({
         .eq("game_id", input.gameId)
         .order("created_at", { ascending: true });
       return data ?? [];
+    }),
+
+  // applyCourse — Owner/Organizer. THE CONTRACT (Slice C §0): snapshot the
+  // course's par[] + handicap_index[] into games.scorecard_schema.units.metadata
+  // (a COPY, not a live ref) so a later edit to the global course never rescores
+  // this game. course_id is kept as provenance. Re-snapshot is allowed before
+  // any score exists; FROZEN once scores are entered (freeze boundary).
+  applyCourse: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), courseId: z.string().min(1) }))
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, game_type_id")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+
+      // Freeze boundary: once any score is in, the par/index the game is being
+      // played on is fixed — re-applying a course would silently rescore it.
+      const { count } = await ctx.supabase
+        .from("score_entries")
+        .select("id", { count: "exact", head: true })
+        .eq("game_id", input.gameId);
+      if ((count ?? 0) > 0) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Scores are already entered — the course can't be changed now.",
+        });
+      }
+
+      const { data: course } = await ctx.supabase
+        .from("courses")
+        .select("hole_count, par, handicap_index")
+        .eq("id", input.courseId)
+        .maybeSingle();
+      if (!course) throw new TRPCError({ code: "NOT_FOUND", message: "Course not found" });
+
+      const holeCount = course.hole_count as number;
+      const par = course.par as number[];
+      const handicapIndex = course.handicap_index as number[];
+      // Defense in depth: never snapshot a broken index even if a row predates
+      // the create-time gate.
+      if (!validateStrokeIndex(handicapIndex, holeCount).valid) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Course stroke index is not a valid permutation — fix it before use.",
+        });
+      }
+
+      const { data: template } = await ctx.supabase
+        .from("game_type_templates")
+        .select("scorecard_schema")
+        .eq("id", game.game_type_id as string)
+        .maybeSingle();
+      const baseSchema = template?.scorecard_schema as ScorecardSchema | null;
+      if (!baseSchema?.units) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Game type has no scorecard schema to snapshot onto.",
+        });
+      }
+
+      const snapshot = buildScorecardSchema(baseSchema, par, handicapIndex, holeCount);
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ scorecard_schema: snapshot, course_id: input.courseId })
+        .eq("id", input.gameId);
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to apply course: ${error.message}`,
+        });
+      }
+
+      const { data } = await ctx.supabase.from("games").select("*").eq("id", input.gameId).single();
+      return data;
     }),
 
   // finish — Owner/Organizer. Compute + persist results, mark complete.

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -190,17 +190,19 @@ export const gamesRouter = router({
 
       const { data: course } = await ctx.supabase
         .from("courses")
-        .select("hole_count, par, handicap_index")
+        .select("hole_count, par, handicap_index, has_stroke_index")
         .eq("id", input.courseId)
         .maybeSingle();
       if (!course) throw new TRPCError({ code: "NOT_FOUND", message: "Course not found" });
 
       const holeCount = course.hole_count as number;
       const par = course.par as number[];
-      const handicapIndex = course.handicap_index as number[];
-      // Defense in depth: never snapshot a broken index even if a row predates
-      // the create-time gate.
-      if (!validateStrokeIndex(handicapIndex, holeCount).valid) {
+      const hasIndex = (course.has_stroke_index as boolean | null) ?? true;
+      // Index-off course → snapshot par only (buildScorecardSchema fills a
+      // sequential index; net falls back to hole order). Index-on → validate it
+      // as defense in depth before snapshotting.
+      const handicapIndex = hasIndex ? (course.handicap_index as number[]) : null;
+      if (hasIndex && !validateStrokeIndex(handicapIndex!, holeCount).valid) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Course stroke index is not a valid permutation — fix it before use.",

--- a/supabase/migrations/20260610130000_039_courses_and_game_scorecard_schema.sql
+++ b/supabase/migrations/20260610130000_039_courses_and_game_scorecard_schema.sql
@@ -1,0 +1,77 @@
+-- 039 — Course library (global) + per-game scorecard_schema (Slice C part 2)
+--
+-- The Course Selector/Builder produces real par + stroke-index data. Per the
+-- spec, course data is a GLOBAL fact (Pebble Creek's index is the same for
+-- everyone) — NOT circle-scoped. `circle_courses` (migration 024) stays a
+-- circle-bound stub reserved for a later Circle-Era *join* to these global
+-- courses; `golf_course_details` is dead (archived migrations only). So this
+-- adds a standalone global `courses` table as the library.
+--
+-- THE CONTRACT: applying a course to a game SNAPSHOTS its par[] + handicap_index[]
+-- into games.scorecard_schema.units.metadata (the shape strokeHoles reads). The
+-- column doesn't exist yet — added here as nullable jsonb; effective schema =
+-- games.scorecard_schema ?? the game-type template's. Idempotent throughout.
+
+-- ── 1. courses — the global course library ─────────────────────────────────
+-- text PK per the app-wide id convention. par + handicap_index are course-level
+-- facts (identical across tees); tee_sets carries the per-tee (optional) yards.
+CREATE TABLE IF NOT EXISTS public.courses (
+  id             text        NOT NULL DEFAULT gen_random_uuid()::text,
+  name           text        NOT NULL,
+  location       text,
+  hole_count     int         NOT NULL DEFAULT 18 CHECK (hole_count IN (9, 18)),
+  par            jsonb       NOT NULL,   -- int[] length = hole_count
+  handicap_index jsonb       NOT NULL,   -- int[] permutation of 1..hole_count
+  tee_sets       jsonb       NOT NULL DEFAULT '[]'::jsonb, -- [{ name, yards: (int|null)[] }]
+  source         text        NOT NULL DEFAULT 'manual',    -- 'manual' | 'golfapi'
+  provider_id    text,       -- external course id (provenance / future dedup)
+  created_by     text        REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (id)
+);
+COMMENT ON TABLE public.courses IS
+  'Global golf course library (par + stroke index + per-tee yards). Course data '
+  'is a global fact, not circle-scoped; circle_courses is reserved for a later '
+  'Circle-Era join to these rows. Slice C part 2.';
+CREATE INDEX IF NOT EXISTS idx_courses_created_at ON public.courses (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_courses_provider_id ON public.courses (provider_id);
+
+ALTER TABLE public.courses ENABLE ROW LEVEL SECURITY;
+
+-- Global library: any authenticated user can read every course and add new ones;
+-- edits/deletes are limited to the creator (a snapshot already protects played
+-- games from later edits — see the games.scorecard_schema contract).
+DROP POLICY IF EXISTS courses_select ON public.courses;
+CREATE POLICY courses_select ON public.courses
+  FOR SELECT TO authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS courses_insert ON public.courses;
+CREATE POLICY courses_insert ON public.courses
+  FOR INSERT TO authenticated
+  WITH CHECK (created_by = (auth.uid())::text);
+
+DROP POLICY IF EXISTS courses_update ON public.courses;
+CREATE POLICY courses_update ON public.courses
+  FOR UPDATE TO authenticated
+  USING (created_by = (auth.uid())::text)
+  WITH CHECK (created_by = (auth.uid())::text);
+
+DROP POLICY IF EXISTS courses_delete ON public.courses;
+CREATE POLICY courses_delete ON public.courses
+  FOR DELETE TO authenticated
+  USING (created_by = (auth.uid())::text);
+
+-- ── 2. games.scorecard_schema — the per-game contract snapshot ──────────────
+-- Nullable: when null the game falls back to its game-type template's schema.
+-- Applying a course writes a COPY of the course par/index here (a snapshot, not
+-- a live ref) so a later edit to the global course never rescores a past game.
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS scorecard_schema jsonb;
+
+-- ── 3. games.course_id — repoint from circle_courses to the global courses ──
+-- course_id is kept as provenance ("this game used Pebble Creek"). It used to
+-- reference the circle_courses stub; the real library is now `courses`.
+ALTER TABLE public.games DROP CONSTRAINT IF EXISTS games_course_id_fkey;
+ALTER TABLE public.games
+  ADD CONSTRAINT games_course_id_fkey
+  FOREIGN KEY (course_id) REFERENCES public.courses(id) ON DELETE SET NULL;

--- a/supabase/migrations/20260610140000_040_courses_has_stroke_index.sql
+++ b/supabase/migrations/20260610140000_040_courses_has_stroke_index.sql
@@ -1,0 +1,9 @@
+-- 040 — courses.has_stroke_index (Slice C addendum C-1)
+--
+-- Stroke index is now optional at course creation ("Add stroke indices" toggle).
+-- When off, the course carries no real index: handicap_index is stored as an
+-- empty array, net play is unavailable, and a game it's applied to falls back to
+-- the sequential allocation. Defaults true so existing rows keep their index.
+-- Idempotent.
+
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS has_stroke_index boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
The Course Selector/Builder — the **producer** of the real par + stroke-index data that GolfCard (part 1) and `strokeHoles` (Slice B) consume. Two paths (lookup / manual), one shared per-hole editor, ending in the same metadata contract.

This PR is built in stages (commits): **(1) data layer** is in; the picker UI + match-new wiring follow on this branch.

## Stage 1 — data layer + service + correctness core
- **Migration 039**: global `courses` table (par[]/handicap_index[]/tee_sets[], text PK, RLS read-all + creator-edit); `games.scorecard_schema` nullable jsonb (the contract target — effective = game's `??` template's); `games.course_id` FK repointed from the `circle_courses` stub to `courses` (provenance).
- **`courseIndex.ts`** (pure): `validateStrokeIndex` (permutation of 1..N), `applyStrokeIndexSwap` (swap-on-edit), `buildScorecardSchema` (the §0 snapshot). 14 tests.
- **`courseService.ts`**: provider abstraction behind `/api/golf-courses/*`, fail-soft to manual; par/index/tee extractors (missing golfapi hcp → `null` so confirm flags it).
- **`courses` router** (create/list/getById, server-side permutation gate) + **`games.applyCourse`** (snapshot write, `course_id` provenance, **frozen once scores exist**). 6 router tests vs the live DB.
- **`strokeHoles` unchanged** — the snapshot feeds its existing read shape; sequential fallback stays dormant.
- CLAUDE.md updated: course data is global; `circle_courses` reserved for a later Circle-Era join.

## Coming on this branch
- Picker UI: search → results → confirm; manual new-course → stepped per-hole editor; shared HoleEditor; swap-on-edit; validation gate; dirty-lookup handling.
- Wire into the match-new "Select a course" stub + apply; wrapper reads the game's snapshot so the sequential fallback is no longer exercised.

## Done-criteria not in scope here
Per-task E2E is the #29-gated suite-wide item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)