### PR TITLE
feat(engine): Handicap assignment (Mode A) + effectiveStrokes read path (Slice C)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -16,6 +16,7 @@ import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf } from "@/lib/strokePlayConfig";
+import { effectiveStrokes } from "@/lib/handicap";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
 /** "07:40" → "7:40 AM". Empty/invalid → "". */
@@ -144,7 +145,7 @@ export default function NewMatchGamePage() {
 
   const handicapOf = useMemo(() => {
     const m = new Map<string, number>();
-    for (const p of serverParticipants) m.set(p.user_id as string, (p.handicap_strokes as number | null) ?? 0);
+    for (const p of serverParticipants) m.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
     return m;
   }, [serverParticipants]);
 

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -14,6 +14,7 @@ import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/Ra
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
 import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/rackNStack";
 import { unitsFromSchema, strokeIndexOf, initialsOf } from "@/lib/strokePlayConfig";
+import { effectiveStrokes } from "@/lib/handicap";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -142,7 +143,7 @@ export default function RackNStackPage() {
   const participants = useMemo(() => groupsQ.data?.participants ?? [], [groupsQ.data]);
   const handicapOf = useMemo(() => {
     const m = new Map<string, number>();
-    for (const p of participants) m.set(p.user_id as string, (p.handicap_strokes as number | null) ?? 0);
+    for (const p of participants) m.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
     return m;
   }, [participants]);
 

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -60,6 +60,15 @@ export default function RackNStackPage() {
   const utils = trpc.useUtils();
 
   const [gameId, setGameId] = useState<string | null>(search.get("game"));
+  // Resume the trip's latest in-progress rack game so returning here (no nav
+  // entry yet) lands on the SAME game instead of starting a fresh one — which
+  // would look like the handicaps/scores were lost.
+  const gamesList = trpc.games.listByTrip.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const resumeId = useMemo(() => {
+    const g = (gamesList.data ?? []).find((x) => x.game_type_id === RACK && x.status !== "complete");
+    return (g?.id as string | undefined) ?? null;
+  }, [gamesList.data]);
+  const gid = gameId ?? resumeId;
   const [mode, setMode] = useState<RackMode>("current");
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
   const [pendingCourse, setPendingCourse] = useState<{ id: string; name: string } | null>(null);
@@ -75,9 +84,9 @@ export default function RackNStackPage() {
   const teamsQ = trpc.teams.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { enabled: !!tripId && !!competitionId });
   const assignQ = trpc.teamAssignments.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { enabled: !!tripId && !!competitionId });
 
-  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
-  const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
-  const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
+  const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
+  const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
@@ -222,15 +231,15 @@ export default function RackNStackPage() {
 
   const onSetStrokes = (userId: string, strokes: number) =>
     setStrokes
-      .mutateAsync({ tripId: tripId!, gameId: gameId!, userId, strokes })
-      .then(() => utils.playGroups.listByGame.invalidate({ tripId: tripId!, gameId: gameId! }));
+      .mutateAsync({ tripId: tripId!, gameId: gid!, userId, strokes })
+      .then(() => utils.playGroups.listByGame.invalidate({ tripId: tripId!, gameId: gid! }));
 
   const handleChange = (pid: string, unit: string, value: number) => {
     setValues((v) => ({ ...v, [pid]: { ...(v[pid] ?? {}), [unit]: value } }));
-    if (!tripId || !gameId) return;
+    if (!tripId || !gid) return;
     upsertEntry.mutate(
-      { tripId, gameId, participantId: pid, unitLabel: unit, value },
-      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId }) }
+      { tripId, gameId: gid, participantId: pid, unitLabel: unit, value },
+      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId: gid }) }
     );
   };
   const handleClear = (pid: string, unit: string) => {
@@ -239,17 +248,17 @@ export default function RackNStackPage() {
       delete next[unit];
       return { ...v, [pid]: next };
     });
