### PR TITLE
fix(d1-followon): competition-tab crash — distribution.slice is not a function

### DIFF
--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -17,7 +17,7 @@ interface LBTeam {
 interface LBGame {
   id: string;
   name: string;
-  distribution: unknown; // tagged PointsDistribution | null — not consumed by this component
+  distribution: number[] | null;
   status: string;
   dropped: boolean;
   gameTypeId: string | null;

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -116,14 +116,17 @@ export async function computeCompetitionLeaderboard(
   return {
     teams: teams ?? [],
     defendingTeamId: (comp?.defending_team_id as string | null) ?? null,
-    games: allGames.map((g) => ({
-      id: g.id as string,
-      name: (g.name as string | null) ?? "Game",
-      distribution: (g.points_distribution as PointsDistribution | null) ?? null,
-      status: g.status as string,
-      dropped: g.status === "dropped",
-      gameTypeId: (g.game_type_id as string | null) ?? null,
-    })),
+    games: allGames.map((g) => {
+      const rawDist = g.points_distribution as PointsDistribution | null;
+      return {
+        id: g.id as string,
+        name: (g.name as string | null) ?? "Game",
+        distribution: isPlacement(rawDist) ? rawDist.values : null,
+        status: g.status as string,
+        dropped: g.status === "dropped",
+        gameTypeId: (g.game_type_id as string | null) ?? null,
+      };
+    }),
     cells,
     pointsAvailable: roll.pointsAvailable,
     winNumber: roll.winNumber,


### PR DESCRIPTION
## Why

PR #357 (tagged \`points_distribution\` shape) was squash-merged, but this fix commit landed on the branch **after** the squash — so it never reached \`main\`. The competition tab is currently crashing in production.

## The bug

\`computeCompetitionLeaderboard\` was returning the raw tagged \`PointsDistribution\` object (e.g. \`{ type: "placement", values: [9,6] }\`) in the \`games[].distribution\` field. \`ScoreboardPanel\` reads that field and calls \`.slice()\` on it expecting \`number[] | null\`, throwing:

```
TypeError: g.distribution.slice is not a function
```

…on tapping the competition tab.

## The fix

Resolve \`distribution\` to a backwards-compatible \`number[] | null\` at the API boundary:
- \`placement\` → \`.values\`
- \`per_match\` → \`null\` (no ranked array)

So no consumer ever sees the tagged shape. \`LBGame.distribution\` in \`CompetitionLeaderboard.tsx\` is restored from \`unknown\` back to \`number[] | null\`.

## Verification

- \`npx tsc --noEmit\` clean
- All 24 D1/D1-follow-on/D2 router tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)