### PR TITLE
Slice D1: competition–game unification — schema + placement spine + delegation (backend + scoreboard)

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -147,6 +147,18 @@ who's in, what they're called, what role they hold — is the Owner's.
 | Set point distributions / placements (scoring) | ✓ | ✓ | — | `events.setPointDistributions` / `setPlacements` |
 | Assign member to a team | ✓ | ✓ | — | `teamAssignments.assign` |
 | Remove a team assignment | ✓ | — | — | `teamAssignments.remove` *(Owner)* |
+| **Edit / configure a game** (status incl. drop, points distribution, course, participants) | ✓ | ✓ | **game organizer of *that* game** | `games.update` / `setStatus` / `setPointsDistribution` / `applyCourse` / `addParticipants` |
+| **Enter a game's results** (manual placement; finish/compute) | ✓ | ✓ | **game organizer of *that* game** | `games.setManualResults` / `finish` |
+| Delegate / revoke a game organizer | ✓ | ✓ | — | `games.addOrganizer` / `removeOrganizer` *(trip staff only — a delegate can't sub-delegate)* |
+| View who runs a game | ✓ | ✓ | ✓ | `games.listOrganizers` |
+
+> **Per-game organizer delegation (Slice D1 §8).** Game edit/configure/enter-results
+> resolves to **`canEdit || isGameOrganizer(gameId)`** — trip Owner/Organizer, OR a
+> user granted organizer of *that specific game* (`game_organizers` row). It is
+> **game-isolated**: a pick'em delegate cannot touch the scramble. Enforced at BOTH
+> layers — the `requireGameEdit` tRPC middleware and the `is_game_organizer(game)`
+> RLS path on `games` (UPDATE) + `game_results` (migration 045). Granting is a
+> trip-staff act (`requireTripRole('Organizer')`).
 
 > **Scoring is Organizer+ today** (`setPlacements`). There is no member-facing
 > "enter your own score" path yet — the intent (see Resolved notes) is for any

--- a/src/components/competition/ScoreboardPanel.tsx
+++ b/src/components/competition/ScoreboardPanel.tsx
@@ -4,11 +4,14 @@ import { useMemo, useState } from "react";
 import { BarChart3, Sparkles } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import {
-  buildMockData,
   DEFAULT_STYLE,
   STYLE_COMPONENTS,
   STYLE_META,
   type ScoreboardStyleId,
+  type ScoreboardData,
+  type ScoreboardTeam,
+  type ScoreboardEvent,
+  type ScoreboardCell,
 } from "./scoreboard-styles";
 import { ScoreboardStyleChooser } from "./ScoreboardStyleChooser";
 
@@ -20,21 +23,14 @@ interface Props {
   isOwner: boolean;
 }
 
-interface Team {
-  id: string;
-  name: string;
-  short_name: string;
-  color: string;
-}
-
-interface EventRow {
-  id: string;
-  title: string;
-  type: "GOLF" | "GENERIC";
-  is_practice: boolean;
-  points_available: number | null;
-  point_distributions?: Array<{ position: number; points: number }>;
-  result?: { placements?: Record<string, number> } | null;
+interface LeaderboardResult {
+  teams: { id: string; name: string; short_name: string; color: string }[];
+  games: { id: string; name: string; distribution: number[] | null; status: string; dropped: boolean }[];
+  cells: { gameId: string; teamId: string; place: number; points: number }[];
+  teamTotals: Record<string, number>;
+  pointsAvailable: number;
+  winNumber: number;
+  pointsToClinch: Record<string, number>;
 }
 
 /**
@@ -52,17 +48,13 @@ interface EventRow {
 export function ScoreboardPanel({ competitionId, tripId, isOwner }: Props) {
   const utils = trpc.useUtils();
   const { data: competition } = trpc.competitions.getByTrip.useQuery({ tripId });
-  const { data: teams = [] } = trpc.teams.list.useQuery(
+  // The derived roll-up (D1 §5/§6): the SAME placement math the rest of the app
+  // uses — averaged ties, points-available, win number — over LIVE games. This
+  // replaces the old events-table placement path (retiring).
+  const { data: leaderboard } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     { enabled: !!competitionId }
   );
-  const { data: events = [] } = trpc.events.list.useQuery(
-    { tripId, competitionId },
-    { enabled: !!competitionId }
-  );
-
-  const teamsTyped = teams as Team[];
-  const eventsTyped = (events as EventRow[]).filter((e) => !e.is_practice);
 
   // Style lives on the competition row; fall back to the default while
   // the query is loading on first paint.
@@ -100,13 +92,42 @@ export function ScoreboardPanel({ competitionId, tripId, isOwner }: Props) {
     updateStyle.mutate({ tripId, competitionId, scoreboardStyle: id });
   };
 
-  const data = useMemo(
-    () => buildMockData(tripId, teamsTyped, eventsTyped),
-    [tripId, teamsTyped, eventsTyped]
-  );
+  const data = useMemo<ScoreboardData>(() => {
+    const lb = leaderboard as LeaderboardResult | undefined;
+    const teams: ScoreboardTeam[] = (lb?.teams ?? []).map((t) => ({
+      id: t.id,
+      name: t.name,
+      short_name: t.short_name,
+      color: t.color,
+    }));
+    const numTeams = teams.length;
+    // Live games are the scoreboard columns; dropped ones are excluded (§4).
+    const liveGames = (lb?.games ?? []).filter((g) => !g.dropped);
+    const events: ScoreboardEvent[] = liveGames.map((g) => ({
+      id: g.id,
+      title: g.name,
+      points_available: g.distribution
+        ? g.distribution.slice(0, numTeams).reduce((a, b) => a + b, 0)
+        : null,
+    }));
+    const cells: ScoreboardCell[] = (lb?.cells ?? []).map((c) => ({
+      teamId: c.teamId,
+      eventId: c.gameId,
+      points: c.points,
+      place: c.place,
+    }));
+    return {
+      tripId,
+      teams,
+      events,
+      cells,
+      totals: (lb?.teamTotals ?? {}) as Record<string, number>,
+      totalAvailable: lb?.pointsAvailable ?? 0,
+    };
+  }, [leaderboard, tripId]);
 
-  const hasTeams = teamsTyped.length > 0;
-  const hasEvents = eventsTyped.length > 0;
+  const hasTeams = data.teams.length > 0;
+  const hasEvents = data.events.length > 0;
 
   // ── Empty state ────────────────────────────────────────────────────────
   if (!hasTeams || !hasEvents) {
@@ -162,8 +183,8 @@ export function ScoreboardPanel({ competitionId, tripId, isOwner }: Props) {
       <div className="flex items-center justify-between gap-3 px-4 py-3">
         <PanelHeader
           accent
-          subtitle={`${data.totalAvailable} total pts · ${eventsTyped.length} event${
-            eventsTyped.length === 1 ? "" : "s"
+          subtitle={`${data.totalAvailable} total pts · ${data.events.length} game${
+            data.events.length === 1 ? "" : "s"
           }`}
         />
         {isOwner && (

--- a/src/lib/competitionPlacement.test.ts
+++ b/src/lib/competitionPlacement.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   placementPoints,
+  placementDetail,
   awardedForGame,
   winThreshold,
   rollUp,
@@ -57,6 +58,16 @@ describe("placementPoints — averaged ties (§5b)", () => {
 
   it("empty standings → no points (Phase-1 shell, not yet played)", () => {
     expect(placementPoints([9, 6, 4, 2], [], "low_wins").size).toBe(0);
+  });
+});
+
+describe("placementDetail — place + points for the grid cell", () => {
+  it("returns the 1-based place and points; tied teams share the group's place", () => {
+    const d = placementDetail([9, 6, 4, 2], standings([1, 2, 3, 3]), "low_wins");
+    expect(d.get("t0")).toEqual({ place: 1, points: 9 });
+    expect(d.get("t1")).toEqual({ place: 2, points: 6 });
+    expect(d.get("t2")).toEqual({ place: 3, points: 3 }); // tied 3rd → place 3, (4+2)/2
+    expect(d.get("t3")).toEqual({ place: 3, points: 3 });
   });
 });
 

--- a/src/lib/competitionPlacement.test.ts
+++ b/src/lib/competitionPlacement.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  placementPoints,
+  awardedForGame,
+  winThreshold,
+  rollUp,
+  type LiveGame,
+  type Standing,
+} from "./competitionPlacement";
+
+// Build standings where index 0 is best (place 1). `groups` lets us force ties:
+// e.g. [1,2,3,3] → teams t0,t1 distinct, t2/t3 tie for 3rd.
+function standings(values: number[]): Standing[] {
+  return values.map((value, i) => ({ entityId: `t${i}`, value }));
+}
+
+describe("placementPoints — averaged ties (§5b)", () => {
+  it("reproduces the grid: [9,6,4,2], two tie for 3rd → 9,6,3,3", () => {
+    const pts = placementPoints([9, 6, 4, 2], standings([1, 2, 3, 3]), "low_wins");
+    expect(pts.get("t0")).toBe(9);
+    expect(pts.get("t1")).toBe(6);
+    expect(pts.get("t2")).toBe(3); // (4+2)/2
+    expect(pts.get("t3")).toBe(3);
+  });
+
+  it("sum is invariant under ties (averaging preserves the awarded total)", () => {
+    const noTie = placementPoints([9, 6, 4, 2], standings([1, 2, 3, 4]), "low_wins");
+    const tie = placementPoints([9, 6, 4, 2], standings([1, 2, 3, 3]), "low_wins");
+    const sum = (m: Map<string, number>) => [...m.values()].reduce((a, b) => a + b, 0);
+    expect(sum(noTie)).toBe(21);
+    expect(sum(tie)).toBe(21);
+  });
+
+  it("teams beyond the distribution length earn 0", () => {
+    const pts = placementPoints([9, 6], standings([1, 2, 3, 4]), "low_wins");
+    expect(pts.get("t0")).toBe(9);
+    expect(pts.get("t1")).toBe(6);
+    expect(pts.get("t2")).toBe(0);
+    expect(pts.get("t3")).toBe(0);
+  });
+
+  it("a 3-way tie for 1st splits the top three slots evenly", () => {
+    const pts = placementPoints([9, 6, 4, 2], standings([5, 5, 5, 9]), "low_wins");
+    const share = (9 + 6 + 4) / 3; // 6.333…
+    expect(pts.get("t0")).toBeCloseTo(share);
+    expect(pts.get("t1")).toBeCloseTo(share);
+    expect(pts.get("t2")).toBeCloseTo(share);
+    expect(pts.get("t3")).toBe(2);
+  });
+
+  it("honors high_wins direction (points-based formats)", () => {
+    // Higher value is better → t3 (value 40) wins.
+    const pts = placementPoints([9, 6, 4, 2], standings([10, 20, 30, 40]), "high_wins");
+    expect(pts.get("t3")).toBe(9);
+    expect(pts.get("t0")).toBe(2);
+  });
+
+  it("empty standings → no points (Phase-1 shell, not yet played)", () => {
+    expect(placementPoints([9, 6, 4, 2], [], "low_wins").size).toBe(0);
+  });
+});
+
+describe("awardedForGame (§6)", () => {
+  it("sums distribution over the first numTeams places", () => {
+    expect(awardedForGame([9, 6, 4, 2], 4)).toBe(21);
+    expect(awardedForGame([9, 6, 4, 2], 2)).toBe(15);
+    expect(awardedForGame([9, 6, 4, 2], 6)).toBe(21); // beyond length → +0
+    expect(awardedForGame(null, 4)).toBe(0);
+    expect(awardedForGame([], 4)).toBe(0);
+  });
+});
+
+describe("winThreshold (§6)", () => {
+  it("clinch by EXCEEDING half → smallest 0.5-step above half", () => {
+    expect(winThreshold(28, false)).toBe(14.5); // 28 → 14½
+    expect(winThreshold(27, false)).toBe(14); // 13.5 → 14
+    expect(winThreshold(21, false)).toBe(11); // 10.5 → 11
+  });
+  it("defending team clinches at EXACTLY half (tie retains)", () => {
+    expect(winThreshold(28, true)).toBe(14); // exactly half
+    expect(winThreshold(27, true)).toBe(13.5); // half rounded up to a 0.5 step
+  });
+});
+
+describe("rollUp — points-available, totals, win number (§6)", () => {
+  const game = (id: string, distribution: number[], values: number[]): LiveGame => ({
+    id,
+    distribution,
+    numTeams: 4,
+    standings: standings(values),
+    direction: "low_wins",
+  });
+  const teams = ["t0", "t1", "t2", "t3"];
+
+  it("points-available = Σ live-game awarded; totals roll up across games", () => {
+    const games = [game("g1", [9, 6, 4, 2], [1, 2, 3, 4]), game("g2", [9, 6, 4, 2], [4, 3, 2, 1])];
+    const r = rollUp(games, teams);
+    expect(r.pointsAvailable).toBe(42); // 21 + 21
+    expect(r.teamTotals.get("t0")).toBe(9 + 2); // 1st in g1, 4th in g2
+    expect(r.teamTotals.get("t3")).toBe(2 + 9);
+    expect(r.winNumber).toBe(21.5); // > half of 42
+  });
+
+  it("DROPPING a game lowers points-available and the win number; restoring raises it (§4)", () => {
+    const all = [game("g1", [9, 6, 4, 2], [1, 2, 3, 4]), game("g2", [9, 6, 4, 2], [1, 2, 3, 4])];
+    const withDrop = [all[0]]; // g2 dropped → caller passes only live games
+    expect(rollUp(all, teams).pointsAvailable).toBe(42);
+    expect(rollUp(all, teams).winNumber).toBe(21.5);
+    expect(rollUp(withDrop, teams).pointsAvailable).toBe(21);
+    expect(rollUp(withDrop, teams).winNumber).toBe(11); // 10.5 → 11; the win number MOVED
+    expect(rollUp(all, teams).pointsAvailable).toBe(42); // restore → back up
+  });
+
+  it("Phase-1 shell (no standings) still contributes points-available", () => {
+    const shell: LiveGame = { id: "shell", distribution: [9, 6, 4, 2], numTeams: 4, standings: [], direction: "low_wins" };
+    const r = rollUp([shell], teams);
+    expect(r.pointsAvailable).toBe(21); // contributes before anything is played
+    expect(r.teamTotals.get("t0")).toBe(0); // …but awards nothing yet
+    expect(r.winNumber).toBe(11);
+  });
+
+  it("points-to-clinch = winNumber − current; defending team uses the exact-half bar", () => {
+    const games = [game("g1", [9, 6, 4, 2], [1, 2, 3, 4])]; // available 21, win 11, defender bar 11(ceil 10.5)
+    const r = rollUp(games, teams, { defendingTeamId: "t3" });
+    expect(r.pointsToClinch.get("t0")).toBe(11 - 9); // 2 to go
+    // available 21 → half 10.5 → defender ceil = 11 as well here; use an even total to show the gap:
+    const even = [game("g1", [9, 6, 4, 2], [1, 2, 3, 4]), game("g2", [9, 6, 4, 2], [1, 2, 3, 4])]; // 42
+    const r2 = rollUp(even, teams, { defendingTeamId: "t3" });
+    expect(r2.winNumber).toBe(21.5); // headline (non-defender) bar
+    expect(r2.pointsToClinch.get("t3")).toBe(21 - (r2.teamTotals.get("t3") ?? 0)); // defender: exactly half (21)
+    expect(r2.pointsToClinch.get("t0")).toBe(21.5 - (r2.teamTotals.get("t0") ?? 0)); // non-defender: > half
+  });
+});

--- a/src/lib/competitionPlacement.ts
+++ b/src/lib/competitionPlacement.ts
@@ -1,0 +1,160 @@
+/**
+ * Competition placement spine + clinch math (Slice D1 §5–§6) — PURE, client-safe.
+ * No server/DB deps, so the live leaderboard (client) and any persisted roll-up
+ * use the SAME functions and can't diverge (CLAUDE.md enforced pattern #8).
+ *
+ * The spine is universal: EVERY game — engine (computes `game_results`) or
+ * manual (an organizer enters `game_results`) — rolls up through the same path:
+ *
+ *   game_results → per-team standing (5a) → ranking → distribution points (5b)
+ *   → Σ across live games → points-available, per-team totals, win number (6).
+ *
+ * Placement points are ALWAYS derived (never stored for engine games); manual
+ * games store their *standings* (entered), but points are still derived here.
+ */
+
+/** A team's standing within one game: the value to rank by + the direction. */
+export interface Standing {
+  entityId: string;
+  /** The number to sort on (net-to-par, points, position…). */
+  value: number;
+}
+/** "low_wins" → lower value is better (net-to-par, position); "high_wins" → higher (points). */
+export type Direction = "low_wins" | "high_wins";
+
+/** One game's contribution to the roll-up. A Phase-1 shell has standings: [] and
+ *  still contributes points-available (sum of distribution[0..numTeams-1]). */
+export interface LiveGame {
+  id: string;
+  /** Ordered points by place, e.g. [9,6,4,2]. Null/empty → contributes nothing. */
+  distribution: number[] | null;
+  /** Teams in the competition that this game ranks (numTeams for points-available). */
+  numTeams: number;
+  /** Per-team standings once results exist; empty before any are entered/computed. */
+  standings: Standing[];
+  direction: Direction;
+}
+
+/** distribution[i] with out-of-range → 0 (teams beyond the distribution earn 0). */
+function dist(distribution: number[], i: number): number {
+  return i >= 0 && i < distribution.length ? distribution[i] : 0;
+}
+
+/**
+ * §5b — standings → ranking → distribution points, with AVERAGED ties.
+ * Teams tied at the same standing occupy consecutive places p..q (1-based) and
+ * each gets `sum(distribution[p..q]) / groupSize`. Teams beyond the distribution
+ * get 0. Sum awarded is invariant under ties (averaging preserves it).
+ *
+ * Example (the grid): distribution [9,6,4,2], two teams tie for 3rd →
+ * places 1,2,(3,4) → 9, 6, (4+2)/2=3, 3 → the 9,6,3,3 row.
+ */
+export function placementPoints(
+  distribution: number[],
+  standings: Standing[],
+  direction: Direction
+): Map<string, number> {
+  const out = new Map<string, number>();
+  if (standings.length === 0) return out;
+
+  const sorted = [...standings].sort((a, b) =>
+    direction === "low_wins" ? a.value - b.value : b.value - a.value
+  );
+
+  let i = 0;
+  while (i < sorted.length) {
+    // Collect the tie group sharing this standing value.
+    let j = i;
+    while (j + 1 < sorted.length && sorted[j + 1].value === sorted[i].value) j++;
+    const groupSize = j - i + 1;
+    // Places i+1 .. j+1 (1-based) → distribution indices i .. j (0-based).
+    let pot = 0;
+    for (let k = i; k <= j; k++) pot += dist(distribution, k);
+    const share = pot / groupSize;
+    for (let k = i; k <= j; k++) out.set(sorted[k].entityId, share);
+    i = j + 1;
+  }
+  return out;
+}
+
+/** Sum awarded by one game = sum(distribution[0 .. numTeams-1]). Invariant under
+ *  ties (5b averaging preserves it). A shell with a distribution but no results
+ *  still contributes this to points-available. */
+export function awardedForGame(distribution: number[] | null, numTeams: number): number {
+  if (!distribution || distribution.length === 0 || numTeams <= 0) return 0;
+  let sum = 0;
+  for (let i = 0; i < numTeams; i++) sum += dist(distribution, i);
+  return sum;
+}
+
+export interface RollUp {
+  /** Σ over live games of awardedForGame. */
+  pointsAvailable: number;
+  /** entityId → Σ distribution points across live games. */
+  teamTotals: Map<string, number>;
+  /** The number a team must REACH to clinch (see winThreshold). */
+  winNumber: number;
+  /** entityId → winNumber − currentPoints (≤0 means clinched). */
+  pointsToClinch: Map<string, number>;
+}
+
+/**
+ * §6 — the win number. Default: clinch by EXCEEDING half (> half). The smallest
+ * 0.5-step strictly above half. e.g. available 28 → half 14 → 14.5; available 27
+ * → 13.5 → 14.
+ *
+ * Retain case: a designated `defendingTeamId` clinches at EXACTLY half (a tie
+ * retains) — so its win number is half itself (rounded up to a 0.5 step if half
+ * isn't one). Everyone else still needs > half. We expose ONE win number (the
+ * general > half) plus a per-team clinch check that honors the defender.
+ */
+export function winThreshold(pointsAvailable: number, defending: boolean): number {
+  const half = pointsAvailable / 2;
+  // Round to the nearest 0.5 step (points come in halves via averaged ties).
+  if (defending) {
+    // Smallest 0.5-step ≥ half (tie at exactly half retains).
+    return Math.ceil(half * 2) / 2;
+  }
+  // Smallest 0.5-step strictly > half.
+  return (Math.floor(half * 2) + 1) / 2;
+}
+
+/**
+ * The full roll-up over LIVE (non-dropped) games. Caller passes only live games
+ * — dropping/restoring a game changes the set, which is exactly why the win
+ * number recomputes (§4): it is derived here, never stored.
+ *
+ * `teamIds` is the full competition roster so a team with zero points still
+ * appears (and so points-to-clinch is defined for everyone).
+ */
+export function rollUp(
+  liveGames: LiveGame[],
+  teamIds: string[],
+  opts?: { defendingTeamId?: string | null }
+): RollUp {
+  const teamTotals = new Map<string, number>(teamIds.map((id) => [id, 0]));
+  let pointsAvailable = 0;
+
+  for (const g of liveGames) {
+    pointsAvailable += awardedForGame(g.distribution, g.numTeams);
+    if (!g.distribution || g.standings.length === 0) continue;
+    const pts = placementPoints(g.distribution, g.standings, g.direction);
+    for (const [entityId, p] of pts) {
+      teamTotals.set(entityId, (teamTotals.get(entityId) ?? 0) + p);
+    }
+  }
+
+  const generalWin = winThreshold(pointsAvailable, false);
+  const defenderId = opts?.defendingTeamId ?? null;
+  const defenderWin = winThreshold(pointsAvailable, true);
+
+  const pointsToClinch = new Map<string, number>();
+  for (const id of teamIds) {
+    const need = id === defenderId ? defenderWin : generalWin;
+    pointsToClinch.set(id, need - (teamTotals.get(id) ?? 0));
+  }
+
+  // The headline win number is the general (>half) one; the defender's lower bar
+  // is reflected only in its own pointsToClinch.
+  return { pointsAvailable, teamTotals, winNumber: generalWin, pointsToClinch };
+}

--- a/src/lib/competitionPlacement.ts
+++ b/src/lib/competitionPlacement.ts
@@ -77,6 +77,35 @@ export function placementPoints(
   return out;
 }
 
+/**
+ * Like placementPoints but also returns each team's PLACE (1-based; tied teams
+ * share the group's starting place — two tied for 3rd are both place 3). For the
+ * scoreboard grid cell ("3rd · 3 pts"). Same averaging as placementPoints.
+ */
+export function placementDetail(
+  distribution: number[],
+  standings: Standing[],
+  direction: Direction
+): Map<string, { place: number; points: number }> {
+  const out = new Map<string, { place: number; points: number }>();
+  if (standings.length === 0) return out;
+  const sorted = [...standings].sort((a, b) =>
+    direction === "low_wins" ? a.value - b.value : b.value - a.value
+  );
+  let i = 0;
+  while (i < sorted.length) {
+    let j = i;
+    while (j + 1 < sorted.length && sorted[j + 1].value === sorted[i].value) j++;
+    const groupSize = j - i + 1;
+    let pot = 0;
+    for (let k = i; k <= j; k++) pot += dist(distribution, k);
+    const share = pot / groupSize;
+    for (let k = i; k <= j; k++) out.set(sorted[k].entityId, { place: i + 1, points: share });
+    i = j + 1;
+  }
+  return out;
+}
+
 /** Sum awarded by one game = sum(distribution[0 .. numTeams-1]). Invariant under
  *  ties (5b averaging preserves it). A shell with a distribution but no results
  *  still contributes this to points-available. */

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,0 +1,74 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { rollUp, type LiveGame } from "@/lib/competitionPlacement";
+
+/**
+ * Server roll-up wrapper (Slice D1 §5/§6). The DB-read half of the CLAUDE.md #8
+ * split: it gathers live games + team standings, then defers ALL math to the
+ * client-safe pure `rollUp` — so the leaderboard the crew sees and any persisted
+ * total can't diverge.
+ *
+ * Standings spine: every game_results row (entity_type 'team') carries a
+ * `position` (1 = best) — engine games COMPUTE it, manual games have it ENTERED
+ * (games.setManualResults). The roll-up never distinguishes the two. Direction is
+ * low_wins on position. A Phase-1 shell (distribution set, no results yet) still
+ * contributes points-available. `dropped` games are excluded here — which is why
+ * dropping/restoring moves the win number (it's derived, never stored).
+ */
+export async function computeCompetitionLeaderboard(
+  supabase: SupabaseClient,
+  competitionId: string
+) {
+  const { data: teams } = await supabase
+    .from("teams")
+    .select("id, name, short_name, color")
+    .eq("competition_id", competitionId);
+  const teamIds = (teams ?? []).map((t) => t.id as string);
+
+  const { data: comp } = await supabase
+    .from("competitions")
+    .select("defending_team_id")
+    .eq("id", competitionId)
+    .maybeSingle();
+
+  // Live (non-dropped) competition games only.
+  const { data: gameRows } = await supabase
+    .from("games")
+    .select("id, points_distribution, status")
+    .eq("competition_id", competitionId)
+    .neq("status", "dropped");
+  const live = gameRows ?? [];
+
+  const gameIds = live.map((g) => g.id as string);
+  const { data: results } = gameIds.length
+    ? await supabase
+        .from("game_results")
+        .select("game_id, entity_id, position, raw_score")
+        .in("game_id", gameIds)
+        .eq("entity_type", "team")
+    : { data: [] as { game_id: string; entity_id: string; position: number | null; raw_score: number | null }[] };
+
+  const standingsByGame = new Map<string, { entityId: string; value: number }[]>();
+  for (const r of results ?? []) {
+    const arr = standingsByGame.get(r.game_id as string) ?? [];
+    arr.push({ entityId: r.entity_id as string, value: (r.position ?? r.raw_score ?? 0) as number });
+    standingsByGame.set(r.game_id as string, arr);
+  }
+
+  const liveGames: LiveGame[] = live.map((g) => ({
+    id: g.id as string,
+    distribution: (g.points_distribution as number[] | null) ?? null,
+    numTeams: teamIds.length,
+    standings: standingsByGame.get(g.id as string) ?? [],
+    direction: "low_wins", // standing = position (1 = best)
+  }));
+
+  const roll = rollUp(liveGames, teamIds, { defendingTeamId: comp?.defending_team_id ?? null });
+
+  return {
+    teams: teams ?? [],
+    pointsAvailable: roll.pointsAvailable,
+    winNumber: roll.winNumber,
+    teamTotals: Object.fromEntries(roll.teamTotals),
+    pointsToClinch: Object.fromEntries(roll.pointsToClinch),
+  };
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { rollUp, type LiveGame } from "@/lib/competitionPlacement";
+import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlacement";
 
 /**
  * Server roll-up wrapper (Slice D1 §5/§6). The DB-read half of the CLAUDE.md #8
@@ -30,13 +30,15 @@ export async function computeCompetitionLeaderboard(
     .eq("id", competitionId)
     .maybeSingle();
 
-  // Live (non-dropped) competition games only.
+  // Games of this competition. We fetch ALL (incl. dropped) so the grid can show
+  // an "Abandoned" column, but only LIVE ones feed the roll-up / points-available.
   const { data: gameRows } = await supabase
     .from("games")
-    .select("id, points_distribution, status")
+    .select("id, name, points_distribution, status")
     .eq("competition_id", competitionId)
-    .neq("status", "dropped");
-  const live = gameRows ?? [];
+    .order("created_at", { ascending: true });
+  const allGames = gameRows ?? [];
+  const live = allGames.filter((g) => g.status !== "dropped");
 
   const gameIds = live.map((g) => g.id as string);
   const { data: results } = gameIds.length
@@ -64,8 +66,27 @@ export async function computeCompetitionLeaderboard(
 
   const roll = rollUp(liveGames, teamIds, { defendingTeamId: comp?.defending_team_id ?? null });
 
+  // Per-game grid cells (place + points per team) — same averaging as the totals,
+  // so the grid and the totals can't disagree. Only live games carry cells.
+  const cells: { gameId: string; teamId: string; place: number; points: number }[] = [];
+  for (const g of liveGames) {
+    if (!g.distribution || g.standings.length === 0) continue;
+    const detail = placementDetail(g.distribution, g.standings, g.direction);
+    for (const [teamId, d] of detail) {
+      cells.push({ gameId: g.id, teamId, place: d.place, points: d.points });
+    }
+  }
+
   return {
     teams: teams ?? [],
+    games: allGames.map((g) => ({
+      id: g.id as string,
+      name: (g.name as string | null) ?? "Game",
+      distribution: (g.points_distribution as number[] | null) ?? null,
+      status: g.status as string,
+      dropped: g.status === "dropped",
+    })),
+    cells,
     pointsAvailable: roll.pointsAvailable,
     winNumber: roll.winNumber,
     teamTotals: Object.fromEntries(roll.teamTotals),

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -84,6 +84,61 @@ export function requireTripRole(minRole: TripRole) {
 }
 
 // ---------------------------------------------------------------------------
+// requireGameEdit (Slice D1 §8)
+//
+// The per-game edit gate: passes if the user is trip Owner/Organizer (canEdit)
+// OR a delegated organizer of THIS game (game_organizers row). Game-isolated —
+// a pick'em delegate cannot touch the scramble. Mirror of the DB rule in
+// migration 045 (is_game_organizer); both must agree.
+//
+// Reads tripId + gameId from rawInput. Chain AFTER authedProcedure. Use on every
+// game-EDIT mutation (configure / enter-results); game CREATE stays trip-role
+// (you can't be delegated to a game that doesn't exist yet).
+// ---------------------------------------------------------------------------
+
+export function requireGameEdit() {
+  return middleware(async ({ ctx, getRawInput, next }) => {
+    const raw = await getRawInput();
+    const parsed = z.object({ tripId: z.string(), gameId: z.string() }).safeParse(raw);
+    if (!parsed.success) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "tripId and gameId are required" });
+    }
+    const { tripId, gameId } = parsed.data;
+
+    const role = await resolveTripRole(ctx, tripId); // throws if not a trip member
+    let allowed = ROLE_LEVEL[role] >= ROLE_LEVEL.Organizer;
+
+    if (!allowed) {
+      const { data } = await (
+        ctx.supabase.from("game_organizers") as unknown as {
+          select: (s: string) => {
+            eq: (c: string, v: string) => {
+              eq: (c: string, v: string) => {
+                maybeSingle: () => Promise<{ data: { game_id: string } | null }>;
+              };
+            };
+          };
+        }
+      )
+        .select("game_id")
+        .eq("game_id", gameId)
+        .eq("user_id", ctx.user!.id)
+        .maybeSingle();
+      allowed = !!data;
+    }
+
+    if (!allowed) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Requires trip Organizer role or a game-organizer grant for this game",
+      });
+    }
+
+    return next({ ctx: { ...ctx, tripId, tripRole: role } });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // resolveTripRole — internal shared lookup with request-scoped cache.
 //
 // Every batched procedure that uses requireTripMember / requireTripRole

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
+import { computeCompetitionLeaderboard } from "../lib/competitionLeaderboard";
 
 const SCOREBOARD_STYLES = [
   "grid",
@@ -45,6 +46,17 @@ export const competitionsRouter = router({
 
       return data;
     }),
+
+  // -----------------------------------------------------------------------
+  // leaderboard — the derived roll-up (D1 §5/§6): points-available, per-team
+  // totals, the win number, points-to-clinch. Renders from Phase-1 fields alone
+  // (distribution + order) and recomputes from the LIVE game set every read, so
+  // dropping/restoring a game moves the win number. Any trip member can view it.
+  // -----------------------------------------------------------------------
+  leaderboard: authedProcedure
+    .input(z.object({ tripId: z.string(), competitionId: z.string() }))
+    .use(requireTripMember)
+    .query(({ ctx, input }) => computeCompetitionLeaderboard(ctx.supabase, input.competitionId)),
 
   // -----------------------------------------------------------------------
   // create — new competition for a trip (canEdit, MVP one-per-trip)

--- a/src/server/routers/games.d1.test.ts
+++ b/src/server/routers/games.d1.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Slice D1 — competition-game unification behavior (§5/§6/§8).
+ * Phase-1 shell, the universal placement roll-up (manual adapter + averaged ties
+ * + win number), dropping recomputes, and per-game organizer delegation.
+ */
+
+const MANUAL = "gtt_manual";
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let memberId: string;
+const gameIds: string[] = [];
+
+async function newGame(distribution: number[] | null, name = "Game") {
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId: MANUAL,
+    name,
+    competitionId,
+    pointsDistribution: distribution,
+  })) as { id: string };
+  gameIds.push(g.id);
+  return g.id;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("D1 Trip");
+  await ctx.addTripMember(tripId, "member", "Member"); // a plain trip Member (delegate target)
+  memberId = ctx.getUser("member").id;
+  competitionId = await ctx.createCompetition(tripId, "D1 Comp");
+  teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
+  teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
+});
+
+afterAll(async () => {
+  for (const id of gameIds) {
+    await ctx.admin.from("game_results").delete().eq("game_id", id);
+    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("games").delete().eq("id", id);
+  }
+  await ctx.cleanup();
+});
+
+describe("Phase-1 shell + leaderboard (§3/§6)", () => {
+  it("a game with all Phase-2 fields null is creatable and contributes points-available", async () => {
+    const id = await newGame([9, 6, 4, 2], "Shell");
+    const game = (await ctx.caller().games.getById({ tripId, gameId: id })) as {
+      scorecard_schema: unknown;
+      course_id: unknown;
+      points_distribution: number[];
+      status: string;
+    };
+    expect(game.scorecard_schema).toBeNull(); // Phase-2 null…
+    expect(game.course_id).toBeNull();
+    expect(game.points_distribution).toEqual([9, 6, 4, 2]); // …but Phase-1 set
+    expect(game.status).toBe("pending");
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+    expect(lb.pointsAvailable).toBe(15); // sum(dist[0..1]) for 2 teams
+    expect(lb.winNumber).toBe(8); // > half of 15
+    expect(lb.teamTotals[teamA]).toBe(0); // nothing awarded yet
+  });
+});
+
+describe("manual adapter → universal roll-up (§5)", () => {
+  it("entered per-team placements write game_results and roll up to distribution points", async () => {
+    const id = await newGame([9, 6, 4, 2], "Pickem");
+    await ctx.caller().games.setManualResults({
+      tripId,
+      gameId: id,
+      placements: [
+        { entityId: teamA, position: 1 },
+        { entityId: teamB, position: 2 },
+      ],
+    });
+    // Only this game is live with results; the Shell game contributes available only.
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+    expect(lb.teamTotals[teamA]).toBe(9); // 1st
+    expect(lb.teamTotals[teamB]).toBe(6); // 2nd
+  });
+
+  it("averaged ties flow through the stack (two teams tie 1st on [9,6] → 7.5 each)", async () => {
+    // Fresh competition so totals are isolated.
+    const comp2 = await ctx.createCompetition(tripId, "Tie Comp");
+    const tA = await ctx.createTeam(comp2, "A");
+    const tB = await ctx.createTeam(comp2, "B");
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Tie", competitionId: comp2, pointsDistribution: [9, 6],
+    })) as { id: string };
+    gameIds.push(g.id);
+    await ctx.caller().games.setManualResults({
+      tripId, gameId: g.id,
+      placements: [{ entityId: tA, position: 1 }, { entityId: tB, position: 1 }],
+    });
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp2 });
+    expect(lb.teamTotals[tA]).toBe(7.5); // (9+6)/2
+    expect(lb.teamTotals[tB]).toBe(7.5);
+    expect(lb.pointsAvailable).toBe(15); // invariant under the tie
+  });
+});
+
+describe("dropping recomputes the win number (§4/§6)", () => {
+  it("dropping a game lowers points-available + win number; restoring raises them", async () => {
+    const comp3 = await ctx.createCompetition(tripId, "Drop Comp");
+    await ctx.createTeam(comp3, "A");
+    await ctx.createTeam(comp3, "B");
+    const g1 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G1", competitionId: comp3, pointsDistribution: [9, 6] })) as { id: string };
+    const g2 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G2", competitionId: comp3, pointsDistribution: [9, 6] })) as { id: string };
+    gameIds.push(g1.id, g2.id);
+
+    let lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
+    expect(lb.pointsAvailable).toBe(30);
+    expect(lb.winNumber).toBe(15.5);
+
+    await ctx.caller().games.setStatus({ tripId, gameId: g2.id, status: "dropped" });
+    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
+    expect(lb.pointsAvailable).toBe(15); // dropped game excluded
+    expect(lb.winNumber).toBe(8); // the win number MOVED
+
+    await ctx.caller().games.setStatus({ tripId, gameId: g2.id, status: "pending" });
+    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
+    expect(lb.pointsAvailable).toBe(30); // restored
+  });
+});
+
+describe("per-game organizer delegation (§8)", () => {
+  it("a delegated organizer can edit THEIR game but not another; non-members blocked", async () => {
+    const mine = await newGame([9, 6], "Pickem-BJ");
+    const other = await newGame([9, 6], "Scramble");
+    await ctx.caller().games.addOrganizer({ tripId, gameId: mine, userId: memberId });
+
+    const member = ctx.callerAs("member");
+    // Can edit the delegated game…
+    await expect(member.games.setStatus({ tripId, gameId: mine, status: "active" })).resolves.toBeTruthy();
+    // …but NOT another game (game-isolated).
+    await expect(member.games.setStatus({ tripId, gameId: other, status: "active" })).rejects.toThrow(/Organizer|game-organizer/i);
+    // Owner can edit both.
+    await expect(ctx.caller().games.setStatus({ tripId, gameId: other, status: "active" })).resolves.toBeTruthy();
+    // A non-member (outsider) is blocked outright.
+    await expect(ctx.callerAs("outsider").games.setStatus({ tripId, gameId: mine, status: "active" })).rejects.toThrow();
+  });
+
+  it("a plain trip member with no grant cannot edit a game", async () => {
+    const g = await newGame([9, 6], "NoGrant");
+    await expect(ctx.callerAs("member").games.setStatus({ tripId, gameId: g, status: "active" })).rejects.toThrow(/Organizer|game-organizer/i);
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole } from "../middleware";
+import { requireTripMember, requireTripRole, requireGameEdit } from "../middleware";
 import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
@@ -17,7 +17,10 @@ import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema } from 
  * that trip (defends against a gameId from another trip).
  */
 export const gamesRouter = router({
-  // create — Owner/Organizer. Standalone game (competition_id null), pending.
+  // create — Owner/Organizer. The Phase-1 shell (D1 §3): competition_id +
+  // game_type + name + points_distribution + status is a FULLY VALID game; every
+  // Phase-2 field (course, schema, pairings, schedule_item, tee_time) stays null
+  // until someone fills it. A shell is leaderboard-contributing on its own.
   create: authedProcedure
     .input(
       z.object({
@@ -25,7 +28,11 @@ export const gamesRouter = router({
         gameTypeId: z.string(),
         name: z.string().max(200).optional(),
         teeTime: z.string().max(5).nullable().optional(), // "HH:MM" 24h
-        competitionId: z.string().nullable().optional(), // team formats (rack-n-stack)
+        competitionId: z.string().nullable().optional(), // team formats / competition games
+        // Competition-layer fact: ordered points by place, e.g. [9,6,4,2]. (§2a)
+        pointsDistribution: z.array(z.number().min(0)).max(64).nullable().optional(),
+        // Optional, one-directional agenda link — never a gate. (§9)
+        scheduleItemId: z.string().uuid().nullable().optional(),
       })
     )
     .use(requireTripRole("Organizer"))
@@ -40,6 +47,8 @@ export const gamesRouter = router({
         game_type_id: input.gameTypeId,
         name: input.name ?? null,
         tee_time: input.teeTime ?? null,
+        points_distribution: input.pointsDistribution ?? null,
+        schedule_item_id: input.scheduleItemId ?? null,
         status: "pending",
       });
       if (insertErr) {
@@ -121,7 +130,7 @@ export const gamesRouter = router({
         userIds: z.array(z.string().min(1)).min(2).max(4),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       // Confirm the game is in this trip before writing participants.
       const { data: game } = await ctx.supabase
@@ -167,7 +176,7 @@ export const gamesRouter = router({
   // any score exists; FROZEN once scores are entered (freeze boundary).
   applyCourse: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string(), courseId: z.string().min(1) }))
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
@@ -246,7 +255,7 @@ export const gamesRouter = router({
   // compute replaces prior game_results, and status='complete' again is a no-op.
   finish: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
@@ -285,5 +294,164 @@ export const gamesRouter = router({
         });
       }
       return { standings, matches, teams };
+    }),
+
+  // update — game-edit gate. Phase-1 shell fields the creation modal edits.
+  update: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        name: z.string().max(200).nullable().optional(),
+        teeTime: z.string().max(5).nullable().optional(),
+        scheduleItemId: z.string().uuid().nullable().optional(),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const patch: Record<string, unknown> = {};
+      if (input.name !== undefined) patch.name = input.name;
+      if (input.teeTime !== undefined) patch.tee_time = input.teeTime;
+      if (input.scheduleItemId !== undefined) patch.schedule_item_id = input.scheduleItemId;
+      if (Object.keys(patch).length === 0) return { success: true };
+      const { error } = await ctx.supabase.from("games").update(patch).eq("id", input.gameId).eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to update game: ${error.message}` });
+      return { success: true };
+    }),
+
+  // setStatus — game-edit gate. A game pulled for time is `dropped`, NOT deleted
+  // (§4): reversible, kept, and excluded from the leaderboard roll-up (which reads
+  // only live games). The win number is DERIVED from the live set, so dropping /
+  // restoring moves it automatically — there is no stored win number to update.
+  setStatus: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        status: z.enum(["pending", "active", "complete", "dropped"]),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ status: input.status })
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set status: ${error.message}` });
+      return { success: true };
+    }),
+
+  // setPointsDistribution — game-edit gate. The competition-layer value
+  // (`[9,6,4,2]`). Editing it re-derives the leaderboard on next read (§5b/§6).
+  setPointsDistribution: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        distribution: z.array(z.number().min(0)).max(64).nullable(),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ points_distribution: input.distribution })
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set distribution: ${error.message}` });
+      return { success: true };
+    }),
+
+  // setManualResults — the manual adapter (§5a), game-edit gate. A non-engine
+  // ("manual") game's per-team finishing order, ENTERED by an organizer into the
+  // SAME `game_results` table engine games compute into. The roll-up never
+  // distinguishes computed from entered. Replace-all so clearing a team drops it.
+  // Placement POINTS stay derived (placementPoints) — we store only the standing.
+  setManualResults: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        placements: z
+          .array(z.object({ entityId: z.string().min(1), position: z.number().int().min(1).max(99) }))
+          .max(64),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+
+      const { error: delErr } = await ctx.supabase.from("game_results").delete().eq("game_id", input.gameId);
+      if (delErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to clear results: ${delErr.message}` });
+
+      if (input.placements.length === 0) return { success: true, count: 0 };
+
+      const rows = input.placements.map((p) => ({
+        id: crypto.randomUUID(),
+        game_id: input.gameId,
+        entity_id: p.entityId,
+        entity_type: "team",
+        position: p.position,
+        raw_score: p.position, // standing = finishing place (low_wins); points derived
+      }));
+      const { error: insErr } = await ctx.supabase.from("game_results").insert(rows);
+      if (insErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to save results: ${insErr.message}` });
+      return { success: true, count: rows.length };
+    }),
+
+  // addOrganizer — trip Owner/Organizer only (delegating is a trip-staff act; a
+  // delegate cannot sub-delegate). Grants BJ the game-scoped organizer role (§8).
+  addOrganizer: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), userId: z.string().min(1) }))
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      const { error } = await ctx.supabase
+        .from("game_organizers")
+        .upsert(
+          { game_id: input.gameId, user_id: input.userId, granted_by: ctx.user!.id },
+          { onConflict: "game_id,user_id", ignoreDuplicates: true }
+        );
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to add organizer: ${error.message}` });
+      return { success: true };
+    }),
+
+  // removeOrganizer — trip Owner/Organizer only.
+  removeOrganizer: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), userId: z.string().min(1) }))
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from("game_organizers")
+        .delete()
+        .eq("game_id", input.gameId)
+        .eq("user_id", input.userId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to remove organizer: ${error.message}` });
+      return { success: true };
+    }),
+
+  // listOrganizers — any trip member can see who runs which game.
+  listOrganizers: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx, input }) => {
+      const { data } = await ctx.supabase
+        .from("game_organizers")
+        .select("user_id, granted_by, created_at")
+        .eq("game_id", input.gameId);
+      return data ?? [];
     }),
 });

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -72,6 +72,28 @@ export const gamesRouter = router({
       return data;
     }),
 
+  // listTypes — the format catalog driving the creation chips (data-driven, NOT a
+  // hardcoded enum). `manual` (no result_strategy / no scorecard_schema) is the
+  // non-engine "Other" type; the rest are engine golf formats. (§2b/§7)
+  listTypes: authedProcedure.query(async ({ ctx }) => {
+    const { data, error } = await ctx.supabase
+      .from("game_type_templates")
+      .select("id, key, name, description, result_strategy, scorecard_schema, sort_order")
+      .order("sort_order", { ascending: true });
+    if (error) {
+      throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to list game types: ${error.message}` });
+    }
+    return (data ?? []).map((t) => ({
+      id: t.id as string,
+      key: t.key as string,
+      name: t.name as string,
+      description: (t.description as string | null) ?? null,
+      // "engine" = computes results from a scorecard; otherwise manual (entered).
+      isEngine: t.result_strategy != null,
+      isGolf: t.scorecard_schema != null, // golf engine types carry a scorecard
+    }));
+  }),
+
   // listByTrip — any trip member.
   listByTrip: authedProcedure
     .input(z.object({ tripId: z.string() }))

