### PR TITLE
feat(d1-followon): tagged points_distribution + match-play per-match adapter

### DIFF
--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { Flag, Plus, Pencil, Star, Trash2, X, Trophy, RotateCcw } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
+import type { PointsDistribution } from "@/lib/pointsDistribution";
 
 /**
  * CompetitionGamesPanel — the Slice D1 §7 contest list + creation flow, on
@@ -33,7 +34,7 @@ export interface GameRow {
   game_type_id: string | null;
   name: string | null;
   status: "pending" | "active" | "complete" | "dropped";
-  points_distribution: number[] | null;
+  points_distribution: PointsDistribution | null;
   scorecard_schema: unknown | null;
   schedule_item_id: string | null;
 }
@@ -45,6 +46,7 @@ interface GameType {
   description: string | null;
   isEngine: boolean;
   isGolf: boolean;
+  resultStrategy: string | null;
 }
 
 export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props) {
@@ -149,9 +151,18 @@ function GameCard({
   onEdit: () => void;
 }) {
   const dropped = game.status === "dropped";
-  const dist = game.points_distribution ?? [];
-  const total = dist.reduce((a, b) => a + b, 0);
-  const distSummary = dist.length > 0 ? dist.map((p, i) => `${ordinalShort(i + 1)}: ${p}`).join(" · ") : null;
+  const dist = game.points_distribution;
+
+  let total = 0;
+  let distSummary: string | null = null;
+  if (dist?.type === "placement") {
+    total = dist.values.reduce((a, b) => a + b, 0);
+    distSummary = dist.values.length > 0
+      ? dist.values.map((p, i) => `${ordinalShort(i + 1)}: ${p}`).join(" · ")
+      : null;
+  } else if (dist?.type === "per_match") {
+    distSummary = `${fmtValue(dist.value)} pt/match`;
+  }
 
   return (
     <div
@@ -175,7 +186,7 @@ function GameCard({
           <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
             {game.name || "Untitled game"}
           </p>
-          {!dropped && total > 0 && (
+          {!dropped && dist?.type === "placement" && total > 0 && (
             <span className="text-[11px] font-semibold tabular-nums" style={{ color: "var(--color-bt-accent)" }}>
               {total} pt{total === 1 ? "" : "s"}
             </span>
@@ -244,22 +255,52 @@ function GameSheet({
     game?.game_type_id ?? golfTypes[0]?.id ?? otherTypes[0]?.id ?? ""
   );
   const [title, setTitle] = useState(game?.name ?? "");
+  // Placement-mode state
   const [points, setPoints] = useState<number[]>(() => {
     const d = game?.points_distribution;
-    return d && d.length > 0 ? [...d] : [0];
+    if (d?.type === "placement") return d.values.length > 0 ? [...d.values] : [0];
+    return [0];
+  });
+  // Per-match-mode state
+  const [perMatchValue, setPerMatchValue] = useState<number>(() => {
+    const d = game?.points_distribution;
+    if (d?.type === "per_match") return d.value;
+    return 1;
   });
   const [error, setError] = useState<string | null>(null);
 
   const visibleTypes = isGolf ? golfTypes : otherTypes;
   // Keep a valid selection when toggling Golf/Other.
   const effectiveTypeId = visibleTypes.some((t) => t.id === gameTypeId) ? gameTypeId : visibleTypes[0]?.id ?? "";
+  const selectedType = types.find((t) => t.id === effectiveTypeId);
+  const isMatchPlay = selectedType?.resultStrategy === "match_play_singles";
+
+  // Projected total readout for match-play: team assignment counts.
+  const { data: teamCounts } = trpc.competitions.teamAssignmentCounts.useQuery(
+    { tripId, competitionId },
+    { enabled: isMatchPlay }
+  );
+  const projectedCap = useMemo(() => {
+    if (!teamCounts) return null;
+    const sizes = Object.values(teamCounts as Record<string, number>);
+    if (sizes.length === 0) return null;
+    return Math.min(...sizes);
+  }, [teamCounts]);
 
   const create = trpc.games.create.useMutation();
   const update = trpc.games.update.useMutation();
   const setDist = trpc.games.setPointsDistribution.useMutation();
   const setStatus = trpc.games.setStatus.useMutation();
 
-  const total = points.reduce((a, b) => a + (b || 0), 0);
+  const placementTotal = points.reduce((a, b) => a + (b || 0), 0);
+
+  function buildDistribution(): PointsDistribution | null {
+    if (isMatchPlay) {
+      return { type: "per_match", value: perMatchValue > 0 ? perMatchValue : 1 };
+    }
+    const values = points.filter((p) => p > 0);
+    return values.length > 0 ? { type: "placement", values: points.map((p) => p || 0) } : null;
+  }
 
   async function persist(): Promise<boolean> {
     setError(null);
@@ -271,7 +312,7 @@ function GameSheet({
       setError("Pick a format");
       return false;
     }
-    const distribution = points.filter((p) => p > 0).length > 0 ? points.map((p) => p || 0) : null;
+    const distribution = buildDistribution();
     try {
       if (isEdit && game) {
         await update.mutateAsync({ tripId, gameId: game.id, name: title.trim() });
@@ -284,7 +325,6 @@ function GameSheet({
           competitionId,
           pointsDistribution: distribution,
         })) as { id: string };
-        // create takes the distribution inline; nothing more to write.
         void created;
       }
       utils.games.listByTrip.invalidate({ tripId });
@@ -299,8 +339,6 @@ function GameSheet({
   async function handleSaveClose() {
     if (await persist()) onClose();
   }
-  // Shell-only for now: configure deep-link is a follow-on (no per-game config
-  // page yet). Persists the shell exactly like Save & close.
   async function handleSaveConfigure() {
     if (await persist()) onClose();
   }
@@ -368,64 +406,16 @@ function GameSheet({
               />
             </Field>
 
-            <Field label="Points Distribution">
-              <div className="space-y-2">
-                {points.map((p, i) => (
-                  <div key={i} className="flex items-center gap-3">
-                    <span className="w-16 flex-shrink-0 text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
-                      {ordinalShort(i + 1)} place
-                    </span>
-                    <input
-                      type="number"
-                      min={0}
-                      value={p || ""}
-                      onChange={(e) => {
-                        const next = [...points];
-                        next[i] = parseFloat(e.target.value) || 0;
-                        setPoints(next);
-                      }}
-                      placeholder="0"
-                      className="w-20 rounded-lg px-2 py-1.5 text-sm outline-none"
-                      style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-                    />
-                    <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>pts</span>
-                    <button
-                      type="button"
-                      onClick={() => setPoints(points.filter((_, j) => j !== i))}
-                      aria-label={`Remove ${ordinalShort(i + 1)} place`}
-                      className="ml-auto flex h-6 w-6 items-center justify-center rounded-md"
-                      style={{ color: "var(--color-bt-text-dim)" }}
-                    >
-                      <X size={12} />
-                    </button>
-                  </div>
-                ))}
-                {(points.length === 0 || (points[points.length - 1] ?? 0) > 0) && (
-                  <button
-                    type="button"
-                    onClick={() => setPoints([...points, 0])}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium"
-                    style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-                  >
-                    <Plus size={12} style={{ color: "var(--color-bt-accent)" }} />
-                    Add {ordinalShort(points.length + 1)} place
-                  </button>
-                )}
-                {points.length > 0 && (
-                  <div className="mt-1 flex items-center justify-between pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
-                    <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-                      Total available
-                    </span>
-                    <span
-                      className="text-sm font-bold tabular-nums"
-                      style={{ color: total > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
-                    >
-                      {total} pt{total === 1 ? "" : "s"}
-                    </span>
-                  </div>
-                )}
-              </div>
-            </Field>
+            {isMatchPlay ? (
+              <PerMatchEditor
+                value={perMatchValue}
+                onChange={setPerMatchValue}
+                projectedCap={projectedCap}
+                teamCountsLoaded={!!teamCounts}
+              />
+            ) : (
+              <PlacementEditor points={points} setPoints={setPoints} total={placementTotal} />
+            )}
 
             {error && (
               <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>
@@ -470,6 +460,139 @@ function GameSheet({
         </div>
       </div>
     </ScrollLock>
+  );
+}
+
+// ── Per-match editor ──────────────────────────────────────────────────────────
+
+function PerMatchEditor({
+  value,
+  onChange,
+  projectedCap,
+  teamCountsLoaded,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  projectedCap: number | null;
+  teamCountsLoaded: boolean;
+}) {
+  const projectedTotal = projectedCap != null ? value * projectedCap : null;
+
+  let totalLabel: string;
+  if (!teamCountsLoaded) {
+    totalLabel = "—";
+  } else if (projectedCap == null || projectedCap === 0) {
+    totalLabel = "— set teams";
+  } else {
+    totalLabel = `proj. ${fmtValue(projectedTotal!)} pts`;
+  }
+
+  return (
+    <Field label="Points per Match">
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <input
+            type="number"
+            min={0.5}
+            step={0.5}
+            value={value}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              if (!isNaN(v) && v > 0) onChange(v);
+            }}
+            className="w-24 rounded-lg px-2 py-1.5 text-sm outline-none"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+          />
+          <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            pt per match · winner takes all, halve splits ½
+          </span>
+        </div>
+        <div className="flex items-center justify-between pt-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Projected total
+          </span>
+          <span
+            className="text-sm font-bold tabular-nums"
+            style={{ color: projectedTotal != null ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+          >
+            {totalLabel}
+          </span>
+        </div>
+      </div>
+    </Field>
+  );
+}
+
+// ── Placement editor ──────────────────────────────────────────────────────────
+
+function PlacementEditor({
+  points,
+  setPoints,
+  total,
+}: {
+  points: number[];
+  setPoints: (p: number[]) => void;
+  total: number;
+}) {
+  return (
+    <Field label="Points Distribution">
+      <div className="space-y-2">
+        {points.map((p, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <span className="w-16 flex-shrink-0 text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {ordinalShort(i + 1)} place
+            </span>
+            <input
+              type="number"
+              min={0}
+              value={p || ""}
+              onChange={(e) => {
+                const next = [...points];
+                next[i] = parseFloat(e.target.value) || 0;
+                setPoints(next);
+              }}
+              placeholder="0"
+              className="w-20 rounded-lg px-2 py-1.5 text-sm outline-none"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+            />
+            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>pts</span>
+            <button
+              type="button"
+              onClick={() => setPoints(points.filter((_, j) => j !== i))}
+              aria-label={`Remove ${ordinalShort(i + 1)} place`}
+              className="ml-auto flex h-6 w-6 items-center justify-center rounded-md"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <X size={12} />
+            </button>
+          </div>
+        ))}
+        {(points.length === 0 || (points[points.length - 1] ?? 0) > 0) && (
+          <button
+            type="button"
+            onClick={() => setPoints([...points, 0])}
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+          >
+            <Plus size={12} style={{ color: "var(--color-bt-accent)" }} />
+            Add {ordinalShort(points.length + 1)} place
+          </button>
+        )}
+        {points.length > 0 && (
+          <div className="mt-1 flex items-center justify-between pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+            <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+              Total available
+            </span>
+            <span
+              className="text-sm font-bold tabular-nums"
+              style={{ color: total > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+            >
+              {total} pt{total === 1 ? "" : "s"}
+            </span>
+          </div>
+        )}
+      </div>
+    </Field>
   );
 }
 
@@ -532,4 +655,12 @@ function ordinalShort(n: number): string {
   const s = ["th", "st", "nd", "rd"];
   const v = n % 100;
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+/** Format a point value: whole numbers show as-is, 0.5 → "½", 1.5 → "1½". */
+function fmtValue(n: number): string {
+  const whole = Math.floor(n);
+  const isHalf = Math.abs(n - whole - 0.5) < 0.001;
+  if (!isHalf) return String(whole);
+  return whole === 0 ? "½" : `${whole}½`;
 }

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -17,7 +17,7 @@ interface LBTeam {
 interface LBGame {
   id: string;
   name: string;
-  distribution: number[] | null;
+  distribution: unknown; // tagged PointsDistribution | null — not consumed by this component
   status: string;
   dropped: boolean;
   gameTypeId: string | null;

--- a/src/lib/pointsDistribution.ts
+++ b/src/lib/pointsDistribution.ts
@@ -1,0 +1,32 @@
+/**
+ * Tagged points-distribution shapes (D1 follow-on).
+ *
+ * `placement` — ranked payout: 1st gets values[0], 2nd gets values[1], etc.
+ *   Averaged ties (two teams tied for 3rd each get (values[2]+values[3])/2).
+ *   Consumed by competitionPlacement.ts placementPoints() unchanged.
+ *
+ * `per_match` — each decided match awards `value` pts to the winning team;
+ *   a halved match awards `value/2` to each side. Team total = Σ won (+ halves).
+ *   The adapter in computeMatchPlayResults writes entity_type='team' raw_score
+ *   rows; computeCompetitionLeaderboard builds a synthetic placement distribution
+ *   from those so rollUp() consumes both adapter kinds identically.
+ */
+export type PlacementDistribution = { type: "placement"; values: number[] };
+export type PerMatchDistribution = { type: "per_match"; value: number };
+export type PointsDistribution = PlacementDistribution | PerMatchDistribution;
+
+export function isPerMatch(d: unknown): d is PerMatchDistribution {
+  return (
+    typeof d === "object" &&
+    d !== null &&
+    (d as PerMatchDistribution).type === "per_match"
+  );
+}
+
+export function isPlacement(d: unknown): d is PlacementDistribution {
+  return (
+    typeof d === "object" &&
+    d !== null &&
+    (d as PlacementDistribution).type === "placement"
+  );
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlacement";
+import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
 
 /**
  * Server roll-up wrapper (Slice D1 §5/§6). The DB-read half of the CLAUDE.md #8
@@ -7,12 +8,17 @@ import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlaceme
  * client-safe pure `rollUp` — so the leaderboard the crew sees and any persisted
  * total can't diverge.
  *
- * Standings spine: every game_results row (entity_type 'team') carries a
- * `position` (1 = best) — engine games COMPUTE it, manual games have it ENTERED
- * (games.setManualResults). The roll-up never distinguishes the two. Direction is
- * low_wins on position. A Phase-1 shell (distribution set, no results yet) still
- * contributes points-available. `dropped` games are excluded here — which is why
- * dropping/restoring moves the win number (it's derived, never stored).
+ * Standings spine:
+ *  - placement games: game_results entity_type='team', position=rank (1=best),
+ *    direction low_wins. Distribution values are the ranked payout array.
+ *  - per_match games: game_results entity_type='team', raw_score=match points
+ *    (written by the adapter in computeMatchPlayResults). No position. We build a
+ *    SYNTHETIC distribution (sorted actual points) so rollUp's placementPoints
+ *    passes the values through directly (direction high_wins).
+ *
+ * `dropped` games are excluded from the roll-up — which is why
+ * dropping/restoring a game recomputes the win number (§4): it is derived here,
+ * never stored.
  */
 export async function computeCompetitionLeaderboard(
   supabase: SupabaseClient,
@@ -49,6 +55,8 @@ export async function computeCompetitionLeaderboard(
         .eq("entity_type", "team")
     : { data: [] as { game_id: string; entity_id: string; position: number | null; raw_score: number | null }[] };
 
+  // For placement games: value = position (lower wins).
+  // For per_match games: value = raw_score (match points, higher wins).
   const standingsByGame = new Map<string, { entityId: string; value: number }[]>();
   for (const r of results ?? []) {
     const arr = standingsByGame.get(r.game_id as string) ?? [];
@@ -56,13 +64,41 @@ export async function computeCompetitionLeaderboard(
     standingsByGame.set(r.game_id as string, arr);
   }
 
-  const liveGames: LiveGame[] = live.map((g) => ({
-    id: g.id as string,
-    distribution: (g.points_distribution as number[] | null) ?? null,
-    numTeams: teamIds.length,
-    standings: standingsByGame.get(g.id as string) ?? [],
-    direction: "low_wins", // standing = position (1 = best)
-  }));
+  const liveGames: LiveGame[] = live.map((g) => {
+    const rawDist = g.points_distribution as PointsDistribution | null;
+    const standings = standingsByGame.get(g.id as string) ?? [];
+
+    if (isPerMatch(rawDist)) {
+      // Adapter (computeMatchPlayResults) writes raw_score per team. Build a
+      // synthetic distribution = sorted actual points so placementPoints passes
+      // them through unchanged (direction high_wins).
+      if (standings.length === 0) {
+        // No decided matches yet — no contribution to points-available or teamTotals.
+        return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "high_wins" as const };
+      }
+      const sorted = [...standings].sort((a, b) => b.value - a.value);
+      return {
+        id: g.id as string,
+        distribution: sorted.map((s) => s.value),
+        numTeams: teamIds.length,
+        standings: sorted,
+        direction: "high_wins" as const,
+      };
+    }
+
+    if (isPlacement(rawDist)) {
+      return {
+        id: g.id as string,
+        distribution: rawDist.values,
+        numTeams: teamIds.length,
+        standings,
+        direction: "low_wins" as const,
+      };
+    }
+
+    // null / unknown shape — contributes nothing
+    return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "low_wins" as const };
+  });
 
   const roll = rollUp(liveGames, teamIds, { defendingTeamId: comp?.defending_team_id ?? null });
 
@@ -83,7 +119,7 @@ export async function computeCompetitionLeaderboard(
     games: allGames.map((g) => ({
       id: g.id as string,
       name: (g.name as string | null) ?? "Game",
-      distribution: (g.points_distribution as number[] | null) ?? null,
+      distribution: (g.points_distribution as PointsDistribution | null) ?? null,
       status: g.status as string,
       dropped: g.status === "dropped",
       gameTypeId: (g.game_type_id as string | null) ?? null,

--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildDecided, matchState } from "@/lib/matchPlay";
 import { effectiveStrokes } from "@/lib/handicap";
+import { isPerMatch, type PerMatchDistribution } from "@/lib/pointsDistribution";
 
 /**
  * DB-persist side of match-play results. Reads each `game_matches` row, gathers
@@ -56,7 +57,7 @@ export async function computeMatchPlayResults(
   const skipComplete = opts?.skipComplete ?? false;
   const { data: matches } = await supabase
     .from("game_matches")
-    .select("id, side_a, side_b, status")
+    .select("id, side_a, side_b, status, result")
     .eq("game_id", gameId);
 
   // Stroke index: the game's course snapshot if one is applied, else undefined
@@ -152,6 +153,25 @@ export async function computeMatchPlayResults(
     await supabase.from("game_results").insert(resultRows);
   }
 
+  // Competition adapter: if this game is in a per_match competition, compute
+  // per-team match totals and write entity_type='team' rows to game_results.
+  // Runs AFTER user rows so the full picture is current before a leaderboard read.
+  const { data: gameInfo } = await supabase
+    .from("games")
+    .select("competition_id, points_distribution")
+    .eq("id", gameId)
+    .maybeSingle();
+  if (gameInfo?.competition_id && isPerMatch(gameInfo.points_distribution)) {
+    await writeTeamMatchPoints(
+      supabase,
+      gameId,
+      gameInfo.competition_id as string,
+      (gameInfo.points_distribution as PerMatchDistribution).value,
+      matches ?? [],
+      outcomes
+    );
+  }
+
   return outcomes;
 }
 
@@ -184,4 +204,81 @@ function mkResult(gameId: string, entityId: string, position: number): GameResul
     position,
     competition_points_earned: null,
   };
+}
+
+/** Aggregate decided match outcomes into per-team competition points and write
+ *  them to game_results (entity_type='team', raw_score=accumulated points).
+ *  Combines skipped-complete matches (from the initial query's result field)
+ *  with freshly-computed outcomes so the team total is always complete. */
+async function writeTeamMatchPoints(
+  supabase: SupabaseClient,
+  gameId: string,
+  competitionId: string,
+  perMatchValue: number,
+  allMatches: { id: unknown; side_a: unknown; side_b: unknown; result: unknown }[],
+  freshOutcomes: MatchOutcome[]
+) {
+  // Fresh outcomes override stale results for the matches we just processed.
+  const resultByMatch = new Map<string, "a_win" | "b_win" | "halve" | null>();
+  for (const m of allMatches) {
+    resultByMatch.set(
+      m.id as string,
+      (m.result as "a_win" | "b_win" | "halve" | null) ?? null
+    );
+  }
+  for (const o of freshOutcomes) {
+    resultByMatch.set(o.matchId, o.result);
+  }
+
+  // user → team for this competition.
+  const { data: assignments } = await supabase
+    .from("team_assignments")
+    .select("user_id, team_id")
+    .eq("competition_id", competitionId);
+  const userTeam = new Map<string, string>();
+  for (const a of assignments ?? []) {
+    userTeam.set(a.user_id as string, a.team_id as string);
+  }
+
+  const teamPoints = new Map<string, number>();
+  for (const m of allMatches) {
+    const result = resultByMatch.get(m.id as string);
+    if (!result) continue;
+    const a = m.side_a as SideRef | null;
+    const b = m.side_b as SideRef | null;
+    if (!a?.id || !b?.id) continue;
+    const aTeam = userTeam.get(a.id);
+    const bTeam = userTeam.get(b.id);
+    if (!aTeam || !bTeam) continue;
+
+    if (result === "a_win") {
+      teamPoints.set(aTeam, (teamPoints.get(aTeam) ?? 0) + perMatchValue);
+    } else if (result === "b_win") {
+      teamPoints.set(bTeam, (teamPoints.get(bTeam) ?? 0) + perMatchValue);
+    } else {
+      // halve — each side gets half
+      teamPoints.set(aTeam, (teamPoints.get(aTeam) ?? 0) + perMatchValue / 2);
+      teamPoints.set(bTeam, (teamPoints.get(bTeam) ?? 0) + perMatchValue / 2);
+    }
+  }
+
+  // Replace all team rows for this game with fresh totals.
+  await supabase
+    .from("game_results")
+    .delete()
+    .eq("game_id", gameId)
+    .eq("entity_type", "team");
+
+  const rows = [...teamPoints.entries()].map(([teamId, pts]) => ({
+    id: crypto.randomUUID(),
+    game_id: gameId,
+    entity_id: teamId,
+    entity_type: "team" as const,
+    raw_score: pts,
+    position: null as number | null,
+    competition_points_earned: null as null,
+  }));
+  if (rows.length > 0) {
+    await supabase.from("game_results").insert(rows);
+  }
 }

--- a/src/server/routers/competitions.d1followon.test.ts
+++ b/src/server/routers/competitions.d1followon.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * D1 follow-on: per-match points distribution (§5 done-criteria).
+ *
+ * Tests the tagged shape, the per_match leaderboard path, the
+ * competition match-points roll-up, and teamAssignmentCounts.
+ *
+ * The match-points adapter (computeMatchPlayResults → writeTeamMatchPoints)
+ * requires a full match-play scoring flow (score_entries → buildDecided →
+ * matchState). To test roll-up independently, we write game_results rows
+ * directly via admin — same isolation pattern as the D2 tests — and verify
+ * computeCompetitionLeaderboard reads them correctly via the endpoint.
+ */
+
+const MANUAL = "gtt_manual";
+const MATCH_PLAY = "gtt_match_play_singles";
+
+let ctx: TestContext;
+let tripId: string;
+const gameIds: string[] = [];
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("D1-FollowOn Trip");
+});
+
+afterAll(async () => {
+  for (const id of gameIds) {
+    await ctx.admin.from("game_results").delete().eq("game_id", id);
+    await ctx.admin.from("games").delete().eq("id", id);
+  }
+  await ctx.cleanup();
+});
+
+// ── §1: tagged shape persists and reads back ─────────────────────────────────
+
+describe("§1 — tagged shape round-trips through the DB", () => {
+  it("placement distribution persists as {type:'placement', values:[...]}", async () => {
+    const comp = await ctx.createCompetition(tripId, "Shape Comp");
+    await ctx.createTeam(comp, "A");
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MANUAL,
+      name: "Placement Game",
+      competitionId: comp,
+      pointsDistribution: { type: "placement", values: [9, 6, 4] },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    const game = (await ctx.caller().games.getById({ tripId, gameId: g.id })) as {
+      points_distribution: unknown;
+    };
+    expect(game.points_distribution).toEqual({ type: "placement", values: [9, 6, 4] });
+  });
+
+  it("per_match distribution persists as {type:'per_match', value:N}", async () => {
+    const comp = await ctx.createCompetition(tripId, "PerMatch Shape Comp");
+    await ctx.createTeam(comp, "A");
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MATCH_PLAY,
+      name: "Singles Day 1",
+      competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 2 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    const game = (await ctx.caller().games.getById({ tripId, gameId: g.id })) as {
+      points_distribution: unknown;
+    };
+    expect(game.points_distribution).toEqual({ type: "per_match", value: 2 });
+  });
+
+  it("setPointsDistribution accepts per_match shape", async () => {
+    const comp = await ctx.createCompetition(tripId, "SetDist Comp");
+    await ctx.createTeam(comp, "A");
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MATCH_PLAY,
+      name: "Day 1 MP",
+      competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 1 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.caller().games.setPointsDistribution({
+      tripId,
+      gameId: g.id,
+      distribution: { type: "per_match", value: 3 },
+    });
+
+    const game = (await ctx.caller().games.getById({ tripId, gameId: g.id })) as {
+      points_distribution: unknown;
+    };
+    expect(game.points_distribution).toEqual({ type: "per_match", value: 3 });
+  });
+});
+
+// ── §3/§5: roll-up parity — per_match team totals via synthetic distribution ─
+
+describe("§5 — roll-up parity: per_match game_results feed through competitionPlacement.ts", () => {
+  it("per_match game with team raw_score rows rolls up to correct leaderboard totals", async () => {
+    const comp = await ctx.createCompetition(tripId, "PerMatch Rollup Comp");
+    const ta = await ctx.createTeam(comp, "Blue", { shortName: "BLU" });
+    const tb = await ctx.createTeam(comp, "Red", { shortName: "RED" });
+
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MATCH_PLAY,
+      name: "Cup Day 1",
+      competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 1 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    // Inject team totals directly (simulating the adapter output).
+    // Blue won 7 matches, Red won 3.
+    await ctx.admin.from("game_results").insert([
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: ta, entity_type: "team", raw_score: 7, position: null, competition_points_earned: null },
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: tb, entity_type: "team", raw_score: 3, position: null, competition_points_earned: null },
+    ]);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    expect(lb.teamTotals[ta]).toBe(7);
+    expect(lb.teamTotals[tb]).toBe(3);
+    // pointsAvailable = synthetic sum = 7+3 = 10
+    expect(lb.pointsAvailable).toBe(10);
+    // winNumber = smallest > 5 = 5.5
+    expect(lb.winNumber).toBe(5.5);
+    // Blue clinched (7 >= 5.5)
+    expect(lb.pointsToClinch[ta]).toBeLessThanOrEqual(0);
+    expect(lb.pointsToClinch[tb]).toBeGreaterThan(0);
+  });
+
+  it("halved match: 0.5-point raw_score survives the numeric column", async () => {
+    const comp = await ctx.createCompetition(tripId, "Halve Comp");
+    const ta = await ctx.createTeam(comp, "A", { shortName: "A" });
+    const tb = await ctx.createTeam(comp, "B", { shortName: "B" });
+
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MATCH_PLAY,
+      name: "Halve Day",
+      competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 1 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    // 2 matches played: 1 halve (each gets 0.5) + A wins 1 (A gets 1).
+    // A total = 1.5, B total = 0.5.
+    await ctx.admin.from("game_results").insert([
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: ta, entity_type: "team", raw_score: 1.5, position: null, competition_points_earned: null },
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: tb, entity_type: "team", raw_score: 0.5, position: null, competition_points_earned: null },
+    ]);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    expect(lb.teamTotals[ta]).toBe(1.5);
+    expect(lb.teamTotals[tb]).toBe(0.5);
+    expect(lb.pointsAvailable).toBe(2); // 1.5+0.5
+  });
+
+  it("per_match shell with no team results contributes 0 to pointsAvailable (no pairings)", async () => {
+    const comp = await ctx.createCompetition(tripId, "PerMatch Shell Comp");
+    await ctx.createTeam(comp, "X", { shortName: "X" });
+    await ctx.createTeam(comp, "Y", { shortName: "Y" });
+
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MATCH_PLAY,
+      name: "Not Paired Yet",
+      competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 1 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    // No game_results inserted (no decided matches yet).
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    expect(lb.pointsAvailable).toBe(0);
+    expect(lb.winNumber).toBe(0.5); // winThreshold(0, false) → 0.5 (smallest > 0)
+    const teams: { id: string }[] = lb.teams;
+    for (const t of teams) {
+      expect(lb.teamTotals[t.id] ?? 0).toBe(0);
+    }
+  });
+
+  it("per_match cells reflect team place and match points", async () => {
+    const comp = await ctx.createCompetition(tripId, "PerMatch Cells Comp");
+    const ta = await ctx.createTeam(comp, "A", { shortName: "A" });
+    const tb = await ctx.createTeam(comp, "B", { shortName: "B" });
+
+    const g = (await ctx.caller().games.create({
+      tripId,
+      gameTypeId: MATCH_PLAY,
+      name: "Cup Day 2",
+      competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 1 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.admin.from("game_results").insert([
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: ta, entity_type: "team", raw_score: 5, position: null, competition_points_earned: null },
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: tb, entity_type: "team", raw_score: 3, position: null, competition_points_earned: null },
+    ]);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+
+    const aCell = lb.cells.find((c: { gameId: string; teamId: string }) => c.gameId === g.id && c.teamId === ta);
+    const bCell = lb.cells.find((c: { gameId: string; teamId: string }) => c.gameId === g.id && c.teamId === tb);
+    expect(aCell).toBeDefined();
+    expect(bCell).toBeDefined();
+    expect(aCell!.points).toBe(5);
+    expect(bCell!.points).toBe(3);
+    // A is 1st (higher pts), B is 2nd
+    expect(aCell!.place).toBe(1);
+    expect(bCell!.place).toBe(2);
+  });
+});
+
+// ── teamAssignmentCounts ──────────────────────────────────────────────────────
+
+describe("competitions.teamAssignmentCounts", () => {
+  it("returns correct member counts per team", async () => {
+    const comp = await ctx.createCompetition(tripId, "Counts Comp");
+    const ta = await ctx.createTeam(comp, "Team A");
+    const tb = await ctx.createTeam(comp, "Team B");
+
+    const userA1 = ctx.getUser("owner").id;
+    const userA2 = ctx.getUser("planner").id;
+    const userB1 = ctx.getUser("member").id;
+
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: userA1, team_id: ta },
+      { competition_id: comp, user_id: userA2, team_id: ta },
+      { competition_id: comp, user_id: userB1, team_id: tb },
+    ]);
+
+    const counts = (await ctx.caller().competitions.teamAssignmentCounts({
+      tripId,
+      competitionId: comp,
+    })) as Record<string, number>;
+
+    expect(counts[ta]).toBe(2);
+    expect(counts[tb]).toBe(1);
+  });
+
+  it("returns empty object when no assignments", async () => {
+    const comp = await ctx.createCompetition(tripId, "Empty Counts Comp");
+    await ctx.createTeam(comp, "A");
+
+    const counts = await ctx.caller().competitions.teamAssignmentCounts({
+      tripId,
+      competitionId: comp,
+    });
+
+    expect(Object.keys(counts as object)).toHaveLength(0);
+  });
+});

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext } from "../../__tests__/helpers/test-setup";
 import { rollUp, placementPoints, winThreshold, type LiveGame } from "../../lib/competitionPlacement";
