### PR TITLE
fix(engine): index-less course strokes fall sequentially (audit C8/C9/C10)

### DIFF
--- a/src/lib/handicap.test.ts
+++ b/src/lib/handicap.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { effectiveStrokes, clampStrokes, strokeHint } from "./handicap";
 import { strokeHoles } from "./matchPlay";
+import { unitsFromSchema, strokeIndexOf } from "./strokePlayConfig";
 
 describe("effectiveStrokes", () => {
   it("defaults null to 0", () => {
@@ -51,5 +52,44 @@ describe("strokeHint", () => {
     const struck = [...strokeHoles(6, REAL)].sort((a, b) => a - b);
     const hint = strokeHint(6, 18, REAL)!;
     for (const h of struck) expect(hint).toContain(String(h));
+  });
+});
+
+// Regression: an index-less course (par snapshotted, handicap_index OMITTED) must
+// fall back SEQUENTIALLY on the client, exactly as the server scores it — never a
+// zero-fill index (which `strokeHoles` would read as "every hole"). Guards the
+// audit C8/C9/C10 divergence: client live strip vs. server persisted result.
+describe("index-less course → sequential fallback (no client/server divergence)", () => {
+  const indexLessSchema = {
+    units: {
+      labels: Array.from({ length: 18 }, (_, i) => String(i + 1)),
+      metadata: { par: Array(18).fill(4) }, // par only — NO handicap_index
+    },
+  };
+  const units = unitsFromSchema(indexLessSchema);
+
+  it("unitsFromSchema leaves strokeIndex undefined (so GolfCard omits the INDEX row)", () => {
+    expect(units.every((u) => u.strokeIndex == null)).toBe(true);
+  });
+
+  it("strokeIndexOf returns the sequential identity [1..18], NOT a zero-fill", () => {
+    const idx = strokeIndexOf(units);
+    expect(idx).toEqual(Array.from({ length: 18 }, (_, i) => i + 1));
+    expect(idx.some((v) => v === 0)).toBe(false);
+  });
+
+  it("allocation is sequential and matches the server's undefined-index fallback", () => {
+    const idx = strokeIndexOf(units);
+    const client = [...strokeHoles(5, idx)].sort((a, b) => a - b);
+    const server = [...strokeHoles(5, undefined)].sort((a, b) => a - b); // server: snapshot omits index
+    expect(client).toEqual([1, 2, 3, 4, 5]); // first 5 holes, NOT all 18
+    expect(client).toEqual(server); // no divergence
+  });
+
+  it("the hint reads 'first N holes' and agrees with the allocation", () => {
+    const idx = strokeIndexOf(units);
+    expect(strokeHint(5, 18, idx)).toBe("5 strokes · first 5 holes");
+    const struck = [...strokeHoles(5, idx)];
+    expect(struck).toEqual([1, 2, 3, 4, 5]);
   });
 });

--- a/src/lib/strokePlayConfig.ts
+++ b/src/lib/strokePlayConfig.ts
@@ -49,9 +49,21 @@ export function unitsFromSchema(schema?: SchemaLike | null): ScoreUnit[] {
   }));
 }
 
-/** The stroke-index array (handicap index per hole) for `strokeHoles`/`buildDecided`. */
+/**
+ * The per-hole stroke-index array for `strokeHoles` / `buildDecided` / `strokeHint`.
+ *
+ * A course's index is all-or-nothing (the picker blocks partial saves), so units
+ * are either ALL ranked or ALL unranked. When complete we return the real index;
+ * when ABSENT we return the SEQUENTIAL identity `[1..N]` — **never a zero-fill**.
+ * A `[0,0,…]` array is the trap: `strokeHoles` treats any length-N array as a real
+ * index and `(0-1) % N = -1 < n` strikes EVERY hole, which both mis-allocates and
+ * diverges from the server (it scores the index-less snapshot via `strokeHoles`'
+ * `undefined` → sequential fallback). Identity `[1..N]` reproduces that exact
+ * sequential allocation and makes the handicap hint read "first N holes".
+ */
 export function strokeIndexOf(units: ScoreUnit[]): number[] {
-  return units.map((u) => u.strokeIndex ?? 0);
+  if (units.every((u) => u.strokeIndex != null)) return units.map((u) => u.strokeIndex as number);
+  return units.map((_, i) => i + 1); // sequential identity — no real index present
 }
 
 // Player identity palette (identity colors, not theme tokens — sanctioned like


### PR DESCRIPTION
Fixes the one correctness defect from the Slice C audit.

## The bug
`strokeIndexOf` returned `u.strokeIndex ?? 0`, fabricating a `[0,0,…]` array for an **index-less course**. `strokeHoles` treats any length-N array as a real index, and `(0-1) % N = -1 < n` is true for **every** hole — so:
- the **client** live strip + handicap hint awarded a stroke on **all 18 holes**, and
- that **diverged from the server**, which scores the index-less snapshot (handicap_index omitted) via `strokeHoles`' `undefined` → sequential fallback.

That's the exact client/server divergence CLAUDE.md enforced-pattern #8 exists to prevent — only triggered on an index-less (muni) course with handicaps. Persisted results were correct; the live display + setup hint were wrong.

## The fix
`strokeIndexOf` now returns the real index when complete, else the **sequential identity `[1..N]`** — provably the same allocation as the server's `undefined` fallback (holes 1..n), and it makes the handicap hint correctly read **"first N holes"** (audit C9) in agreement with `strokeHoles` (C10). GolfCard's INDEX-row omission is unchanged (it reads `units`, which stay `undefined`).

## Test (closes the coverage gap behind audit #25)
New `handicap.test.ts` block: an index-less schema → `strokeIndex` undefined → `strokeIndexOf` returns `[1..18]` (not `[0,…]`) → allocation `== strokeHoles(undefined)` (first N holes) → hint reads "first N holes" and agrees. These assertions fail against the old `[0,…]` behavior.

## Verification
- `tsc --noEmit` clean
- `handicap.test.ts` 15/15; full lib suite 45/45; slice suite was 76/76 pre-fix
- Slice C screens load clean on a fresh dev server (no console errors)

Follow-up (audit C8, tracked separately): extract one shared `hasCompleteIndex()` predicate so the four independent "complete index?" checks can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)