### PR TITLE
Slice D2: Competition leaderboard — 2-team hero + N-team ranked list

### DIFF
--- a/src/app/trips/[tripId]/leaderboard/page.tsx
+++ b/src/app/trips/[tripId]/leaderboard/page.tsx
@@ -4,33 +4,28 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Trophy } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { useTripRole } from "@/hooks/useTripRole";
 import { useRealtimeCompetition } from "@/hooks/useRealtimeCompetition";
 import { TopNav } from "@/components/TopNav";
 import { TripBottomNav } from "@/components/BottomNav";
-import { ScoreboardPanel } from "@/components/competition/ScoreboardPanel";
+import { CompetitionLeaderboard } from "@/components/competition/CompetitionLeaderboard";
 
 /**
- * Live Leaderboard — renders the owner's chosen scoreboard style.
+ * Live Leaderboard — Tier-1 competition standings view (Slice D2).
  *
- * Drops the old 4-tab placeholder (Overview / Groups / Trip Info /
- * History). Now this page is just the styled scoreboard. The owner
- * picks the style from the comp tab; everyone else sees whatever was
- * picked. The scoreboard is driven by the games-based competition
- * leaderboard (game_results); manual placement entry on a game is a
- * follow-on UI (games.setManualResults).
+ * Renders the CompetitionLeaderboard hero: 2-team head-to-head or N-team ranked
+ * list, magic number, session breakdown, clinch state. Data comes from the
+ * competitions.leaderboard query (no realtime subscription in D2 scope — the
+ * component polls on a 30-second interval; a future realtime invalidation can
+ * drop in without a rewrite). The owner's scoreboard-style picker (8 variants)
+ * stays on the Comp tab (ScoreboardPanel); this page is the dedicated hero view.
  *
- * Shows a placeholder when the competition isn't live yet (status !==
- * "active"). The bottom-nav Live entry only renders when status ===
- * "active", so most users shouldn't see that state — it's a fallback
- * for hard URL loads.
+ * Shows a placeholder when the competition isn't live (status !== "active").
  */
 export default function LiveLeaderboardPage() {
   const { tripId } = useParams<{ tripId: string }>();
-  const { isOwner } = useTripRole(tripId);
 
   // Realtime subscription so the leaderboard reflects owner changes
-  // (scoreboard_style, Go Live toggle) without a refresh.
+  // (Go Live toggle) without a refresh.
   useRealtimeCompetition(tripId);
 
   const { data: competition, isLoading } = trpc.competitions.getByTrip.useQuery({
@@ -64,19 +59,14 @@ export default function LiveLeaderboardPage() {
                 </p>
               )}
             </div>
-            <ScoreboardPanel
+            <CompetitionLeaderboard
               competitionId={competition.id}
               tripId={tripId}
-              isOwner={!!isOwner}
             />
           </div>
         )}
       </div>
 