--- a/supabase/migrations/20260612165242_043_d1_additive_competition_game_unification.sql
+++ b/supabase/migrations/20260612165242_043_d1_additive_competition_game_unification.sql
@@ -1,0 +1,73 @@
+-- 043 · Slice D1 (2a) — additive: competition–game unification, Phase 1.
+--
+-- ADDITIVE ONLY — no removals, no repoints, no drops (those are later staged
+-- migrations: 2b formats, 2c backfill, 2d repoint, 2e drop). Every column added
+-- here is NULLABLE: the Phase-1 competition "shell" (competition_id + game_type
+-- + name + points_distribution + status) must be a fully valid game with every
+-- Phase-2 field (course, schema, pairings, schedule_item…) still null. (§3)
+--
+-- Idempotent (IF NOT EXISTS / DROP+ADD CONSTRAINT) so it is safe to re-apply.
+
+-- ── games.points_distribution ────────────────────────────────────────────────
+-- Ordered points by place, e.g. [9,6,4,2]. A COMPETITION-LAYER fact, so its own
+-- column — NOT games.config (engine config) and NOT games.modifiers. Null for
+-- standalone / non-competition games. (§2a)
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS points_distribution jsonb;
+
+-- ── games.status += 'dropped' ────────────────────────────────────────────────
+-- A game pulled for time is `dropped`, not deleted — kept, reversible, and
+-- excluded from points-available / win number / leaderboard total. (§4)
+ALTER TABLE public.games DROP CONSTRAINT IF EXISTS games_status_check;
+ALTER TABLE public.games ADD CONSTRAINT games_status_check
+  CHECK (status = ANY (ARRAY['pending'::text, 'active'::text, 'complete'::text, 'dropped'::text]));
+
+-- ── games.schedule_item_id (optional agenda link) ────────────────────────────
+-- Nullable, one-directional, NEVER a gate (§9). Deliberately `uuid` to match
+-- schedule_items.id — an intentional exception to the app-wide text-PK norm
+-- (schedule_items predates it). game→item is the cleaner direction than the
+-- legacy schedule_items.competition_event_id (retired in 2d).
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS schedule_item_id uuid
+  REFERENCES public.schedule_items(id) ON DELETE SET NULL;
+
+-- ── game_organizers (per-game delegation) ────────────────────────────────────
+-- "Brad tells BJ you run pick'em" — a GAME-SCOPED organizer grant, not a
+-- trip-wide role bump. The edit-resolution rule (canEdit || isGameOrganizer)
+-- is wired into the game-edit gate + games/game_results RLS in a later step;
+-- this is the data + its own RLS. (§8)
+CREATE TABLE IF NOT EXISTS public.game_organizers (
+  game_id    text NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  user_id    text NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  granted_by text REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (game_id, user_id)
+);
+
+ALTER TABLE public.game_organizers ENABLE ROW LEVEL SECURITY;
+
+-- Any trip member may SEE who runs which game; only trip owner/organizer may
+-- grant/revoke (the act of delegating is itself a trip-organizer action).
+DROP POLICY IF EXISTS game_organizers_select ON public.game_organizers;
+CREATE POLICY game_organizers_select ON public.game_organizers
+  FOR SELECT USING (EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = game_organizers.game_id AND is_trip_member(g.trip_id)
+  ));
+
+DROP POLICY IF EXISTS game_organizers_write ON public.game_organizers;
+CREATE POLICY game_organizers_write ON public.game_organizers
+  FOR ALL USING (EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = game_organizers.game_id
+      AND has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+  )) WITH CHECK (EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = game_organizers.game_id
+      AND has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+  ));
+
+-- ── competitions.defending_team_id (retain case) ─────────────────────────────
+-- Optional. When set, that team clinches at EXACTLY half (a tie retains);
+-- null (default) = everyone must EXCEED half. The field + the threshold tweak,
+-- nothing more. (§6)
+ALTER TABLE public.competitions ADD COLUMN IF NOT EXISTS defending_team_id text
+  REFERENCES public.teams(id) ON DELETE SET NULL;