+import type { PointsDistribution } from "../../lib/pointsDistribution";
 
 /**
  * Slice D2 — CompetitionLeaderboard data contract (§6).
@@ -19,7 +20,7 @@ let tripId: string;
 let competitionId: string;
 const gameIds: string[] = [];
 
-async function makeGame(distribution: number[] | null, name = "Game") {
+async function makeGame(distribution: PointsDistribution | null, name = "Game") {
   const g = (await ctx.caller().games.create({
     tripId,
     gameTypeId: MANUAL,
@@ -68,7 +69,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
   });
 
   it("early state: all totals zero, winNumber derived, game returns with no cells", async () => {
-    const gameId = await makeGame([9, 6], "Shell Game");
+    const gameId = await makeGame({ type: "placement", values: [9, 6] }, "Shell Game");
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
 
@@ -86,7 +87,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
   });
 
   it("in-progress: scores entered, teamTotals and pointsToClinch update", async () => {
-    const gameId = await makeGame([9, 6], "Scored Game");
+    const gameId = await makeGame({ type: "placement", values: [9, 6] }, "Scored Game");
     await enterResults(gameId, [
       { teamId: teamA, position: 1 },
       { teamId: teamB, position: 2 },
@@ -116,7 +117,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
       gameTypeId: MANUAL,
       name: "Clincher",
       competitionId: cleanComp,
-      pointsDistribution: [10, 0],
+      pointsDistribution: { type: "placement", values: [10, 0] },
     }) as { id: string };
     gameIds.push(g.id);
 
@@ -155,7 +156,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
       gameTypeId: MANUAL,
       name: "Retain Test",
       competitionId: cleanComp,
-      pointsDistribution: [14, 14],
+      pointsDistribution: { type: "placement", values: [14, 14] },
     }) as { id: string };
     gameIds.push(g.id);
 
@@ -191,7 +192,7 @@ describe("D2 §6 — N-team (3+ teams) ranked list data", () => {
       gameTypeId: MANUAL,
       name: "3-way",
       competitionId: comp,
-      pointsDistribution: [9, 6, 4],
+      pointsDistribution: { type: "placement", values: [9, 6, 4] },
     }) as { id: string };
     gameIds.push(g.id);
 
@@ -227,13 +228,13 @@ describe("D2 §6 — dropped game excluded from totals and winNumber", () => {
 
     const g1r = await ctx.caller().games.create({
       tripId, gameTypeId: MANUAL, name: "Live", competitionId: comp,
-      pointsDistribution: [9, 6],
+      pointsDistribution: { type: "placement", values: [9, 6] },
     }) as { id: string };
     const g1 = g1r.id;
     gameIds.push(g1);
     const g2r = await ctx.caller().games.create({
       tripId, gameTypeId: MANUAL, name: "To Drop", competitionId: comp,
-      pointsDistribution: [9, 6],
+      pointsDistribution: { type: "placement", values: [9, 6] },
     }) as { id: string };
     const g2 = g2r.id;
     gameIds.push(g2);
@@ -267,7 +268,7 @@ describe("D2 §6 — non-engine game with no entry shows at 0, not hidden", () =
 
     const g = await ctx.caller().games.create({
       tripId, gameTypeId: MANUAL, name: "Not Entered Yet", competitionId: comp,
-      pointsDistribution: [5, 3],
+      pointsDistribution: { type: "placement", values: [5, 3] },
     }) as { id: string };
     gameIds.push(g.id);
 
@@ -294,7 +295,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     await ctx.createTeam(comp, "A", { shortName: "A" });
     const g = await ctx.caller().games.create({
       tripId, gameTypeId: MANUAL, name: "Shape Test", competitionId: comp,
-      pointsDistribution: [9],
+      pointsDistribution: { type: "placement", values: [9] },
     }) as { id: string };
     gameIds.push(g.id);
 
@@ -316,7 +317,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
 
     const g = await ctx.caller().games.create({
       tripId, gameTypeId: MANUAL, name: "Delegate", competitionId: comp,
-      pointsDistribution: [9, 6],
+      pointsDistribution: { type: "placement", values: [9, 6] },
     }) as { id: string };
     gameIds.push(g.id);
 

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -59,6 +59,27 @@ export const competitionsRouter = router({
     .query(({ ctx, input }) => computeCompetitionLeaderboard(ctx.supabase, input.competitionId)),
 
   // -----------------------------------------------------------------------
+  // teamAssignmentCounts — per-team member headcount for this competition.
+  // Used by GameSheet to project per_match total before pairings exist:
+  // projected cap = min(...counts), projected total = value × cap.
+  // -----------------------------------------------------------------------
+  teamAssignmentCounts: authedProcedure
+    .input(z.object({ tripId: z.string(), competitionId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx, input }) => {
+      const { data } = await ctx.supabase
+        .from("team_assignments")
+        .select("team_id")
+        .eq("competition_id", input.competitionId);
+      const counts: Record<string, number> = {};
+      for (const r of data ?? []) {
+        const tid = r.team_id as string;
+        counts[tid] = (counts[tid] ?? 0) + 1;
+      }
+      return counts;
+    }),
+
+  // -----------------------------------------------------------------------
   // create — new competition for a trip (canEdit, MVP one-per-trip)
   // -----------------------------------------------------------------------
   create: authedProcedure

--- a/src/server/routers/games.d1.test.ts
+++ b/src/server/routers/games.d1.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext } from "../../__tests__/helpers/test-setup";
+import type { PointsDistribution } from "../../lib/pointsDistribution";
 
 /**
  * Slice D1 — competition-game unification behavior (§5/§6/§8).
@@ -17,7 +18,7 @@ let teamB: string;
 let memberId: string;
 const gameIds: string[] = [];
 
-async function newGame(distribution: number[] | null, name = "Game") {
+async function newGame(distribution: PointsDistribution | null, name = "Game") {
   const g = (await ctx.caller().games.create({
     tripId,
     gameTypeId: MANUAL,
@@ -28,6 +29,9 @@ async function newGame(distribution: number[] | null, name = "Game") {
   gameIds.push(g.id);
   return g.id;
 }
+
+const DIST_9642: PointsDistribution = { type: "placement", values: [9, 6, 4, 2] };
+const DIST_96: PointsDistribution = { type: "placement", values: [9, 6] };
 
 beforeAll(async () => {
   ctx = await TestContext.create();
@@ -50,16 +54,16 @@ afterAll(async () => {
 
 describe("Phase-1 shell + leaderboard (§3/§6)", () => {
   it("a game with all Phase-2 fields null is creatable and contributes points-available", async () => {
-    const id = await newGame([9, 6, 4, 2], "Shell");
+    const id = await newGame(DIST_9642, "Shell");
     const game = (await ctx.caller().games.getById({ tripId, gameId: id })) as {
       scorecard_schema: unknown;
       course_id: unknown;
-      points_distribution: number[];
+      points_distribution: PointsDistribution;
       status: string;
     };
     expect(game.scorecard_schema).toBeNull(); // Phase-2 null…
     expect(game.course_id).toBeNull();
-    expect(game.points_distribution).toEqual([9, 6, 4, 2]); // …but Phase-1 set
+    expect(game.points_distribution).toEqual({ type: "placement", values: [9, 6, 4, 2] }); // …but Phase-1 set
     expect(game.status).toBe("pending");
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
@@ -71,7 +75,7 @@ describe("Phase-1 shell + leaderboard (§3/§6)", () => {
 
 describe("manual adapter → universal roll-up (§5)", () => {
   it("entered per-team placements write game_results and roll up to distribution points", async () => {
-    const id = await newGame([9, 6, 4, 2], "Pickem");
+    const id = await newGame(DIST_9642, "Pickem");
     await ctx.caller().games.setManualResults({
       tripId,
       gameId: id,
@@ -92,7 +96,8 @@ describe("manual adapter → universal roll-up (§5)", () => {
     const tA = await ctx.createTeam(comp2, "A");
     const tB = await ctx.createTeam(comp2, "B");
     const g = (await ctx.caller().games.create({
-      tripId, gameTypeId: MANUAL, name: "Tie", competitionId: comp2, pointsDistribution: [9, 6],
+      tripId, gameTypeId: MANUAL, name: "Tie", competitionId: comp2,
+      pointsDistribution: { type: "placement", values: [9, 6] },
     })) as { id: string };
     gameIds.push(g.id);
     await ctx.caller().games.setManualResults({
@@ -111,8 +116,8 @@ describe("dropping recomputes the win number (§4/§6)", () => {
     const comp3 = await ctx.createCompetition(tripId, "Drop Comp");
     await ctx.createTeam(comp3, "A");
     await ctx.createTeam(comp3, "B");
-    const g1 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G1", competitionId: comp3, pointsDistribution: [9, 6] })) as { id: string };
-    const g2 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G2", competitionId: comp3, pointsDistribution: [9, 6] })) as { id: string };
+    const g1 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G1", competitionId: comp3, pointsDistribution: DIST_96 })) as { id: string };
+    const g2 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G2", competitionId: comp3, pointsDistribution: DIST_96 })) as { id: string };
     gameIds.push(g1.id, g2.id);
 
     let lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
@@ -132,8 +137,8 @@ describe("dropping recomputes the win number (§4/§6)", () => {
 
 describe("per-game organizer delegation (§8)", () => {
   it("a delegated organizer can edit THEIR game but not another; non-members blocked", async () => {
-    const mine = await newGame([9, 6], "Pickem-BJ");
-    const other = await newGame([9, 6], "Scramble");
+    const mine = await newGame(DIST_96, "Pickem-BJ");
+    const other = await newGame(DIST_96, "Scramble");
     await ctx.caller().games.addOrganizer({ tripId, gameId: mine, userId: memberId });
 
     const member = ctx.callerAs("member");
@@ -148,7 +153,7 @@ describe("per-game organizer delegation (§8)", () => {
   });
 
   it("a plain trip member with no grant cannot edit a game", async () => {
-    const g = await newGame([9, 6], "NoGrant");
+    const g = await newGame(DIST_96, "NoGrant");
     await expect(ctx.callerAs("member").games.setStatus({ tripId, gameId: g, status: "active" })).rejects.toThrow(/Organizer|game-organizer/i);
   });
 });

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -29,8 +29,14 @@ export const gamesRouter = router({
         name: z.string().max(200).optional(),
         teeTime: z.string().max(5).nullable().optional(), // "HH:MM" 24h
         competitionId: z.string().nullable().optional(), // team formats / competition games
-        // Competition-layer fact: ordered points by place, e.g. [9,6,4,2]. (§2a)
-        pointsDistribution: z.array(z.number().min(0)).max(64).nullable().optional(),
+        // Competition-layer fact: tagged distribution shape (D1 follow-on §1).
+        pointsDistribution: z
+          .discriminatedUnion("type", [
+            z.object({ type: z.literal("placement"), values: z.array(z.number().min(0)).max(64) }),
+            z.object({ type: z.literal("per_match"), value: z.number().min(0) }),
+          ])
+          .nullable()
+          .optional(),
         // Optional, one-directional agenda link — never a gate. (§9)
         scheduleItemId: z.string().uuid().nullable().optional(),
       })
@@ -91,6 +97,7 @@ export const gamesRouter = router({
       // "engine" = computes results from a scorecard; otherwise manual (entered).
       isEngine: t.result_strategy != null,
       isGolf: t.scorecard_schema != null, // golf engine types carry a scorecard
+      resultStrategy: (t.result_strategy as string | null) ?? null,
     }));
   }),
 
@@ -371,7 +378,12 @@ export const gamesRouter = router({
       z.object({
         tripId: z.string(),
         gameId: z.string(),
-        distribution: z.array(z.number().min(0)).max(64).nullable(),
+        distribution: z
+          .discriminatedUnion("type", [
+            z.object({ type: z.literal("placement"), values: z.array(z.number().min(0)).max(64) }),
+            z.object({ type: z.literal("per_match"), value: z.number().min(0) }),
+          ])
+          .nullable(),
       })
     )
     .use(requireGameEdit())

--- a/supabase/migrations/20260613120000_048_d1_followon_tagged_points_distribution.sql
+++ b/supabase/migrations/20260613120000_048_d1_followon_tagged_points_distribution.sql
@@ -1,0 +1,32 @@
+-- 048 — D1 follow-on: tagged points_distribution shape + numeric raw_score
+--
+-- Two structural changes:
+--
+-- 1. game_results.raw_score: integer → numeric.
+--    Match-play halved matches produce 0.5-point awards; integer truncates them.
+--    All existing rows are integer and convert silently.
+--
+-- 2. games.points_distribution: bare number[] → tagged jsonb shape.
+--    The bare array assumed all games used ranked placement. The tag makes the
+--    adapter kind explicit and allows a second kind (per_match) to coexist:
+--      { "type": "placement", "values": [9,6,4,2] }   — ranked payout
+--      { "type": "per_match", "value": 1 }             — winner/halve per match
+--    Live data is test-only (DB reset 2026-06-06), so plain UPDATE is safe.
+--
+-- Order: convert match-play games FIRST so their bare arrays get the per_match
+-- tag instead of being wrapped as placement.
+
+-- 1. numeric raw_score (supports fractional half-point halve awards)
+ALTER TABLE public.game_results ALTER COLUMN raw_score TYPE numeric;
+
+-- 2a. Match-play games → per_match shape (default value=1 per match).
+--     Reset any existing array they had — it was nonsensical for match play.
+UPDATE public.games
+SET points_distribution = '{"type":"per_match","value":1}'::jsonb
+WHERE game_type_id = 'gtt_match_play_singles';
+
+-- 2b. Remaining non-null arrays → placement shape.
+UPDATE public.games
+SET points_distribution = jsonb_build_object('type', 'placement', 'values', points_distribution)
+WHERE points_distribution IS NOT NULL
+  AND jsonb_typeof(points_distribution) = 'array';


### PR DESCRIPTION
## Summary

- **Migration 048**: `game_results.raw_score integer → numeric` (supports 0.5 half-point halve awards); reshapes all `games.points_distribution` rows from bare `number[]` to tagged `{ type, values/value }` shape
- **`src/lib/pointsDistribution.ts`** (new): shared `PointsDistribution` union type + `isPerMatch`/`isPlacement` guards — single canonical definition for server lib, router, and UI
- **Match-play adapter**: `computeMatchPlayResults` now runs `writeTeamMatchPoints()` as its final phase when `points_distribution.type === 'per_match'` — reads match outcomes + team assignments, writes `entity_type='team' / raw_score=total` rows so the leaderboard roll-up is automatic on every score/handicap/player change
- **Leaderboard** (`computeCompetitionLeaderboard`): reads tagged shape; per_match games get a synthetic distribution (sorted actual team totals) so `rollUp()` + `placementPoints()` in `competitionPlacement.ts` are unchanged — both adapter kinds feed the same roll-up path
- **`CompetitionGamesPanel` GameSheet**: forks on `resultStrategy` — match-play shows a per-match value stepper + projected total readout (3 states: actual/projected/no-teams via `competitions.teamAssignmentCounts`); placement keeps the existing ranked editor
- **`competitions.teamAssignmentCounts`** (new): lightweight per-team member headcount endpoint used by GameSheet projected-total readout

## Test plan

- [x] `competitions.d1followon.test.ts` — 9 new tests: tagged shape round-trip (placement + per_match), `setPointsDistribution` per_match, roll-up parity, halve (0.5 raw_score), shell contributes 0 before pairings, per_match cells, `teamAssignmentCounts` (count + empty)
- [x] `games.d1.test.ts` — 6 tests updated to tagged shape; all pass
- [x] `competitions.d2.test.ts` — 9 tests updated to tagged shape; all pass
- [x] TypeScript — `npx tsc --noEmit` clean
- [x] All 24 tests pass against remote DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)