-      {/* Bottom nav — only render when the comp is live (matches
-          page.tsx). Live tab will highlight as active since pathname
-          matches its href. When not live, the inline CTA in the empty
-          state handles navigation back. */}
       {competition?.status === "active" && (
         <TripBottomNav tripId={tripId} showComp={true} />
       )}

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -1,0 +1,756 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { ChevronRight, Check, Radio, Trophy } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface LBTeam {
+  id: string;
+  name: string;
+  short_name: string;
+  color: string;
+}
+
+interface LBGame {
+  id: string;
+  name: string;
+  distribution: number[] | null;
+  status: string;
+  dropped: boolean;
+  gameTypeId: string | null;
+}
+
+interface LBCell {
+  gameId: string;
+  teamId: string;
+  place: number;
+  points: number;
+}
+
+interface LeaderboardData {
+  teams: LBTeam[];
+  games: LBGame[];
+  cells: LBCell[];
+  teamTotals: Record<string, number>;
+  pointsAvailable: number;
+  winNumber: number;
+  pointsToClinch: Record<string, number>;
+  defendingTeamId: string | null;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** "8.5" → "8½", "14" → "14", "0.5" → "½" */
+function fmtPts(n: number): string {
+  const whole = Math.floor(n);
+  const isHalf = Math.abs(n - whole - 0.5) < 0.001;
+  if (!isHalf) return String(whole);
+  return whole === 0 ? "½" : `${whole}½`;
+}
+
+/** Map known game type IDs to their game board route segment. */
+const GAME_ROUTES: Record<string, string> = {
+  gtt_stroke_play: "new",
+  gtt_match_play_singles: "match/new",
+  gtt_rack_n_stack: "rack/new",
+};
+
+function gameHref(
+  tripId: string,
+  gameTypeId: string | null,
+  gameId: string
+): string | null {
+  if (!gameTypeId) return null;
+  const seg = GAME_ROUTES[gameTypeId];
+  return seg ? `/trips/${tripId}/games/${seg}?game=${gameId}` : null;
+}
+
+// ── Root component ────────────────────────────────────────────────────────────
+
+interface Props {
+  competitionId: string;
+  tripId: string;
+}
+
+export function CompetitionLeaderboard({ competitionId, tripId }: Props) {
+  const { data: lb, isLoading } = trpc.competitions.leaderboard.useQuery(
+    { tripId, competitionId },
+    {
+      enabled: !!competitionId,
+      // No realtime subscription (D2 scope): refresh on a 30-second interval
+      // so the board updates without a manual reload. A future realtime
+      // invalidation can drop in by cancelling this interval.
+      refetchInterval: 30_000,
+    }
+  );
+
+  const data = lb as LeaderboardData | undefined;
+
+  const liveGames = useMemo(
+    () => (data?.games ?? []).filter((g) => !g.dropped),
+    [data]
+  );
+
+  const cellsByGame = useMemo(() => {
+    const m = new Map<string, Map<string, LBCell>>();
+    for (const c of data?.cells ?? []) {
+      if (!m.has(c.gameId)) m.set(c.gameId, new Map());
+      m.get(c.gameId)!.set(c.teamId, c);
+    }
+    return m;
+  }, [data?.cells]);
+
+  if (isLoading || !data) return null;
+
+  const { teams, teamTotals, pointsAvailable, winNumber, pointsToClinch, defendingTeamId } = data;
+
+  if (teams.length === 0) {
+    return <NoTeamsState />;
+  }
+
+  const sessionsDone = liveGames.filter((g) => g.status === "complete").length;
+  const allZero = teams.every((t) => (teamTotals[t.id] ?? 0) === 0);
+  const nothingPlayed = liveGames.every((g) => g.status === "pending");
+  const isEarly = allZero && nothingPlayed && liveGames.length > 0;
+  const clincher = teams.find((t) => (pointsToClinch[t.id] ?? 1) <= 0) ?? null;
+
+  if (isEarly) {
+    return (
+      <EarlyState
+        teams={teams}
+        liveGames={liveGames}
+        winNumber={winNumber}
+        tripId={tripId}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="competition-leaderboard">
+      {/* Win banner */}
+      {clincher && (
+        <ClinchedBanner
+          clincher={clincher}
+          isDefender={clincher.id === defendingTeamId}
+          teams={teams}
+          teamTotals={teamTotals}
+        />
+      )}
+
+      {/* Main standings panel */}
+      <div
+        className="overflow-hidden rounded-xl"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {/* Magic-number subtitle */}
+        <div className="px-4 pt-3 pb-2">
+          <p
+            className="text-[11px] font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {clincher
+              ? "Final"
+              : pointsAvailable > 0
+              ? `First to ${fmtPts(winNumber)} wins`
+              : "Competition standings"}
+          </p>
+        </div>
+
+        {teams.length === 2 ? (
+          <TwoTeamHero
+            teams={teams}
+            teamTotals={teamTotals}
+            pointsAvailable={pointsAvailable}
+            winNumber={winNumber}
+            pointsToClinch={pointsToClinch}
+            clincher={clincher}
+          />
+        ) : (
+          <NTeamRankedList
+            teams={teams}
+            teamTotals={teamTotals}
+            pointsAvailable={pointsAvailable}
+            winNumber={winNumber}
+            pointsToClinch={pointsToClinch}
+            clincher={clincher}
+          />
+        )}
+      </div>
+
+      {/* Session breakdown */}
+      {liveGames.length > 0 && (
+        <SessionBreakdown
+          games={liveGames}
+          teams={teams}
+          cellsByGame={cellsByGame}
+          sessionsDone={sessionsDone}
+          tripId={tripId}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── TwoTeamHero ──────────────────────────────────────────────────────────────
+
+function TwoTeamHero({
+  teams,
+  teamTotals,
+  pointsAvailable,
+  winNumber,
+  pointsToClinch,
+  clincher,
+}: {
+  teams: LBTeam[];
+  teamTotals: Record<string, number>;
+  pointsAvailable: number;
+  winNumber: number;
+  pointsToClinch: Record<string, number>;
+  clincher: LBTeam | null;
+}) {
+  const [a, b] = teams;
+  const aTotal = teamTotals[a.id] ?? 0;
+  const bTotal = teamTotals[b.id] ?? 0;
+  const aToGo = pointsToClinch[a.id] ?? winNumber;
+  const bToGo = pointsToClinch[b.id] ?? winNumber;
+
+  // Progress bar proportions — each team's share of pointsAvailable.
+  const aWidth = pointsAvailable > 0 ? Math.min(100, (aTotal / pointsAvailable) * 100) : 0;
+  const bWidth = pointsAvailable > 0 ? Math.min(100, (bTotal / pointsAvailable) * 100) : 0;
+
+  return (
+    <div className="px-4 pb-4">
+      {/* Team name row */}
+      <div className="flex items-center justify-between">
+        <p className="text-[11px] font-bold uppercase tracking-widest" style={{ color: a.color }}>
+          {a.short_name}
+        </p>
+        <p className="text-[11px] font-bold uppercase tracking-widest" style={{ color: b.color }}>
+          {b.short_name}
+        </p>
+      </div>
+
+      {/* Big totals */}
+      <div className="flex items-baseline justify-between">
+        <span
+          className="text-5xl font-black tabular-nums leading-none"
+          style={{ color: a.color }}
+        >
+          {fmtPts(aTotal)}
+        </span>
+        <span
+          className="mx-3 text-2xl font-light"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          –
+        </span>
+        <span
+          className="text-5xl font-black tabular-nums leading-none"
+          style={{ color: b.color }}
+        >
+          {fmtPts(bTotal)}
+        </span>
+      </div>
+
+      {/* "X to clinch" sub-labels */}
+      {!clincher && (
+        <div className="mt-1 flex items-start justify-between">
+          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {aToGo > 0 ? `${fmtPts(aToGo)} to clinch` : "Clinched"}
+          </p>
+          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {bToGo > 0 ? `${fmtPts(bToGo)} to clinch` : "Clinched"}
+          </p>
+        </div>
+      )}
+
+      {/* Progress bar */}
+      <div
+        className="mt-3 flex h-2 w-full overflow-hidden rounded-full"
+        style={{ background: "var(--color-bt-card-raised)" }}
+      >
+        <div
+          className="h-full rounded-l-full transition-all duration-500"
+          style={{ width: `${aWidth}%`, background: a.color }}
+        />
+        <div
+          className="h-full rounded-r-full transition-all duration-500 ml-auto"
+          style={{ width: `${bWidth}%`, background: b.color }}
+        />
+      </div>
+
+      {/* Footer row */}
+      <div className="mt-1.5 flex items-center justify-between">
+        <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          {pointsAvailable > 0 ? `${fmtPts(pointsAvailable)} pts in play` : "No pts yet"}
+        </p>
+        {!clincher && pointsAvailable > 0 && (
+          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            clinch {fmtPts(winNumber)}
+          </p>
+        )}
+        {clincher && (
+          <p className="text-[11px] font-semibold" style={{ color: "var(--color-bt-accent)" }}>
+            Final
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── NTeamRankedList ───────────────────────────────────────────────────────────
+
+function NTeamRankedList({
+  teams,
+  teamTotals,
+  pointsAvailable,
+  winNumber,
+  pointsToClinch,
+  clincher,
+}: {
+  teams: LBTeam[];
+  teamTotals: Record<string, number>;
+  pointsAvailable: number;
+  winNumber: number;
+  pointsToClinch: Record<string, number>;
+  clincher: LBTeam | null;
+}) {
+  const sorted = [...teams].sort(
+    (a, b) => (teamTotals[b.id] ?? 0) - (teamTotals[a.id] ?? 0)
+  );
+
+  return (
+    <div className="px-4 pb-3">
+      {!clincher && pointsAvailable > 0 && (
+        <p
+          className="mb-3 text-[11px]"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          {fmtPts(pointsAvailable)} pts in play
+        </p>
+      )}
+      <div className="space-y-2">
+        {sorted.map((team, idx) => {
+          const total = teamTotals[team.id] ?? 0;
+          const barWidth =
+            pointsAvailable > 0
+              ? Math.min(100, (total / pointsAvailable) * 100)
+              : 0;
+          const toGo = pointsToClinch[team.id] ?? winNumber;
+          const hasClinched = toGo <= 0;
+
+          return (
+            <div key={team.id} className="flex items-center gap-3">
+              {/* Rank */}
+              <span
+                className="w-4 shrink-0 text-[12px] font-semibold tabular-nums"
+                style={{ color: hasClinched ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+              >
+                {idx + 1}
+              </span>
+
+              {/* Dot + name */}
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ background: team.color }}
+                  />
+                  <span
+                    className="truncate text-sm font-semibold"
+                    style={{ color: hasClinched ? "var(--color-bt-text)" : "var(--color-bt-text)" }}
+                  >
+                    {team.name}
+                  </span>
+                  {hasClinched && (
+                    <Trophy
+                      size={12}
+                      style={{ color: "var(--color-bt-accent)", flexShrink: 0 }}
+                    />
+                  )}
+                </div>
+                {/* Bar */}
+                <div
+                  className="h-1.5 w-full overflow-hidden rounded-full"
+                  style={{ background: "var(--color-bt-card-raised)" }}
+                >
+                  <div
+                    className="h-full rounded-full transition-all duration-500"
+                    style={{ width: `${barWidth}%`, background: team.color }}
+                  />
+                </div>
+              </div>
+
+              {/* Points */}
+              <span
+                className="shrink-0 text-base font-bold tabular-nums"
+                style={{ color: hasClinched ? team.color : "var(--color-bt-text)" }}
+              >
+                {fmtPts(total)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── SessionBreakdown ─────────────────────────────────────────────────────────
+
+function SessionBreakdown({
+  games,
+  teams,
+  cellsByGame,
+  sessionsDone,
+  tripId,
+}: {
+  games: LBGame[];
+  teams: LBTeam[];
+  cellsByGame: Map<string, Map<string, LBCell>>;
+  sessionsDone: number;
+  tripId: string;
+}) {
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+    >
+      <div
+        className="px-4 py-2.5"
+        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+      >
+        <p
+          className="text-[11px] font-semibold uppercase tracking-wider"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Sessions{" "}
+          <span style={{ color: "var(--color-bt-text)" }}>
+            · {sessionsDone} of {games.length} done
+          </span>
+        </p>
+      </div>
+
+      <div className="divide-y" style={{ "--tw-divide-color": "var(--color-bt-border)" } as React.CSSProperties}>
+        {games.map((game) => (
+          <SessionRow
+            key={game.id}
+            game={game}
+            teams={teams}
+            cells={cellsByGame.get(game.id)}
+            tripId={tripId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SessionRow({
+  game,
+  teams,
+  cells,
+  tripId,
+}: {
+  game: LBGame;
+  teams: LBTeam[];
+  cells: Map<string, LBCell> | undefined;
+  tripId: string;
+}) {
+  const href = gameHref(tripId, game.gameTypeId, game.id);
+  const hasScores = cells && cells.size > 0;
+
+  const inner = (
+    <div className="flex flex-col gap-0.5 px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className="truncate text-sm font-semibold"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {game.name}
+        </span>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <StatusBadge status={game.status} />
+          {href && (
+            <ChevronRight size={14} style={{ color: "var(--color-bt-text-dim)" }} />
+          )}
+        </div>
+      </div>
+
+      {/* Per-team score line */}
+      <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+        {teams.map((team) => {
+          const cell = cells?.get(team.id);
+          return (
+            <span
+              key={team.id}
+              className="flex items-center gap-1 text-[12px]"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <span
+                className="inline-block h-1.5 w-1.5 rounded-full"
+                style={{ background: team.color }}
+              />
+              <span style={{ color: hasScores ? team.color : "var(--color-bt-text-dim)" }}>
+                {team.short_name}
+              </span>
+              {cell ? (
+                <span style={{ color: "var(--color-bt-text)" }}>{fmtPts(cell.points)}</span>
+              ) : (
+                <span style={{ color: "var(--color-bt-text-dim)" }}>–</span>
+              )}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block hover:opacity-80 transition-opacity">
+        {inner}
+      </Link>
+    );
+  }
+  return <div>{inner}</div>;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "complete") {
+    return (
+      <span
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          color: "var(--color-bt-text-dim)",
+        }}
+      >
+        <Check size={9} />
+        Final
+      </span>
+    );
+  }
+  if (status === "in_progress") {
+    return (
+      <span
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
+        style={{
+          background: "var(--color-bt-accent-faint)",
+          color: "var(--color-bt-accent)",
+          border: "1px solid var(--color-bt-accent-border)",
+        }}
+      >
+        <Radio size={9} />
+        Live
+      </span>
+    );
+  }
+  // pending / unknown
+  return (
+    <span
+      className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+      style={{
+        background: "var(--color-bt-card-raised)",
+        color: "var(--color-bt-text-dim)",
+      }}
+    >
+      Upcoming
+    </span>
+  );
+}
+
+// ── EarlyState ────────────────────────────────────────────────────────────────
+
+function EarlyState({
+  teams,
+  liveGames,
+  winNumber,
+  tripId,
+}: {
+  teams: LBTeam[];
+  liveGames: LBGame[];
+  winNumber: number;
+  tripId: string;
+}) {
+  return (
+    <div className="space-y-3" data-testid="competition-leaderboard">
+      {/* Team dots row */}
+      <div
+        className="flex flex-wrap items-center gap-3 rounded-xl px-4 py-4"
+        style={{
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        {teams.map((team) => (
+          <div key={team.id} className="flex items-center gap-2">
+            <span
+              className="h-3 w-3 rounded-full"
+              style={{ background: team.color }}
+            />
+            <span
+              className="text-sm font-semibold"
+              style={{ color: "var(--color-bt-text)" }}
+            >
+              {team.name}
+            </span>
+          </div>
+        ))}
+
+        <div
+          className="mt-3 w-full"
+          style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        />
+        <div className="w-full pt-1">
+          <p
+            className="text-sm font-semibold"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            The cup hasn&rsquo;t started
+          </p>
+          <p
+            className="mt-1 text-[12px] leading-relaxed"
+            style={{ color: "var(--color-bt-text-dim)" }}
+          >
+            {liveGames.length} session{liveGames.length !== 1 ? "s" : ""} ·{" "}
+            first to {fmtPts(winNumber)} wins. Standings appear as games finish.
+          </p>
+        </div>
+      </div>
+
+      {/* Schedule */}
+      {liveGames.length > 0 && (
+        <div
+          className="overflow-hidden rounded-xl"
+          style={{
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+          }}
+        >
+          <div
+            className="px-4 py-2.5"
+            style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+          >
+            <p
+              className="text-[11px] font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              The Schedule
+            </p>
+          </div>
+          <div className="divide-y" style={{ "--tw-divide-color": "var(--color-bt-border)" } as React.CSSProperties}>
+            {liveGames.map((game) => {
+              const href = gameHref(tripId, game.gameTypeId, game.id);
+              const row = (
+                <div className="flex items-center justify-between gap-2 px-4 py-3">
+                  <span
+                    className="truncate text-sm"
+                    style={{ color: "var(--color-bt-text)" }}
+                  >
+                    {game.name}
+                  </span>
+                  <div className="flex items-center gap-1.5">
+                    <StatusBadge status={game.status} />
+                    {href && (
+                      <ChevronRight
+                        size={14}
+                        style={{ color: "var(--color-bt-text-dim)" }}
+                      />
+                    )}
+                  </div>
+                </div>
+              );
+              return href ? (
+                <Link
+                  key={game.id}
+                  href={href}
+                  className="block hover:opacity-80 transition-opacity"
+                >
+                  {row}
+                </Link>
+              ) : (
+                <div key={game.id}>{row}</div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── ClinchedBanner ────────────────────────────────────────────────────────────
+
+function ClinchedBanner({
+  clincher,
+  isDefender,
+  teams,
+  teamTotals,
+}: {
+  clincher: LBTeam;
+  isDefender: boolean;
+  teams: LBTeam[];
+  teamTotals: Record<string, number>;
+}) {
+  const sorted = [...teams].sort(
+    (a, b) => (teamTotals[b.id] ?? 0) - (teamTotals[a.id] ?? 0)
+  );
+  const scoreLabel = sorted
+    .map((t) => fmtPts(teamTotals[t.id] ?? 0))
+    .join("–");
+
+  const verb = isDefender ? "retains" : "wins the cup";
+
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl px-4 py-3"
+      style={{
+        background: "var(--color-bt-accent-faint)",
+        border: "1px solid var(--color-bt-accent-border)",
+      }}
+      data-testid="clinch-banner"
+    >
+      <Trophy size={18} style={{ color: "var(--color-bt-accent)", flexShrink: 0 }} />
+      <p className="text-sm font-semibold" style={{ color: "var(--color-bt-accent)" }}>
+        {clincher.name} {verb} · {scoreLabel}
+      </p>
+    </div>
+  );
+}
+
+// ── NoTeamsState ──────────────────────────────────────────────────────────────
+
+function NoTeamsState() {
+  return (
+    <div
+      className="flex flex-col items-center gap-2 rounded-xl px-4 py-10 text-center"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      data-testid="competition-leaderboard"
+    >
+      <Trophy size={24} style={{ color: "var(--color-bt-text-dim)" }} />
+      <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+        No teams yet
+      </p>
+      <p
+        className="max-w-xs text-[12px] leading-relaxed"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Add teams and games in the Competition tab to see standings here.
+      </p>
+    </div>
+  );
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -34,7 +34,7 @@ export async function computeCompetitionLeaderboard(
   // an "Abandoned" column, but only LIVE ones feed the roll-up / points-available.
   const { data: gameRows } = await supabase
     .from("games")
-    .select("id, name, points_distribution, status")
+    .select("id, name, points_distribution, status, game_type_id")
     .eq("competition_id", competitionId)
     .order("created_at", { ascending: true });
   const allGames = gameRows ?? [];
@@ -79,12 +79,14 @@ export async function computeCompetitionLeaderboard(
 
   return {
     teams: teams ?? [],
+    defendingTeamId: (comp?.defending_team_id as string | null) ?? null,
     games: allGames.map((g) => ({
       id: g.id as string,
       name: (g.name as string | null) ?? "Game",
       distribution: (g.points_distribution as number[] | null) ?? null,
       status: g.status as string,
       dropped: g.status === "dropped",
+      gameTypeId: (g.game_type_id as string | null) ?? null,
     })),
     cells,
     pointsAvailable: roll.pointsAvailable,

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+import { rollUp, placementPoints, winThreshold, type LiveGame } from "../../lib/competitionPlacement";
+
+/**
+ * Slice D2 — CompetitionLeaderboard data contract (§6).
+ *
+ * These tests verify the leaderboard endpoint produces exactly the shape the
+ * CompetitionLeaderboard component expects, covering the four §6 scenarios.
+ * All math delegates to competitionPlacement.ts (client-safe lib) — the
+ * assertions here prove the endpoint matches what the lib would compute, not a
+ * re-implementation of the math.
+ */
+
+const MANUAL = "gtt_manual";
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+const gameIds: string[] = [];
+
+async function makeGame(distribution: number[] | null, name = "Game") {
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId: MANUAL,
+    name,
+    competitionId,
+    pointsDistribution: distribution,
+  })) as { id: string };
+  gameIds.push(g.id);
+  return g.id;
+}
+
+async function enterResults(
+  gameId: string,
+  placements: { teamId: string; position: number }[]
+) {
+  await ctx
+    .caller()
+    .games.setManualResults({
+      tripId,
+      gameId,
+      placements: placements.map((p) => ({ entityId: p.teamId, position: p.position })),
+    });
+}
+
+async function dropGame(gameId: string) {
+  await ctx.caller().games.drop({ tripId, gameId });
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("D2 Leaderboard Trip");
+  competitionId = await ctx.createCompetition(tripId, "D2 Cup");
+});
+
+afterAll(async () => {
+  for (const id of gameIds) {
+    await ctx.admin.from("game_results").delete().eq("game_id", id);
+    await ctx.admin.from("games").delete().eq("id", id);
+  }
+  await ctx.cleanup();
+});
+
+describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
+  let teamA: string;
+  let teamB: string;
+
+  beforeAll(async () => {
+    teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
+    teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
+  });
+
+  it("early state: all totals zero, winNumber derived, game returns with no cells", async () => {
+    const gameId = await makeGame([9, 6], "Shell Game");
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+
+    expect(lb.teamTotals[teamA]).toBe(0);
+    expect(lb.teamTotals[teamB]).toBe(0);
+    // winNumber = smallest > half of 15 (9+6) → 8
+    expect(lb.winNumber).toBe(8);
+    expect(lb.pointsAvailable).toBe(15);
+    // No results → no cells
+    expect(lb.cells.filter((c: { gameId: string }) => c.gameId === gameId)).toHaveLength(0);
+    // Game is present in the response
+    const game = lb.games.find((g: { id: string }) => g.id === gameId);
+    expect(game).toBeDefined();
+    expect(game!.dropped).toBe(false);
+  });
+
+  it("in-progress: scores entered, teamTotals and pointsToClinch update", async () => {
+    const gameId = await makeGame([9, 6], "Scored Game");
+    await enterResults(gameId, [
+      { teamId: teamA, position: 1 },
+      { teamId: teamB, position: 2 },
+    ]);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+
+    // Points earned: 9 for 1st, 6 for 2nd across all live games with this setup
+    // We only assert the game we just set, net of the shell (0 for shell)
+    const aTotal = lb.teamTotals[teamA] as number;
+    const bTotal = lb.teamTotals[teamB] as number;
+    expect(aTotal).toBeGreaterThan(bTotal);
+
+    // pointsToClinch = winNumber - total
+    const aPtc = lb.pointsToClinch[teamA] as number;
+    expect(aPtc).toBe(lb.winNumber - aTotal);
+  });
+
+  it("clinched: pointsToClinch <= 0 when a team reaches winNumber", async () => {
+    // Create a fresh competition for a clean slate
+    const cleanComp = await ctx.createCompetition(tripId, "D2 Clinch Comp");
+    const ta = await ctx.createTeam(cleanComp, "Blue2", { shortName: "B2" });
+    const tb = await ctx.createTeam(cleanComp, "Red2", { shortName: "R2" });
+
+    const g = await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MANUAL,
+      name: "Clincher",
+      competitionId: cleanComp,
+      pointsDistribution: [10, 0],
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.caller().games.setManualResults({
+      tripId,
+      gameId: g.id,
+      placements: [
+        { entityId: ta, position: 1 },
+        { entityId: tb, position: 2 },
+      ],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: cleanComp });
+
+    // ta has 10 pts, available=10 → half=5 → winNumber=5.5 (smallest > half)
+    expect(lb.teamTotals[ta]).toBe(10);
+    expect(lb.teamTotals[tb]).toBe(0);
+    expect(lb.winNumber).toBe(5.5);
+    expect(lb.pointsToClinch[ta]).toBeLessThanOrEqual(0);
+    expect(lb.pointsToClinch[tb]).toBeGreaterThan(0);
+  });
+
+  it("retain case: defending team clinches at half (not > half)", async () => {
+    const cleanComp = await ctx.createCompetition(tripId, "D2 Retain Comp");
+    const defender = await ctx.createTeam(cleanComp, "Defender", { shortName: "DEF" });
+    const challenger = await ctx.createTeam(cleanComp, "Challenger", { shortName: "CHL" });
+
+    // Set defending_team_id directly on the competition (no tRPC for this yet)
+    await ctx.admin
+      .from("competitions")
+      .update({ defending_team_id: defender })
+      .eq("id", cleanComp);
+
+    const g = await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MANUAL,
+      name: "Retain Test",
+      competitionId: cleanComp,
+      pointsDistribution: [14, 14],
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.caller().games.setManualResults({
+      tripId,
+      gameId: g.id,
+      placements: [
+        { entityId: defender, position: 1 },
+        { entityId: challenger, position: 2 },
+      ],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: cleanComp });
+
+    expect(lb.defendingTeamId).toBe(defender);
+    // Available = 28, winThreshold(28, false) = 14.5, winThreshold(28, true) = 14
+    // Defender has 14 pts → pointsToClinch = 14 - 14 = 0 → clinched (retain)
+    // Challenger has 14 pts too, but winThreshold(28, false) = 14.5 → 14.5-14=0.5 → not clinched
+    expect(lb.pointsToClinch[defender]).toBeLessThanOrEqual(0);
+    expect(lb.pointsToClinch[challenger]).toBeGreaterThan(0);
+  });
+});
+
+describe("D2 §6 — N-team (3+ teams) ranked list data", () => {
+  it("3-team competition: winNumber and pointsToClinch work for all three teams", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 3-Team Comp");
+    const t1 = await ctx.createTeam(comp, "Alpha", { shortName: "ALP" });
+    const t2 = await ctx.createTeam(comp, "Beta", { shortName: "BET" });
+    const t3 = await ctx.createTeam(comp, "Gamma", { shortName: "GAM" });
+
+    const g = await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MANUAL,
+      name: "3-way",
+      competitionId: comp,
+      pointsDistribution: [9, 6, 4],
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.caller().games.setManualResults({
+      tripId,
+      gameId: g.id,
+      placements: [
+        { entityId: t1, position: 1 },
+        { entityId: t2, position: 2 },
+        { entityId: t3, position: 3 },
+      ],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    expect(lb.teams).toHaveLength(3);
+    expect(lb.teamTotals[t1]).toBe(9);
+    expect(lb.teamTotals[t2]).toBe(6);
+    expect(lb.teamTotals[t3]).toBe(4);
+    // available = 19, winNumber = smallest > 9.5 → 10
+    expect(lb.winNumber).toBe(10);
+    expect(lb.pointsToClinch[t1]).toBe(1); // 10-9=1
+    expect(lb.pointsToClinch[t2]).toBe(4); // 10-6=4
+    expect(lb.pointsToClinch[t3]).toBe(6); // 10-4=6
+  });
+});
+
+describe("D2 §6 — dropped game excluded from totals and winNumber", () => {
+  it("dropping a game moves the winNumber and removes it from cells", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 Drop Comp");
+    const ta = await ctx.createTeam(comp, "Blue", { shortName: "BLU" });
+    const tb = await ctx.createTeam(comp, "Red", { shortName: "RED" });
+
+    const g1r = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Live", competitionId: comp,
+      pointsDistribution: [9, 6],
+    }) as { id: string };
+    const g1 = g1r.id;
+    gameIds.push(g1);
+    const g2r = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "To Drop", competitionId: comp,
+      pointsDistribution: [9, 6],
+    }) as { id: string };
+    const g2 = g2r.id;
+    gameIds.push(g2);
+
+    await ctx.caller().games.setManualResults({ tripId, gameId: g1, placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 2 }] });
+    await ctx.caller().games.setManualResults({ tripId, gameId: g2, placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 2 }] });
+
+    const before = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(before.pointsAvailable).toBe(30); // 15+15
+    expect(before.teamTotals[ta]).toBe(18); // 9+9
+
+    await ctx.caller().games.setStatus({ tripId, gameId: g2, status: "dropped" });
+
+    const after = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    // Dropped game excluded from roll-up
+    expect(after.pointsAvailable).toBe(15);
+    expect(after.teamTotals[ta]).toBe(9);
+    // Dropped game still present in games[] but with dropped:true
+    const droppedGame = after.games.find((g: { id: string }) => g.id === g2);
+    expect(droppedGame?.dropped).toBe(true);
+    // No cells for dropped game
+    expect(after.cells.filter((c: { gameId: string }) => c.gameId === g2)).toHaveLength(0);
+  });
+});
+
+describe("D2 §6 — non-engine game with no entry shows at 0, not hidden", () => {
+  it("manual game with no results contributes to pointsAvailable but has no cells", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 NoEntry Comp");
+    await ctx.createTeam(comp, "X", { shortName: "X" });
+    await ctx.createTeam(comp, "Y", { shortName: "Y" });
+
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Not Entered Yet", competitionId: comp,
+      pointsDistribution: [5, 3],
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    // Game is present (honest, not hidden)
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id);
+    expect(game).toBeDefined();
+    expect(game!.dropped).toBe(false);
+    // Points-available counts it (8 in play)
+    expect(lb.pointsAvailable).toBe(8);
+    // No cells (no results entered)
+    expect(lb.cells.filter((c: { gameId: string }) => c.gameId === g.id)).toHaveLength(0);
+    // Teams show at 0
+    for (const team of lb.teams) {
+      expect(lb.teamTotals[team.id] ?? 0).toBe(0);
+    }
+  });
+});
+
+describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
+  it("game_type_id and defendingTeamId are present in response", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 Shape Comp");
+    await ctx.createTeam(comp, "A", { shortName: "A" });
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Shape Test", competitionId: comp,
+      pointsDistribution: [9],
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id);
+    expect(game).toBeDefined();
+    expect("gameTypeId" in game!).toBe(true);
+    expect(game!.gameTypeId).toBe(MANUAL);
+    expect("defendingTeamId" in lb).toBe(true);
+  });
+
+  it("reads competitionPlacement.ts — rollUp matches the endpoint's teamTotals", async () => {
+    // This test proves the endpoint delegates to the lib (CLAUDE.md #8 — single
+    // source of truth). We run the same inputs through rollUp directly and compare.
+    const comp = await ctx.createCompetition(tripId, "D2 Delegation Comp");
+    const t1 = await ctx.createTeam(comp, "P", { shortName: "P" });
+    const t2 = await ctx.createTeam(comp, "Q", { shortName: "Q" });
+
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Delegate", competitionId: comp,
+      pointsDistribution: [9, 6],
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.caller().games.setManualResults({
+      tripId, gameId: g.id,
+      placements: [{ entityId: t1, position: 1 }, { entityId: t2, position: 2 }],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    // Reproduce what the lib computes from these inputs
+    const liveInput: LiveGame[] = [{
+      id: g.id,
+      distribution: [9, 6],
+      numTeams: 2,
+      standings: [
+        { entityId: t1, value: 1 },
+        { entityId: t2, value: 2 },
+      ],
+      direction: "low_wins",
+    }];
+    const roll = rollUp(liveInput, [t1, t2]);
+
+    expect(lb.teamTotals[t1]).toBe(roll.teamTotals.get(t1));
+    expect(lb.teamTotals[t2]).toBe(roll.teamTotals.get(t2));
+    expect(lb.winNumber).toBe(roll.winNumber);
+    expect(lb.pointsAvailable).toBe(roll.pointsAvailable);
+  });
+});

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -44,10 +44,6 @@ async function enterResults(
     });
 }
 
-async function dropGame(gameId: string) {
-  await ctx.caller().games.drop({ tripId, gameId });
-}
-
 beforeAll(async () => {
   ctx = await TestContext.create();
   tripId = await ctx.createTrip("D2 Leaderboard Trip");


### PR DESCRIPTION
## Summary

- **`CompetitionLeaderboard.tsx`** — new Tier-1 hero view replacing `ScoreboardPanel` on the Live tab. Reads `competitions.leaderboard` (30-second refetch, no realtime subscription per D2 scope; invalidation-ready for the future realtime channel).
- **2-team hero**: large color-anchored totals, split progress bar, points-to-clinch sub-labels, clinch-number footer
- **N-team (3+)**: ranked standings list with per-team progress bars, trophy on clinch; the same component handles both layouts — 2-team is a styling, not a hardcoded structure (spec fences held)
- **Three states**: early ("cup hasn't started" + schedule), in-progress, clinched (defender-aware "retains" vs "wins the cup")
- **Session breakdown**: game rows with Final/Live/Upcoming badges, per-team distribution points, tappable nav seam to existing game boards (`gtt_stroke_play` → `/games/new`, `gtt_match_play_singles` → `/games/match/new`, `gtt_rack_n_stack` → `/games/rack/new`)
- **Non-engine games** show present-at-0 in the breakdown (not hidden), as specified in §0
- **`competitionLeaderboard.ts`**: added `game_type_id` (nav seam routing) and `defendingTeamId` (retain case) to response
- **`leaderboard/page.tsx`**: `ScoreboardPanel` → `CompetitionLeaderboard`; `ScoreboardPanel` stays on the Comp tab with its 8 owner-selectable styles

## Test plan

- [x] 9 integration tests in `competitions.d2.test.ts` — all passing
  - 2-team: early, in-progress, clinched, retain states
  - 3-team N-team shape
  - Dropped game excluded from winNumber and cells
  - Non-engine game with no entry: present-at-0, not hidden
  - Response shape includes `gameTypeId` + `defendingTeamId`
  - rollUp delegation: endpoint totals match `competitionPlacement.ts` directly
- [x] `tsc --noEmit` clean
- [x] No console errors (verified in browser preview)
- [x] Spec fences held: no realtime subscription, no manual-placement UI, no duplicate math, no hardcoded team counts/colors, no `a/b` shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)