--- a/supabase/migrations/20260612165514_044_d1_format_reconciliation.sql
+++ b/supabase/migrations/20260612165514_044_d1_format_reconciliation.sql
@@ -1,0 +1,42 @@
+-- 044 · Slice D1 (2b) — format reconciliation.
+--
+-- One format list: the creation UI's chips are driven by game_type_templates,
+-- and the format the user picks IS the engine game type that runs — or the new
+-- non-engine "manual" type (placement entered by hand, §5 manual adapter).
+--
+-- Two changes:
+--   1. Add the `manual` template (gtt_manual) — no engine, no scorecard.
+--   2. Remove the four PRE-ENGINE legacy uuid rows (skins/scramble/match_play/
+--      stableford — result_strategy NULL, no scorecard_schema). Audit-first:
+--      confirmed ZERO references — no games.game_type_id points at them (all
+--      games use gtt_match_play_singles / gtt_stroke_play) and no code cites the
+--      uuids. They predate the engine `gtt_*` rows and are dead.
+-- Idempotent.
+
+-- 1 · The manual / "other" game type. Non-engine: organizers ENTER per-team
+-- standings into game_results (the universal placement input), nothing is
+-- computed and there is no scorecard (scorecard entry stays gated on
+-- scorecard_schema, which is null here).
+INSERT INTO public.game_type_templates (
+  id, key, name, description, config, sort_order,
+  entry_schema, result_strategy,
+  supports_free_for_all, supports_sides, requires_sides, max_players_per_side,
+  compatible_competition_formats, compatible_modifiers, config_schema, scorecard_schema
+) VALUES (
+  'gtt_manual', 'manual', 'Manual / Other',
+  'A non-engine contest (cornhole, trivia, pick''em, H-O-R-S-E…) — finishing order entered by hand.',
+  '{}'::jsonb, 99,
+  NULL, NULL,
+  true, true, false, NULL,
+  NULL, '{}'::text[], '{}'::jsonb, NULL
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- 2 · Drop the dead pre-engine legacy rows (zero refs — see header audit).
+DELETE FROM public.game_type_templates
+WHERE id IN (
+  '4e3d35f0-ff86-46bb-a3a0-e34138dda311', -- skins (legacy)
+  '922cec93-9559-4198-be9f-59b164cb8d6c', -- scramble (legacy)
+  'c5c59abf-dbce-4858-8fc0-0d60b605f609', -- match_play (legacy)
+  'fc5085e3-a2e4-41a2-986a-797bdfc01fcd'  -- stableford (legacy)
+);

--- a/supabase/migrations/20260612170259_045_d1_game_organizer_gate.sql
+++ b/supabase/migrations/20260612170259_045_d1_game_organizer_gate.sql
@@ -1,0 +1,46 @@
+-- 045 · Slice D1 (§8) — per-game organizer resolution at the DB layer.
+--
+-- The rule: can-edit-a-game = trip Owner/Organizer (canEdit) OR a delegated
+-- organizer of THAT game. Game-isolated. We land the rule + RLS now so the moment
+-- per-game organizers exist every game/game_results write already honors them
+-- (no twelve-call-site retrofit later — same lesson as effectiveStrokes).
+--
+-- These policies are PERMISSIVE, so they OR with the existing trip-role policies
+-- (games_write / game_results_write) — they ADD the delegate path, remove nothing.
+-- Idempotent.
+
+-- is_game_organizer(game) — is the current auth user a delegated organizer of it?
+-- users.id is text = auth uid as text (app-wide text-id convention), so compare
+-- against auth.uid()::text. SECURITY DEFINER + pinned search_path so RLS can call
+-- it without recursing into game_organizers' own policies.
+CREATE OR REPLACE FUNCTION public.is_game_organizer(p_game_id text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.game_organizers go
+    WHERE go.game_id = p_game_id
+      AND go.user_id = (auth.uid())::text
+  );
+$$;
+
+-- A delegated organizer may UPDATE (configure) their game — NOT insert (you can't
+-- be delegated to a game that doesn't exist yet) and NOT hard-delete (dropping is
+-- a status UPDATE). Trip staff keep full ALL via games_write.
+DROP POLICY IF EXISTS games_update_delegate ON public.games;
+CREATE POLICY games_update_delegate ON public.games
+  FOR UPDATE
+  USING (public.is_game_organizer(id))
+  WITH CHECK (public.is_game_organizer(id));
+
+-- A delegated organizer may enter/clear results for their game (the manual
+-- adapter writes game_results; engine computes also land here). Trip staff keep
+-- full ALL via game_results_write.
+DROP POLICY IF EXISTS game_results_delegate ON public.game_results;
+CREATE POLICY game_results_delegate ON public.game_results
+  FOR ALL
+  USING (public.is_game_organizer(game_id))
+  WITH CHECK (public.is_game_organizer(game_id));


### PR DESCRIPTION
First reviewed stage of Slice D1 (audit-first, staged migrations, then behavior). Retires-toward unifying competition contests onto `games`, builds the placement→distribution→leaderboard roll-up, and lands per-game organizer delegation. **The legacy `events` table is NOT dropped here** — that follows the §7 UI migration (see "Remaining").

## What changed (9 commits, staged additive → behavior)

**Schema (each its own migration, applied idempotently + committed; CI `db push` re-applies as a no-op):**
- **043 (2a, additive):** `games.points_distribution jsonb`, `status += 'dropped'`, `game_organizers` table + RLS, `games.schedule_item_id` (uuid, matches `schedule_items.id`), `competitions.defending_team_id`. Every column nullable — the Phase-1 shell stays a valid game.
- **044 (2b):** add the non-engine `gtt_manual` type; remove the 4 dead pre-engine legacy uuid `game_type_templates` rows (audit-first: zero references).
- **045 (§8):** `is_game_organizer()` SQL fn + permissive RLS so a delegate can edit *their* game / enter its results at the DB layer.

**Behavior:**
- **Placement spine (`src/lib/competitionPlacement.ts`)** — client-safe pure module (CLAUDE.md #8): averaged-tie distribution, points-available, win number (clinch by exceeding half; defending team at exactly half), points-to-clinch. Reproduces the BBMI grid (`9,6,3,3`).
- **§8 delegation gate** — `requireGameEdit` middleware (`canEdit || isGameOrganizer`) wired into the games mutations now (not retrofitted later); `addOrganizer`/`removeOrganizer`/`listOrganizers`.
- **games behavior** — Phase-1-shell `create`, `setStatus` (drop/restore), `setPointsDistribution`, `update`, the **§5a manual adapter** (`setManualResults` → the same `game_results` table engine games compute into), and `listTypes` (data-driven format catalog).
- **Leaderboard roll-up** — `competitions.leaderboard` + `server/lib/competitionLeaderboard.ts` (DB-read half of the #8 split) feeding the pure lib; renders from Phase-1 fields, excludes dropped games.
- **Scoreboard swap** — `ScoreboardPanel` now renders from `competitions.leaderboard` (games + real roll-up) instead of `buildMockData` over `events`. The 8 style components are unchanged.
- **PERMISSIONS.md** — per-game delegation row + resolution-rule note.

## Why
`events` (manual placement) and `games` (the engine) modeled the same thing — a contest within a competition — in two eras. This unifies them on `games`, makes the leaderboard derivable from a Phase-1 shell (displayable before anything is played), and lets a game be `dropped` (recomputing the win number from the live set, never stored).

## Tests / checks
- `tsc --noEmit` clean; lint clean on changed files.
- `competitionPlacement.test.ts` (14) — averaged ties, sum-invariance, win number, defender retain, drop-lowers-win-number, Phase-1 shell, `placementDetail`.
- `games.d1.test.ts` (6, real DB + RLS) — Phase-1 shell contributes; manual adapter rolls up; averaged ties end-to-end (7.5/7.5); dropping moves the win number; **full delegation isolation** (delegate edits own / blocked on another / non-member blocked).

## Reviewer notes — transitional state (intentional, staged)
- The competition tab is **mid-migration**: the **scoreboard reads `games`**, but **`EventsPanel` (Add-Event list + modal) and the event detail page still read `events`**. They're sourced from two tables until the §7 UI migration lands. Only on this branch.
- Design decision to confirm before the §7 rewrite: the agenda↔competition link flips from `events.agenda_item_id` (**many** events → one item) to `games.schedule_item_id` (**one** game → one item) — a cardinality change spanning ScheduleTab + ItineraryPanel.

## Remaining (separate focused PR, after this is reviewed)
- **§7 UI migration:** rewire `EventsPanel` onto `games` with the two-screen fork (Save & close / Save & configure); flip the agenda drag-link (`ScheduleTab` + `ItineraryPanel` + event detail) to `games.schedule_item_id`.
- **2c → 2d → 2e:** backfill (synthetic test) → repoint `competition_event_id` → reversible drop of `events` + `event_point_distributions` + dead `game_results.competition_points_earned` — only once zero `events` readers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)