### PR TITLE
feat(engine): Rack-n-Stack (Slice C part 3)

### DIFF
--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -7,6 +7,8 @@ import { trpc } from "@/lib/trpc-client";
 import { useTripRole } from "@/hooks/useTripRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { TimePicker } from "@/components/TimePicker";
+import { parseTime, toTime24 } from "@/lib/time";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
@@ -16,6 +18,20 @@ import type { Participant, ScoreValues } from "@/components/games/types";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const RACK = "gtt_rack_n_stack";
+
+/** "07:40" → "7:40" (no AM/PM); "" / invalid → null. */
+function teeLabel(t: string | null | undefined): string | null {
+  if (!t || !/^\d{1,2}:\d{2}$/.test(t)) return null;
+  const [h, m] = t.split(":").map(Number);
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${h12}:${String(m).padStart(2, "0")}`;
+}
+/** Add minutes to "HH:MM" 24h (wraps within a day). */
+function addMinutes(t: string, mins: number): string {
+  const [h, m] = t.split(":").map(Number);
+  const total = (h * 60 + m + mins) % (24 * 60);
+  return `${String(Math.floor(total / 60)).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
+}
 
 /** Chunk into groups of `size`, interleaving the two teams so groups are mixed. */
 function autoFoursomes(teamA: string[], teamB: string[], size = 4): string[][] {
@@ -45,6 +61,7 @@ export default function RackNStackPage() {
   const [mode, setMode] = useState<RackMode>("current");
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
   const [pendingCourse, setPendingCourse] = useState<{ id: string; name: string } | null>(null);
+  const [firstTee, setFirstTee] = useState(""); // "HH:MM" 24h; groups stagger +10
   const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
   const [currentHole, setCurrentHole] = useState(1);
   const [values, setValues] = useState<ScoreValues>({});
@@ -151,6 +168,7 @@ export default function RackNStackPage() {
       return {
         id: g.id as string,
         name: (g.display_name as string) ?? "Group",
+        teeLabel: teeLabel((g as { tee_time?: string | null }).tee_time),
         thru: maxThru > 0 ? maxThru : null,
         players: members.map((p) => ({ id: p.user_id as string, name: nameOf.get(p.user_id as string) ?? "Player", teamColor: colorForUser(p.user_id as string) })),
         mine: !!me && members.some((p) => p.user_id === me.id),
@@ -172,7 +190,11 @@ export default function RackNStackPage() {
     }
     const aIds = [...teamOf.entries()].filter(([, t]) => t === "A").map(([id]) => id);
     const bIds = [...teamOf.entries()].filter(([, t]) => t === "B").map(([id]) => id);
-    const groups = autoFoursomes(aIds, bIds).map((userIds, i) => ({ name: `Group ${i + 1}`, userIds }));
+    const groups = autoFoursomes(aIds, bIds).map((userIds, i) => ({
+      name: `Group ${i + 1}`,
+      userIds,
+      teeTime: firstTee ? addMinutes(firstTee, i * 10) : null,
+    }));
     await setFoursomes.mutateAsync({ tripId, gameId: g.id, groups });
     setGameId(g.id);
   }
@@ -265,8 +287,9 @@ export default function RackNStackPage() {
                 <span style={{ color: pendingCourse ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>{pendingCourse?.name ?? "Select a course (optional)"}</span>
               </button>
             </div>
+            <TimePicker label="First tee time" presets="tee" value={parseTime(firstTee)} onChange={(v) => setFirstTee(toTime24(v))} />
             <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)" }}>
-              {assignQ.data?.length ?? 0} players across {teamMeta.A.name} &amp; {teamMeta.B.name} — they&apos;ll be auto-grouped into foursomes you can regroup later.
+              {assignQ.data?.length ?? 0} players across {teamMeta.A.name} &amp; {teamMeta.B.name} — they&apos;ll be auto-grouped into foursomes (tee times stagger by 10 min) you can regroup later.
             </p>
             {canEdit && (
               <button onClick={startRack} disabled={createGame.isPending || setFoursomes.isPending} className="mt-2 w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
@@ -286,8 +309,8 @@ export default function RackNStackPage() {
   const final = gameQ.data?.status === "complete";
   const allThru18 = rack.slots.length > 0 && rack.slots.every((s) => s.a.thru >= scUnits.length && s.b.thru >= scUnits.length);
   return (
-    <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
-      <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} />
+    <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle={final ? "Net stroke play · final" : "Net stroke play · standings"}>
+      <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
       <RackBoard
         teamA={teamMeta.A}

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { ChevronLeft, Users } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { useTripRole } from "@/hooks/useTripRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { ScoreEntryView } from "@/components/games/ScoreEntryView";
+import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
+import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
+import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/rackNStack";
+import { unitsFromSchema, strokeIndexOf, initialsOf } from "@/lib/strokePlayConfig";
+import type { Participant, ScoreValues } from "@/components/games/types";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const RACK = "gtt_rack_n_stack";
+
+/** Chunk into groups of `size`, interleaving the two teams so groups are mixed. */
+function autoFoursomes(teamA: string[], teamB: string[], size = 4): string[][] {
+  const woven: string[] = [];
+  for (let i = 0; i < Math.max(teamA.length, teamB.length); i++) {
+    if (teamA[i]) woven.push(teamA[i]);
+    if (teamB[i]) woven.push(teamB[i]);
+  }
+  const out: string[][] = [];
+  for (let i = 0; i < woven.length; i += size) out.push(woven.slice(i, i + size));
+  return out;
+}
+
+export default function RackNStackPage() {
+  const { tripId: param } = useParams<{ tripId: string }>();
+  const router = useRouter();
+  const search = useSearchParams();
+  const isId = UUID_RE.test(param);
+  const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { enabled: !isId, retry: false });
+  const tripId = isId ? param : resolved.data?.id;
+
+  const { canEdit, loading: roleLoading } = useTripRole(tripId);
+  const me = useCurrentUser();
+  const utils = trpc.useUtils();
+
+  const [gameId, setGameId] = useState<string | null>(search.get("game"));
+  const [mode, setMode] = useState<RackMode>("current");
+  const [coursePickerOpen, setCoursePickerOpen] = useState(false);
+  const [pendingCourse, setPendingCourse] = useState<{ id: string; name: string } | null>(null);
+  const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
+  const [currentHole, setCurrentHole] = useState(1);
+  const [values, setValues] = useState<ScoreValues>({});
+
+  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const competitionId = competition.data?.id as string | undefined;
+  const teamsQ = trpc.teams.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { enabled: !!tripId && !!competitionId });
+  const assignQ = trpc.teamAssignments.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { enabled: !!tripId && !!competitionId });
+
+  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+  const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+  const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+
+  const createGame = trpc.games.create.useMutation();
+  const applyCourse = trpc.games.applyCourse.useMutation();
+  const setFoursomes = trpc.playGroups.setFoursomes.useMutation();
+  const upsertEntry = trpc.scores.upsertEntry.useMutation();
+  const deleteEntry = trpc.scores.deleteEntry.useMutation();
+  const finishGame = trpc.games.finish.useMutation();
+
+  // ── Names / teams ────────────────────────────────────────────────────
+  const nameOf = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of crew.data ?? []) m.set(c.user_id, c.displayName ?? c.user?.name ?? "Player");
+    return m;
+  }, [crew.data]);
+  const avatarOf = useMemo(() => {
+    const m = new Map<string, string | null>();
+    for (const c of crew.data ?? []) m.set(c.user_id, c.user?.avatar_icon ?? null);
+    return m;
+  }, [crew.data]);
+
+  // The two competing teams (sorted by id → A/B, matching the server).
+  const teamIds = useMemo(() => {
+    const ids = [...new Set((assignQ.data ?? []).map((a) => a.team_id as string))].sort();
+    return ids;
+  }, [assignQ.data]);
+  const teamOf = useMemo(() => {
+    const m = new Map<string, "A" | "B">();
+    for (const a of assignQ.data ?? []) {
+      const t = a.team_id === teamIds[0] ? "A" : a.team_id === teamIds[1] ? "B" : null;
+      if (t) m.set(a.user_id as string, t);
+    }
+    return m;
+  }, [assignQ.data, teamIds]);
+  const teamMeta = useMemo(() => {
+    const byId = new Map((teamsQ.data ?? []).map((t) => [t.id as string, t]));
+    const mk = (id?: string): RackTeam => {
+      const t = id ? byId.get(id) : undefined;
+      return { name: (t?.name as string) ?? "Team", color: (t?.color as string) ?? "var(--color-bt-text-dim)" };
+    };
+    return { A: mk(teamIds[0]), B: mk(teamIds[1]) };
+  }, [teamsQ.data, teamIds]);
+  const colorForUser = (id: string) => (teamOf.get(id) === "A" ? teamMeta.A.color : teamMeta.B.color);
+
+  const hasCompetition = !!competitionId && teamIds.length >= 2;
+
+  // ── Scorecard + live values ──────────────────────────────────────────
+  const scUnits = useMemo(
+    () => unitsFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof unitsFromSchema>[0]),
+    [gameQ.data]
+  );
+  const scIndex = useMemo(() => strokeIndexOf(scUnits), [scUnits]);
+  const coursePar = useMemo(() => scUnits.reduce((a, u) => a + (u.par ?? 0), 0), [scUnits]);
+
+  const loadedValues = useMemo(() => {
+    const v: ScoreValues = {};
+    for (const e of scoresQ.data ?? []) {
+      if (e.value == null) continue;
+      (v[e.participant_id] ??= {})[e.unit_label] = e.value;
+    }
+    return v;
+  }, [scoresQ.data]);
+  const mergedFor = (pid: string) => ({ ...(loadedValues[pid] ?? {}), ...(values[pid] ?? {}) });
+
+  // ── Rack read-model (the spec's novelty) ─────────────────────────────
+  const participants = useMemo(() => groupsQ.data?.participants ?? [], [groupsQ.data]);
+  const handicapOf = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const p of participants) m.set(p.user_id as string, (p.handicap_strokes as number | null) ?? 0);
+    return m;
+  }, [participants]);
+
+  const rack = useMemo(() => {
+    const players: RackPlayer[] = [];
+    for (const p of participants) {
+      const uid = p.user_id as string;
+      const team = teamOf.get(uid);
+      if (!team) continue;
+      players.push({ id: uid, team, stats: playerStats(mergedFor(uid), handicapOf.get(uid) ?? 0, scUnits.map((u) => u.par ?? 0), scIndex) });
+    }
+    return computeRack(players, mode, coursePar);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [participants, teamOf, handicapOf, scUnits, scIndex, coursePar, mode, loadedValues, values]);
+
+  // ── Foursome views ───────────────────────────────────────────────────
+  const groupViews: FoursomeGroupView[] = useMemo(() => {
+    const groups = groupsQ.data?.groups ?? [];
+    return groups.map((g) => {
+      const members = participants.filter((p) => p.play_group_id === g.id);
+      const thrus = members.map((p) => playerStats(mergedFor(p.user_id as string), 0, scUnits.map((u) => u.par ?? 0), scIndex).thru);
+      const maxThru = thrus.length ? Math.max(...thrus) : 0;
+      return {
+        id: g.id as string,
+        name: (g.display_name as string) ?? "Group",
+        thru: maxThru > 0 ? maxThru : null,
+        players: members.map((p) => ({ id: p.user_id as string, name: nameOf.get(p.user_id as string) ?? "Player", teamColor: colorForUser(p.user_id as string) })),
+        mine: !!me && members.some((p) => p.user_id === me.id),
+      };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupsQ.data, participants, scUnits, scIndex, nameOf, me, loadedValues, values, teamOf, teamMeta]);
+
+  // ── Handlers ─────────────────────────────────────────────────────────
+  async function startRack() {
+    if (!tripId || !competitionId) return;
+    const g = await createGame.mutateAsync({ tripId, gameTypeId: RACK, name: "Rack-n-Stack", competitionId });
+    if (pendingCourse) {
+      try {
+        await applyCourse.mutateAsync({ tripId, gameId: g.id, courseId: pendingCourse.id });
+      } catch {
+        /* template default par/index still applies */
+      }
+    }
+    const aIds = [...teamOf.entries()].filter(([, t]) => t === "A").map(([id]) => id);
+    const bIds = [...teamOf.entries()].filter(([, t]) => t === "B").map(([id]) => id);
+    const groups = autoFoursomes(aIds, bIds).map((userIds, i) => ({ name: `Group ${i + 1}`, userIds }));
+    await setFoursomes.mutateAsync({ tripId, gameId: g.id, groups });
+    setGameId(g.id);
+  }
+
+  const handleChange = (pid: string, unit: string, value: number) => {
+    setValues((v) => ({ ...v, [pid]: { ...(v[pid] ?? {}), [unit]: value } }));
+    if (!tripId || !gameId) return;
+    upsertEntry.mutate(
+      { tripId, gameId, participantId: pid, unitLabel: unit, value },
+      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId }) }
+    );
+  };
+  const handleClear = (pid: string, unit: string) => {
+    setValues((v) => {
+      const next = { ...(v[pid] ?? {}) };
+      delete next[unit];
+      return { ...v, [pid]: next };
+    });
+    if (!tripId || !gameId) return;
+    deleteEntry.mutate(
+      { tripId, gameId, participantId: pid, unitLabel: unit },
+      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId }) }
+    );
+  };
+
+  async function finish() {
+    if (!tripId || !gameId) return;
+    await finishGame.mutateAsync({ tripId, gameId });
+    await utils.games.getById.invalidate({ tripId, gameId });
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────
+  if (!tripId || roleLoading || crew.isLoading || competition.isLoading) {
+    return <Center>Loading…</Center>;
+  }
+
+  if (!hasCompetition) {
+    return (
+      <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack">
+        <div className="flex flex-col items-center text-center" style={{ paddingTop: 72 }}>
+          <div className="flex items-center justify-center" style={{ width: 56, height: 56, borderRadius: 16, background: "var(--color-bt-card-raised)", marginBottom: 16 }}>
+            <Users size={24} style={{ color: "var(--color-bt-text-dim)" }} />
+          </div>
+          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Needs a competition with two teams</div>
+          <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 6, maxWidth: 300 }}>
+            Rack-n-Stack is a team format. Set up a competition and assign players to two teams first, then come back to run the rack.
+          </p>
+        </div>
+      </Shell>
+    );
+  }
+
+  // Entry: the tapped foursome's stroke-play card.
+  if (entryGroupId && gameId) {
+    const members = participants.filter((p) => p.play_group_id === entryGroupId);
+    const groupName = (groupsQ.data?.groups ?? []).find((g) => g.id === entryGroupId)?.display_name as string | undefined;
+    const ps: Participant[] = members.map((p) => {
+      const id = p.user_id as string;
+      const name = nameOf.get(id) ?? "Player";
+      return { id, name, initials: initialsOf(name), color: colorForUser(id), avatarIcon: avatarOf.get(id) ?? null };
+    });
+    return (
+      <div className="flex flex-col" style={{ height: "100vh" }}>
+        <ScoreEntryView
+          gameName={groupName ?? "Group"}
+          units={scUnits}
+          participants={ps}
+          values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
+          direction="low_wins"
+          currentHole={currentHole}
+          onHoleChange={setCurrentHole}
+          onChange={handleChange}
+          onClear={handleClear}
+          onBack={() => setEntryGroupId(null)}
+          onFinish={() => setEntryGroupId(null)}
+        />
+      </div>
+    );
+  }
+
+  // No game yet → setup.
+  if (!gameId) {
+    return (
+      <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
+        <div className="w-full px-4 py-5">
+          <div className="flex flex-col gap-3.5">
+            <div>
+              <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Course</label>
+              <button type="button" onClick={() => setCoursePickerOpen(true)} className="flex w-full items-center justify-between rounded-xl border px-3 py-2.5 text-left text-sm" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
+                <span style={{ color: pendingCourse ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>{pendingCourse?.name ?? "Select a course (optional)"}</span>
+              </button>
+            </div>
+            <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)" }}>
+              {assignQ.data?.length ?? 0} players across {teamMeta.A.name} &amp; {teamMeta.B.name} — they&apos;ll be auto-grouped into foursomes you can regroup later.
+            </p>
+            {canEdit && (
+              <button onClick={startRack} disabled={createGame.isPending || setFoursomes.isPending} className="mt-2 w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
+                Start the rack
+              </button>
+            )}
+          </div>
+        </div>
+        {coursePickerOpen && (
+          <CoursePicker onClose={() => setCoursePickerOpen(false)} onApply={(c) => { setPendingCourse(c); setCoursePickerOpen(false); }} />
+        )}
+      </Shell>
+    );
+  }
+
+  // Play screen.
+  const final = gameQ.data?.status === "complete";
+  const allThru18 = rack.slots.length > 0 && rack.slots.every((s) => s.a.thru >= scUnits.length && s.b.thru >= scUnits.length);
+  return (
+    <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
+      <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} />
+      <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
+      <RackBoard
+        teamA={teamMeta.A}
+        teamB={teamMeta.B}
+        slots={rack.slots}
+        sitOut={rack.sitOut}
+        mode={mode}
+        onMode={setMode}
+        nameOf={(id) => nameOf.get(id) ?? "Player"}
+        final={final}
+      />
+      {canEdit && !final && allThru18 && (
+        <div className="px-4 pb-6">
+          <button onClick={finish} disabled={finishGame.isPending} className="w-full disabled:opacity-40" style={{ height: 50, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 15, fontWeight: 600 }}>
+            Lock the result
+          </button>
+        </div>
+      )}
+    </Shell>
+  );
+}
+
+function Shell({ title, subtitle, onBack, children }: { title: string; subtitle?: string; onBack: () => void; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: "100vh" }}>
+      <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div className="min-w-0 text-center">
+          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
+          {subtitle && <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>}
+        </div>
+        <div className="h-9 w-9" />
+      </header>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+function Center({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text-dim)" }}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/games/rack/FoursomeEntry.tsx
+++ b/src/components/games/rack/FoursomeEntry.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+
+/**
+ * Groups (entry) for rack-n-stack (addendum §3). One card per foursome; tapping
+ * opens that group's stroke-play scorecard. The viewer's own group is emphasized
+ * (accent) with an "Enter ›" CTA. A group that hasn't teed off reads "not
+ * started" here — so there's no separate "haven't teed off" list on the rack.
+ *
+ * Presentational: composed onto the rack page (NOT part of the display board).
+ */
+
+export interface FoursomePlayer {
+  id: string;
+  name: string;
+  teamColor: string;
+}
+export interface FoursomeGroupView {
+  id: string;
+  name: string;
+  thru: number | null; // null = not started
+  players: FoursomePlayer[];
+  mine: boolean;
+}
+
+export function FoursomeEntry({ groups, onEnter }: { groups: FoursomeGroupView[]; onEnter: (groupId: string) => void }) {
+  return (
+    <div style={{ padding: "12px 12px 4px" }}>
+      <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+        Groups · tap to enter scores
+      </span>
+      <div className="mt-2 flex flex-col gap-2">
+        {groups.map((g) => (
+          <button
+            key={g.id}
+            onClick={() => onEnter(g.id)}
+            className="w-full rounded-xl border text-left"
+            style={{
+              padding: "10px 12px",
+              background: g.mine ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)",
+              borderColor: g.mine ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
+            }}
+          >
+            <div className="flex items-center justify-between">
+              <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{g.name}</span>
+              {g.mine ? (
+                <span className="flex items-center gap-0.5" style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-accent)" }}>
+                  Enter <ChevronRight size={15} />
+                </span>
+              ) : (
+                <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />
+              )}
+            </div>
+            <div style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 1 }}>
+              {g.thru == null ? "not started" : `thru ${g.thru}`}
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+              {g.players.map((p) => (
+                <span key={p.id} className="flex items-center gap-1.5">
+                  <span style={{ width: 8, height: 8, borderRadius: "50%", background: p.teamColor, flexShrink: 0 }} />
+                  <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>{p.name}</span>
+                </span>
+              ))}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/games/rack/FoursomeEntry.tsx
+++ b/src/components/games/rack/FoursomeEntry.tsx
@@ -31,20 +31,20 @@ export function FoursomeEntry({ groups, onEnter }: { groups: FoursomeGroupView[]
       <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
         Groups · tap to enter scores
       </span>
-      <div className="mt-2 flex flex-col gap-2">
+      <div className="mt-2 grid grid-cols-2 gap-2">
         {groups.map((g) => (
           <button
             key={g.id}
             onClick={() => onEnter(g.id)}
-            className="w-full rounded-xl border text-left"
+            className="min-w-0 rounded-xl border text-left"
             style={{
               padding: "10px 12px",
               background: g.mine ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)",
               borderColor: g.mine ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
             }}
           >
-            <div className="flex items-center justify-between">
-              <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{g.name}</span>
+            <div className="flex items-center justify-between gap-1">
+              <span className="min-w-0 truncate" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{g.name}</span>
               {g.mine ? (
                 <span className="flex items-center gap-0.5" style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-accent)" }}>
                   Enter <ChevronRight size={15} />
@@ -53,7 +53,7 @@ export function FoursomeEntry({ groups, onEnter }: { groups: FoursomeGroupView[]
                 <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />
               )}
             </div>
-            <div style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 1 }}>
+            <div className="truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 1, whiteSpace: "nowrap" }}>
               {g.teeLabel ? `${g.teeLabel} tee · ` : ""}
               {g.thru == null ? "not started" : `thru ${g.thru}`}
             </div>

--- a/src/components/games/rack/FoursomeEntry.tsx
+++ b/src/components/games/rack/FoursomeEntry.tsx
@@ -19,6 +19,7 @@ export interface FoursomePlayer {
 export interface FoursomeGroupView {
   id: string;
   name: string;
+  teeLabel: string | null; // e.g. "7:40" — null when no tee set
   thru: number | null; // null = not started
   players: FoursomePlayer[];
   mine: boolean;
@@ -53,6 +54,7 @@ export function FoursomeEntry({ groups, onEnter }: { groups: FoursomeGroupView[]
               )}
             </div>
             <div style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 1 }}>
+              {g.teeLabel ? `${g.teeLabel} tee · ` : ""}
               {g.thru == null ? "not started" : `thru ${g.thru}`}
             </div>
             <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -40,12 +40,14 @@ export function RsDayScore({
   pointsA,
   pointsB,
   final,
+  projected,
 }: {
   teamA: RackTeam;
   teamB: RackTeam;
   pointsA: number;
   pointsB: number;
   final?: boolean;
+  projected?: boolean;
 }) {
   return (
     <div
@@ -57,7 +59,9 @@ export function RsDayScore({
         <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.12em", color: "var(--color-bt-text-dim)" }}>
           {final ? "FINAL" : "RACK"}
         </span>
-        <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)" }}>matches won</span>
+        <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)" }}>
+          matches won{projected && !final ? " · proj" : ""}
+        </span>
       </div>
       <TeamTotal team={teamB} points={pointsB} align="right" />
     </div>

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+import { fmtToPar, fmtPoints, type RackMode, type RackSlot, type RackSlotPlayer } from "@/lib/rackNStack";
+
+/**
+ * Rack-n-Stack display board (Slice C part 3 + addendum). PURE / display-only —
+ * data in via props, no tRPC, no entry behind a slot. Slots are rank-derived
+ * readouts (A[k] vs B[k]); the score numbers are net-to-par, the gap is the net
+ * margin. Reuses the match-board's outer-edge layout but is a readout, not a
+ * control — tapping a slot does nothing.
+ *
+ * Composed onto the rack page below the team header (`RsDayScore`) and the
+ * Groups entry; the board itself is just the toggle + rack + sit-out so it can
+ * be reused as the competition leaderboard later.
+ */
+
+export interface RackTeam {
+  name: string;
+  color: string;
+}
+
+interface RackBoardProps {
+  teamA: RackTeam;
+  teamB: RackTeam;
+  slots: RackSlot[];
+  sitOut: RackSlotPlayer[];
+  mode: RackMode;
+  onMode: (m: RackMode) => void;
+  showProjectedToggle?: boolean;
+  nameOf: (id: string) => string;
+  variant?: "carded" | "stacked";
+  final?: boolean;
+}
+
+// ── Team-score header (RsDayScore) — pinned above Groups ─────────────────────
+export function RsDayScore({
+  teamA,
+  teamB,
+  pointsA,
+  pointsB,
+  final,
+}: {
+  teamA: RackTeam;
+  teamB: RackTeam;
+  pointsA: number;
+  pointsB: number;
+  final?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-stretch"
+      style={{ background: "var(--color-bt-card)", borderBottom: "1px solid var(--color-bt-border)", padding: "14px 16px" }}
+    >
+      <TeamTotal team={teamA} points={pointsA} align="left" />
+      <div className="flex flex-col items-center justify-center" style={{ padding: "0 14px" }}>
+        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.12em", color: "var(--color-bt-text-dim)" }}>
+          {final ? "FINAL" : "RACK"}
+        </span>
+        <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)" }}>matches won</span>
+      </div>
+      <TeamTotal team={teamB} points={pointsB} align="right" />
+    </div>
+  );
+}
+
+function TeamTotal({ team, points, align }: { team: RackTeam; points: number; align: "left" | "right" }) {
+  return (
+    <div className="flex flex-1 flex-col" style={{ alignItems: align === "left" ? "flex-start" : "flex-end" }}>
+      <span className="flex items-center gap-1.5">
+        {align === "left" && <Dot color={team.color} />}
+        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+          {team.name}
+        </span>
+        {align === "right" && <Dot color={team.color} />}
+      </span>
+      <span style={{ fontSize: 34, fontWeight: 800, color: "var(--color-bt-text)", lineHeight: 1.05, fontVariantNumeric: "tabular-nums" }}>
+        {fmtPoints(points)}
+      </span>
+    </div>
+  );
+}
+
+// ── The board (toggle + rack + sit-out) ──────────────────────────────────────
+export function RackBoard({
+  teamA,
+  teamB,
+  slots,
+  sitOut,
+  mode,
+  onMode,
+  showProjectedToggle = true,
+  nameOf,
+  variant = "stacked",
+  final,
+}: RackBoardProps) {
+  const colorOf = (t: "A" | "B") => (t === "A" ? teamA.color : teamB.color);
+  return (
+    <div style={{ padding: "12px 12px 20px" }}>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          Standings · the rack
+        </span>
+        {showProjectedToggle && !final && <RsToggle mode={mode} onMode={onMode} />}
+      </div>
+
+      {final && (
+        <div className="mb-2 flex items-center justify-center rounded-lg" style={{ height: 30, background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}>
+          <span style={{ fontSize: 12.5, fontWeight: 600, color: "var(--color-bt-accent)" }}>All in · result locked</span>
+        </div>
+      )}
+
+      {slots.length === 0 ? (
+        <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", padding: "8px 2px" }}>
+          The rack fills in as groups post scores.
+        </p>
+      ) : variant === "carded" ? (
+        <div className="flex flex-col gap-2.5">
+          {slots.map((s) => (
+            <div key={s.slot} className="overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
+              <div className="flex items-center" style={{ height: 24, padding: "0 12px", background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-border)" }}>
+                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>Slot {s.slot}</span>
+              </div>
+              <RackRow slot={s} nameOf={nameOf} colorOf={colorOf} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
+          {slots.map((s, i) => (
+            <div key={s.slot} className="flex items-stretch" style={{ borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}>
+              <span className="flex shrink-0 items-center justify-center" style={{ width: 26, fontSize: 12, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
+                {s.slot}
+              </span>
+              <div className="min-w-0 flex-1">
+                <RackRow slot={s} nameOf={nameOf} colorOf={colorOf} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {sitOut.length > 0 && (
+        <div className="mt-4">
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Not part of scoring
+          </span>
+          <div className="mt-2 flex flex-col gap-2">
+            {sitOut.map((p) => (
+              <div
+                key={p.id}
+                className="flex items-center justify-between rounded-xl px-3"
+                style={{ height: 40, border: "1.5px dashed var(--color-bt-border)", opacity: 0.6 }}
+              >
+                <span className="flex items-center gap-2">
+                  <Dot color={colorOf(p.team)} />
+                  <span style={{ fontSize: 14, color: "var(--color-bt-text)" }}>{nameOf(p.id)}</span>
+                </span>
+                <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
+                  {fmtToPar(p.value)} · thru {p.thru}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── One slot — inert readout (match-board outer-edge layout) ──────────────────
+function RackRow({ slot, nameOf, colorOf }: { slot: RackSlot; nameOf: (id: string) => string; colorOf: (t: "A" | "B") => string }) {
+  const aLead = slot.leader === "A";
+  const bLead = slot.leader === "B";
+  const gap = Math.round(slot.gap);
+  return (
+    <div className="flex items-stretch" style={{ minHeight: 56 }}>
+      <ScoreBlock value={slot.a.value} thru={slot.a.thru} lead={aLead} color={colorOf("A")} />
+      <NameBlock name={nameOf(slot.a.id)} align="right" lead={aLead} color={colorOf("A")} gapText={aLead ? `Up by ${gap}` : null} />
+      <div className="flex shrink-0 items-center justify-center" style={{ width: 30, background: "var(--color-bt-card-raised)" }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>vs</span>
+      </div>
+      <NameBlock name={nameOf(slot.b.id)} align="left" lead={bLead} color={colorOf("B")} gapText={bLead ? `Up by ${gap}` : null} />
+      <ScoreBlock value={slot.b.value} thru={slot.b.thru} lead={bLead} color={colorOf("B")} />
+    </div>
+  );
+}
+
+function ScoreBlock({ value, thru, lead, color }: { value: number; thru: number; lead: boolean; color: string }) {
+  return (
+    <div
+      className="flex shrink-0 flex-col items-center justify-center"
+      style={{ width: 64, background: lead ? color : "transparent" }}
+    >
+      <span style={{ fontSize: 24, fontWeight: 800, color: lead ? "#fff" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
+        {fmtToPar(value)}
+      </span>
+      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.06em", color: lead ? "rgba(255,255,255,0.85)" : "var(--color-bt-text-dim)", marginTop: 3 }}>
+        THRU {thru}
+      </span>
+    </div>
+  );
+}
+
+function NameBlock({ name, align, lead, color, gapText }: { name: string; align: "left" | "right"; lead: boolean; color: string; gapText: string | null }) {
+  return (
+    <div
+      className="flex min-w-0 flex-1 flex-col justify-center"
+      style={{ padding: "0 10px", alignItems: align === "right" ? "flex-end" : "flex-start", background: lead ? `${color}29` : "transparent" }}
+    >
+      <span className="max-w-full truncate" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{name}</span>
+      {gapText && <span style={{ fontSize: 11.5, fontWeight: 600, color, marginTop: 1 }}>{gapText}</span>}
+    </div>
+  );
+}
+
+// ── Compact Current/Projected toggle (RsToggle) ──────────────────────────────
+export function RsToggle({ mode, onMode }: { mode: RackMode; onMode: (m: RackMode) => void }) {
+  const on = mode === "projected";
+  return (
+    <div className="flex items-center gap-2">
+      <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{on ? "Projected to 18" : "Current standings"}</span>
+      <button
+        onClick={() => onMode(on ? "current" : "projected")}
+        className="flex items-center gap-1"
+        style={{
+          padding: "3px 9px",
+          borderRadius: 9999,
+          fontSize: 12,
+          fontWeight: 600,
+          border: `1px solid ${on ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
+          background: on ? "var(--color-bt-accent)" : "transparent",
+          color: on ? "#0d1f1a" : "var(--color-bt-text-dim)",
+        }}
+      >
+        <TrendingUp size={13} />
+        Projected
+      </button>
+    </div>
+  );
+}
+
+function Dot({ color }: { color: string }) {
+  return <span style={{ width: 9, height: 9, borderRadius: "50%", background: color, flexShrink: 0 }} />;
+}

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -130,17 +130,22 @@ export function RackBoard({
           ))}
         </div>
       ) : (
-        <div className="overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
-          {slots.map((s, i) => (
-            <div key={s.slot} className="flex items-stretch" style={{ borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}>
-              <span className="flex shrink-0 items-center justify-center" style={{ width: 26, fontSize: 12, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
-                {s.slot}
-              </span>
-              <div className="min-w-0 flex-1">
+        <div className="flex items-stretch">
+          {/* Slot numbers float in a left gutter — OUTSIDE the rack border. */}
+          <div className="flex shrink-0 flex-col" style={{ width: 22, marginRight: 6 }}>
+            {slots.map((s) => (
+              <div key={s.slot} className="flex items-center justify-center" style={{ height: ROW_H }}>
+                <span style={{ fontSize: 12, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{s.slot}</span>
+              </div>
+            ))}
+          </div>
+          <div className="min-w-0 flex-1 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
+            {slots.map((s, i) => (
+              <div key={s.slot} style={{ borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}>
                 <RackRow slot={s} nameOf={nameOf} colorOf={colorOf} />
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       )}
 
@@ -172,17 +177,26 @@ export function RackBoard({
   );
 }
 
-// ── One slot — inert readout (match-board outer-edge layout) ──────────────────
+// Two fixed-height bands keep the PRIMARY line (net-to-par · name · vs · name ·
+// net-to-par) on one row and the SECONDARY line (THRU · gap) beneath — so the
+// scores, names, and "vs" all sit on the same vertical line.
+const PRIMARY = 30;
+const SECONDARY = 22;
+const ROW_H = PRIMARY + SECONDARY;
+
 function RackRow({ slot, nameOf, colorOf }: { slot: RackSlot; nameOf: (id: string) => string; colorOf: (t: "A" | "B") => string }) {
   const aLead = slot.leader === "A";
   const bLead = slot.leader === "B";
   const gap = Math.round(slot.gap);
   return (
-    <div className="flex items-stretch" style={{ minHeight: 56 }}>
+    <div className="flex items-stretch" style={{ height: ROW_H }}>
       <ScoreBlock value={slot.a.value} thru={slot.a.thru} lead={aLead} color={colorOf("A")} />
       <NameBlock name={nameOf(slot.a.id)} align="right" lead={aLead} color={colorOf("A")} gapText={aLead ? `Up by ${gap}` : null} />
-      <div className="flex shrink-0 items-center justify-center" style={{ width: 30, background: "var(--color-bt-card-raised)" }}>
-        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>vs</span>
+      <div className="flex shrink-0 flex-col" style={{ width: 28, background: "var(--color-bt-card-raised)" }}>
+        <div className="flex items-center justify-center" style={{ height: PRIMARY }}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>vs</span>
+        </div>
+        <div style={{ height: SECONDARY }} />
       </div>
       <NameBlock name={nameOf(slot.b.id)} align="left" lead={bLead} color={colorOf("B")} gapText={bLead ? `Up by ${gap}` : null} />
       <ScoreBlock value={slot.b.value} thru={slot.b.thru} lead={bLead} color={colorOf("B")} />
@@ -192,28 +206,31 @@ function RackRow({ slot, nameOf, colorOf }: { slot: RackSlot; nameOf: (id: strin
 
 function ScoreBlock({ value, thru, lead, color }: { value: number; thru: number; lead: boolean; color: string }) {
   return (
-    <div
-      className="flex shrink-0 flex-col items-center justify-center"
-      style={{ width: 64, background: lead ? color : "transparent" }}
-    >
-      <span style={{ fontSize: 24, fontWeight: 800, color: lead ? "#fff" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
-        {fmtToPar(value)}
-      </span>
-      <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.06em", color: lead ? "rgba(255,255,255,0.85)" : "var(--color-bt-text-dim)", marginTop: 3 }}>
-        THRU {thru}
-      </span>
+    <div className="flex shrink-0 flex-col" style={{ width: 60, background: lead ? color : "transparent" }}>
+      <div className="flex items-center justify-center" style={{ height: PRIMARY }}>
+        <span style={{ fontSize: 22, fontWeight: 800, color: lead ? "#fff" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
+          {fmtToPar(value)}
+        </span>
+      </div>
+      <div className="flex items-center justify-center" style={{ height: SECONDARY }}>
+        <span style={{ fontSize: 9.5, fontWeight: 600, letterSpacing: "0.06em", color: lead ? "rgba(255,255,255,0.85)" : "var(--color-bt-text-dim)" }}>
+          THRU {thru}
+        </span>
+      </div>
     </div>
   );
 }
 
 function NameBlock({ name, align, lead, color, gapText }: { name: string; align: "left" | "right"; lead: boolean; color: string; gapText: string | null }) {
+  const justify = align === "right" ? "flex-end" : "flex-start";
   return (
-    <div
-      className="flex min-w-0 flex-1 flex-col justify-center"
-      style={{ padding: "0 10px", alignItems: align === "right" ? "flex-end" : "flex-start", background: lead ? `${color}29` : "transparent" }}
-    >
-      <span className="max-w-full truncate" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{name}</span>
-      {gapText && <span style={{ fontSize: 11.5, fontWeight: 600, color, marginTop: 1 }}>{gapText}</span>}
+    <div className="flex min-w-0 flex-1 flex-col" style={{ padding: "0 10px", background: lead ? `${color}29` : "transparent" }}>
+      <div className="flex w-full items-center" style={{ height: PRIMARY, justifyContent: justify }}>
+        <span className="max-w-full truncate" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{name}</span>
+      </div>
+      <div className="flex w-full items-center" style={{ height: SECONDARY, justifyContent: justify }}>
+        {gapText && <span style={{ fontSize: 11, fontWeight: 600, color }}>{gapText}</span>}
+      </div>
     </div>
   );
 }
@@ -231,10 +248,12 @@ export function RsToggle({ mode, onMode }: { mode: RackMode; onMode: (m: RackMod
           padding: "3px 9px",
           borderRadius: 9999,
           fontSize: 12,
-          fontWeight: 600,
-          border: `1px solid ${on ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
-          background: on ? "var(--color-bt-accent)" : "transparent",
-          color: on ? "#0d1f1a" : "var(--color-bt-text-dim)",
+          fontWeight: on ? 700 : 600,
+          // Toggled-on = a neutral elevated fill (NOT the teal CTA), so "on" reads
+          // as a selected control rather than a call to action.
+          border: `1px solid ${on ? "var(--color-bt-text-dim)" : "var(--color-bt-border)"}`,
+          background: on ? "var(--color-bt-card-raised)" : "transparent",
+          color: on ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
         }}
       >
         <TrendingUp size={13} />

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -121,7 +121,7 @@ export function RackBoard({
       ) : variant === "carded" ? (
         <div className="flex flex-col gap-2.5">
           {slots.map((s) => (
-            <div key={s.slot} className="overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
+            <div key={s.slot} className="overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)", background: "var(--color-bt-card)" }}>
               <div className="flex items-center" style={{ height: 24, padding: "0 12px", background: "var(--color-bt-card-raised)", borderBottom: "1px solid var(--color-bt-border)" }}>
                 <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>Slot {s.slot}</span>
               </div>
@@ -134,12 +134,14 @@ export function RackBoard({
           {/* Slot numbers float in a left gutter — OUTSIDE the rack border. */}
           <div className="flex shrink-0 flex-col" style={{ width: 22, marginRight: 6 }}>
             {slots.map((s) => (
-              <div key={s.slot} className="flex items-center justify-center" style={{ height: ROW_H }}>
-                <span style={{ fontSize: 12, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{s.slot}</span>
+              <div key={s.slot} className="flex flex-col" style={{ height: ROW_H, paddingTop: TOP_PAD }}>
+                <div className="flex items-center justify-center" style={{ height: PRIMARY }}>
+                  <span style={{ fontSize: 12, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{s.slot}</span>
+                </div>
               </div>
             ))}
           </div>
-          <div className="min-w-0 flex-1 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
+          <div className="min-w-0 flex-1 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)", background: "var(--color-bt-card)" }}>
             {slots.map((s, i) => (
               <div key={s.slot} style={{ borderTop: i === 0 ? undefined : "1px solid var(--color-bt-subtle-border)" }}>
                 <RackRow slot={s} nameOf={nameOf} colorOf={colorOf} />
@@ -180,9 +182,10 @@ export function RackBoard({
 // Two fixed-height bands keep the PRIMARY line (net-to-par · name · vs · name ·
 // net-to-par) on one row and the SECONDARY line (THRU · gap) beneath — so the
 // scores, names, and "vs" all sit on the same vertical line.
+const TOP_PAD = 6; // breathing room above the score/name
 const PRIMARY = 30;
 const SECONDARY = 22;
-const ROW_H = PRIMARY + SECONDARY;
+const ROW_H = TOP_PAD + PRIMARY + SECONDARY;
 
 function RackRow({ slot, nameOf, colorOf }: { slot: RackSlot; nameOf: (id: string) => string; colorOf: (t: "A" | "B") => string }) {
   const aLead = slot.leader === "A";
@@ -192,7 +195,7 @@ function RackRow({ slot, nameOf, colorOf }: { slot: RackSlot; nameOf: (id: strin
     <div className="flex items-stretch" style={{ height: ROW_H }}>
       <ScoreBlock value={slot.a.value} thru={slot.a.thru} lead={aLead} color={colorOf("A")} />
       <NameBlock name={nameOf(slot.a.id)} align="right" lead={aLead} color={colorOf("A")} gapText={aLead ? `Up by ${gap}` : null} />
-      <div className="flex shrink-0 flex-col" style={{ width: 28, background: "var(--color-bt-card-raised)" }}>
+      <div className="flex shrink-0 flex-col" style={{ width: 28, paddingTop: TOP_PAD, background: "var(--color-bt-card-raised)" }}>
         <div className="flex items-center justify-center" style={{ height: PRIMARY }}>
           <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>vs</span>
         </div>
@@ -206,7 +209,7 @@ function RackRow({ slot, nameOf, colorOf }: { slot: RackSlot; nameOf: (id: strin
 
 function ScoreBlock({ value, thru, lead, color }: { value: number; thru: number; lead: boolean; color: string }) {
   return (
-    <div className="flex shrink-0 flex-col" style={{ width: 60, background: lead ? color : "transparent" }}>
+    <div className="flex shrink-0 flex-col" style={{ width: 60, paddingTop: TOP_PAD, background: lead ? color : "transparent" }}>
       <div className="flex items-center justify-center" style={{ height: PRIMARY }}>
         <span style={{ fontSize: 22, fontWeight: 800, color: lead ? "#fff" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
           {fmtToPar(value)}
@@ -224,7 +227,7 @@ function ScoreBlock({ value, thru, lead, color }: { value: number; thru: number;
 function NameBlock({ name, align, lead, color, gapText }: { name: string; align: "left" | "right"; lead: boolean; color: string; gapText: string | null }) {
   const justify = align === "right" ? "flex-end" : "flex-start";
   return (
-    <div className="flex min-w-0 flex-1 flex-col" style={{ padding: "0 10px", background: lead ? `${color}29` : "transparent" }}>
+    <div className="flex min-w-0 flex-1 flex-col" style={{ padding: `${TOP_PAD}px 10px 0`, background: lead ? `${color}29` : "transparent" }}>
       <div className="flex w-full items-center" style={{ height: PRIMARY, justifyContent: justify }}>
         <span className="max-w-full truncate" style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{name}</span>
       </div>

--- a/src/lib/rackNStack.test.ts
+++ b/src/lib/rackNStack.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  playerStats,
+  projectedNetToPar,
+  computeRack,
+  fmtToPar,
+  fmtPoints,
+  type RackPlayer,
+} from "./rackNStack";
+
+const PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4]; // 72
+const SEQ = Array.from({ length: 18 }, (_, i) => i + 1); // sequential index
+const COURSE_PAR = PAR.reduce((a, p) => a + p, 0);
+
+const holes = (vals: number[]): Record<string, number> =>
+  Object.fromEntries(vals.map((v, i) => [String(i + 1), v]));
+
+describe("playerStats", () => {
+  it("computes net-to-par / thru over played holes", () => {
+    // 3 holes: par 4,5,3; gross 4,5,3 → even, 0 handicap.
+    const s = playerStats(holes([4, 5, 3]), 0, PAR, SEQ);
+    expect(s).toMatchObject({ netToPar: 0, gross: 12, thru: 3, netStrokes: 12 });
+  });
+
+  it("applies a handicap stroke on the allocated holes", () => {
+    // 2 strokes → sequential index gives strokes on holes 1 & 2.
+    // gross 5,5 on par 4,5 → net 4,4 → net-to-par (4-4)+(4-5) = -1.
+    const s = playerStats(holes([5, 5]), 2, PAR, SEQ);
+    expect(s.netToPar).toBe(-1);
+    expect(s.netStrokes).toBe(8);
+    expect(s.gross).toBe(10);
+  });
+});
+
+describe("projectedNetToPar", () => {
+  it("is null below the thru threshold", () => {
+    expect(projectedNetToPar(12, 3, COURSE_PAR)).toBeNull();
+  });
+  it("pace-normalizes to 18 once thru ≥ 4", () => {
+    // even par through 4 (16 net on par-16 front) → projects to even (0).
+    const through4Par = PAR.slice(0, 4).reduce((a, p) => a + p, 0); // 16
+    expect(projectedNetToPar(through4Par, 4, COURSE_PAR)).toBeCloseTo(0, 5);
+  });
+});
+
+describe("computeRack — current mode", () => {
+  const mk = (id: string, team: "A" | "B", netToPar: number, thru: number, gross = 40): RackPlayer => ({
+    id,
+    team,
+    stats: { netToPar, netStrokes: gross, gross, thru },
+  });
+
+  it("pairs by rank and the lower net-to-par wins the slot", () => {
+    const r = computeRack(
+      [mk("a1", "A", -2, 9), mk("a2", "A", 3, 9), mk("b1", "B", 1, 9), mk("b2", "B", 5, 9)],
+      "current",
+      COURSE_PAR
+    );
+    expect(r.slots).toHaveLength(2);
+    // slot 1: A best (-2) vs B best (1) → A leads, gap 3
+    expect(r.slots[0]).toMatchObject({ slot: 1, leader: "A", gap: 3 });
+    // slot 2: A(3) vs B(5) → A leads
+    expect(r.slots[1].leader).toBe("A");
+    expect(r.points).toEqual({ A: 2, B: 0 });
+  });
+
+  it("halves a tied slot ½/½", () => {
+    const r = computeRack([mk("a", "A", 2, 9), mk("b", "B", 2, 9)], "current", COURSE_PAR);
+    expect(r.slots[0].leader).toBeNull();
+    expect(r.slots[0].gap).toBe(0);
+    expect(r.points).toEqual({ A: 0.5, B: 0.5 });
+  });
+
+  it("surpluses the larger team's bottom player (sit-out, no point)", () => {
+    const r = computeRack(
+      [mk("a1", "A", -1, 9), mk("a2", "A", 2, 9), mk("a3", "A", 6, 9), mk("b1", "B", 0, 9), mk("b2", "B", 4, 9)],
+      "current",
+      COURSE_PAR
+    );
+    expect(r.slots).toHaveLength(2);
+    expect(r.sitOut.map((p) => p.id)).toEqual(["a3"]); // worst A sits
+    expect(r.points).toEqual({ A: 2, B: 0 });
+  });
+
+  it("excludes not-started players (thru 0) until they post", () => {
+    const r = computeRack([mk("a", "A", 0, 0), mk("b", "B", 0, 5)], "current", COURSE_PAR);
+    expect(r.slots).toHaveLength(0); // A not started → no pair
+    expect(r.sitOut).toHaveLength(1); // B alone → surplus
+    expect(r.sitOut[0].id).toBe("b");
+  });
+});
+
+describe("computeRack — projected mode reorders by pace", () => {
+  it("ranks by projected net-to-par when thru ≥ threshold", () => {
+    // A1: +1 thru 9 → projects ~+2; A2: -1 thru 2 → projection null → falls back to current -1.
+    const players: RackPlayer[] = [
+      { id: "a1", team: "A", stats: { netToPar: 1, netStrokes: 37, gross: 37, thru: 9 } },
+      { id: "a2", team: "A", stats: { netToPar: -1, netStrokes: 8, gross: 8, thru: 2 } },
+      { id: "b1", team: "B", stats: { netToPar: 0, netStrokes: 36, gross: 36, thru: 9 } },
+      { id: "b2", team: "B", stats: { netToPar: 0, netStrokes: 36, gross: 36, thru: 9 } },
+    ];
+    const cur = computeRack(players, "current", COURSE_PAR);
+    // current: A sorted [-1 (a2), +1 (a1)]
+    expect(cur.slots[0].a.id).toBe("a2");
+    const proj = computeRack(players, "projected", COURSE_PAR);
+    // projected: a2 has no projection (thru 2 → fallback -1); a1 projects ~+2.
+    // a2's value (-1) < a1's (~+2) so a2 still first here — assert it's a valid permutation, no crash.
+    expect(proj.slots).toHaveLength(2);
+    expect(new Set([proj.slots[0].a.id, proj.slots[1].a.id])).toEqual(new Set(["a1", "a2"]));
+  });
+});
+
+describe("formatters", () => {
+  it("fmtToPar", () => {
+    expect(fmtToPar(0)).toBe("E");
+    expect(fmtToPar(3)).toBe("+3");
+    expect(fmtToPar(-2)).toBe("−2");
+    expect(fmtToPar(2.4)).toBe("+2"); // projected rounds
+  });
+  it("fmtPoints with halves", () => {
+    expect(fmtPoints(0)).toBe("0");
+    expect(fmtPoints(2)).toBe("2");
+    expect(fmtPoints(1.5)).toBe("1½");
+    expect(fmtPoints(0.5)).toBe("½");
+  });
+});

--- a/src/lib/rackNStack.ts
+++ b/src/lib/rackNStack.ts
@@ -1,0 +1,172 @@
+/**
+ * Rack-n-Stack scoring core (Slice C part 3) — PURE, client-safe.
+ *
+ * Net stroke play with a derived, rank-paired scoreboard: sort EACH team by
+ * net-to-par ascending, pair by rank (A[k] vs B[k]); each slot is a 1v1 where
+ * the lower net-to-par wins a point for their team (a tie halves ½/½). The unit
+ * you SCORE in (the foursome) ≠ the unit the board DISPLAYS (the rank slot) —
+ * this module only computes the display/standings read-model; entry is ordinary
+ * stroke play. Same shared module feeds the live client board and the server
+ * finish so they can't diverge (CLAUDE.md pattern #8).
+ *
+ * Net per hole uses the GolfCard contract: gross − (stroke received on that hole
+ * via `strokeHoles`), then minus par for net-to-par. `strokeHoles` is reused
+ * unchanged.
+ */
+
+import { strokeHoles } from "./matchPlay";
+
+/** Projection is unstable on a handful of holes — suppress it below this thru. */
+export const MIN_PROJECT_THRU = 4;
+
+export type RackMode = "current" | "projected";
+export type Team = "A" | "B";
+
+export interface RackStats {
+  /** Net strokes − par, summed over holes played. */
+  netToPar: number;
+  /** Net strokes (gross − handicap allocation), summed over holes played. */
+  netStrokes: number;
+  /** Gross strokes summed over holes played (tie-break). */
+  gross: number;
+  /** Holes with a posted score. */
+  thru: number;
+}
+
+/** Per-player net-to-par / thru over the holes they've actually scored. */
+export function playerStats(
+  grossByHole: Record<string, number | null | undefined>,
+  handicapStrokes: number,
+  par: number[],
+  strokeIndex: number[]
+): RackStats {
+  const received = strokeHoles(handicapStrokes, strokeIndex);
+  let netToPar = 0;
+  let netStrokes = 0;
+  let gross = 0;
+  let thru = 0;
+  for (let h = 1; h <= par.length; h++) {
+    const g = grossByHole[String(h)];
+    if (g == null) continue;
+    const net = g - (received.has(h) ? 1 : 0);
+    netToPar += net - par[h - 1];
+    netStrokes += net;
+    gross += g;
+    thru += 1;
+  }
+  return { netToPar, netStrokes, gross, thru };
+}
+
+/** Pace-normalized net-to-par: (net ÷ holes) × 18 − course par. null below the
+ *  thru threshold (division too unstable to show) or when nothing's played. */
+export function projectedNetToPar(netStrokes: number, thru: number, coursePar: number): number | null {
+  if (thru < MIN_PROJECT_THRU || thru === 0) return null;
+  return (netStrokes / thru) * 18 - coursePar;
+}
+
+export interface RackPlayer {
+  id: string;
+  team: Team;
+  stats: RackStats;
+}
+
+export interface RackSlotPlayer {
+  id: string;
+  team: Team;
+  /** The net-to-par shown in the active mode (current, or projected when set). */
+  value: number;
+  netToPar: number;
+  projected: number | null;
+  thru: number;
+}
+
+export interface RackSlot {
+  slot: number; // 1-based rank
+  a: RackSlotPlayer;
+  b: RackSlotPlayer;
+  /** Slot winner by the active mode's value; null = tie (halve). */
+  leader: Team | null;
+  /** Net gap between the two values (≥0); the board renders "Up by {gap}". */
+  gap: number;
+}
+
+export interface RackResult {
+  slots: RackSlot[];
+  /** Surplus bottom players on the larger team — no slot, no point. */
+  sitOut: RackSlotPlayer[];
+  /** Team points from slot wins (halves = ½), in the active mode. */
+  points: { A: number; B: number };
+}
+
+/** The net-to-par a slot pairs/leads on in `mode`: projected when available, else current. */
+function valueOf(p: RackPlayer, mode: RackMode, coursePar: number): number {
+  const proj = projectedNetToPar(p.stats.netStrokes, p.stats.thru, coursePar);
+  return mode === "projected" && proj != null ? proj : p.stats.netToPar;
+}
+
+function toSlotPlayer(p: RackPlayer, mode: RackMode, coursePar: number): RackSlotPlayer {
+  return {
+    id: p.id,
+    team: p.team,
+    value: valueOf(p, mode, coursePar),
+    netToPar: p.stats.netToPar,
+    projected: projectedNetToPar(p.stats.netStrokes, p.stats.thru, coursePar),
+    thru: p.stats.thru,
+  };
+}
+
+/**
+ * Build the rack: exclude not-started players (thru 0), sort each team by the
+ * active value (then net-to-par, gross, id — deterministic so the board doesn't
+ * flicker), pair by rank, resolve slots, and surplus the larger team's bottom.
+ */
+export function computeRack(players: RackPlayer[], mode: RackMode, coursePar: number): RackResult {
+  const started = players.filter((p) => p.stats.thru > 0);
+  const key = (p: RackPlayer): [number, number, number] => [
+    valueOf(p, mode, coursePar),
+    p.stats.netToPar,
+    p.stats.gross,
+  ];
+  const cmp = (x: RackPlayer, y: RackPlayer) => {
+    const kx = key(x);
+    const ky = key(y);
+    for (let i = 0; i < kx.length; i++) if (kx[i] !== ky[i]) return kx[i] - ky[i];
+    return x.id < y.id ? -1 : x.id > y.id ? 1 : 0;
+  };
+  const A = started.filter((p) => p.team === "A").sort(cmp);
+  const B = started.filter((p) => p.team === "B").sort(cmp);
+  const n = Math.min(A.length, B.length);
+
+  const slots: RackSlot[] = [];
+  let pa = 0;
+  let pb = 0;
+  for (let k = 0; k < n; k++) {
+    const sa = toSlotPlayer(A[k], mode, coursePar);
+    const sb = toSlotPlayer(B[k], mode, coursePar);
+    const leader: Team | null = sa.value < sb.value ? "A" : sa.value > sb.value ? "B" : null;
+    if (leader === "A") pa += 1;
+    else if (leader === "B") pb += 1;
+    else {
+      pa += 0.5;
+      pb += 0.5;
+    }
+    slots.push({ slot: k + 1, a: sa, b: sb, leader, gap: Math.abs(sa.value - sb.value) });
+  }
+  const surplus = (A.length > B.length ? A.slice(n) : B.slice(n)).map((p) => toSlotPlayer(p, mode, coursePar));
+  return { slots, sitOut: surplus, points: { A: pa, B: pb } };
+}
+
+/** Format a net-to-par for display: "E" / "+n" / "−n" (rounds projected). */
+export function fmtToPar(value: number): string {
+  const r = Math.round(value);
+  if (r === 0) return "E";
+  return r > 0 ? `+${r}` : `−${Math.abs(r)}`;
+}
+
+/** Format a team point total with a ½ glyph (1.5 → "1½"). */
+export function fmtPoints(p: number): string {
+  const whole = Math.floor(p);
+  const half = p - whole >= 0.5;
+  if (half) return whole === 0 ? "½" : `${whole}½`;
+  return String(whole);
+}

--- a/src/server/lib/rackNStack.ts
+++ b/src/server/lib/rackNStack.ts
@@ -1,0 +1,118 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { playerStats, computeRack, type RackPlayer, type Team } from "@/lib/rackNStack";
+
+/**
+ * DB-persist side of rack-n-stack. Builds the SAME read-model the live client
+ * board uses (shared `computeRack` — CLAUDE.md #8): net-to-par per player from
+ * `score_entries` + `handicap_strokes` + the game's par/index, grouped by the
+ * competition's two teams (via `team_assignments`), sorted and rank-paired. The
+ * outcome is TEAM points (slot wins; halves = ½) distilled to `game_results`
+ * (`entity_type='team'`). Slots are NOT persisted (derived read-model only).
+ *
+ * `competition_points_earned` stays null — Slice D maps team points to
+ * competition points. Computed in 'current' mode (the canonical result; both
+ * display modes converge at 18 holes).
+ */
+
+export interface RackTeamOutcome {
+  teamId: string;
+  points: number;
+  position: number;
+}
+
+interface SchemaShape {
+  units?: { metadata?: { par?: number[]; handicap_index?: number[] } };
+}
+
+export async function computeRackNStackResults(
+  supabase: SupabaseClient,
+  gameId: string
+): Promise<RackTeamOutcome[]> {
+  const { data: game } = await supabase
+    .from("games")
+    .select("scorecard_schema, game_type_id, competition_id")
+    .eq("id", gameId)
+    .maybeSingle();
+  if (!game?.competition_id) return []; // rack needs a competition (2 teams)
+
+  // Effective par/index: the game's course snapshot, else its template default.
+  let schema = game.scorecard_schema as SchemaShape | null;
+  if (!schema?.units?.metadata?.par && game.game_type_id) {
+    const { data: tmpl } = await supabase
+      .from("game_type_templates")
+      .select("scorecard_schema")
+      .eq("id", game.game_type_id as string)
+      .maybeSingle();
+    schema = (tmpl?.scorecard_schema as SchemaShape | null) ?? null;
+  }
+  const par = schema?.units?.metadata?.par;
+  const strokeIndex = schema?.units?.metadata?.handicap_index;
+  if (!par || !strokeIndex) return [];
+  const coursePar = par.reduce((a, p) => a + p, 0);
+
+  // user_id → team_id, for this game's competition (the two teams).
+  const { data: assigns } = await supabase
+    .from("team_assignments")
+    .select("user_id, team_id")
+    .eq("competition_id", game.competition_id as string);
+  const teamOf = new Map<string, string>();
+  for (const a of assigns ?? []) teamOf.set(a.user_id as string, a.team_id as string);
+  const teamIds = [...new Set([...teamOf.values()])].sort(); // deterministic A/B
+  if (teamIds.length < 2) return []; // need exactly the two competing teams
+  const slot: Record<string, Team> = { [teamIds[0]]: "A", [teamIds[1]]: "B" };
+
+  const { data: parts } = await supabase
+    .from("game_participants")
+    .select("user_id, handicap_strokes")
+    .eq("game_id", gameId);
+  const hcap = new Map<string, number>();
+  for (const p of parts ?? []) hcap.set(p.user_id as string, (p.handicap_strokes as number | null) ?? 0);
+
+  const { data: entries } = await supabase
+    .from("score_entries")
+    .select("participant_id, unit_label, value")
+    .eq("game_id", gameId)
+    .eq("participant_type", "user");
+  const gross = new Map<string, Record<string, number>>();
+  for (const e of entries ?? []) {
+    if (e.value == null) continue;
+    const pid = e.participant_id as string;
+    if (!gross.has(pid)) gross.set(pid, {});
+    gross.get(pid)![e.unit_label as string] = e.value as number;
+  }
+
+  const players: RackPlayer[] = [];
+  for (const p of parts ?? []) {
+    const uid = p.user_id as string;
+    const teamId = teamOf.get(uid);
+    if (!teamId || !(teamId in slot)) continue; // only the two competing teams
+    players.push({
+      id: uid,
+      team: slot[teamId],
+      stats: playerStats(gross.get(uid) ?? {}, hcap.get(uid) ?? 0, par, strokeIndex),
+    });
+  }
+
+  const { points } = computeRack(players, "current", coursePar);
+  const teamPoints: Record<string, number> = { [teamIds[0]]: points.A, [teamIds[1]]: points.B };
+
+  // position: higher points lead (ties share 1).
+  const ranked = teamIds.slice().sort((x, y) => teamPoints[y] - teamPoints[x]);
+  const position = (id: string) =>
+    teamPoints[id] === teamPoints[ranked[0]] ? 1 : 2;
+
+  await supabase.from("game_results").delete().eq("game_id", gameId);
+  const rows = teamIds.map((teamId) => ({
+    id: crypto.randomUUID(),
+    game_id: gameId,
+    entity_id: teamId,
+    entity_type: "team" as const,
+    raw_score: null,
+    points: teamPoints[teamId],
+    position: position(teamId),
+    competition_points_earned: null,
+  }));
+  if (rows.length > 0) await supabase.from("game_results").insert(rows);
+
+  return teamIds.map((teamId) => ({ teamId, points: teamPoints[teamId], position: position(teamId) }));
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -23,6 +23,7 @@ import { newsRouter } from "./routers/news";
 import { gamesRouter } from "./routers/games";
 import { scoresRouter } from "./routers/scores";
 import { matchesRouter } from "./routers/matches";
+import { playGroupsRouter } from "./routers/playGroups";
 
 export const appRouter = router({
   users: usersRouter,
@@ -49,6 +50,7 @@ export const appRouter = router({
   games: gamesRouter,
   scores: scoresRouter,
   matches: matchesRouter,
+  playGroups: playGroupsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -4,6 +4,7 @@ import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
 import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
+import { computeRackNStackResults } from "../lib/rackNStack";
 import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema } from "@/lib/courseIndex";
 
 /**
@@ -24,6 +25,7 @@ export const gamesRouter = router({
         gameTypeId: z.string(),
         name: z.string().max(200).optional(),
         teeTime: z.string().max(5).nullable().optional(), // "HH:MM" 24h
+        competitionId: z.string().nullable().optional(), // team formats (rack-n-stack)
       })
     )
     .use(requireTripRole("Organizer"))
@@ -34,7 +36,7 @@ export const gamesRouter = router({
       const { error: insertErr } = await ctx.supabase.from("games").insert({
         id,
         trip_id: ctx.tripId,
-        competition_id: null,
+        competition_id: input.competitionId ?? null,
         game_type_id: input.gameTypeId,
         name: input.name ?? null,
         tee_time: input.teeTime ?? null,
@@ -263,9 +265,14 @@ export const gamesRouter = router({
         .maybeSingle();
       const strategy = (template?.result_strategy as string | null) ?? "stroke_total";
 
-      const isMatchPlay = strategy === "match_play";
-      const matches = isMatchPlay ? await computeMatchPlayResults(ctx.supabase, input.gameId) : [];
-      const standings = isMatchPlay ? [] : await computeStrokePlayResults(ctx.supabase, input.gameId);
+      // Data-driven branch on the template's result_strategy (CLAUDE.md #8) —
+      // new strategies slot in here without touching the rest of finish.
+      const matches = strategy === "match_play" ? await computeMatchPlayResults(ctx.supabase, input.gameId) : [];
+      const teams = strategy === "rack_n_stack" ? await computeRackNStackResults(ctx.supabase, input.gameId) : [];
+      const standings =
+        strategy === "match_play" || strategy === "rack_n_stack"
+          ? []
+          : await computeStrokePlayResults(ctx.supabase, input.gameId);
 
       const { error } = await ctx.supabase
         .from("games")
@@ -277,6 +284,6 @@ export const gamesRouter = router({
           message: `Failed to finish game: ${error.message}`,
         });
       }
-      return { standings, matches };
+      return { standings, matches, teams };
     }),
 });

--- a/src/server/routers/playGroups.ts
+++ b/src/server/routers/playGroups.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, authedProcedure } from "../trpc";
+import { requireTripMember, requireTripRole } from "../middleware";
+
+/**
+ * playGroups — foursomes for a game (the scoring-side use of `play_groups`,
+ * Slice C rack-n-stack). A foursome is a mixed-team group of ~4 that walks
+ * together and shares one stroke-play card; `game_participants.play_group_id`
+ * links each player to theirs. Setting foursomes also seeds the roster (the
+ * union of the grouped players). Handicaps are per-participant (net play).
+ *
+ * Rack-n-stack slots are NOT here — they're a derived read-model computed live
+ * over score_entries; only the foursomes (entry units) persist.
+ */
+export const playGroupsRouter = router({
+  // setFoursomes — Owner/Organizer. Replaces the game's foursomes + roster.
+  setFoursomes: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        groups: z
+          .array(z.object({ name: z.string().max(60).optional(), userIds: z.array(z.string().min(1)).min(1).max(6) }))
+          .max(12),
+      })
+    )
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+
+      // Roster = the union of grouped players. Idempotent re-adds (UNIQUE).
+      const allIds = [...new Set(input.groups.flatMap((g) => g.userIds))];
+      if (allIds.length > 0) {
+        const rows = allIds.map((userId) => ({
+          id: crypto.randomUUID(),
+          game_id: input.gameId,
+          user_id: userId,
+          play_group_id: null,
+          team_id: null,
+        }));
+        const { error: pErr } = await ctx.supabase
+          .from("game_participants")
+          .upsert(rows, { onConflict: "game_id,user_id", ignoreDuplicates: true });
+        if (pErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to add players: ${pErr.message}` });
+      }
+
+      // Rebuild play_groups (SET NULL clears participants' play_group_id first).
+      await ctx.supabase.from("play_groups").delete().eq("game_id", input.gameId);
+
+      for (let i = 0; i < input.groups.length; i++) {
+        const g = input.groups[i];
+        const groupId = crypto.randomUUID();
+        const { error: gErr } = await ctx.supabase
+          .from("play_groups")
+          .insert({ id: groupId, game_id: input.gameId, display_name: g.name ?? `Group ${i + 1}` });
+        if (gErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to create group: ${gErr.message}` });
+        const { error: aErr } = await ctx.supabase
+          .from("game_participants")
+          .update({ play_group_id: groupId })
+          .eq("game_id", input.gameId)
+          .in("user_id", g.userIds);
+        if (aErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to assign group: ${aErr.message}` });
+      }
+
+      return await readGroups(ctx.supabase, input.gameId);
+    }),
+
+  // setHandicap — Owner/Organizer. Net strokes for one participant (null = 0).
+  setHandicap: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), userId: z.string().min(1), strokes: z.number().int().min(0).max(54) }))
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from("game_participants")
+        .update({ handicap_strokes: input.strokes })
+        .eq("game_id", input.gameId)
+        .eq("user_id", input.userId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set handicap: ${error.message}` });
+      return { ok: true };
+    }),
+
+  // listByGame — any trip member. Foursomes + each participant's group/handicap.
+  listByGame: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx, input }) => readGroups(ctx.supabase, input.gameId)),
+});
+
+async function readGroups(supabase: import("@supabase/supabase-js").SupabaseClient, gameId: string) {
+  const { data: groups } = await supabase
+    .from("play_groups")
+    .select("id, display_name, created_at")
+    .eq("game_id", gameId)
+    .order("created_at", { ascending: true });
+  const { data: participants } = await supabase
+    .from("game_participants")
+    .select("user_id, play_group_id, handicap_strokes")
+    .eq("game_id", gameId);
+  return { groups: groups ?? [], participants: participants ?? [] };
+}

--- a/src/server/routers/playGroups.ts
+++ b/src/server/routers/playGroups.ts
@@ -21,7 +21,13 @@ export const playGroupsRouter = router({
         tripId: z.string(),
         gameId: z.string(),
         groups: z
-          .array(z.object({ name: z.string().max(60).optional(), userIds: z.array(z.string().min(1)).min(1).max(6) }))
+          .array(
+            z.object({
+              name: z.string().max(60).optional(),
+              teeTime: z.string().max(5).nullable().optional(), // "HH:MM" 24h
+              userIds: z.array(z.string().min(1)).min(1).max(6),
+            })
+          )
           .max(12),
       })
     )
@@ -59,7 +65,7 @@ export const playGroupsRouter = router({
         const groupId = crypto.randomUUID();
         const { error: gErr } = await ctx.supabase
           .from("play_groups")
-          .insert({ id: groupId, game_id: input.gameId, display_name: g.name ?? `Group ${i + 1}` });
+          .insert({ id: groupId, game_id: input.gameId, display_name: g.name ?? `Group ${i + 1}`, tee_time: g.teeTime ?? null });
         if (gErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to create group: ${gErr.message}` });
         const { error: aErr } = await ctx.supabase
           .from("game_participants")
@@ -96,7 +102,7 @@ export const playGroupsRouter = router({
 async function readGroups(supabase: import("@supabase/supabase-js").SupabaseClient, gameId: string) {
   const { data: groups } = await supabase
     .from("play_groups")
-    .select("id, display_name, created_at")
+    .select("id, display_name, tee_time, created_at")
     .eq("game_id", gameId)
     .order("created_at", { ascending: true });
   const { data: participants } = await supabase

--- a/src/server/routers/rackNStack.test.ts
+++ b/src/server/routers/rackNStack.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+const RACK = "gtt_rack_n_stack";
+const PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4]; // front 9; net par over 9 = 36
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string, teamB: string;
+let owner: string, planner: string, member: string, outsider: string;
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Rack Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer");
+  await ctx.addTripMember(tripId, "member", "Member");
+  await ctx.addTripMember(tripId, "outsider", "Member");
+  owner = ctx.user.id;
+  planner = ctx.getUser("planner").id;
+  member = ctx.getUser("member").id;
+  outsider = ctx.getUser("outsider").id;
+
+  competitionId = await ctx.createCompetition(tripId, "Rack Cup");
+  teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU", color: "#3b82f6" });
+  teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED", color: "#ef4444" });
+  // owner+planner → Blue; member+outsider → Red.
+  await ctx.admin.from("team_assignments").insert([
+    { competition_id: competitionId, user_id: owner, team_id: teamA },
+    { competition_id: competitionId, user_id: planner, team_id: teamA },
+    { competition_id: competitionId, user_id: member, team_id: teamB },
+    { competition_id: competitionId, user_id: outsider, team_id: teamB },
+  ]);
+});
+
+afterAll(async () => {
+  await ctx.cleanup();
+});
+
+async function enter(gameId: string, userId: string, gross: number[]) {
+  for (let i = 0; i < gross.length; i++) {
+    await ctx.callerAs("planner").scores.upsertEntry({
+      tripId,
+      gameId,
+      participantId: userId,
+      unitLabel: String(i + 1),
+      value: gross[i],
+    });
+  }
+}
+
+describe("rack-n-stack — finish distills team points to game_results", () => {
+  it("Blue (all pars) beats Red (all bogeys) 2–0 over two slots", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "Day 1", competitionId });
+    const gameId = game.id as string;
+
+    // Two foursomes (mixed) — grouping is entry-only; slots derive from teams.
+    await ctx.callerAs("planner").playGroups.setFoursomes({
+      tripId,
+      gameId,
+      groups: [
+        { name: "Group 1", userIds: [owner, member] },
+        { name: "Group 2", userIds: [planner, outsider] },
+      ],
+    });
+
+    // Blue plays pars (net-to-par 0); Red plays bogeys (+9 thru 9). Handicap 0.
+    await enter(gameId, owner, PAR);
+    await enter(gameId, planner, PAR);
+    await enter(gameId, member, PAR.map((p) => p + 1));
+    await enter(gameId, outsider, PAR.map((p) => p + 1));
+
+    const res = await ctx.caller().games.finish({ tripId, gameId });
+    const teams = res.teams as { teamId: string; points: number; position: number }[];
+    const blue = teams.find((t) => t.teamId === teamA)!;
+    const red = teams.find((t) => t.teamId === teamB)!;
+    expect(blue.points).toBe(2);
+    expect(red.points).toBe(0);
+    expect(blue.position).toBe(1);
+    expect(red.position).toBe(2);
+
+    // Persisted as team rows with the numeric points column.
+    const { data: rows } = await ctx.admin
+      .from("game_results")
+      .select("entity_id, entity_type, points")
+      .eq("game_id", gameId);
+    expect(rows).toHaveLength(2);
+    expect(rows!.every((r) => r.entity_type === "team")).toBe(true);
+    expect(rows!.find((r) => r.entity_id === teamA)!.points).toBe(2);
+  });
+
+  it("a tied slot halves ½/½", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "Day 2", competitionId });
+    const gameId = game.id as string;
+    await ctx.callerAs("planner").playGroups.setFoursomes({
+      tripId,
+      gameId,
+      groups: [{ name: "G", userIds: [owner, member] }],
+    });
+    // One vs one, identical scores → halve.
+    await enter(gameId, owner, PAR);
+    await enter(gameId, member, PAR);
+    const res = await ctx.caller().games.finish({ tripId, gameId });
+    const teams = res.teams as { teamId: string; points: number }[];
+    expect(teams.find((t) => t.teamId === teamA)!.points).toBe(0.5);
+    expect(teams.find((t) => t.teamId === teamB)!.points).toBe(0.5);
+  });
+});

--- a/supabase/migrations/20260610150000_041_rack_n_stack.sql
+++ b/supabase/migrations/20260610150000_041_rack_n_stack.sql
@@ -1,0 +1,65 @@
+-- 041 — Rack-n-Stack template + game_results.points (Slice C part 3)
+--
+-- Rack-n-stack is net stroke play with a rank-paired scoreboard, run inside a
+-- 2-team competition. Entry is ordinary per-user per-hole stroke play
+-- (entry_schema='user_holes'); the novelty is the standings, computed as a
+-- derived read-model (NOT persisted pairings). games.finish branches on
+-- result_strategy='rack_n_stack'. Idempotent.
+
+-- Team points can be fractional (a tied slot halves ½/½), which raw_score (int)
+-- can't hold. Add a nullable numeric `points` for the team tally; raw_score
+-- stays the gross integer for stroke play, competition_points_earned stays for
+-- the Slice D competition mapping.
+ALTER TABLE public.game_results ADD COLUMN IF NOT EXISTS points numeric;
+
+INSERT INTO public.game_type_templates (
+  id, key, name, description, sort_order,
+  entry_schema, result_strategy,
+  supports_free_for_all, supports_sides, requires_sides, max_players_per_side,
+  compatible_competition_formats, compatible_modifiers,
+  config_schema, scorecard_schema
+)
+VALUES (
+  'gtt_rack_n_stack', 'rack_n_stack', 'Rack-n-Stack',
+  'Net stroke play scored as a rank-paired team board: each team is sorted by net-to-par and paired by rank; the lower net wins each slot (a tie halves).', 2,
+  'user_holes', 'rack_n_stack',
+  false, true, true, NULL,
+  ARRAY['ryder_cup']::text[], ARRAY[]::text[],
+  '{}'::jsonb,
+  '{
+    "units": {
+      "type": "holes", "count": 18, "ordered": true,
+      "labels": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18"],
+      "metadata": {
+        "par": [4,5,3,4,4,3,5,4,4,4,3,5,4,4,3,4,5,4],
+        "handicap_index": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
+      }
+    },
+    "entry": { "value_type": "integer", "value_label": "Strokes", "min": 1, "max": null },
+    "scoring": {
+      "strategy": "rack_n_stack", "direction": "low_wins", "aggregation": "net_to_par",
+      "sections": [
+        { "name": "Front 9", "units": ["1","2","3","4","5","6","7","8","9"] },
+        { "name": "Back 9", "units": ["10","11","12","13","14","15","16","17","18"] }
+      ],
+      "tiebreaker": "shared"
+    },
+    "participants": { "min": 2, "max": null, "participant_type": "individual", "assigned_pairings": false },
+    "interaction": { "model": "simultaneous", "entry_timing": "per_unit" }
+  }'::jsonb
+)
+ON CONFLICT (id) DO UPDATE SET
+  key = EXCLUDED.key,
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  sort_order = EXCLUDED.sort_order,
+  entry_schema = EXCLUDED.entry_schema,
+  result_strategy = EXCLUDED.result_strategy,
+  supports_free_for_all = EXCLUDED.supports_free_for_all,
+  supports_sides = EXCLUDED.supports_sides,
+  requires_sides = EXCLUDED.requires_sides,
+  max_players_per_side = EXCLUDED.max_players_per_side,
+  compatible_competition_formats = EXCLUDED.compatible_competition_formats,
+  compatible_modifiers = EXCLUDED.compatible_modifiers,
+  config_schema = EXCLUDED.config_schema,
+  scorecard_schema = EXCLUDED.scorecard_schema;

--- a/supabase/migrations/20260610160000_042_play_groups_tee_time.sql
+++ b/supabase/migrations/20260610160000_042_play_groups_tee_time.sql
@@ -1,0 +1,7 @@
+-- 042 — play_groups.tee_time (Slice C part 3, rack-n-stack groups)
+--
+-- Foursomes go off in waves; each group has its own tee time shown in the Groups
+-- entry meta ("7:40 tee · thru N"). Stored as "HH:MM" 24h text (formatted
+-- client-side), nullable. Idempotent.
+
+ALTER TABLE public.play_groups ADD COLUMN IF NOT EXISTS tee_time text;


### PR DESCRIPTION
Rack-n-Stack — net stroke play with a derived, rank-paired team scoreboard, run inside a 2-team competition. The scoring input is ordinary stroke play (per foursome); the novelty is the standings: sort each team by net-to-par, pair by rank (A[k] vs B[k]), lower net wins the slot for their team (tie halves ½).

Built in stages on this branch: **(1) scoring core + finish** is in; the rack screen UI (header → Groups entry → Projected toggle → rack rows → sit-out) follows.

## Stage 1 — scoring core + persistence
- **`src/lib/rackNStack.ts`** (pure): `playerStats` (net-to-par/thru via the GolfCard contract + `strokeHoles`), `projectedNetToPar` (pace-normalized, suppressed < thru 4), `computeRack` (sort by net-to-par → pair by rank → lower wins / tie halves / surplus sits out / thru-0 excluded; current + projected modes), `fmtToPar`/`fmtPoints`. 11 tests.
- **Migration 041**: `rack_n_stack` template (`result_strategy`, `requires_sides`) + `game_results.points numeric` (team tallies carry ½; `raw_score` int can't).
- **`computeRackNStackResults`** (server): the same shared `computeRack` over `score_entries` + `handicap_strokes` + `team_assignments`; writes team rows (`entity_type='team'`, points incl ½). **Slots are not persisted** (derived read-model). `finish` branches on `result_strategy` (data-driven). `competition_points_earned` stays null (Slice D maps).
- **`playGroups` router** (foursomes + roster + handicap); `games.create` gains optional `competitionId`. **`strokeHoles` unchanged.**
- 2 server tests vs the live DB (2–0 sweep; tied slot halves).

## Coming on this branch
The rack page: `RsDayScore` header (matches won, ½), `FoursomeEntry` (Groups · tap to enter → scorecard), `RsToggle` (Current/Projected), `RackRow` (net-to-par + THRU on outer edges, names flank a permanent `vs`, leader fill + "Up by N"), carded + stacked variants, "Not part of scoring" sit-out, and a "needs a competition" empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)