-    if (!tripId || !gameId) return;
+    if (!tripId || !gid) return;
     deleteEntry.mutate(
-      { tripId, gameId, participantId: pid, unitLabel: unit },
-      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId }) }
+      { tripId, gameId: gid, participantId: pid, unitLabel: unit },
+      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId: gid }) }
     );
   };
 
   async function finish() {
-    if (!tripId || !gameId) return;
-    await finishGame.mutateAsync({ tripId, gameId });
-    await utils.games.getById.invalidate({ tripId, gameId });
+    if (!tripId || !gid) return;
+    await finishGame.mutateAsync({ tripId, gameId: gid });
+    await utils.games.getById.invalidate({ tripId, gameId: gid });
   }
 
   // ── Render ───────────────────────────────────────────────────────────
@@ -274,7 +283,7 @@ export default function RackNStackPage() {
   }
 
   // Entry: the tapped foursome's stroke-play card.
-  if (entryGroupId && gameId) {
+  if (entryGroupId && gid) {
     const members = participants.filter((p) => p.play_group_id === entryGroupId);
     const groupName = (groupsQ.data?.groups ?? []).find((g) => g.id === entryGroupId)?.display_name as string | undefined;
     const ps: Participant[] = members.map((p) => {
@@ -303,7 +312,7 @@ export default function RackNStackPage() {
 
   // Handicaps setup step (after pairings; before play). Reached only via the
   // canEdit-gated start/edit affordances; the mutation is server-canEdit-gated.
-  if (showHandicaps && gameId) {
+  if (showHandicaps && gid) {
     return (
       <div className="flex flex-col" style={{ height: "100vh" }}>
         <HandicapRoster
@@ -319,7 +328,7 @@ export default function RackNStackPage() {
   }
 
   // No game yet → setup.
-  if (!gameId) {
+  if (!gid) {
     return (
       <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
         <div className="w-full px-4 py-5">

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -12,6 +12,7 @@ import { parseTime, toTime24 } from "@/lib/time";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
+import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
 import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/rackNStack";
 import { unitsFromSchema, strokeIndexOf, initialsOf } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
@@ -64,6 +65,7 @@ export default function RackNStackPage() {
   const [pendingCourse, setPendingCourse] = useState<{ id: string; name: string } | null>(null);
   const [firstTee, setFirstTee] = useState(""); // "HH:MM" 24h; groups stagger +10
   const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
+  const [showHandicaps, setShowHandicaps] = useState(false);
   const [currentHole, setCurrentHole] = useState(1);
   const [values, setValues] = useState<ScoreValues>({});
 
@@ -80,6 +82,7 @@ export default function RackNStackPage() {
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
   const setFoursomes = trpc.playGroups.setFoursomes.useMutation();
+  const setStrokes = trpc.playGroups.setParticipantStrokes.useMutation();
   const upsertEntry = trpc.scores.upsertEntry.useMutation();
   const deleteEntry = trpc.scores.deleteEntry.useMutation();
   const finishGame = trpc.games.finish.useMutation();
@@ -178,6 +181,22 @@ export default function RackNStackPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [groupsQ.data, participants, scUnits, scIndex, nameOf, me, loadedValues, values, teamOf, teamMeta]);
 
+  const handicapPlayers: HandicapPlayer[] = useMemo(
+    () =>
+      participants.map((p) => {
+        const id = p.user_id as string;
+        return {
+          id,
+          name: nameOf.get(id) ?? "Player",
+          avatarIcon: avatarOf.get(id) ?? null,
+          teamColor: teamOf.get(id) ? colorForUser(id) : null,
+          strokes: handicapOf.get(id) ?? 0,
+        };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [participants, nameOf, avatarOf, teamOf, teamMeta, handicapOf]
+  );
+
   // ── Handlers ─────────────────────────────────────────────────────────
   async function startRack() {
     if (!tripId || !competitionId) return;
@@ -198,7 +217,13 @@ export default function RackNStackPage() {
     }));
     await setFoursomes.mutateAsync({ tripId, gameId: g.id, groups });
     setGameId(g.id);
+    setShowHandicaps(true); // Pairings ✓ → Handicaps step
   }
+
+  const onSetStrokes = (userId: string, strokes: number) =>
+    setStrokes
+      .mutateAsync({ tripId: tripId!, gameId: gameId!, userId, strokes })
+      .then(() => utils.playGroups.listByGame.invalidate({ tripId: tripId!, gameId: gameId! }));
 
   const handleChange = (pid: string, unit: string, value: number) => {
     setValues((v) => ({ ...v, [pid]: { ...(v[pid] ?? {}), [unit]: value } }));
@@ -276,6 +301,23 @@ export default function RackNStackPage() {
     );
   }
 
+  // Handicaps setup step (after pairings; before play). Reached only via the
+  // canEdit-gated start/edit affordances; the mutation is server-canEdit-gated.
+  if (showHandicaps && gameId) {
+    return (
+      <div className="flex flex-col" style={{ height: "100vh" }}>
+        <HandicapRoster
+          players={handicapPlayers}
+          holeCount={scUnits.length}
+          strokeIndex={scIndex}
+          onSetStrokes={onSetStrokes}
+          onDone={() => setShowHandicaps(false)}
+          onBack={() => setShowHandicaps(false)}
+        />
+      </div>
+    );
+  }
+
   // No game yet → setup.
   if (!gameId) {
     return (
@@ -313,6 +355,13 @@ export default function RackNStackPage() {
     <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle={final ? "Net stroke play · final" : "Net stroke play · standings"}>
       <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
+      {canEdit && !final && (
+        <div className="px-3">
+          <button onClick={() => setShowHandicaps(true)} style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-accent)" }}>
+            Edit handicaps
+          </button>
+        </div>
+      )}
       <RackBoard
         teamA={teamMeta.A}
         teamB={teamMeta.B}

--- a/src/components/games/HandicapRoster.tsx
+++ b/src/components/games/HandicapRoster.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ChevronLeft, Plus, Minus } from "lucide-react";
+import { Avatar } from "@/components/Avatar";
+import { clampStrokes, strokeHint, MAX_STROKES } from "@/lib/handicap";
+
+/**
+ * Handicaps setup step (Slice C, Mode A) — the per-player ABSOLUTE handicap
+ * roster. Captures an integer 0–18 per participant (0 = SCR/scratch); net is
+ * derived downstream. Each stepper change is optimistic + debounced (~400ms) and
+ * persists via `onSetStrokes` without tapping Done — Done only advances. A row
+ * rolls back on a persist error.
+ *
+ * Persistence-agnostic per CLAUDE.md #7: data in via props, changes out via
+ * `onSetStrokes`; no tRPC here. Team dots are READ from props (the competition),
+ * never set here.
+ */
+
+export interface HandicapPlayer {
+  id: string;
+  name: string;
+  avatarIcon?: string | null;
+  /** Team color in a competition; null/undefined → standalone (no dot). */
+  teamColor?: string | null;
+  strokes: number;
+}
+
+const DEBOUNCE_MS = 400;
+
+export function HandicapRoster({
+  players,
+  holeCount,
+  strokeIndex,
+  onSetStrokes,
+  onDone,
+  onBack,
+}: {
+  players: HandicapPlayer[];
+  holeCount: number;
+  strokeIndex: number[] | null;
+  onSetStrokes: (userId: string, strokes: number) => Promise<unknown>;
+  onDone: () => void;
+  onBack: () => void;
+}) {
+  // `local` holds only EDITED rows; an unedited row reads the prop value. So a
+  // background refetch (after persist) flows through props without an effect.
+  const [local, setLocal] = useState<Record<string, number>>({});
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const strokesOf = (p: HandicapPlayer) => local[p.id] ?? p.strokes;
+
+  useEffect(() => {
+    const t = timers.current;
+    return () => Object.values(t).forEach(clearTimeout);
+  }, []);
+
+  const bump = (id: string, current: number, delta: number) => {
+    const next = clampStrokes(current + delta);
+    if (next === current) return;
+    setLocal((l) => ({ ...l, [id]: next })); // optimistic
+    clearTimeout(timers.current[id]);
+    timers.current[id] = setTimeout(() => {
+      onSetStrokes(id, next).catch(() => {
+        // Rollback: drop the local override → the row falls back to the prop
+        // (the server value, unchanged by the failed write).
+        setLocal((l) => {
+          const copy = { ...l };
+          delete copy[id];
+          return copy;
+        });
+      });
+    }, DEBOUNCE_MS);
+  };
+
+  const allScratch = players.every((p) => strokesOf(p) === 0);
+
+  return (
+    <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div className="min-w-0 text-center">
+          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Handicaps</div>
+          <div style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
+            <span style={{ color: "var(--color-bt-accent)" }}>Pairings ✓</span> › Handicaps › Course
+          </div>
+        </div>
+        <div className="h-9 w-9" />
+      </header>
+
+      <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
+        <div style={{ fontSize: 20, fontWeight: 700, color: "var(--color-bt-text)" }}>Strokes for this game</div>
+        <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 4, lineHeight: 1.5 }}>
+          Strokes come off gross and land on the hardest holes — a guess to keep it competitive, not an official handicap.
+        </p>
+
+        {allScratch && (
+          <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 12, padding: "10px 12px", borderRadius: 10, background: "var(--color-bt-card)" }}>
+            Everyone&apos;s scratch — net plays as gross. Set strokes below, or leave it and tap Done.
+          </p>
+        )}
+
+        <div className="mt-4 flex flex-col gap-2">
+          {players.map((p) => {
+            const strokes = strokesOf(p);
+            const hint = strokeHint(strokes, holeCount, strokeIndex);
+            return (
+              <div key={p.id} className="flex items-center gap-3 rounded-xl border px-3" style={{ minHeight: 60, padding: "8px 12px", background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}>
+                <Avatar name={p.name} avatarIcon={p.avatarIcon} sizePx={34} />
+                <div className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5">
+                    {p.teamColor && <span style={{ width: 8, height: 8, borderRadius: "50%", background: p.teamColor, flexShrink: 0 }} />}
+                    <span className="truncate" style={{ fontSize: 15, fontWeight: 500, color: "var(--color-bt-text)" }}>{p.name}</span>
+                  </span>
+                  {hint && <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 1 }}>{hint}</span>}
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <StepBtn dir="dec" disabled={strokes <= 0} onClick={() => bump(p.id, strokes, -1)} />
+                  <span style={{ minWidth: 34, textAlign: "center", fontSize: strokes === 0 ? 13 : 17, fontWeight: 700, color: strokes === 0 ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+                    {strokes === 0 ? "SCR" : strokes}
+                  </span>
+                  <StepBtn dir="inc" disabled={strokes >= MAX_STROKES} onClick={() => bump(p.id, strokes, 1)} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="shrink-0" style={{ padding: 16, borderTop: "1px solid var(--color-bt-subtle-border)" }}>
+        <button onClick={onDone} className="w-full" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function StepBtn({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="flex items-center justify-center disabled:opacity-30"
+      style={{ width: 34, height: 34, borderRadius: 9, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
+    >
+      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
+    </button>
+  );
+}

--- a/src/components/games/HandicapRoster.tsx
+++ b/src/components/games/HandicapRoster.tsx
@@ -47,29 +47,47 @@ export function HandicapRoster({
   // background refetch (after persist) flows through props without an effect.
   const [local, setLocal] = useState<Record<string, number>>({});
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const pending = useRef<Record<string, number>>({}); // edits not yet persisted
+  const onSetRef = useRef(onSetStrokes);
+  useEffect(() => {
+    onSetRef.current = onSetStrokes;
+  });
   const strokesOf = (p: HandicapPlayer) => local[p.id] ?? p.strokes;
 
+  const persist = (id: string, value: number) => {
+    delete pending.current[id];
+    onSetRef.current(id, value).catch(() => {
+      // Rollback: drop the local override → the row falls back to the prop
+      // (the server value, unchanged by the failed write).
+      setLocal((l) => {
+        const copy = { ...l };
+        delete copy[id];
+        return copy;
+      });
+    });
+  };
+
+  // On unmount (Done / Back / nav-away) FLUSH any pending debounced edit so the
+  // value survives leaving without tapping Done — never silently drop it.
   useEffect(() => {
     const t = timers.current;
-    return () => Object.values(t).forEach(clearTimeout);
+    const p = pending.current;
+    return () => {
+      Object.values(t).forEach(clearTimeout);
+      for (const [id, v] of Object.entries(p)) persist(id, v);
+    };
   }, []);
 
-  const bump = (id: string, current: number, delta: number) => {
-    const next = clampStrokes(current + delta);
-    if (next === current) return;
+  const bump = (id: string, base: number, delta: number) => {
+    // Read the freshest value (a rapid second tap before re-render) from the
+    // pending ref, then local, then the prop — so fast +/+ increments correctly.
+    const cur = pending.current[id] ?? local[id] ?? base;
+    const next = clampStrokes(cur + delta);
+    if (next === cur) return;
+    pending.current[id] = next;
     setLocal((l) => ({ ...l, [id]: next })); // optimistic
     clearTimeout(timers.current[id]);
-    timers.current[id] = setTimeout(() => {
-      onSetStrokes(id, next).catch(() => {
-        // Rollback: drop the local override → the row falls back to the prop
-        // (the server value, unchanged by the failed write).
-        setLocal((l) => {
-          const copy = { ...l };
-          delete copy[id];
-          return copy;
-        });
-      });
-    }, DEBOUNCE_MS);
+    timers.current[id] = setTimeout(() => persist(id, next), DEBOUNCE_MS);
   };
 
   const allScratch = players.every((p) => strokesOf(p) === 0);

--- a/src/lib/handicap.test.ts
+++ b/src/lib/handicap.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { effectiveStrokes, clampStrokes, strokeHint } from "./handicap";
+import { strokeHoles } from "./matchPlay";
+
+describe("effectiveStrokes", () => {
+  it("defaults null to 0", () => {
+    expect(effectiveStrokes({ handicap_strokes: null })).toBe(0);
+    expect(effectiveStrokes({})).toBe(0);
+  });
+  it("passes through in-range", () => {
+    expect(effectiveStrokes({ handicap_strokes: 7 })).toBe(7);
+  });
+  it("clamps over the cap and below 0", () => {
+    expect(effectiveStrokes({ handicap_strokes: 25 })).toBe(18);
+    expect(effectiveStrokes({ handicap_strokes: -3 })).toBe(0);
+  });
+  it("clampStrokes rounds + clamps", () => {
+    expect(clampStrokes(25)).toBe(18);
+    expect(clampStrokes(-3)).toBe(0);
+    expect(clampStrokes(4.6)).toBe(5);
+  });
+});
+
+describe("strokeHint", () => {
+  const SEQ = Array.from({ length: 18 }, (_, i) => i + 1); // sequential default
+  const REAL = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
+
+  it("no hint at scratch", () => {
+    expect(strokeHint(0, 18, REAL)).toBeNull();
+  });
+  it("every hole at the cap", () => {
+    expect(strokeHint(18, 18, REAL)).toBe("a stroke on every hole");
+  });
+  it("bare count with no index", () => {
+    expect(strokeHint(5, 18)).toBe("5 strokes");
+  });
+  it("first-N phrasing for a sequential index", () => {
+    expect(strokeHint(5, 18, SEQ)).toBe("5 strokes · first 5 holes");
+  });
+  it("names the struck holes for a real index, ≤9", () => {
+    // strokeHoles(3, REAL) → holes whose index is 1,2,3 = holes 4, 13, 2.
+    const struck = [...strokeHoles(3, REAL)].sort((a, b) => a - b);
+    expect(strokeHint(3, 18, REAL)).toBe(`3 strokes · holes ${struck.join(", ")}`);
+  });
+  it("inverts the list for a real index, >9", () => {
+    const struck = new Set(strokeHoles(12, REAL));
+    const unstruck = Array.from({ length: 18 }, (_, i) => i + 1).filter((h) => !struck.has(h));
+    expect(strokeHint(12, 18, REAL)).toBe(`12 strokes · all but holes ${unstruck.join(", ")}`);
+  });
+  it("agrees with strokeHoles (named holes are exactly the struck set)", () => {
+    const struck = [...strokeHoles(6, REAL)].sort((a, b) => a - b);
+    const hint = strokeHint(6, 18, REAL)!;
+    for (const h of struck) expect(hint).toContain(String(h));
+  });
+});

--- a/src/lib/handicap.ts
+++ b/src/lib/handicap.ts
@@ -1,0 +1,57 @@
+/**
+ * Handicap read path + hint deriver (Slice C, Mode A) — PURE, client-safe.
+ *
+ * A handicap is an integer 0–18 per participant (0 = scratch; 18 is a hard cap —
+ * strokes-above-18 allocation is deferred, the cap absorbs blowups). Net is
+ * computed downstream (`net = gross − strokeHoles(strokes, index)`); this module
+ * only resolves the stroke count and describes where it lands.
+ */
+
+import { strokeHoles } from "./matchPlay";
+
+export const MAX_STROKES = 18;
+
+/** Clamp an arbitrary number to a valid handicap (0–18 integer). */
+export function clampStrokes(n: number): number {
+  return Math.min(MAX_STROKES, Math.max(0, Math.round(n)));
+}
+
+/**
+ * THE single read path for a participant's effective strokes. Every net/standings
+ * computation reads through this — never inline `?? 0` at a call site.
+ *
+ * Today it reads the game layer only. When competition- and profile-level
+ * handicaps land, this becomes `game ?? competition ?? profile` — a change HERE,
+ * not at every consumer. Keep it the one chokepoint.
+ */
+export function effectiveStrokes(participant: { handicap_strokes?: number | null }): number {
+  return clampStrokes(participant.handicap_strokes ?? 0);
+}
+
+/**
+ * Per-row "where strokes land" hint (§4) — derived, display-only, and ALWAYS in
+ * agreement with `strokeHoles` (it's computed from it). Collapses high counts so
+ * the list stays useful, and only names holes when a real (non-sequential) index
+ * is present — mirroring the GolfCard INDEX row.
+ *
+ * - 0 strokes → null (no hint).
+ * - strokes ≥ holeCount → "a stroke on every hole".
+ * - no index passed → bare "N strokes" (no hole promise).
+ * - sequential index (no real course index) → "N strokes · first N holes".
+ * - real index, ≤9 → "N strokes · holes a, b, c" (the struck holes).
+ * - real index, >9 → "N strokes · all but holes x, y" (the easiest unstruck).
+ */
+export function strokeHint(strokes: number, holeCount: number, strokeIndex?: number[] | null): string | null {
+  if (strokes <= 0) return null;
+  if (strokes >= holeCount) return "a stroke on every hole";
+  if (!strokeIndex) return `${strokes} strokes`;
+
+  const struck = [...strokeHoles(strokes, strokeIndex)].sort((a, b) => a - b);
+  const isSequential = struck.every((h, i) => h === i + 1);
+  if (isSequential) return `${strokes} strokes · first ${strokes} holes`;
+  if (strokes <= 9) return `${strokes} strokes · holes ${struck.join(", ")}`;
+
+  const struckSet = new Set(struck);
+  const unstruck = Array.from({ length: holeCount }, (_, i) => i + 1).filter((h) => !struckSet.has(h));
+  return `${strokes} strokes · all but holes ${unstruck.join(", ")}`;
+}

--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildDecided, matchState } from "@/lib/matchPlay";
+import { effectiveStrokes } from "@/lib/handicap";
 
 /**
  * DB-persist side of match-play results. Reads each `game_matches` row, gathers
@@ -69,7 +70,7 @@ export async function computeMatchPlayResults(
     .eq("game_id", gameId);
   const hcap = new Map<string, number>();
   for (const p of parts ?? []) {
-    hcap.set(p.user_id as string, (p.handicap_strokes as number | null) ?? 0);
+    hcap.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
   }
 
   // user_id → { unit_label → gross }.

--- a/src/server/lib/rackNStack.ts
+++ b/src/server/lib/rackNStack.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { playerStats, computeRack, type RackPlayer, type Team } from "@/lib/rackNStack";
+import { effectiveStrokes } from "@/lib/handicap";
 
 /**
  * DB-persist side of rack-n-stack. Builds the SAME read-model the live client
@@ -66,7 +67,7 @@ export async function computeRackNStackResults(
     .select("user_id, handicap_strokes")
     .eq("game_id", gameId);
   const hcap = new Map<string, number>();
-  for (const p of parts ?? []) hcap.set(p.user_id as string, (p.handicap_strokes as number | null) ?? 0);
+  for (const p of parts ?? []) hcap.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
 
   const { data: entries } = await supabase
     .from("score_entries")

--- a/src/server/routers/playGroups.ts
+++ b/src/server/routers/playGroups.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
+import { clampStrokes } from "@/lib/handicap";
+import { computeMatchPlayResults } from "../lib/matchPlay";
+import { computeRackNStackResults } from "../lib/rackNStack";
 
 /**
  * playGroups — foursomes for a game (the scoring-side use of `play_groups`,
@@ -79,17 +82,43 @@ export const playGroupsRouter = router({
     }),
 
   // setHandicap — Owner/Organizer. Net strokes for one participant (null = 0).
-  setHandicap: authedProcedure
-    .input(z.object({ tripId: z.string(), gameId: z.string(), userId: z.string().min(1), strokes: z.number().int().min(0).max(54) }))
+  // setParticipantStrokes — Owner/Organizer. The per-player ABSOLUTE handicap
+  // (Mode A), distinct from match play's relative one-side setHandicap. Server-
+  // clamped to 0–18. Handicap is a scoring input, so the change re-derives the
+  // game's in-progress results (CLAUDE.md "derived values recompute" pattern) —
+  // a frozen/complete game is never rewritten.
+  setParticipantStrokes: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), userId: z.string().min(1), strokes: z.number().int() }))
     .use(requireTripRole("Organizer"))
     .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, status, game_type_id")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+
+      const strokes = clampStrokes(input.strokes);
       const { error } = await ctx.supabase
         .from("game_participants")
-        .update({ handicap_strokes: input.strokes })
+        .update({ handicap_strokes: strokes })
         .eq("game_id", input.gameId)
         .eq("user_id", input.userId);
-      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set handicap: ${error.message}` });
-      return { ok: true };
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set strokes: ${error.message}` });
+
+      // Re-derive in-progress results; leave a complete (frozen) game untouched.
+      if (game.status !== "complete") {
+        const { data: tmpl } = await ctx.supabase
+          .from("game_type_templates")
+          .select("result_strategy")
+          .eq("id", game.game_type_id as string)
+          .maybeSingle();
+        const strategy = (tmpl?.result_strategy as string | null) ?? "stroke_total";
+        if (strategy === "match_play") await computeMatchPlayResults(ctx.supabase, input.gameId, { skipComplete: true });
+        else if (strategy === "rack_n_stack") await computeRackNStackResults(ctx.supabase, input.gameId);
+      }
+      return { ok: true, strokes };
     }),
 
   // listByGame — any trip member. Foursomes + each participant's group/handicap.

--- a/src/server/routers/rackNStack.test.ts
+++ b/src/server/routers/rackNStack.test.ts
@@ -89,6 +89,32 @@ describe("rack-n-stack — finish distills team points to game_results", () => {
     expect(rows!.find((r) => r.entity_id === teamA)!.points).toBe(2);
   });
 
+  it("setParticipantStrokes clamps 0–18, persists, and is canEdit-gated", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "HC", competitionId });
+    const gameId = game.id as string;
+    await ctx.callerAs("planner").playGroups.setFoursomes({ tripId, gameId, groups: [{ userIds: [owner, member] }] });
+
+    // Over-cap clamps to 18.
+    const r = await ctx.callerAs("planner").playGroups.setParticipantStrokes({ tripId, gameId, userId: owner, strokes: 25 });
+    expect(r.strokes).toBe(18);
+    const { data: row } = await ctx.admin
+      .from("game_participants")
+      .select("handicap_strokes")
+      .eq("game_id", gameId)
+      .eq("user_id", owner)
+      .single();
+    expect(row!.handicap_strokes).toBe(18);
+
+    // Negative clamps to 0.
+    const r0 = await ctx.callerAs("planner").playGroups.setParticipantStrokes({ tripId, gameId, userId: owner, strokes: -3 });
+    expect(r0.strokes).toBe(0);
+
+    // A plain member cannot set strokes (game setup is canEdit-only).
+    await expect(
+      ctx.callerAs("member").playGroups.setParticipantStrokes({ tripId, gameId, userId: owner, strokes: 5 })
+    ).rejects.toThrow();
+  });
+
   it("a tied slot halves ½/½", async () => {
     const game = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "Day 2", competitionId });
     const gameId = game.id as string;


### PR DESCRIPTION
The per-player **absolute** handicap setup screen (Mode A) + the single read path that turns a participant's strokes into net.

## §2 — one read path (own commit)
- **`effectiveStrokes(participant)` = `clamp(handicap_strokes ?? 0, 0, 18)`** — the one chokepoint, commented for the future `game ?? competition ?? profile` cascade. Consolidated the 4 scattered `?? 0` reads (match page, rack page, server matchPlay, server rackNStack) through it — no parallel path.
- **`strokeHint`** deriver (§4): collapses high counts (list ≤9, invert >9, "every hole" at N), index-conditional (named holes only with a real index, else "first N holes", bare "N strokes" with none), and **always agrees with `strokeHoles`** (computed from it).
- **`setParticipantStrokes`** (renamed from the rack's `setHandicap`): absolute per-player, **server-clamped 0–18**, `canEdit`-gated, **re-derives in-progress results** (data-driven on `result_strategy`; frozen game untouched). Distinct from match play's relative Mode B.

## §3 — the screen
`HandicapRoster` to the approved mock: "Handicaps" + `Pairings ✓ › Handicaps › Course`, intro line, all-scratch empty state, roster (avatar + **team-color dot read from the competition** + stepper rendering `SCR` at 0, `−`/`+` disabled at 0/18), per-row hint. Changes are **optimistic + debounced ~400ms**, persist without tapping Done (**Done only advances**), roll back on error. Wired into the rack flow (Start → Handicaps → play; "Edit handicaps" reopens).

## Tests
- `handicap.test.ts`: `effectiveStrokes` (null→0, passthrough, over-cap clamp); `strokeHint` (≤9 list, >9 invert, every-hole, sequential "first N", agreement with `strokeHoles`).
- `setParticipantStrokes` server test: clamp 25→18 / −3→0, persists, member rejected.

Everyone-scratch is a valid saved state (net = gross). `tsc`/lint clean. No USGA math, no competition-level screen, no profile, no change to match Mode B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)