### PR TITLE
feat(engine): optional stroke index ↔ conditional GolfCard INDEX row (Slice C)

### DIFF
--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -229,6 +229,7 @@ export function ScoreEntryView({
           {par != null && (
             <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
               Par {par}
+              {unit?.strokeIndex != null && ` · Hdcp ${unit.strokeIndex}`}
             </div>
           )}
           <HoleProgress count={units.length} currentHole={hole} completed={completedHoleNumbers} />

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -508,7 +508,7 @@ function ConfirmScreen({
           </div>
         </div>
       </div>
-      <Footer label={indexUsable ? "Use this course" : "Finish the index to use it"} disabled={!indexUsable || saving} onClick={onUse} />
+      <Footer label={indexUsable ? "Use this course" : "Finish the index to use this course"} disabled={!indexUsable || saving} onClick={onUse} />
     </>
   );
 }

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -363,6 +363,7 @@ export function CoursePicker({
           setActiveTee={setActiveTee}
           indexOptedIn={indexOptedIn}
           onOptInIndex={() => setIndexOptedIn(true)}
+          indexUsable={indexUsable}
           setPar={setPar}
           setIndex={setIndex}
           setYards={setYards}
@@ -766,6 +767,7 @@ function EntryScreen({
   setActiveTee,
   indexOptedIn,
   onOptInIndex,
+  indexUsable,
   setPar,
   setIndex,
   setYards,
@@ -778,6 +780,7 @@ function EntryScreen({
   setActiveTee: (i: number) => void;
   indexOptedIn: boolean;
   onOptInIndex: () => void;
+  indexUsable: boolean;
   setPar: (h: number, v: number) => void;
   setIndex: (h: number, v: number) => void;
   setYards: (h: number, v: number | null) => void;
@@ -803,6 +806,11 @@ function EntryScreen({
     setYards(hole, cur == null || cur < 10 ? null : Math.floor(cur / 10));
   };
   const lastHole = hole >= n;
+  // Per-hole Next is never blocked. The last-hole "Done · review card" IS gated,
+  // but only on a started-but-incomplete stroke index table (a course-wide
+  // datum): rank them all, or leave the table empty (fallback). The inline amber
+  // reminder explains why it's disabled.
+  const reviewBlocked = lastHole && !indexUsable;
   const footerLabel = lastHole ? "Done · review card" : "Next hole ›";
   const onAdvance = () => (lastHole ? onReview() : setHole(hole + 1));
 
@@ -852,7 +860,8 @@ function EntryScreen({
           <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", whiteSpace: "nowrap", fontVariantNumeric: "tabular-nums" }}>Hole {hole} / {n}</span>
           <button
             onClick={onAdvance}
-            className="flex-1"
+            disabled={reviewBlocked}
+            className="flex-1 disabled:opacity-40"
             style={{ height: 54, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
           >
             {footerLabel}

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -248,9 +248,10 @@ export function CoursePicker({
         <button onClick={back} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
           <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
         </button>
-        <div className="flex min-w-0 flex-col items-center" style={{ lineHeight: 1.1 }}>
-          <div className="max-w-full truncate" style={{ fontSize: 17, fontWeight: 700, color: "var(--color-bt-text)" }}>{headerTitle}</div>
-          {headerSubtitle && <div style={{ fontSize: 11.5, fontWeight: 500, color: "var(--color-bt-text-dim)", marginTop: 2 }}>{headerSubtitle}</div>}
+        {/* Same shape + spacing as the score-entry header (ScoreEntryView). */}
+        <div className="flex min-w-0 flex-col items-center text-center">
+          <div className="max-w-full truncate" style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{headerTitle}</div>
+          {headerSubtitle && <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{headerSubtitle}</div>}
         </div>
         <button onClick={onClose} aria-label="Close" className="flex h-9 w-9 items-center justify-center">
           <X size={20} style={{ color: "var(--color-bt-text-dim)" }} />
@@ -724,10 +725,10 @@ function EntryScreen({
 }) {
   const n = draft.holeCount;
   const completed = draft.index.map((v, i) => (v != null ? i + 1 : 0)).filter(Boolean);
-  // The keypad is a yards tool — it docks only while the yards field is focused
-  // (tap the field to open, "Done" to dismiss). Hole nav is the ‹ › arrows; the
-  // footer carries Next / Save when the keypad isn't up.
+  // The keypad is a dismissable yards accessory; the footer below it is the
+  // PERSISTENT advance/save control. Advancing never depends on the keypad.
   const [yardsActive, setYardsActive] = useState(false);
+  const teeName = draft.teeSets[activeTee]?.name?.trim() || `Tee ${activeTee + 1}`;
   const yardsOf = () => draft.teeSets[activeTee]?.yards[hole - 1] ?? null;
   const pushDigit = (d: number) => {
     const cur = yardsOf();
@@ -741,14 +742,18 @@ function EntryScreen({
     setYards(hole, cur == null || cur < 10 ? null : Math.floor(cur / 10));
   };
   const lastHole = hole >= n;
-  const onNext = () => (lastHole ? onSave() : setHole(hole + 1));
-  const footerLabel = lastHole ? (!indexUsable ? "Finish the index" : saving ? "Saving…" : "Save course") : `Hole ${hole + 1} ›`;
+  // A started-but-incomplete index blocks the footer (the index is course-wide);
+  // the ‹ › arrows still move between holes so you can finish it.
+  const blocked = !indexUsable;
+  const footerLabel = blocked ? "Finish the index to use this course" : lastHole ? (saving ? "Saving…" : "Save course") : "Next hole ›";
+  const onAdvance = () => (lastHole ? onSave() : setHole(hole + 1));
 
   return (
     <>
-      <div className="flex shrink-0 items-center justify-between" style={{ padding: "12px 16px" }}>
+      <div className="flex shrink-0 items-center justify-between" style={{ padding: "16px 16px" }}>
         <NavArrow dir="prev" disabled={hole <= 1} onClick={() => setHole(hole - 1)} />
-        <div className="flex flex-col items-center" style={{ flex: 1, minWidth: 0 }}>
+        <div className="flex flex-col items-center" style={{ gap: 12, flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--color-bt-text)" }}>Hole {hole}</div>
           <HoleProgress count={n} currentHole={hole} completed={completed} />
         </div>
         <NavArrow dir="next" disabled={hole >= n} onClick={() => setHole(hole + 1)} />
@@ -772,11 +777,28 @@ function EntryScreen({
         />
       </div>
 
-      {yardsActive ? (
-        <Keypad onDigit={pushDigit} onBackspace={backspace} onNext={() => setYardsActive(false)} nextLabel="Done ✓" />
-      ) : (
-        <Footer label={footerLabel} disabled={lastHole && (!indexUsable || saving)} onClick={onNext} />
+      {yardsActive && (
+        <Keypad
+          title={`Yards · ${teeName}`}
+          hint="Done to keep editing the hole"
+          onDigit={pushDigit}
+          onBackspace={backspace}
+          onDone={() => setYardsActive(false)}
+        />
       )}
+      <div className="shrink-0" style={{ padding: "12px 16px 24px", borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-card-float)" }}>
+        <div className="flex items-center gap-3">
+          <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", whiteSpace: "nowrap", fontVariantNumeric: "tabular-nums" }}>Hole {hole} / {n}</span>
+          <button
+            onClick={onAdvance}
+            disabled={blocked || (lastHole && saving)}
+            className="flex-1 disabled:opacity-40"
+            style={{ height: 54, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
+          >
+            {footerLabel}
+          </button>
+        </div>
+      </div>
     </>
   );
 }
@@ -804,6 +826,7 @@ function HoleEditScreen({
   onDone: () => void;
 }) {
   const [yardsActive, setYardsActive] = useState(false);
+  const teeName = draft.teeSets[activeTee]?.name?.trim() || `Tee ${activeTee + 1}`;
   const yardsOf = () => draft.teeSets[activeTee]?.yards[hole - 1] ?? null;
   const pushDigit = (d: number) => {
     const cur = yardsOf();
@@ -837,11 +860,16 @@ function HoleEditScreen({
           showSwapWarning
         />
       </div>
-      {yardsActive ? (
-        <Keypad onDigit={pushDigit} onBackspace={backspace} onNext={() => setYardsActive(false)} nextLabel="Done ✓" />
-      ) : (
-        <Footer label="Done" disabled={flagged.has(hole)} onClick={onDone} />
+      {yardsActive && (
+        <Keypad
+          title={`Yards · ${teeName}`}
+          hint="Done to keep editing the hole"
+          onDigit={pushDigit}
+          onBackspace={backspace}
+          onDone={() => setYardsActive(false)}
+        />
       )}
+      <Footer label="Save hole" disabled={flagged.has(hole)} onClick={onDone} />
     </>
   );
 }

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -23,10 +23,11 @@ import { NavArrow, HoleProgress } from "../entryChrome";
  * → stepped per-hole entry), both producing a saved global `courses` row; on
  * apply it hands the parent { id, name } to snapshot onto the game.
  *
- * Stroke index is optional (a creation toggle); when on it's enforced as a valid
- * 1..N permutation via the 18-cell grid's swap-on-pick, and Use/Save is blocked
- * until complete. Per-hole controls are tap-first: par segmented, yards keypad,
- * index grid — no ± steppers.
+ * Par is required; the stroke index is OPTIONAL. An untouched index saves on par
+ * alone (sequential fallback) — only a STARTED-but-incomplete index blocks
+ * Use/Save; a complete one is enforced as a valid 1..N permutation via the
+ * 18-cell grid's swap-on-pick. A dirty/partial pulled index is treated as absent.
+ * Per-hole controls are tap-first: par segmented, yards keypad, index grid.
  */
 
 type TeeSet = { name: string; yards: (number | null)[] };
@@ -106,16 +107,17 @@ export function CoursePicker({
     () => validateStrokeIndex(draft.index, draft.holeCount),
     [draft.index, draft.holeCount]
   );
-  const indexComplete = !draft.hasStrokeIndex || validation.valid;
-  const missingCount = draft.hasStrokeIndex
-    ? validation.unsetHoles.length + validation.duplicateHoles.length + validation.outOfRangeHoles.length
-    : 0;
+  // The stroke index is OPTIONAL: untouched (no hole set) is a legal, saveable
+  // state (sequential fallback). Only a STARTED-but-incomplete index blocks
+  // Use/Save. A complete permutation is the real index.
+  const indexStarted = draft.hasStrokeIndex && draft.index.some((v) => v != null);
+  const indexUsable = !indexStarted || validation.valid; // untouched OR complete
   const flagged = useMemo(
     () =>
-      draft.hasStrokeIndex
+      indexStarted && !validation.valid
         ? new Set([...validation.unsetHoles, ...validation.duplicateHoles, ...validation.outOfRangeHoles])
         : new Set<number>(),
-    [validation, draft.hasStrokeIndex]
+    [validation, indexStarted]
   );
 
   const setPar = (h: number, value: number) => {
@@ -150,12 +152,19 @@ export function CoursePicker({
     }
     const holeCount = (detail.holes.length >= 18 ? 18 : 9) as 9 | 18;
     const tees = teeSetsFromDetail(detail);
+    // Dirty lookup data: a complete clean permutation is kept; a missing/partial
+    // pulled index is treated as ABSENT (cleared to untouched → fallback) rather
+    // than carried in as a started-but-broken index.
+    const pulledIndex = indexFromDetail(detail).slice(0, holeCount);
+    const cleanIndex = validateStrokeIndex(pulledIndex, holeCount).valid
+      ? pulledIndex
+      : Array(holeCount).fill(null);
     setDraft({
       name: detail.name,
       location: detail.location,
       holeCount,
       par: parFromDetail(detail).slice(0, holeCount),
-      index: indexFromDetail(detail).slice(0, holeCount),
+      index: cleanIndex,
       hasStrokeIndex: true,
       teeSets: tees.length ? tees.map((t) => ({ ...t, yards: t.yards.slice(0, holeCount) })) : [blankTee(holeCount, "White")],
       source: "golfapi",
@@ -185,19 +194,22 @@ export function CoursePicker({
   }
 
   async function save() {
-    if (!indexComplete || !draft.name.trim()) return;
+    if (!indexUsable || !draft.name.trim()) return;
     // Reviewing an existing library course, unedited → apply it directly.
     if (draft.existingId && !edited) {
       onApply({ id: draft.existingId, name: draft.name.trim() });
       return;
     }
+    // Snapshot the index ONLY when it's a complete permutation; an untouched or
+    // index-less course saves on par alone (sequential fallback).
+    const hasIndex = validation.valid;
     const course = await createCourse.mutateAsync({
       name: draft.name.trim(),
       location: draft.location.trim() || undefined,
       holeCount: draft.holeCount,
       par: draft.par,
-      handicapIndex: draft.hasStrokeIndex ? (draft.index as number[]) : undefined,
-      hasStrokeIndex: draft.hasStrokeIndex,
+      handicapIndex: hasIndex ? (draft.index as number[]) : undefined,
+      hasStrokeIndex: hasIndex,
       teeSets: draft.teeSets,
       source: draft.source,
       providerId: draft.providerId,
@@ -263,8 +275,7 @@ export function CoursePicker({
           draft={draft}
           activeTee={activeTee}
           setActiveTee={setActiveTee}
-          indexComplete={indexComplete}
-          missingCount={missingCount}
+          indexUsable={indexUsable}
           flagged={flagged}
           saving={createCourse.isPending}
           onEditHole={(h) => setEditingHole(h)}
@@ -279,8 +290,7 @@ export function CoursePicker({
           setHole={setHole}
           activeTee={activeTee}
           setActiveTee={setActiveTee}
-          indexComplete={indexComplete}
-          missingCount={missingCount}
+          indexUsable={indexUsable}
           saving={createCourse.isPending}
           setPar={setPar}
           setIndex={setIndex}
@@ -403,8 +413,7 @@ function ConfirmScreen({
   draft,
   activeTee,
   setActiveTee,
-  indexComplete,
-  missingCount,
+  indexUsable,
   flagged,
   saving,
   onEditHole,
@@ -413,8 +422,7 @@ function ConfirmScreen({
   draft: Draft;
   activeTee: number;
   setActiveTee: (i: number) => void;
-  indexComplete: boolean;
-  missingCount: number;
+  indexUsable: boolean;
   flagged: Set<number>;
   saving: boolean;
   onEditHole: (h: number) => void;
@@ -447,13 +455,19 @@ function ConfirmScreen({
           </div>
         )}
 
-        {draft.hasStrokeIndex && !indexComplete && (
+        {!indexUsable ? (
           <div className="mt-3 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}>
             <AlertTriangle size={15} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
             <span style={{ fontSize: 12.5, color: "var(--color-bt-warning)" }}>
-              This course&apos;s stroke index is incomplete — a wrong index mis-allocates handicap strokes. Tap the flagged holes to fix before using.
+              Stroke index started but incomplete — finish it (a wrong index mis-allocates handicap strokes), or clear it to play on par alone. Tap the flagged holes.
             </span>
           </div>
+        ) : (
+          !draft.index.some((v) => v != null) && (
+            <p className="mt-3" style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.5 }}>
+              No hole difficulty set — strokes fall on holes 1–{draft.holeCount}. Tap a hole to set the index any time so handicaps land on the hardest holes.
+            </p>
+          )
         )}
 
         <div className="mt-3 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
@@ -494,7 +508,7 @@ function ConfirmScreen({
           </div>
         </div>
       </div>
-      <Footer label={indexComplete ? "Use this course" : `${missingCount} holes need a valid index`} disabled={!indexComplete || saving} onClick={onUse} />
+      <Footer label={indexUsable ? "Use this course" : "Finish the index to use it"} disabled={!indexUsable || saving} onClick={onUse} />
     </>
   );
 }
@@ -673,8 +687,7 @@ function EntryScreen({
   setHole,
   activeTee,
   setActiveTee,
-  indexComplete,
-  missingCount,
+  indexUsable,
   saving,
   setPar,
   setIndex,
@@ -686,8 +699,7 @@ function EntryScreen({
   setHole: (h: number) => void;
   activeTee: number;
   setActiveTee: (i: number) => void;
-  indexComplete: boolean;
-  missingCount: number;
+  indexUsable: boolean;
   saving: boolean;
   setPar: (h: number, v: number) => void;
   setIndex: (h: number, v: number) => void;
@@ -738,16 +750,13 @@ function EntryScreen({
           yardsActive
           onYardsTap={() => {}}
         />
-        {lastHole && !indexComplete && (
-          <p style={{ fontSize: 12.5, color: "var(--color-bt-warning)", marginTop: 12 }}>{missingCount} holes still need a stroke index.</p>
-        )}
       </div>
 
       <Keypad
         onDigit={pushDigit}
         onBackspace={backspace}
         onNext={onNext}
-        nextLabel={lastHole ? (saving ? "Saving…" : "Save ›") : `Hole ${hole + 1} ›`}
+        nextLabel={lastHole ? (!indexUsable ? "Finish the index" : saving ? "Saving…" : "Save ›") : `Hole ${hole + 1} ›`}
       />
     </>
   );

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight, Search, Plus, X, AlertTriangle, MapPin, PencilLine, GripVertical } from "lucide-react";
+import { ChevronLeft, ChevronRight, Search, Plus, X, AlertTriangle, MapPin, PencilLine, GripVertical, Check } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { HoleEditor, Keypad } from "./HoleEditor";
 import {
@@ -45,7 +45,7 @@ interface Draft {
   existingId?: string;
 }
 
-type Screen = "search" | "confirm" | "new" | "entry";
+type Screen = "search" | "confirm" | "new" | "entry" | "saved";
 
 const blankTee = (n: number, name: string): TeeSet => ({ name, yards: Array(n).fill(null) });
 
@@ -81,6 +81,14 @@ export function CoursePicker({
   // True once any hole is edited — a reviewed library course is applied as-is
   // when untouched, or saved as a new course (a copy) when edited.
   const [edited, setEdited] = useState(false);
+  // The stroke index table is opt-in (per the empty-grid scrim) — course-level
+  // UI state, not per-hole (the same table is filled from any hole's screen).
+  const [indexOptedIn, setIndexOptedIn] = useState(false);
+  // The Confirm/review card is two modes: 'use' (pick → drop into the game) and
+  // 'summary' (manual add → save to My courses, NOT auto-used).
+  const [confirmMode, setConfirmMode] = useState<"use" | "summary">("use");
+  // The course just saved via "Save to my courses" — highlighted on My courses.
+  const [savedId, setSavedId] = useState<string | null>(null);
 
   const recent = trpc.courses.list.useQuery({ limit: 8 });
   const createCourse = trpc.courses.create.useMutation();
@@ -140,6 +148,8 @@ export function CoursePicker({
 
   async function pull(summary: CourseSummary) {
     setEdited(false);
+    setIndexOptedIn(false);
+    setConfirmMode("use");
     setPulling(true);
     const detail = await getCourseDetail(summary.id);
     setPulling(false);
@@ -178,6 +188,8 @@ export function CoursePicker({
   // / fix-a-hole). Untouched → applied as-is; edited → saved as a copy.
   function reviewRecent(c: RecentCourse) {
     setEdited(false);
+    setIndexOptedIn(false);
+    setConfirmMode("use");
     setDraft({
       name: c.name,
       location: c.location ?? "",
@@ -193,15 +205,10 @@ export function CoursePicker({
     setScreen("confirm");
   }
 
-  async function save() {
-    if (!indexUsable || !draft.name.trim()) return;
-    // Reviewing an existing library course, unedited → apply it directly.
-    if (draft.existingId && !edited) {
-      onApply({ id: draft.existingId, name: draft.name.trim() });
-      return;
-    }
-    // Snapshot the index ONLY when it's a complete permutation; an untouched or
-    // index-less course saves on par alone (sequential fallback).
+  // Persist the draft as a global course. The index is snapshotted ONLY when the
+  // table is a complete 1..N ranking; an untouched (or partial-cleared) table
+  // saves on par alone (fallback: handicap from the first hole onward).
+  async function persistDraft() {
     const hasIndex = validation.valid;
     const course = await createCourse.mutateAsync({
       name: draft.name.trim(),
@@ -214,7 +221,28 @@ export function CoursePicker({
       source: draft.source,
       providerId: draft.providerId,
     });
+    return course;
+  }
+
+  // mode 'use' — pick a course to drop into the game.
+  async function useCourse() {
+    if (!indexUsable || !draft.name.trim()) return;
+    // Reviewing an existing library course, unedited → apply it directly.
+    if (draft.existingId && !edited) {
+      onApply({ id: draft.existingId, name: draft.name.trim() });
+      return;
+    }
+    const course = await persistDraft();
     onApply({ id: course.id as string, name: course.name as string });
+  }
+
+  // mode 'summary' — manual add lands on My courses (NOT auto-used in a game).
+  async function saveToMyCourses() {
+    if (!indexUsable || !draft.name.trim()) return;
+    const course = await persistDraft();
+    setSavedId(course.id as string);
+    await recent.refetch();
+    setScreen("saved");
   }
 
   // On the per-hole screens (stepped entry + single-hole edit) the title is the
@@ -227,14 +255,20 @@ export function CoursePicker({
       : screen === "search"
         ? "Add a course"
         : screen === "confirm"
-          ? "Confirm course"
+          ? confirmMode === "summary"
+            ? "Course summary"
+            : "Confirm course"
           : screen === "new"
             ? "New course"
-            : "Enter holes";
-  const headerSubtitle = holeShown != null ? `Hole ${holeShown} of ${draft.holeCount}` : null;
+            : screen === "saved"
+              ? "My courses"
+              : "Enter holes";
+  const headerSubtitle =
+    holeShown != null ? `Hole ${holeShown} of ${draft.holeCount}` : screen === "confirm" && confirmMode === "summary" ? "Review what you entered" : null;
   const back = () => {
     if (editingHole != null) return setEditingHole(null);
-    if (screen === "confirm" || screen === "new") return setScreen("search");
+    if (screen === "confirm") return setScreen(confirmMode === "summary" ? "entry" : "search");
+    if (screen === "new" || screen === "saved") return setScreen("search");
     if (screen === "entry") return setScreen("new");
     onClose();
   };
@@ -265,6 +299,8 @@ export function CoursePicker({
           activeTee={activeTee}
           setActiveTee={setActiveTee}
           flagged={flagged}
+          indexOptedIn={indexOptedIn}
+          onOptInIndex={() => setIndexOptedIn(true)}
           setPar={setPar}
           setIndex={setIndex}
           setYards={setYards}
@@ -282,6 +318,8 @@ export function CoursePicker({
           onPickRecent={reviewRecent}
           onManual={() => {
             setEdited(false);
+            setIndexOptedIn(false);
+            setConfirmMode("summary");
             setDraft(blankDraft(18));
             setActiveTee(0);
             setScreen("new");
@@ -290,16 +328,32 @@ export function CoursePicker({
       ) : screen === "confirm" ? (
         <ConfirmScreen
           draft={draft}
+          mode={confirmMode}
           activeTee={activeTee}
           setActiveTee={setActiveTee}
           indexUsable={indexUsable}
           flagged={flagged}
           saving={createCourse.isPending}
           onEditHole={(h) => setEditingHole(h)}
-          onUse={save}
+          onPrimary={confirmMode === "summary" ? saveToMyCourses : useCourse}
         />
       ) : screen === "new" ? (
         <NewCourseScreen draft={draft} setDraft={setDraft} onStart={() => { setHole(1); setScreen("entry"); }} />
+      ) : screen === "saved" ? (
+        <SavedScreen
+          courses={(recent.data as RecentCourse[]) ?? []}
+          savedId={savedId}
+          onPick={reviewRecent}
+          onAddAnother={() => {
+            setEdited(false);
+            setIndexOptedIn(false);
+            setConfirmMode("summary");
+            setSavedId(null);
+            setDraft(blankDraft(18));
+            setActiveTee(0);
+            setScreen("new");
+          }}
+        />
       ) : (
         <EntryScreen
           draft={draft}
@@ -307,12 +361,12 @@ export function CoursePicker({
           setHole={setHole}
           activeTee={activeTee}
           setActiveTee={setActiveTee}
-          indexUsable={indexUsable}
-          saving={createCourse.isPending}
+          indexOptedIn={indexOptedIn}
+          onOptInIndex={() => setIndexOptedIn(true)}
           setPar={setPar}
           setIndex={setIndex}
           setYards={setYards}
-          onSave={save}
+          onReview={() => setScreen("confirm")}
         />
       )}
     </div>
@@ -428,26 +482,38 @@ function CourseRow({ name, sub, onClick }: { name: string; sub?: string | null; 
 // ── Confirm (lookup) ──────────────────────────────────────────────────────────
 function ConfirmScreen({
   draft,
+  mode,
   activeTee,
   setActiveTee,
   indexUsable,
   flagged,
   saving,
   onEditHole,
-  onUse,
+  onPrimary,
 }: {
   draft: Draft;
+  mode: "use" | "summary";
   activeTee: number;
   setActiveTee: (i: number) => void;
   indexUsable: boolean;
   flagged: Set<number>;
   saving: boolean;
   onEditHole: (h: number) => void;
-  onUse: () => void;
+  onPrimary: () => void;
 }) {
   const tee = draft.teeSets[activeTee];
   const totalPar = draft.par.reduce<number>((a, p) => a + p, 0);
   const totalYards = (tee?.yards ?? []).reduce<number>((a, y) => a + (y ?? 0), 0);
+  const indexStarted = draft.index.some((v) => v != null);
+  const indexComplete = validateStrokeIndex(draft.index, draft.holeCount).valid;
+  const showIndexCol = indexStarted; // show the rank column once any rank exists
+  const primaryLabel = !indexUsable
+    ? "Finish the stroke index table to save"
+    : saving
+      ? "Saving…"
+      : mode === "summary"
+        ? "Save to my courses"
+        : "Use this course";
   return (
     <>
       <div className="flex-1 overflow-y-auto" style={{ padding: "16px 16px 8px" }}>
@@ -476,19 +542,26 @@ function ConfirmScreen({
           <div className="mt-3 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}>
             <AlertTriangle size={15} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
             <span style={{ fontSize: 12.5, color: "var(--color-bt-text)" }}>
-              Stroke index started but incomplete — finish it (a wrong index mis-allocates handicap strokes), or clear it to play on par alone. Tap the flagged holes.
+              You started the stroke index table — rank every hole, or clear it to use an assigned handicap from the first hole onward. Tap the flagged holes.
+            </span>
+          </div>
+        ) : indexComplete ? (
+          <div className="mt-3 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-accent-faint)", borderColor: "var(--color-bt-accent-border)" }}>
+            <Check size={15} style={{ color: "var(--color-bt-accent)", flexShrink: 0, marginTop: 1 }} />
+            <span style={{ fontSize: 12.5, color: "var(--color-bt-text)" }}>
+              Stroke index table complete — handicap strokes land on the hardest holes first.
             </span>
           </div>
         ) : (
-          !draft.index.some((v) => v != null) && (
-            <p className="mt-3" style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.5 }}>
-              No hole difficulty set — strokes fall on holes 1–{draft.holeCount}. Tap a hole to set the index any time so handicaps land on the hardest holes.
-            </p>
-          )
+          <p className="mt-3" style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.5 }}>
+            {draft.source === "golfapi"
+              ? "No difficulty ranking — this listing's stroke index table was missing or incomplete, so an assigned handicap is used starting on the first hole and continuing on. Tap a hole to fill in the table yourself."
+              : "No stroke index table — an assigned handicap is used starting on the first hole and continuing on. Tap a hole to fill one in."}
+          </p>
         )}
 
         <div className="mt-3 overflow-hidden rounded-xl border" style={{ borderColor: "var(--color-bt-border)" }}>
-          <HoleHeader hasIndex={draft.hasStrokeIndex} />
+          <HoleHeader hasIndex={showIndexCol} />
           {draft.par.map((p, i) => {
             const h = i + 1;
             const bad = flagged.has(h);
@@ -508,7 +581,7 @@ function ConfirmScreen({
                   )}
                 </Cell>
                 <Cell>{p}</Cell>
-                {draft.hasStrokeIndex && <Cell warn={bad}>{draft.index[i] ?? "—"}</Cell>}
+                {showIndexCol && <Cell warn={bad}>{draft.index[i] ?? "—"}</Cell>}
                 <IconCol>
                   <PencilLine size={13} style={{ color: "var(--color-bt-text-dim)" }} />
                 </IconCol>
@@ -520,12 +593,12 @@ function ConfirmScreen({
             <Cell bold left>Total</Cell>
             <Cell dim>{totalYards > 0 ? totalYards.toLocaleString() : "—"}</Cell>
             <Cell bold>{totalPar}</Cell>
-            {draft.hasStrokeIndex && <Cell> </Cell>}
+            {showIndexCol && <Cell> </Cell>}
             <span style={{ width: ICON_COL, flexShrink: 0 }} />
           </div>
         </div>
       </div>
-      <Footer label={indexUsable ? "Use this course" : "Finish the index to use this course"} disabled={!indexUsable || saving} onClick={onUse} />
+      <Footer label={primaryLabel} disabled={!indexUsable || saving} onClick={onPrimary} />
     </>
   );
 }
@@ -589,21 +662,8 @@ function NewCourseScreen({
             </div>
           </Field>
 
-          {/* Stroke index toggle. */}
-          <button
-            onClick={() => setDraft((d) => ({ ...d, hasStrokeIndex: !d.hasStrokeIndex }))}
-            className="flex items-center justify-between gap-3 rounded-xl border px-3 py-2.5 text-left"
-            style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}
-          >
-            <span className="min-w-0">
-              <span style={{ display: "block", fontSize: 14, fontWeight: 600, color: "var(--color-bt-text)" }}>Add stroke indices</span>
-              <span style={{ display: "block", fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 2 }}>
-                The course&apos;s 1–{draft.holeCount} difficulty ranking. Needed for net play — skip if you don&apos;t have it.
-              </span>
-            </span>
-            <Switch on={draft.hasStrokeIndex} />
-          </button>
-
+          {/* No stroke-index toggle here — the table is opt-in later, on the
+              empty index grid in the per-hole editor (spec §2). */}
           <Field label="Tee sets">
             <TeeList tees={draft.teeSets} onName={setTeeName} onRemove={removeTee} onReorder={reorderTee} />
             <button onClick={addTee} className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-xl border py-2" style={{ borderStyle: "dashed", borderColor: "var(--color-bt-accent-border)", color: "var(--color-bt-accent)" }}>
@@ -704,29 +764,30 @@ function EntryScreen({
   setHole,
   activeTee,
   setActiveTee,
-  indexUsable,
-  saving,
+  indexOptedIn,
+  onOptInIndex,
   setPar,
   setIndex,
   setYards,
-  onSave,
+  onReview,
 }: {
   draft: Draft;
   hole: number;
   setHole: (h: number) => void;
   activeTee: number;
   setActiveTee: (i: number) => void;
-  indexUsable: boolean;
-  saving: boolean;
+  indexOptedIn: boolean;
+  onOptInIndex: () => void;
   setPar: (h: number, v: number) => void;
   setIndex: (h: number, v: number) => void;
   setYards: (h: number, v: number | null) => void;
-  onSave: () => void;
+  onReview: () => void;
 }) {
   const n = draft.holeCount;
   const completed = draft.index.map((v, i) => (v != null ? i + 1 : 0)).filter(Boolean);
   // The keypad is a dismissable yards accessory; the footer below it is the
-  // PERSISTENT advance/save control. Advancing never depends on the keypad.
+  // PERSISTENT advance control. Per-hole Next is NEVER blocked — the only gate
+  // is the completion CTA on the review card (spec §4).
   const [yardsActive, setYardsActive] = useState(false);
   const teeName = draft.teeSets[activeTee]?.name?.trim() || `Tee ${activeTee + 1}`;
   const yardsOf = () => draft.teeSets[activeTee]?.yards[hole - 1] ?? null;
@@ -742,11 +803,8 @@ function EntryScreen({
     setYards(hole, cur == null || cur < 10 ? null : Math.floor(cur / 10));
   };
   const lastHole = hole >= n;
-  // A started-but-incomplete index blocks the footer (the index is course-wide);
-  // the ‹ › arrows still move between holes so you can finish it.
-  const blocked = !indexUsable;
-  const footerLabel = blocked ? "Finish the index to use this course" : lastHole ? (saving ? "Saving…" : "Save course") : "Next hole ›";
-  const onAdvance = () => (lastHole ? onSave() : setHole(hole + 1));
+  const footerLabel = lastHole ? "Done · review card" : "Next hole ›";
+  const onAdvance = () => (lastHole ? onReview() : setHole(hole + 1));
 
   return (
     <>
@@ -767,9 +825,10 @@ function EntryScreen({
           holeCount={n}
           par={draft.par[hole - 1]}
           onPar={(v) => setPar(hole, v)}
-          hasStrokeIndex={draft.hasStrokeIndex}
           index={draft.index}
           onIndexPick={(v) => setIndex(hole, v)}
+          indexOptedIn={indexOptedIn}
+          onOptInIndex={onOptInIndex}
           tees={draft.teeSets}
           activeTee={activeTee}
           onTee={setActiveTee}
@@ -793,8 +852,7 @@ function EntryScreen({
           <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", whiteSpace: "nowrap", fontVariantNumeric: "tabular-nums" }}>Hole {hole} / {n}</span>
           <button
             onClick={onAdvance}
-            disabled={blocked || (lastHole && saving)}
-            className="flex-1 disabled:opacity-40"
+            className="flex-1"
             style={{ height: 54, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
           >
             {footerLabel}
@@ -812,6 +870,8 @@ function HoleEditScreen({
   activeTee,
   setActiveTee,
   flagged,
+  indexOptedIn,
+  onOptInIndex,
   setPar,
   setIndex,
   setYards,
@@ -822,6 +882,8 @@ function HoleEditScreen({
   activeTee: number;
   setActiveTee: (i: number) => void;
   flagged: Set<number>;
+  indexOptedIn: boolean;
+  onOptInIndex: () => void;
   setPar: (h: number, v: number) => void;
   setIndex: (h: number, v: number) => void;
   setYards: (h: number, v: number | null) => void;
@@ -850,9 +912,10 @@ function HoleEditScreen({
           holeCount={draft.holeCount}
           par={draft.par[hole - 1]}
           onPar={(v) => setPar(hole, v)}
-          hasStrokeIndex={draft.hasStrokeIndex}
           index={draft.index}
           onIndexPick={(v) => setIndex(hole, v)}
+          indexOptedIn={indexOptedIn}
+          onOptInIndex={onOptInIndex}
           tees={draft.teeSets}
           activeTee={activeTee}
           onTee={setActiveTee}
@@ -904,14 +967,68 @@ function TeeChip({ name, on, onClick }: { name: string; on: boolean; onClick: ()
   );
 }
 
-function Switch({ on }: { on: boolean }) {
+// ── My courses (manual-add destination) ───────────────────────────────────────
+// Lands here after "Save to my courses" — the new course is highlighted (NEW),
+// NOT auto-selected for play. Adding a course and using one are separate
+// concerns (spec §6); tapping a row reviews it (→ Confirm, mode 'use').
+function SavedScreen({
+  courses,
+  savedId,
+  onPick,
+  onAddAnother,
+}: {
+  courses: RecentCourse[];
+  savedId: string | null;
+  onPick: (c: RecentCourse) => void;
+  onAddAnother: () => void;
+}) {
+  const saved = courses.find((c) => c.id === savedId);
   return (
-    <span
-      className="relative shrink-0"
-      style={{ width: 40, height: 24, borderRadius: 9999, background: on ? "var(--color-bt-accent)" : "var(--color-bt-border)", transition: "background 0.15s" }}
-    >
-      <span style={{ position: "absolute", top: 2, left: on ? 18 : 2, width: 20, height: 20, borderRadius: "50%", background: "#fff", transition: "left 0.15s" }} />
-    </span>
+    <>
+      <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
+        {saved && (
+          <div className="mb-4 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-accent-faint)", borderColor: "var(--color-bt-accent-border)" }}>
+            <Check size={15} style={{ color: "var(--color-bt-accent)", flexShrink: 0, marginTop: 1 }} />
+            <span style={{ fontSize: 13, color: "var(--color-bt-text)" }}>
+              <span style={{ fontWeight: 600 }}>{saved.name}</span> added to your courses.
+            </span>
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          {courses.map((c) => {
+            const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
+            const isNew = c.id === savedId;
+            return (
+              <button
+                key={c.id}
+                onClick={() => onPick(c)}
+                className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left"
+                style={{
+                  background: isNew ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)",
+                  borderColor: isNew ? "var(--color-bt-accent-border)" : "var(--color-bt-border)",
+                }}
+              >
+                <span className="min-w-0">
+                  <span className="flex items-center gap-2">
+                    <span className="truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{c.name}</span>
+                    {isNew && (
+                      <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: "0.08em", color: "var(--color-bt-accent)", border: "1px solid var(--color-bt-accent-border)", borderRadius: 4, padding: "1px 5px" }}>
+                        NEW
+                      </span>
+                    )}
+                  </span>
+                  <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
+                    {[c.location, par ? `Par ${par}` : "", `${c.hole_count} holes`].filter(Boolean).join(" · ")}
+                  </span>
+                </span>
+                <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <Footer label="Add another course" onClick={onAddAnother} />
+    </>
   );
 }
 

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -750,13 +750,15 @@ function EntryScreen({
 
   return (
     <>
-      <div className="flex shrink-0 items-center justify-between" style={{ padding: "16px 16px" }}>
-        <NavArrow dir="prev" disabled={hole <= 1} onClick={() => setHole(hole - 1)} />
-        <div className="flex flex-col items-center" style={{ gap: 12, flex: 1, minWidth: 0 }}>
+      <div className="shrink-0" style={{ padding: "12px 16px 6px" }}>
+        <div className="flex items-center justify-between">
+          <NavArrow dir="prev" disabled={hole <= 1} onClick={() => setHole(hole - 1)} />
           <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--color-bt-text)" }}>Hole {hole}</div>
-          <HoleProgress count={n} currentHole={hole} completed={completed} />
+          <NavArrow dir="next" disabled={hole >= n} onClick={() => setHole(hole + 1)} />
         </div>
-        <NavArrow dir="next" disabled={hole >= n} onClick={() => setHole(hole + 1)} />
+        <div style={{ marginTop: 14 }}>
+          <HoleProgress count={n} currentHole={hole} completed={completed} maxWidth="100%" />
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto" style={{ padding: "4px 16px 8px" }}>
@@ -779,14 +781,14 @@ function EntryScreen({
 
       {yardsActive && (
         <Keypad
-          title={`Yards · ${teeName}`}
+          title={`Yards · ${teeName} Tees`}
           hint="Done to keep editing the hole"
           onDigit={pushDigit}
           onBackspace={backspace}
           onDone={() => setYardsActive(false)}
         />
       )}
-      <div className="shrink-0" style={{ padding: "12px 16px 24px", borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-card-float)" }}>
+      <div className="shrink-0" style={{ padding: "10px 16px 14px", background: "transparent" }}>
         <div className="flex items-center gap-3">
           <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", whiteSpace: "nowrap", fontVariantNumeric: "tabular-nums" }}>Hole {hole} / {n}</span>
           <button
@@ -862,7 +864,7 @@ function HoleEditScreen({
       </div>
       {yardsActive && (
         <Keypad
-          title={`Yards · ${teeName}`}
+          title={`Yards · ${teeName} Tees`}
           hint="Done to keep editing the hole"
           onDigit={pushDigit}
           onBackspace={backspace}

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -217,8 +217,21 @@ export function CoursePicker({
     onApply({ id: course.id as string, name: course.name as string });
   }
 
+  // On the per-hole screens (stepped entry + single-hole edit) the title is the
+  // course itself, with "Hole N of N" as the subtitle (so the hole number lives
+  // in the header, not buried at the bottom of the editor).
+  const holeShown = editingHole ?? (screen === "entry" ? hole : null);
   const headerTitle =
-    screen === "search" ? "Add a course" : screen === "confirm" ? "Confirm course" : screen === "new" ? "New course" : "Enter holes";
+    holeShown != null
+      ? draft.name.trim() || "New course"
+      : screen === "search"
+        ? "Add a course"
+        : screen === "confirm"
+          ? "Confirm course"
+          : screen === "new"
+            ? "New course"
+            : "Enter holes";
+  const headerSubtitle = holeShown != null ? `Hole ${holeShown} of ${draft.holeCount}` : null;
   const back = () => {
     if (editingHole != null) return setEditingHole(null);
     if (screen === "confirm" || screen === "new") return setScreen("search");
@@ -235,7 +248,10 @@ export function CoursePicker({
         <button onClick={back} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
           <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
         </button>
-        <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{headerTitle}</div>
+        <div className="flex min-w-0 flex-col items-center" style={{ lineHeight: 1.1 }}>
+          <div className="max-w-full truncate" style={{ fontSize: 17, fontWeight: 700, color: "var(--color-bt-text)" }}>{headerTitle}</div>
+          {headerSubtitle && <div style={{ fontSize: 11.5, fontWeight: 500, color: "var(--color-bt-text-dim)", marginTop: 2 }}>{headerSubtitle}</div>}
+        </div>
         <button onClick={onClose} aria-label="Close" className="flex h-9 w-9 items-center justify-center">
           <X size={20} style={{ color: "var(--color-bt-text-dim)" }} />
         </button>
@@ -458,7 +474,7 @@ function ConfirmScreen({
         {!indexUsable ? (
           <div className="mt-3 flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-warning-faint)", borderColor: "var(--color-bt-warning-border)" }}>
             <AlertTriangle size={15} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
-            <span style={{ fontSize: 12.5, color: "var(--color-bt-warning)" }}>
+            <span style={{ fontSize: 12.5, color: "var(--color-bt-text)" }}>
               Stroke index started but incomplete — finish it (a wrong index mis-allocates handicap strokes), or clear it to play on par alone. Tap the flagged holes.
             </span>
           </div>
@@ -708,6 +724,10 @@ function EntryScreen({
 }) {
   const n = draft.holeCount;
   const completed = draft.index.map((v, i) => (v != null ? i + 1 : 0)).filter(Boolean);
+  // The keypad is a yards tool — it docks only while the yards field is focused
+  // (tap the field to open, "Done" to dismiss). Hole nav is the ‹ › arrows; the
+  // footer carries Next / Save when the keypad isn't up.
+  const [yardsActive, setYardsActive] = useState(false);
   const yardsOf = () => draft.teeSets[activeTee]?.yards[hole - 1] ?? null;
   const pushDigit = (d: number) => {
     const cur = yardsOf();
@@ -722,13 +742,13 @@ function EntryScreen({
   };
   const lastHole = hole >= n;
   const onNext = () => (lastHole ? onSave() : setHole(hole + 1));
+  const footerLabel = lastHole ? (!indexUsable ? "Finish the index" : saving ? "Saving…" : "Save course") : `Hole ${hole + 1} ›`;
 
   return (
     <>
       <div className="flex shrink-0 items-center justify-between" style={{ padding: "12px 16px" }}>
         <NavArrow dir="prev" disabled={hole <= 1} onClick={() => setHole(hole - 1)} />
-        <div className="flex flex-col items-center" style={{ gap: 10, flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 22, fontWeight: 700, color: "var(--color-bt-text)" }}>Hole {hole}</div>
+        <div className="flex flex-col items-center" style={{ flex: 1, minWidth: 0 }}>
           <HoleProgress count={n} currentHole={hole} completed={completed} />
         </div>
         <NavArrow dir="next" disabled={hole >= n} onClick={() => setHole(hole + 1)} />
@@ -747,17 +767,16 @@ function EntryScreen({
           activeTee={activeTee}
           onTee={setActiveTee}
           yards={yardsOf()}
-          yardsActive
-          onYardsTap={() => {}}
+          yardsActive={yardsActive}
+          onYardsTap={() => setYardsActive(true)}
         />
       </div>
 
-      <Keypad
-        onDigit={pushDigit}
-        onBackspace={backspace}
-        onNext={onNext}
-        nextLabel={lastHole ? (!indexUsable ? "Finish the index" : saving ? "Saving…" : "Save ›") : `Hole ${hole + 1} ›`}
-      />
+      {yardsActive ? (
+        <Keypad onDigit={pushDigit} onBackspace={backspace} onNext={() => setYardsActive(false)} nextLabel="Done ✓" />
+      ) : (
+        <Footer label={footerLabel} disabled={lastHole && (!indexUsable || saving)} onClick={onNext} />
+      )}
     </>
   );
 }
@@ -840,13 +859,13 @@ function TeeChip({ name, on, onClick }: { name: string; on: boolean; onClick: ()
       onClick={onClick}
       className="flex shrink-0 items-center gap-1.5"
       style={{
-        padding: "5px 12px",
-        borderRadius: 9999,
+        padding: "7px 12px",
+        borderRadius: 8,
         fontSize: 13,
-        fontWeight: 600,
-        border: `1px solid ${on ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
-        background: on ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
-        color: on ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+        fontWeight: on ? 600 : 500,
+        border: "1px solid var(--color-bt-border)",
+        background: on ? "var(--color-bt-card-float)" : "var(--color-bt-card-raised)",
+        color: on ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
       }}
     >
       <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(name), flexShrink: 0 }} />

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -66,7 +66,7 @@ export function HoleEditor({
   // them actually helps someone finish.
   const unset = idxValidation.unsetHoles;
   const idxRemainingLabel =
-    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need a rank` : `Unset: holes ${unset.join(", ")}`;
+    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need a rank` : `Remaining holes: ${unset.join(", ")}`;
   return (
     <div className="flex flex-col" style={{ gap: 16 }}>
       {/* Tee tabs — which tee's yardage you're filling. */}
@@ -238,7 +238,7 @@ export function HoleEditor({
             <div className="mt-2 flex items-start gap-2 rounded-lg px-2.5 py-2" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning-border)" }}>
               <AlertTriangle size={14} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
               <span style={{ fontSize: 12, color: "var(--color-bt-text)", lineHeight: 1.4 }}>
-                <span style={{ fontWeight: 700 }}>Finish the index to use it.</span> {idxRemainingLabel}.
+                <span style={{ fontWeight: 700 }}>Complete the stroke index table.</span> {idxRemainingLabel}.
               </span>
             </div>
             <p style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", marginTop: 6, lineHeight: 1.45 }}>

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Delete, AlertTriangle } from "lucide-react";
+import { Check, Delete, AlertTriangle, Info } from "lucide-react";
 import { teeColor } from "@/lib/courseService";
 import { validateStrokeIndex, type IndexEntry } from "@/lib/courseIndex";
 
@@ -59,7 +59,7 @@ export function HoleEditor({
   // them actually helps someone finish.
   const unset = idxValidation.unsetHoles;
   const idxRemainingLabel =
-    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need a rank` : `holes ${unset.join(", ")} still need a rank`;
+    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need a rank` : `Unset: holes ${unset.join(", ")}`;
   return (
     <div className="flex flex-col" style={{ gap: 16 }}>
       {/* Tee tabs — which tee's yardage you're filling. */}
@@ -210,9 +210,14 @@ export function HoleEditor({
                 Each rank 1–{holeCount} is used once — setting one already in use swaps with the hole that holds it.
               </p>
             </>
+          ) : idxValidation.valid ? (
+            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8, lineHeight: 1.45 }}>
+              All {holeCount} ranks set. Strokes land on the hardest holes; tap any to adjust (it swaps).
+            </p>
           ) : (
-            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8 }}>
-              Optional — read it off the course&apos;s scorecard, or leave it unset and strokes fall on holes 1–{holeCount}. Each rank 1–{holeCount} is used once.
+            <p className="mt-2 flex items-start gap-1.5" style={{ fontSize: 12, color: "var(--color-bt-text-dim)", lineHeight: 1.45 }}>
+              <Info size={13} style={{ flexShrink: 0, marginTop: 1 }} />
+              <span>No hole difficulty set — strokes will fall on holes 1–{holeCount}. Add a stroke index any time for handicaps to land on the hardest holes.</span>
             </p>
           )}
         </div>
@@ -225,24 +230,30 @@ export function HoleEditor({
   );
 }
 
-/** Docked 3-column numeric keypad that fills the active yards field.
- *  `1–9`, then `⌫ · 0 · Next ›` (accent Next commits + advances). */
+/** Dismissable yards keypad — an ACCESSORY that sits above the persistent
+ *  footer, never the advance control. `1–9`, then `⌫ · 0 · ✓`; the accent ✓
+ *  closes the keypad ("Done to keep editing the hole"). Hole advance lives in
+ *  the footer (Next hole ›), so it never depends on which field you touched
+ *  last. Matches StrokeKeypad (light card-float panel, dark bold keys). */
 export function Keypad({
+  title,
+  hint,
   onDigit,
   onBackspace,
-  onNext,
-  nextLabel,
+  onDone,
 }: {
+  title: string;
+  hint?: string;
   onDigit: (d: number) => void;
   onBackspace: () => void;
-  onNext: () => void;
-  nextLabel: string;
+  onDone: () => void;
 }) {
-  // Matches StrokeKeypad (the normal hole keypad) exactly — light card-float
-  // panel, darker card buttons, bold numbers — differing only in the bottom row
-  // (0 instead of 10+, the accent Next instead of the ✓ confirm).
   return (
-    <div style={{ background: "var(--color-bt-card-float)", borderTop: "1px solid var(--color-bt-border)", padding: "12px 16px 22px" }}>
+    <div style={{ background: "var(--color-bt-card-float)", borderTop: "1px solid var(--color-bt-border)", padding: "10px 16px 14px" }}>
+      <div className="mb-2 flex items-center justify-between">
+        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>{title}</span>
+        {hint && <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{hint}</span>}
+      </div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8 }}>
         {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((d) => (
           <Key key={d} onClick={() => onDigit(d)}>
@@ -253,8 +264,8 @@ export function Keypad({
           <Delete size={20} strokeWidth={1.9} />
         </Key>
         <Key onClick={() => onDigit(0)}>0</Key>
-        <Key onClick={onNext} accent>
-          {nextLabel}
+        <Key onClick={onDone} aria-label="Done" accent>
+          <Check size={22} strokeWidth={2.4} />
         </Key>
       </div>
     </div>

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -124,7 +124,7 @@ export function HoleEditor({
 
       {/* Yards — tappable numeric field; the keypad (screen) fills it. */}
       <div>
-        <FieldLabel>{`Yards · ${teeName}`}</FieldLabel>
+        <FieldLabel>{`Yards · ${teeName} Tees`}</FieldLabel>
         <button
           onClick={onYardsTap}
           className="flex w-full items-center justify-between rounded-xl border px-3"
@@ -143,7 +143,7 @@ export function HoleEditor({
             )}
             {yardsActive && <span style={{ color: "var(--color-bt-accent)", fontWeight: 400 }}>|</span>}
           </span>
-          <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>yds · optional</span>
+          <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>yds</span>
         </button>
       </div>
 

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -54,6 +54,12 @@ export function HoleEditor({
   const idxValidation = validateStrokeIndex(index, holeCount);
   const idxStarted = index.some((v) => v != null);
   const idxSetCount = index.filter((v) => v != null).length;
+  // Collapse the "still needs an index" list (same rule as the handicap hint):
+  // a count once more than a handful are outstanding, names only when naming
+  // them actually helps someone finish.
+  const unset = idxValidation.unsetHoles;
+  const idxRemainingLabel =
+    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need an index` : `holes ${unset.join(", ")} still need an index`;
   return (
     <div className="flex flex-col" style={{ gap: 16 }}>
       {/* Tee tabs — which tee's yardage you're filling. */}
@@ -190,7 +196,7 @@ export function HoleEditor({
           </div>
           {idxStarted && !idxValidation.valid ? (
             <p style={{ fontSize: 12, color: "var(--color-bt-warning)", marginTop: 8, lineHeight: 1.45 }}>
-              Finish the index to use it. Unset holes: {idxValidation.unsetHoles.join(", ") || "—"}. Each rank 1–{holeCount} is used once; setting one already in use swaps with the hole that holds it.
+              Finish the index to use it — {idxRemainingLabel}. Each rank 1–{holeCount} is used once; setting one already in use swaps with the hole that holds it.
             </p>
           ) : (
             <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8 }}>

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -2,7 +2,7 @@
 
 import { Check, Delete } from "lucide-react";
 import { teeColor } from "@/lib/courseService";
-import type { IndexEntry } from "@/lib/courseIndex";
+import { validateStrokeIndex, type IndexEntry } from "@/lib/courseIndex";
 
 /**
  * HoleEditor — the SHARED per-hole editor (Slice C, addendum C-1). One component,
@@ -51,6 +51,9 @@ export function HoleEditor({
   showSwapWarning,
 }: HoleEditorProps) {
   const teeName = tees[activeTee]?.name?.trim() || `Tee ${activeTee + 1}`;
+  const idxValidation = validateStrokeIndex(index, holeCount);
+  const idxStarted = index.some((v) => v != null);
+  const idxSetCount = index.filter((v) => v != null).length;
   return (
     <div className="flex flex-col" style={{ gap: 16 }}>
       {/* Tee tabs — which tee's yardage you're filling. */}
@@ -134,10 +137,22 @@ export function HoleEditor({
         </button>
       </div>
 
-      {/* Stroke index — 18-cell grid, or the off-line. */}
+      {/* Stroke index — OPTIONAL 18-cell grid (three states), or the fallback line. */}
       {hasStrokeIndex ? (
         <div>
-          <FieldLabel>Stroke index · 1 = hardest</FieldLabel>
+          <div className="mb-2 flex items-center justify-between">
+            <FieldLabel>{idxStarted ? "Stroke index · 1 = hardest" : "Stroke index · optional"}</FieldLabel>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: "0.06em",
+                color: idxValidation.valid ? "var(--color-bt-accent)" : idxStarted ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)",
+              }}
+            >
+              {idxValidation.valid ? "✓ COMPLETE" : idxStarted ? `${idxSetCount} OF ${holeCount} SET` : "NOT SET"}
+            </span>
+          </div>
           {showSwapWarning && (
             <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginBottom: 8 }}>
               Reassigning an index swaps it with the hole that currently holds it.
@@ -173,13 +188,19 @@ export function HoleEditor({
               );
             })}
           </div>
-          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8 }}>
-            Read it off the course&apos;s scorecard. Each rank 1–{holeCount} is used once; ✓ = already assigned.
-          </p>
+          {idxStarted && !idxValidation.valid ? (
+            <p style={{ fontSize: 12, color: "var(--color-bt-warning)", marginTop: 8, lineHeight: 1.45 }}>
+              Finish the index to use it. Unset holes: {idxValidation.unsetHoles.join(", ") || "—"}. Each rank 1–{holeCount} is used once; setting one already in use swaps with the hole that holds it.
+            </p>
+          ) : (
+            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8 }}>
+              Optional — read it off the course&apos;s scorecard, or leave it unset and strokes fall on holes 1–{holeCount}. Each rank 1–{holeCount} is used once.
+            </p>
+          )}
         </div>
       ) : (
         <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.5 }}>
-          Stroke indices are off for this course — net play is unavailable. Add them in course settings.
+          No hole difficulty set — strokes fall on holes 1–{holeCount}. Turn on stroke indices for handicaps to land on the hardest holes instead.
         </p>
       )}
 

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Delete } from "lucide-react";
+import { Check, Delete, AlertTriangle } from "lucide-react";
 import { teeColor } from "@/lib/courseService";
 import { validateStrokeIndex, type IndexEntry } from "@/lib/courseIndex";
 
@@ -59,7 +59,7 @@ export function HoleEditor({
   // them actually helps someone finish.
   const unset = idxValidation.unsetHoles;
   const idxRemainingLabel =
-    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need an index` : `holes ${unset.join(", ")} still need an index`;
+    unset.length > 6 ? `${unset.length} of ${holeCount} holes still need a rank` : `holes ${unset.join(", ")} still need a rank`;
   return (
     <div className="flex flex-col" style={{ gap: 16 }}>
       {/* Tee tabs — which tee's yardage you're filling. */}
@@ -135,8 +135,12 @@ export function HoleEditor({
             boxShadow: yardsActive ? "0 0 0 3px rgba(45,212,191,0.12)" : undefined,
           }}
         >
-          <span style={{ fontSize: 22, fontWeight: 700, color: yards == null ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
-            {yards == null ? "—" : yards}
+          <span style={{ fontSize: 22, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+            {yards == null ? (
+              <span style={{ color: "var(--color-bt-text-dim)", opacity: 0.4 }}>000</span>
+            ) : (
+              <span style={{ color: "var(--color-bt-text)" }}>{yards}</span>
+            )}
             {yardsActive && <span style={{ color: "var(--color-bt-accent)", fontWeight: 400 }}>|</span>}
           </span>
           <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>yds · optional</span>
@@ -195,9 +199,17 @@ export function HoleEditor({
             })}
           </div>
           {idxStarted && !idxValidation.valid ? (
-            <p style={{ fontSize: 12, color: "var(--color-bt-warning)", marginTop: 8, lineHeight: 1.45 }}>
-              Finish the index to use it — {idxRemainingLabel}. Each rank 1–{holeCount} is used once; setting one already in use swaps with the hole that holds it.
-            </p>
+            <>
+              <div className="mt-2 flex items-start gap-2 rounded-lg px-2.5 py-2" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning-border)" }}>
+                <AlertTriangle size={14} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
+                <span style={{ fontSize: 12, color: "var(--color-bt-warning)", lineHeight: 1.4 }}>
+                  <span style={{ fontWeight: 700 }}>Finish the index to use it.</span> {idxRemainingLabel}.
+                </span>
+              </div>
+              <p style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", marginTop: 6, lineHeight: 1.45 }}>
+                Each rank 1–{holeCount} is used once — setting one already in use swaps with the hole that holds it.
+              </p>
+            </>
           ) : (
             <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8 }}>
               Optional — read it off the course&apos;s scorecard, or leave it unset and strokes fall on holes 1–{holeCount}. Each rank 1–{holeCount} is used once.
@@ -230,19 +242,19 @@ export function Keypad({
   onNext: () => void;
   nextLabel: string;
 }) {
+  // Matches StrokeKeypad (the normal hole keypad) exactly — light card-float
+  // panel, darker card buttons, bold numbers — differing only in the bottom row
+  // (0 instead of 10+, the accent Next instead of the ✓ confirm).
   return (
-    <div
-      className="shrink-0"
-      style={{ padding: 10, borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)" }}
-    >
-      <div className="grid gap-2" style={{ gridTemplateColumns: "repeat(3, 1fr)" }}>
+    <div style={{ background: "var(--color-bt-card-float)", borderTop: "1px solid var(--color-bt-border)", padding: "12px 16px 22px" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8 }}>
         {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((d) => (
           <Key key={d} onClick={() => onDigit(d)}>
             {d}
           </Key>
         ))}
-        <Key onClick={onBackspace} aria-label="Backspace">
-          <Delete size={20} style={{ color: "var(--color-bt-text)" }} />
+        <Key onClick={onBackspace} aria-label="Backspace" dim>
+          <Delete size={20} strokeWidth={1.9} />
         </Key>
         <Key onClick={() => onDigit(0)}>0</Key>
         <Key onClick={onNext} accent>
@@ -253,19 +265,19 @@ export function Keypad({
   );
 }
 
-function Key({ children, onClick, accent, ...rest }: { children: React.ReactNode; onClick: () => void; accent?: boolean } & React.HTMLAttributes<HTMLButtonElement>) {
+const KEY_H = 54;
+function Key({ children, onClick, accent, dim, ...rest }: { children: React.ReactNode; onClick: () => void; accent?: boolean; dim?: boolean } & React.HTMLAttributes<HTMLButtonElement>) {
   return (
     <button
       onClick={onClick}
       {...rest}
-      className="flex items-center justify-center"
+      className="flex items-center justify-center font-semibold transition-transform active:scale-[0.97]"
       style={{
-        height: 48,
+        height: KEY_H,
         borderRadius: 10,
-        fontSize: accent ? 15 : 20,
-        fontWeight: accent ? 600 : 600,
-        background: accent ? "var(--color-bt-accent)" : "var(--color-bt-card-raised)",
-        color: accent ? "#0d1f1a" : "var(--color-bt-text)",
+        fontSize: accent ? 15 : 24,
+        background: accent ? "var(--color-bt-accent)" : "var(--color-bt-card)",
+        color: accent ? "#0d1f1a" : dim ? "var(--color-bt-text-dim)" : "var(--color-bt-text)",
         border: accent ? "none" : "1px solid var(--color-bt-border)",
       }}
     >

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -76,13 +76,13 @@ export function HoleEditor({
                   onClick={() => onTee(i)}
                   className="flex shrink-0 items-center gap-1.5"
                   style={{
-                    padding: "5px 11px",
-                    borderRadius: 9999,
+                    padding: "7px 12px",
+                    borderRadius: 8,
                     fontSize: 13,
-                    fontWeight: 600,
-                    border: `1px solid ${on ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
-                    background: on ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
-                    color: on ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
+                    fontWeight: on ? 600 : 500,
+                    border: "1px solid var(--color-bt-border)",
+                    background: on ? "var(--color-bt-card-float)" : "var(--color-bt-card-raised)",
+                    color: on ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
                   }}
                 >
                   <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(name), flexShrink: 0 }} />
@@ -202,7 +202,7 @@ export function HoleEditor({
             <>
               <div className="mt-2 flex items-start gap-2 rounded-lg px-2.5 py-2" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning-border)" }}>
                 <AlertTriangle size={14} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
-                <span style={{ fontSize: 12, color: "var(--color-bt-warning)", lineHeight: 1.4 }}>
+                <span style={{ fontSize: 12, color: "var(--color-bt-text)", lineHeight: 1.4 }}>
                   <span style={{ fontWeight: 700 }}>Finish the index to use it.</span> {idxRemainingLabel}.
                 </span>
               </div>
@@ -221,10 +221,6 @@ export function HoleEditor({
           No hole difficulty set — strokes fall on holes 1–{holeCount}. Turn on stroke indices for handicaps to land on the hardest holes instead.
         </p>
       )}
-
-      <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
-        Hole {holeNumber} of {holeCount}
-      </p>
     </div>
   );
 }

--- a/src/components/games/course/HoleEditor.tsx
+++ b/src/components/games/course/HoleEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Delete, AlertTriangle, Info } from "lucide-react";
+import { Check, Delete, AlertTriangle } from "lucide-react";
 import { teeColor } from "@/lib/courseService";
 import { validateStrokeIndex, type IndexEntry } from "@/lib/courseIndex";
 
@@ -18,10 +18,13 @@ interface HoleEditorProps {
   holeCount: number;
   par: number;
   onPar: (value: number) => void;
-  hasStrokeIndex: boolean;
   /** Full index array (for grid selection / used-elsewhere ✓ / swap). */
   index: IndexEntry[];
   onIndexPick: (rank: number) => void;
+  /** The stroke index table is OPTIONAL — opt-in lives here, on the empty grid.
+   *  Until opted in (and with no rank set), the grid is faint under a scrim. */
+  indexOptedIn: boolean;
+  onOptInIndex: () => void;
   tees: { name: string }[];
   activeTee: number;
   onTee: (i: number) => void;
@@ -39,9 +42,10 @@ export function HoleEditor({
   holeCount,
   par,
   onPar,
-  hasStrokeIndex,
   index,
   onIndexPick,
+  indexOptedIn,
+  onOptInIndex,
   tees,
   activeTee,
   onTee,
@@ -54,7 +58,10 @@ export function HoleEditor({
   const idxValidation = validateStrokeIndex(index, holeCount);
   const idxStarted = index.some((v) => v != null);
   const idxSetCount = index.filter((v) => v != null).length;
-  // Collapse the "still needs an index" list (same rule as the handicap hint):
+  // Empty + not opted in → the quiet opt-in scrim over a faint grid (the table
+  // is OPTIONAL, so it must not shout). Anything else → the live grid.
+  const showScrim = !idxStarted && !indexOptedIn;
+  // Collapse the "still needs a rank" clause (same rule as the handicap hint):
   // a count once more than a handful are outstanding, names only when naming
   // them actually helps someone finish.
   const unset = idxValidation.unsetHoles;
@@ -147,28 +154,33 @@ export function HoleEditor({
         </button>
       </div>
 
-      {/* Stroke index — OPTIONAL 18-cell grid (three states), or the fallback line. */}
-      {hasStrokeIndex ? (
-        <div>
-          <div className="mb-2 flex items-center justify-between">
-            <FieldLabel>{idxStarted ? "Stroke index · 1 = hardest" : "Stroke index · optional"}</FieldLabel>
+      {/* Stroke index TABLE — optional, all-or-nothing. Empty → opt-in scrim
+          over a faint grid; otherwise the live grid (partial → amber reminder,
+          complete → quiet note). The fallback (no table) is fully valid. */}
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <FieldLabel>{idxStarted ? "Stroke index table · 1 = hardest" : "Stroke index table · optional"}</FieldLabel>
+          {!showScrim && (idxValidation.valid || idxStarted) && (
             <span
               style={{
                 fontSize: 10,
                 fontWeight: 700,
                 letterSpacing: "0.06em",
-                color: idxValidation.valid ? "var(--color-bt-accent)" : idxStarted ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)",
+                color: idxValidation.valid ? "var(--color-bt-accent)" : "var(--color-bt-warning)",
               }}
             >
-              {idxValidation.valid ? "✓ COMPLETE" : idxStarted ? `${idxSetCount} OF ${holeCount} SET` : "NOT SET"}
+              {idxValidation.valid ? "✓ COMPLETE" : `${idxSetCount} OF ${holeCount} SET`}
             </span>
-          </div>
-          {showSwapWarning && (
-            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginBottom: 8 }}>
-              Reassigning an index swaps it with the hole that currently holds it.
-            </p>
           )}
-          <div className="grid gap-1.5" style={{ gridTemplateColumns: "repeat(6, 1fr)" }}>
+        </div>
+        {showSwapWarning && !showScrim && (
+          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginBottom: 8 }}>
+            Reassigning a rank swaps it with the hole that currently holds it.
+          </p>
+        )}
+
+        <div className="relative">
+          <div className="grid gap-1.5" style={{ gridTemplateColumns: "repeat(6, 1fr)", opacity: showScrim ? 0.28 : 1 }}>
             {Array.from({ length: holeCount }, (_, i) => i + 1).map((rank) => {
               const owner = index.findIndex((v) => v === rank);
               const selected = owner === holeNumber - 1;
@@ -177,6 +189,7 @@ export function HoleEditor({
                 <button
                   key={rank}
                   onClick={() => onIndexPick(rank)}
+                  disabled={showScrim}
                   className="relative flex items-center justify-center"
                   style={{
                     height: 40,
@@ -198,34 +211,50 @@ export function HoleEditor({
               );
             })}
           </div>
-          {idxStarted && !idxValidation.valid ? (
-            <>
-              <div className="mt-2 flex items-start gap-2 rounded-lg px-2.5 py-2" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning-border)" }}>
-                <AlertTriangle size={14} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
-                <span style={{ fontSize: 12, color: "var(--color-bt-text)", lineHeight: 1.4 }}>
-                  <span style={{ fontWeight: 700 }}>Finish the index to use it.</span> {idxRemainingLabel}.
-                </span>
-              </div>
-              <p style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", marginTop: 6, lineHeight: 1.45 }}>
-                Each rank 1–{holeCount} is used once — setting one already in use swaps with the hole that holds it.
+
+          {/* Quiet opt-in scrim — the table is optional, so no border, no shout. */}
+          {showScrim && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2.5 px-4 text-center" style={{ background: "color-mix(in srgb, var(--color-bt-base) 82%, transparent)" }}>
+              <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.45, maxWidth: 280 }}>
+                Ranking holes is optional, but you must rank them all if you do.
               </p>
-            </>
-          ) : idxValidation.valid ? (
-            <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8, lineHeight: 1.45 }}>
-              All {holeCount} ranks set. Strokes land on the hardest holes; tap any to adjust (it swaps).
-            </p>
-          ) : (
-            <p className="mt-2 flex items-start gap-1.5" style={{ fontSize: 12, color: "var(--color-bt-text-dim)", lineHeight: 1.45 }}>
-              <Info size={13} style={{ flexShrink: 0, marginTop: 1 }} />
-              <span>No hole difficulty set — strokes will fall on holes 1–{holeCount}. Add a stroke index any time for handicaps to land on the hardest holes.</span>
-            </p>
+              <button
+                onClick={onOptInIndex}
+                className="rounded-lg border px-3 py-2"
+                style={{ borderColor: "var(--color-bt-accent-border)", color: "var(--color-bt-accent)", fontSize: 13, fontWeight: 600, background: "transparent" }}
+              >
+                Add a stroke index table
+              </button>
+            </div>
           )}
         </div>
-      ) : (
-        <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", lineHeight: 1.5 }}>
-          No hole difficulty set — strokes fall on holes 1–{holeCount}. Turn on stroke indices for handicaps to land on the hardest holes instead.
-        </p>
-      )}
+
+        {showScrim ? (
+          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8, lineHeight: 1.45 }}>
+            Skip it and an assigned handicap is used starting on the first hole and continuing on.
+          </p>
+        ) : idxStarted && !idxValidation.valid ? (
+          <>
+            <div className="mt-2 flex items-start gap-2 rounded-lg px-2.5 py-2" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning-border)" }}>
+              <AlertTriangle size={14} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
+              <span style={{ fontSize: 12, color: "var(--color-bt-text)", lineHeight: 1.4 }}>
+                <span style={{ fontWeight: 700 }}>Finish the index to use it.</span> {idxRemainingLabel}.
+              </span>
+            </div>
+            <p style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", marginTop: 6, lineHeight: 1.45 }}>
+              Each rank 1–{holeCount} is used once — setting one already in use swaps with the hole that holds it.
+            </p>
+          </>
+        ) : idxValidation.valid ? (
+          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8, lineHeight: 1.45 }}>
+            All {holeCount} ranks set. Strokes land on the hardest holes; tap any to adjust (it swaps).
+          </p>
+        ) : (
+          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 8, lineHeight: 1.45 }}>
+            Rank every hole 1–{holeCount}, or leave it — skip it and an assigned handicap is used starting on the first hole and continuing on.
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/games/entryChrome.tsx
+++ b/src/components/games/entryChrome.tsx
@@ -19,10 +19,13 @@ export function HoleProgress({
   count,
   currentHole,
   completed,
+  maxWidth = 232,
 }: {
   count: number;
   currentHole: number;
   completed: number[];
+  /** Cap the bar width (default 232, centered). Pass "100%" for edge-to-edge. */
+  maxWidth?: number | string;
 }) {
   const reached = Math.max(currentHole, ...(completed.length ? completed : [currentHole]));
   return (
@@ -34,7 +37,7 @@ export function HoleProgress({
         gap: 2.5,
         height: 4,
         width: "100%",
-        maxWidth: 232,
+        maxWidth,
         margin: "0 auto",
       }}
     >

--- a/src/lib/courseIndex.test.ts
+++ b/src/lib/courseIndex.test.ts
@@ -115,12 +115,13 @@ describe("buildScorecardSchema", () => {
     expect(s.scoring?.sections?.[0].units).toHaveLength(9);
   });
 
-  it("fills a sequential index when none is provided (stroke index off)", () => {
+  it("OMITS handicap_index when none is provided (index optional → fallback)", () => {
     const par = Array(18).fill(4);
     const s = buildScorecardSchema(template, par, [], 18);
-    expect(s.units.metadata?.handicap_index).toEqual(Array.from({ length: 18 }, (_, i) => i + 1));
+    expect(s.units.metadata?.par).toEqual(par);
+    expect(s.units.metadata?.handicap_index).toBeUndefined();
     const s9 = buildScorecardSchema(template, Array(9).fill(4), undefined, 9);
-    expect(s9.units.metadata?.handicap_index).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(s9.units.metadata?.handicap_index).toBeUndefined();
   });
 
   it("does not mutate the template", () => {

--- a/src/lib/courseIndex.ts
+++ b/src/lib/courseIndex.ts
@@ -115,17 +115,15 @@ export function buildScorecardSchema(
 ): ScorecardSchema {
   const next = JSON.parse(JSON.stringify(template)) as ScorecardSchema;
   const labels = range(1, holeCount);
-  // A course without a real index (stroke index off) snapshots a sequential
-  // 1..N index of the right length — net falls back to hole order; it never
-  // leaves a stale 18-long template index on a 9-hole game.
-  const index = handicapIndex?.length ? handicapIndex : Array.from({ length: holeCount }, (_, i) => i + 1);
+  // Par is always snapshotted. The stroke index is OPTIONAL: snapshot it only
+  // when a complete one is supplied; otherwise OMIT handicap_index entirely so
+  // `strokeHoles` falls back to sequential allocation and GolfCard omits the
+  // INDEX row (an index-less / muni course is a legitimate state, not an error).
+  const metadata: ScorecardUnits["metadata"] = { ...(next.units.metadata ?? {}), par };
+  if (handicapIndex?.length) metadata.handicap_index = handicapIndex;
+  else delete metadata.handicap_index;
 
-  next.units = {
-    ...next.units,
-    count: holeCount,
-    labels,
-    metadata: { ...(next.units.metadata ?? {}), par, handicap_index: index },
-  };
+  next.units = { ...next.units, count: holeCount, labels, metadata };
 
   if (next.scoring) {
     const frontName = next.scoring.sections?.[0]?.name ?? "Front 9";

--- a/src/lib/strokePlayConfig.ts
+++ b/src/lib/strokePlayConfig.ts
@@ -36,12 +36,16 @@ interface SchemaLike {
 export function unitsFromSchema(schema?: SchemaLike | null): ScoreUnit[] {
   const meta = schema?.units?.metadata;
   const labels = schema?.units?.labels;
-  if (!labels?.length || !meta?.par || !meta?.handicap_index) return STROKE_PLAY_UNITS;
+  if (!labels?.length || !meta?.par) return STROKE_PLAY_UNITS;
+  // The stroke index is OPTIONAL: an index-less course snapshots par with no
+  // handicap_index, so strokeIndex stays undefined here → the GolfCard INDEX row
+  // omits itself and strokeHoles falls back to sequential.
+  const hasIndex = meta.handicap_index?.length === labels.length;
   return labels.map((label, i) => ({
     label,
     section: i < 9 ? "front" : "back",
     par: meta.par![i],
-    strokeIndex: meta.handicap_index![i],
+    strokeIndex: hasIndex ? meta.handicap_index![i] : undefined,
   }));
 }
 

--- a/src/server/routers/courses.test.ts
+++ b/src/server/routers/courses.test.ts
@@ -52,7 +52,7 @@ describe("courses router — global library", () => {
     ).rejects.toThrow(/18 entries/i);
   });
 
-  it("saves an index-off course (no handicapIndex) and applies a sequential snapshot", async () => {
+  it("saves an index-less course (par only) and snapshots par WITHOUT an index", async () => {
     const course = await ctx.caller().courses.create({
       name: "Gross Only GC",
       holeCount: 18,
@@ -65,10 +65,10 @@ describe("courses router — global library", () => {
 
     const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Gross" });
     const updated = await ctx.caller().games.applyCourse({ tripId, gameId: game.id as string, courseId: course.id as string });
-    const schema = updated!.scorecard_schema as { units: { metadata: { par: number[]; handicap_index: number[] } } };
+    const schema = updated!.scorecard_schema as { units: { metadata: { par: number[]; handicap_index?: number[] } } };
     expect(schema.units.metadata.par).toEqual(PAR);
-    // No real index → sequential 1..18 snapshot (net falls back to hole order).
-    expect(schema.units.metadata.handicap_index).toEqual(Array.from({ length: 18 }, (_, i) => i + 1));
+    // No index → handicap_index OMITTED; strokeHoles falls back to sequential.
+    expect(schema.units.metadata.handicap_index).toBeUndefined();
   });
 
   it("list + getById surface a saved course", async () => {


### PR DESCRIPTION
Aligns the already-shipped course picker (#348) + GolfCard (#347) to the **amended** spec: **par required, stroke index optional**. An index-less (muni) course is a legitimate, saveable, usable state — `strokeHoles` falls back to sequential allocation — not "net play unavailable." The picker's optional index and GolfCard's **conditional INDEX row** are a matched pair, so they change together.

## Data contract
- **`buildScorecardSchema`**: OMIT `handicap_index` when none is supplied (was filling a sequential 1..N). Index-less courses snapshot **par only** → `strokeHoles` falls back AND GolfCard omits the INDEX row. `strokeHoles` unchanged.
- **`unitsFromSchema`**: par-with-no-index → `strokeIndex` undefined (so `StandardGrid`'s existing `hasIndex` check omits the row + Hdcp header segment).

## Picker — three-state optional index (per the mock)
- **Untouched** → "STROKE INDEX · OPTIONAL / NOT SET", saves on par alone with the quiet "strokes fall on holes 1–N" note.
- **Started-but-incomplete** → blocked: "Finish the index to use it" + "Unset holes: …" warning + the `N OF 18 SET` badge.
- **Complete** → ✓ permutation (swap-on-edit).
- A **dirty/partial pulled index** is treated as **absent** (cleared to untouched), never carried into the snapshot. Save snapshots the index only when it's a complete permutation.

## GolfCard
- INDEX row + per-hole `· Hdcp {index}` segment render only when the effective schema carries a complete index (row already conditional; now correctly fed).

CLAUDE.md's "course data is global" note already landed in #348 — Done-criterion met (no new commit needed).

Verified live: manual course → "OPTIONAL / NOT SET" + fallback note; setting one cell → "1 OF 18 SET" + "Finish the index" warning. `tsc`/lint clean; 40 affected unit/router tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)