### PR TITLE
feat(d): Slice D — add-game two-tab creation & configuration flow

### DIFF
--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -471,6 +471,8 @@ function GameSheet({
                 delegateId={desiredDelegate}
                 setDelegateId={setDelegateId}
                 isMatchPlay={isMatchPlay}
+                isGolf={isGolf}
+                courseId={game?.course_id ?? null}
                 total={total}
                 placeInputs={placeInputs}
                 setPlaceInputs={setPlaceInputs}
@@ -693,11 +695,11 @@ function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout
 // ── Configuration tab ─────────────────────────────────────────────────────────
 
 function ConfigTab({
-  canEdit, members, delegateId, setDelegateId, isMatchPlay, total, placeInputs, setPlaceInputs,
+  canEdit, members, delegateId, setDelegateId, isMatchPlay, isGolf, courseId, total, placeInputs, setPlaceInputs,
   placement, pFit, mFit, readout, perMatchValue, rules, setRules, compFormat, openFormatSheet,
 }: {
   canEdit: boolean; members: Member[]; delegateId: string | null; setDelegateId: (id: string | null) => void;
-  isMatchPlay: boolean; total: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
+  isMatchPlay: boolean; isGolf: boolean; courseId: string | null; total: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
   placement: ReturnType<typeof validatePlacement>; pFit: ReturnType<typeof placementFit>;
   mFit: ReturnType<typeof matchFit>; readout: ReturnType<typeof matchReadout>;
   perMatchValue: number; rules: string; setRules: (s: string) => void;
@@ -750,7 +752,53 @@ function ConfigTab({
           Sets the label on the leaderboard. Running it up in-app comes later — until then you enter results by hand.
         </p>
       </Field>
+
+      <MakeItReady canEdit={canEdit} isGolf={isGolf} isMatchPlay={isMatchPlay} courseId={courseId} />
     </>
+  );
+}
+
+/**
+ * MAKE IT READY — the day-of setup checklist (owner only). Stubbed: the rows show
+ * the correct ready/not-set state but the deep setup (course picker, pairings,
+ * handicaps) is wired in a follow-up — for now results are entered by hand. Rows
+ * are model-aware: every game can group/pair; only golf/match carry a course and
+ * handicaps.
+ */
+function MakeItReady({
+  canEdit, isGolf, isMatchPlay, courseId,
+}: {
+  canEdit: boolean; isGolf: boolean; isMatchPlay: boolean; courseId: string | null;
+}) {
+  if (!canEdit) return null;
+  const rows: { Icon: typeof Flag; label: string; state: string; ready: boolean }[] = [];
+  if (isGolf) rows.push({ Icon: Flag, label: "Course", state: courseId ? "Applied" : "Not set", ready: !!courseId });
+  rows.push({ Icon: Users, label: "Groups & pairings", state: "Not set", ready: false });
+  if (isGolf || isMatchPlay) rows.push({ Icon: Target, label: "Handicaps", state: "Not set", ready: false });
+
+  return (
+    <Field label="Make it ready">
+      <div className="space-y-1.5">
+        {rows.map((r) => (
+          <div
+            key={r.label}
+            className="flex items-center justify-between rounded-lg px-3 py-2.5 text-sm"
+            style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+          >
+            <span className="flex items-center gap-2" style={{ color: "var(--color-bt-text)" }}>
+              <r.Icon size={14} style={{ color: "var(--color-bt-accent)" }} />
+              {r.label}
+            </span>
+            <span className="text-[11px] font-semibold" style={{ color: r.ready ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>
+              {r.state}
+            </span>
+          </div>
+        ))}
+      </div>
+      <p className="mt-1 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        Course, pairings and handicap setup lands in a follow-up — for now, enter results by hand.
+      </p>
+    </Field>
   );
 }
 

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -134,6 +134,7 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
           <button
             type="button"
             onClick={() => setCreating(true)}
+            data-testid="add-game"
             className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold"
             style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
           >

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
-  Flag, Plus, Pencil, Star, Trash2, X, Trophy, RotateCcw,
-  Spade, Target, Beer, Dices, Swords, Radio, ChevronRight, Check, Users,
+  Flag, Plus, Minus, Pencil, Star, Trash2, X, Trophy, RotateCcw,
+  Spade, Target, Beer, Dices, Swords, Radio, ChevronRight, Check, Users, Info, SlidersHorizontal,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
@@ -17,18 +17,14 @@ import {
  * (Game · Configuration), on `games`.
  *
  * Game tab (owner-controlled): Type → format → name → course (golf) → the
- * owner-set point value (a placement TOTAL, or a match per-match value). Non-golf
- * types offer a single "Generic <Type> Game" — manual-scored, never a named
- * "Manual" choice.
+ * owner-set point value (a placement TOTAL, or a match per-match value), set with
+ * an integrated stepper. Non-golf types offer a single "Generic <Type> Game".
  *
  * Configuration tab (the hub returned to via the dashboard tap-through):
- * role-aware delegation at the top; a MODEL-AWARE point editor (placement → place
- * splits that must SUM to the owner total; match → a derived "N matches ready"
- * readout, no place table); the "How's it played?" competition-format chooser;
- * and soft fit-warnings that live here only. A single save persists both tabs.
- *
- * Validation/derivation is the pure gameConfig.ts (shared with the server), so
- * the UI blocks exactly what the API rejects.
+ * a single role-aware delegate at the top; a MODEL-AWARE point editor (placement
+ * → place splits that must SUM to the owner total; match → a derived readout);
+ * the rules-of-the-day explainer; and the "How's it played?" format chooser. A
+ * single save persists both tabs (and reconciles the delegate grant).
  */
 
 interface Props {
@@ -49,6 +45,7 @@ export interface GameRow {
   points_distribution: PointsDistribution | null;
   points_total: number | null;
   competition_format: string | null;
+  rules_for_today: string | null;
   scorecard_schema: unknown | null;
   course_id: string | null;
   schedule_item_id: string | null;
@@ -64,6 +61,8 @@ interface GameType {
   resultStrategy: string | null;
   category: string;
 }
+
+interface Member { memberId: string; displayName: string }
 
 // ── Static option tables ──────────────────────────────────────────────────────
 
@@ -196,8 +195,6 @@ function GameCard({
   const dropped = game.status === "dropped";
   const dist = game.points_distribution;
 
-  // Model-aware points line: placement → "8 · 5│3│0"; match → "8 · 8 matches"
-  // (or "needs split"/"matches not set"); unallocated → "needs split".
   let pointsLine: string | null = null;
   if (dist?.type === "placement") {
     const total = game.points_total ?? dist.values.reduce((a, b) => a + b, 0);
@@ -286,22 +283,24 @@ function GameSheet({
   const [title, setTitle] = useState(game?.name ?? "");
   const [tab, setTab] = useState<Tab>("game");
 
-  // Placement: owner total (Game tab) + the place split (Config tab). 1st place
-  // initializes EMPTY (never 0) so "untouched" stays distinct from "entered 0".
-  const [total, setTotal] = useState<string>(
-    game?.points_total != null ? String(game.points_total) : ""
-  );
+  // Owner total (placement) / per-match value (match) — integer steppers, so
+  // there's always a concrete value (defaults: 8 placement, 1 per match).
+  const [total, setTotal] = useState<number>(game?.points_total ?? 8);
+  const [perMatchValue, setPerMatchValue] = useState<number>(() => {
+    const d = game?.points_distribution;
+    return d?.type === "per_match" ? d.value : 1;
+  });
+  // Placement split. 1st place initializes EMPTY (never 0) so "untouched" stays
+  // distinct from "entered 0".
   const [placeInputs, setPlaceInputs] = useState<string[]>(() => {
     const d = game?.points_distribution;
     if (d?.type === "placement" && d.values.length > 0) return d.values.map(String);
     return [""];
   });
-  // Match: per-match value (Game tab).
-  const [perMatchValue, setPerMatchValue] = useState<string>(() => {
-    const d = game?.points_distribution;
-    return d?.type === "per_match" ? String(d.value) : "1";
-  });
   const [compFormat, setCompFormat] = useState<string | null>(game?.competition_format ?? null);
+  const [rules, setRules] = useState<string>(game?.rules_for_today ?? "");
+  // Single delegate. undefined = not-yet-initialized from the existing grant.
+  const [delegateId, setDelegateId] = useState<string | null | undefined>(game ? undefined : null);
   const [formatSheetOpen, setFormatSheetOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -309,10 +308,21 @@ function GameSheet({
   const categoryTypes = types.filter((t) => t.category === category);
   const effectiveTypeId = categoryTypes.some((t) => t.id === gameTypeId) ? gameTypeId : categoryTypes[0]?.id ?? "";
   const selectedType = types.find((t) => t.id === effectiveTypeId);
-  const isMatchPlay = selectedType?.resultStrategy === "match_play"; // FIX: was compared to a key
+  const isMatchPlay = selectedType?.resultStrategy === "match_play";
   const isGolf = category === "golf";
 
-  // Team headcounts drive the match readout + placement fit (members-with-teams).
+  // Members (for the delegate picker + name resolution) and the existing grant.
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId }, { enabled: canEdit });
+  const orgQuery = trpc.games.listOrganizers.useQuery(
+    { tripId, gameId: game?.id ?? "" },
+    { enabled: !!game?.id }
+  );
+  const originalOrgId = ((orgQuery.data as { user_id: string }[] | undefined)?.[0]?.user_id) ?? null;
+  useEffect(() => {
+    if (game && delegateId === undefined && orgQuery.isSuccess) setDelegateId(originalOrgId);
+  }, [game, delegateId, orgQuery.isSuccess, originalOrgId]);
+  const desiredDelegate = delegateId === undefined ? originalOrgId : delegateId;
+
   const { data: teamCounts } = trpc.competitions.teamAssignmentCounts.useQuery({ tripId, competitionId });
   const teamSizes = useMemo(() => Object.values((teamCounts as Record<string, number>) ?? {}), [teamCounts]);
   const numTeams = teamSizes.length;
@@ -322,53 +332,64 @@ function GameSheet({
   const setDist = trpc.games.setPointsDistribution.useMutation();
   const setTotalM = trpc.games.setPointsTotal.useMutation();
   const setStatus = trpc.games.setStatus.useMutation();
+  const addOrg = trpc.games.addOrganizer.useMutation();
+  const removeOrg = trpc.games.removeOrganizer.useMutation();
 
-  // Derived placement validation (the same pure fn the server uses).
-  const totalNum = Number(total) || 0;
+  // Derived validation (the same pure fn the server uses).
   const started = !isMatchPlay && (placeInputs[0]?.trim() ?? "") !== "";
   const enteredValues = started ? placeInputs.map((s) => Number(s.trim() || "0")) : [];
-  const placement = validatePlacement(totalNum, enteredValues);
+  const placement = validatePlacement(total, enteredValues);
   const pFit = placementFit(enteredValues, numTeams);
   const mFit = matchFit(teamSizes, matchFormatFor(effectiveTypeId));
-  const readout = matchReadout(Number(perMatchValue) || 0, teamSizes, matchFormatFor(effectiveTypeId));
+  const readout = matchReadout(perMatchValue, teamSizes, matchFormatFor(effectiveTypeId));
+  const blockedPartial = started && !placement.saveable;
+
+  // Clear a submit error as soon as the user changes anything relevant.
+  useEffect(() => {
+    if (error) setError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title, total, perMatchValue, placeInputs, compFormat, effectiveTypeId, rules]);
 
   function buildDistribution(): PointsDistribution | null {
-    if (isMatchPlay) return { type: "per_match", value: Number(perMatchValue) > 0 ? Number(perMatchValue) : 1 };
+    if (isMatchPlay) return { type: "per_match", value: perMatchValue > 0 ? perMatchValue : 1 };
     return started ? { type: "placement", values: enteredValues } : null;
+  }
+
+  async function reconcileDelegate(gameId: string) {
+    const original = isEdit ? originalOrgId : null;
+    if (desiredDelegate === original) return;
+    if (original) await removeOrg.mutateAsync({ tripId, gameId, userId: original });
+    if (desiredDelegate) await addOrg.mutateAsync({ tripId, gameId, userId: desiredDelegate });
   }
 
   async function persist(): Promise<boolean> {
     setError(null);
-    if (canEdit && !title.trim()) { setError("Title is required"); setTab("game"); return false; }
+    if (canEdit && !title.trim()) { setError("Add a title to save this game"); setTab("game"); return false; }
     if (!effectiveTypeId) { setError("Pick a format"); setTab("game"); return false; }
-    if (canEdit && !isMatchPlay && totalNum <= 0) { setError("Set a point value on the Game tab"); setTab("game"); return false; }
-    if (!isMatchPlay && started && !placement.saveable) {
-      setError(`Points must total ${fmtValue(totalNum)} exactly — ${fmtValue(placement.allocated)} of ${fmtValue(totalNum)} placed`);
-      setTab("config");
-      return false;
-    }
+    if (blockedPartial) { setTab("config"); return false; } // button is disabled too
     const distribution = buildDistribution();
     try {
+      let gameId: string;
       if (isEdit && game) {
+        gameId = game.id;
         if (canEdit) {
-          await update.mutateAsync({ tripId, gameId: game.id, name: title.trim(), competitionFormat: (compFormat as never) ?? null });
-          await setTotalM.mutateAsync({ tripId, gameId: game.id, total: isMatchPlay ? null : totalNum });
+          await update.mutateAsync({ tripId, gameId, name: title.trim(), competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null });
+          await setTotalM.mutateAsync({ tripId, gameId, total: isMatchPlay ? null : total });
         } else {
-          // Delegate: distribution + format only (can't touch name/total).
-          await update.mutateAsync({ tripId, gameId: game.id, competitionFormat: (compFormat as never) ?? null });
+          await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null });
         }
-        await setDist.mutateAsync({ tripId, gameId: game.id, distribution });
+        await setDist.mutateAsync({ tripId, gameId, distribution });
       } else {
         const created = (await create.mutateAsync({
-          tripId,
-          gameTypeId: effectiveTypeId,
-          name: title.trim(),
-          competitionId,
-          pointsDistribution: distribution,
-          pointsTotal: isMatchPlay ? null : totalNum,
+          tripId, gameTypeId: effectiveTypeId, name: title.trim(), competitionId,
+          pointsDistribution: distribution, pointsTotal: isMatchPlay ? null : total,
         })) as { id: string };
-        if (compFormat) await update.mutateAsync({ tripId, gameId: created.id, competitionFormat: compFormat as never });
+        gameId = created.id;
+        if (compFormat || rules.trim()) {
+          await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null });
+        }
       }
+      if (canEdit) await reconcileDelegate(gameId);
       utils.games.listByTrip.invalidate({ tripId });
       utils.competitions.leaderboard.invalidate({ tripId, competitionId });
       return true;
@@ -405,7 +426,6 @@ function GameSheet({
           style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Header + tabs */}
           <div style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
             <div className="flex items-center justify-between px-4 py-3">
               <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
@@ -447,10 +467,11 @@ function GameSheet({
             ) : (
               <ConfigTab
                 canEdit={canEdit}
-                tripId={tripId}
-                gameId={game?.id ?? null}
+                members={members as Member[]}
+                delegateId={desiredDelegate}
+                setDelegateId={setDelegateId}
                 isMatchPlay={isMatchPlay}
-                totalNum={totalNum}
+                total={total}
                 placeInputs={placeInputs}
                 setPlaceInputs={setPlaceInputs}
                 placement={placement}
@@ -458,6 +479,8 @@ function GameSheet({
                 mFit={mFit}
                 readout={readout}
                 perMatchValue={perMatchValue}
+                rules={rules}
+                setRules={setRules}
                 compFormat={compFormat}
                 openFormatSheet={() => setFormatSheetOpen(true)}
               />
@@ -466,7 +489,6 @@ function GameSheet({
             {error && <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>{error}</p>}
           </div>
 
-          {/* Footer */}
           <div className="flex items-center gap-2 border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>
             {isEdit && game && canEdit && (
               <button
@@ -494,7 +516,7 @@ function GameSheet({
             <button
               type="button"
               onClick={handleSave}
-              disabled={busy}
+              disabled={busy || blockedPartial}
               data-testid="save-game"
               className="flex-1 rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
               style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
@@ -527,10 +549,10 @@ function GameTab({
   setCategory: (c: string) => void; categoryTypes: GameType[]; effectiveTypeId: string;
   setGameTypeId: (id: string) => void; selectedType: GameType | undefined; title: string;
   setTitle: (s: string) => void; isGolf: boolean; courseId: string | null; isMatchPlay: boolean;
-  total: string; setTotal: (s: string) => void; perMatchValue: string; setPerMatchValue: (s: string) => void;
+  total: number; setTotal: (n: number) => void; perMatchValue: number; setPerMatchValue: (n: number) => void;
   readout: ReturnType<typeof matchReadout>;
 }) {
-  const readOnly = !canEdit; // delegate: Game tab is the owner's, shown read-only
+  const readOnly = !canEdit;
   return (
     <>
       {!isEdit && (
@@ -553,7 +575,7 @@ function GameTab({
           </div>
           {selectedType && !selectedType.isEngine && (
             <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              No built-in scoring engine for this type yet — name it below and enter the result by hand. Known games (Poker, Euchre…) get their own scoring later.
+              No built-in scoring engine for this type yet — name it below and enter the result by hand.
             </p>
           )}
         </Field>
@@ -586,44 +608,78 @@ function GameTab({
       )}
 
       {isMatchPlay ? (
-        <Field label="Points per match">
-          <div className="flex items-center gap-3">
-            <input
-              type="number" min={0.5} step={0.5} value={perMatchValue} readOnly={readOnly}
-              onChange={(e) => setPerMatchValue(e.target.value)}
-              className="w-24 rounded-lg px-2 py-1.5 text-sm outline-none"
-              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-            />
-            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-              per match · winner takes all, halve splits ½
-            </span>
-          </div>
-          <MatchReadoutLine readout={readout} />
-        </Field>
+        <PointStepper
+          label="Points per match"
+          caption="POINTS PER MATCH"
+          value={perMatchValue}
+          onChange={readOnly ? () => {} : setPerMatchValue}
+          footer={<MatchReadoutLine readout={readout} />}
+        />
       ) : (
-        <Field label="Point value" required>
-          <div className="flex items-center gap-3">
-            <input
-              type="number" min={0} step={1} value={total} readOnly={readOnly}
-              onChange={(e) => setTotal(e.target.value)}
-              placeholder="8"
-              className="w-24 rounded-lg px-2 py-1.5 text-sm outline-none"
-              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-            />
-            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>points for this game</span>
-          </div>
-          <p className="mt-1.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            Split across finishing places on the Configuration tab ›
-          </p>
-        </Field>
+        <PointStepper
+          label="Point value"
+          caption="POINTS FOR THIS GAME"
+          value={total}
+          onChange={readOnly ? () => {} : setTotal}
+          footer={
+            <div className="flex items-center gap-1.5">
+              <SlidersHorizontal size={12} style={{ color: "var(--color-bt-text-dim)" }} />
+              <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Split across finishing places on the Configuration tab ›
+              </span>
+            </div>
+          }
+        />
       )}
     </>
   );
 }
 
+/** The integrated −/value/+ point control (matches the mock). */
+function PointStepper({
+  label, caption, value, onChange, footer,
+}: {
+  label: string; caption: string; value: number; onChange: (n: number) => void; footer?: React.ReactNode;
+}) {
+  return (
+    <Field label={label} required>
+      <div className="rounded-xl" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}>
+        <div className="flex items-center gap-3 px-3 py-3">
+          <StepBtn dir="dec" disabled={value <= 1} onClick={() => onChange(Math.max(1, value - 1))} />
+          <div className="flex-1 text-center">
+            <div className="text-3xl font-black leading-none tabular-nums" style={{ color: "var(--color-bt-text)" }}>{fmtValue(value)}</div>
+            <div className="mt-1 text-[10px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{caption}</div>
+          </div>
+          <StepBtn dir="inc" onClick={() => onChange(value + 1)} />
+        </div>
+        {footer && (
+          <div className="px-3 py-2.5" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+            {footer}
+          </div>
+        )}
+      </div>
+    </Field>
+  );
+}
+
+function StepBtn({ dir, onClick, disabled }: { dir: "inc" | "dec"; onClick: () => void; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={dir === "inc" ? "Increase" : "Decrease"}
+      className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg disabled:opacity-40"
+      style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+    >
+      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
+    </button>
+  );
+}
+
 function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout> }) {
   return (
-    <div className="mt-2 flex items-center justify-between pt-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+    <div className="flex items-center justify-between">
       <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
         Points available
       </span>
@@ -637,36 +693,48 @@ function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout
 // ── Configuration tab ─────────────────────────────────────────────────────────
 
 function ConfigTab({
-  canEdit, tripId, gameId, isMatchPlay, totalNum, placeInputs, setPlaceInputs,
-  placement, pFit, mFit, readout, perMatchValue, compFormat, openFormatSheet,
+  canEdit, members, delegateId, setDelegateId, isMatchPlay, total, placeInputs, setPlaceInputs,
+  placement, pFit, mFit, readout, perMatchValue, rules, setRules, compFormat, openFormatSheet,
 }: {
-  canEdit: boolean; tripId: string; gameId: string | null; isMatchPlay: boolean; totalNum: number;
-  placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
+  canEdit: boolean; members: Member[]; delegateId: string | null; setDelegateId: (id: string | null) => void;
+  isMatchPlay: boolean; total: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
   placement: ReturnType<typeof validatePlacement>; pFit: ReturnType<typeof placementFit>;
   mFit: ReturnType<typeof matchFit>; readout: ReturnType<typeof matchReadout>;
-  perMatchValue: string; compFormat: string | null; openFormatSheet: () => void;
+  perMatchValue: number; rules: string; setRules: (s: string) => void;
+  compFormat: string | null; openFormatSheet: () => void;
 }) {
   return (
     <>
-      <DelegationBlock canEdit={canEdit} tripId={tripId} gameId={gameId} />
+      <DelegationBlock canEdit={canEdit} members={members} delegateId={delegateId} setDelegateId={setDelegateId} />
 
       {isMatchPlay ? (
         <Field label="Point value">
           <div className="flex items-baseline gap-2">
-            <span className="text-2xl font-black tabular-nums" style={{ color: "var(--color-bt-text)" }}>{fmtValue(Number(perMatchValue) || 0)}</span>
+            <span className="text-2xl font-black tabular-nums" style={{ color: "var(--color-bt-text)" }}>{fmtValue(perMatchValue)}</span>
             <span className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>/ match · set on Game tab</span>
           </div>
-          <MatchReadoutLine readout={readout} />
-          <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-            A match game splits the per-match value across matches — no place table. The total lands once team sizes set the match count.
-          </p>
+          <div className="mt-2 pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+            <MatchReadoutLine readout={readout} />
+          </div>
         </Field>
       ) : (
-        <PlacementEditor totalNum={totalNum} placeInputs={placeInputs} setPlaceInputs={setPlaceInputs} placement={placement} />
+        <PlacementEditor total={total} placeInputs={placeInputs} setPlaceInputs={setPlaceInputs} placement={placement} />
       )}
 
       {!isMatchPlay && pFit.state === "warn" && <FitWarning message={pFit.message!} />}
       {isMatchPlay && mFit.state === "warn" && <FitWarning message={mFit.message!} />}
+
+      <Field label="Rules explainer">
+        <textarea
+          value={rules}
+          onChange={(e) => setRules(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          placeholder="Tap out the rules of the day — formats, gimmes, mulligans, tiebreakers…"
+          className="w-full resize-none rounded-lg px-3 py-2 text-sm outline-none"
+          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+        />
+      </Field>
 
       <Field label="Competition format">
         <button
@@ -686,22 +754,19 @@ function ConfigTab({
   );
 }
 
-function DelegationBlock({ canEdit, tripId, gameId }: { canEdit: boolean; tripId: string; gameId: string | null }) {
-  const utils = trpc.useUtils();
+function DelegationBlock({
+  canEdit, members, delegateId, setDelegateId,
+}: {
+  canEdit: boolean; members: Member[]; delegateId: string | null; setDelegateId: (id: string | null) => void;
+}) {
   const [picking, setPicking] = useState(false);
-  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId }, { enabled: picking });
-  const { data: organizers = [] } = trpc.games.listOrganizers.useQuery(
-    { tripId, gameId: gameId ?? "" },
-    { enabled: !!gameId }
-  );
-  const addOrg = trpc.games.addOrganizer.useMutation();
 
   if (!canEdit) {
     return (
       <div className="flex items-start gap-2.5 rounded-xl px-3 py-3" style={{ background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}>
         <Users size={16} style={{ color: "var(--color-bt-accent)", flexShrink: 0, marginTop: 1 }} />
         <div>
-          <p className="text-sm font-semibold" style={{ color: "var(--color-bt-accent)" }}>You've been asked to help set this up</p>
+          <p className="text-sm font-semibold" style={{ color: "var(--color-bt-accent)" }}>You&rsquo;ve been asked to help set this up</p>
           <p className="mt-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
             Configure away. The owner keeps the basics (name, course, value) on the Game tab.
           </p>
@@ -710,11 +775,19 @@ function DelegationBlock({ canEdit, tripId, gameId }: { canEdit: boolean; tripId
     );
   }
 
-  const orgCount = (organizers as { user_id: string }[]).length;
+  const assigned = members.find((m) => m.memberId === delegateId);
   return (
-    <Field label="Delegate" >
-      {!gameId ? (
-        <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>Save the game first, then you can hand its setup to someone.</p>
+    <Field label="Delegate">
+      {assigned ? (
+        <div
+          className="flex items-center justify-between rounded-lg px-3 py-2.5 text-sm"
+          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <span className="flex items-center gap-2"><Users size={14} style={{ color: "var(--color-bt-accent)" }} />{assigned.displayName}</span>
+          <button type="button" onClick={() => { setDelegateId(null); setPicking(false); }} aria-label="Remove delegate" className="flex h-6 w-6 items-center justify-center rounded-md" style={{ color: "var(--color-bt-text-dim)" }}>
+            <X size={13} />
+          </button>
+        </div>
       ) : !picking ? (
         <button
           type="button"
@@ -723,19 +796,15 @@ function DelegationBlock({ canEdit, tripId, gameId }: { canEdit: boolean; tripId
           style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
         >
           <Users size={15} style={{ color: "var(--color-bt-accent)" }} />
-          {orgCount > 0 ? `${orgCount} organizer${orgCount === 1 ? "" : "s"} · add another` : "Assign a game organizer"}
+          Assign a game organizer
         </button>
       ) : (
         <div className="space-y-1.5">
-          {(members as { memberId: string; displayName: string }[]).map((m) => (
+          {members.map((m) => (
             <button
               key={m.memberId}
               type="button"
-              onClick={async () => {
-                await addOrg.mutateAsync({ tripId, gameId, userId: m.memberId });
-                utils.games.listOrganizers.invalidate({ tripId, gameId });
-                setPicking(false);
-              }}
+              onClick={() => { setDelegateId(m.memberId); setPicking(false); }}
               className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm"
               style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
             >
@@ -743,10 +812,13 @@ function DelegationBlock({ canEdit, tripId, gameId }: { canEdit: boolean; tripId
               <Plus size={13} style={{ color: "var(--color-bt-accent)" }} />
             </button>
           ))}
+          {members.length === 0 && (
+            <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>No crew to assign yet.</p>
+          )}
         </div>
       )}
       <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-        Hand this game's setup and running to someone — they get the game-organizer grant and their own Configuration tab.
+        Hand this game&rsquo;s setup and running to one person — they get their own Configuration tab.
       </p>
     </Field>
   );
@@ -763,16 +835,16 @@ function FitWarning({ message }: { message: string }) {
 // ── Placement editor (distributes the owner total) ────────────────────────────
 
 function PlacementEditor({
-  totalNum, placeInputs, setPlaceInputs, placement,
+  total, placeInputs, setPlaceInputs, placement,
 }: {
-  totalNum: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
+  total: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
   placement: ReturnType<typeof validatePlacement>;
 }) {
   const started = (placeInputs[0]?.trim() ?? "") !== "";
   return (
     <Field label="Point distribution">
-      <p className="mb-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-        The owner set this game at <span style={{ color: "var(--color-bt-text)" }}>{fmtValue(totalNum)} points</span>. Spread them across team places — the split must total {fmtValue(totalNum)} exactly.
+      <p className="mb-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text)" }}>
+        The owner set this game at <span className="font-semibold" style={{ color: "var(--color-bt-accent)" }}>{fmtValue(total)} points</span>. Spread them across team places — the split must total {fmtValue(total)} exactly.
       </p>
       <div className="space-y-2">
         {placeInputs.map((p, i) => (
@@ -783,7 +855,6 @@ function PlacementEditor({
             <input
               type="number" min={0} value={p}
               onChange={(e) => { const next = [...placeInputs]; next[i] = e.target.value; setPlaceInputs(next); }}
-              placeholder="pts"
               className="w-20 rounded-lg px-2 py-1.5 text-sm outline-none"
               style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
             />
@@ -816,21 +887,27 @@ function PlacementEditor({
           <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
             Allocated
           </span>
-          {!started ? (
-            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>0 of {fmtValue(totalNum)} pts · undistributed for now</span>
-          ) : placement.saveable ? (
-            <span className="flex items-center gap-1 text-sm font-bold tabular-nums" style={{ color: "var(--color-bt-accent)" }}>
-              <Check size={13} /> {fmtValue(placement.allocated)} of {fmtValue(totalNum)} pts
-            </span>
-          ) : (
-            <span className="text-sm font-bold tabular-nums" style={{ color: "var(--color-bt-danger)" }}>
-              {fmtValue(placement.allocated)} of {fmtValue(totalNum)} pts
-            </span>
-          )}
+          <span
+            className="flex items-center gap-1 text-sm font-bold tabular-nums"
+            style={{ color: !started ? "var(--color-bt-text-dim)" : placement.saveable ? "var(--color-bt-accent)" : "var(--color-bt-danger)" }}
+          >
+            {started && placement.saveable && <Check size={13} />}
+            {fmtValue(placement.allocated)} of {fmtValue(total)} pts
+          </span>
         </div>
+        {!started && (
+          <div className="flex items-start gap-1.5">
+            <Info size={12} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0, marginTop: 1 }} />
+            <span className="text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+              Points haven&rsquo;t been distributed yet — it can wait until later.
+            </span>
+          </div>
+        )}
         {started && !placement.saveable && (
           <p className="text-[11px]" style={{ color: "var(--color-bt-danger)" }}>
-            {placement.remaining > 0 ? `${fmtValue(placement.remaining)} left to place` : `${fmtValue(-placement.remaining)} over — total must be ${fmtValue(totalNum)} to save`}
+            {placement.remaining > 0
+              ? `${fmtValue(placement.remaining)} point${placement.remaining === 1 ? "" : "s"} left to allocate`
+              : `${fmtValue(-placement.remaining)} point${-placement.remaining === 1 ? "" : "s"} over — must total ${fmtValue(total)}`}
           </p>
         )}
       </div>
@@ -853,7 +930,7 @@ function FormatSheet({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
-          <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>How's it played?</h3>
+          <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>How&rsquo;s it played?</h3>
           <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
             <X size={16} />
           </button>
@@ -882,7 +959,7 @@ function FormatSheet({
             </button>
           ))}
           <p className="px-1 pt-1 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-            However it runs, you can always enter the result by hand — picking a format never leaves you stuck on "coming soon."
+            However it runs, you can always enter the result by hand — picking a format never leaves you stuck on &ldquo;coming soon.&rdquo;
           </p>
         </div>
       </div>
@@ -944,9 +1021,9 @@ function Chip({ active, onClick, children }: { active: boolean; onClick: () => v
 function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
   return (
     <div>
-      <div className="mb-1.5 flex items-baseline gap-1.5">
+      <div className="mb-1.5 flex items-center gap-1.5">
         <label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</label>
-        {required && <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>required</span>}
+        {required && <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: "var(--color-bt-danger)" }} />}
       </div>
       {children}
     </div>

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1,20 +1,34 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Flag, Plus, Pencil, Star, Trash2, X, Trophy, RotateCcw } from "lucide-react";
+import {
+  Flag, Plus, Pencil, Star, Trash2, X, Trophy, RotateCcw,
+  Spade, Target, Beer, Dices, Swords, Radio, ChevronRight, Check, Users,
+} from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import type { PointsDistribution } from "@/lib/pointsDistribution";
+import {
+  validatePlacement, matchReadout, placementFit, matchFit, type MatchFormat,
+} from "@/lib/gameConfig";
 
 /**
- * CompetitionGamesPanel — the Slice D1 §7 contest list + creation flow, on
- * `games` (the legacy `events`-table EventsPanel is retired by this slice).
+ * CompetitionGamesPanel — the Slice D contest list + the two-tab add/edit page
+ * (Game · Configuration), on `games`.
  *
- * A competition contest is a `games` row. Phase 1 (this panel): name, format
- * (game_type), points distribution, status — fully valid with every Phase-2 field
- * (course / scorecard / pairings) null. The two-screen fork (Save & close vs
- * Save & configure ›) persists the shell; the configure deep-link is a follow-on
- * once a per-game config page exists (shell-only for now, by decision).
+ * Game tab (owner-controlled): Type → format → name → course (golf) → the
+ * owner-set point value (a placement TOTAL, or a match per-match value). Non-golf
+ * types offer a single "Generic <Type> Game" — manual-scored, never a named
+ * "Manual" choice.
+ *
+ * Configuration tab (the hub returned to via the dashboard tap-through):
+ * role-aware delegation at the top; a MODEL-AWARE point editor (placement → place
+ * splits that must SUM to the owner total; match → a derived "N matches ready"
+ * readout, no place table); the "How's it played?" competition-format chooser;
+ * and soft fit-warnings that live here only. A single save persists both tabs.
+ *
+ * Validation/derivation is the pure gameConfig.ts (shared with the server), so
+ * the UI blocks exactly what the API rejects.
  */
 
 interface Props {
@@ -23,9 +37,7 @@ interface Props {
   canEdit: boolean;
 }
 
-/** Drag payload key for a game id — read by the agenda (ScheduleTab) drop
- *  targets to link a game onto a schedule item. Mirrors the retired
- *  EventsPanel DND_EVENT_KEY, now keyed on games (Slice D1 agenda-link flip). */
+/** Drag payload key for a game id — read by the agenda drop targets. */
 export const DND_GAME_KEY = "application/x-buddytrip-game-id";
 
 export interface GameRow {
@@ -35,7 +47,10 @@ export interface GameRow {
   name: string | null;
   status: "pending" | "active" | "complete" | "dropped";
   points_distribution: PointsDistribution | null;
+  points_total: number | null;
+  competition_format: string | null;
   scorecard_schema: unknown | null;
+  course_id: string | null;
   schedule_item_id: string | null;
 }
 
@@ -47,16 +62,44 @@ interface GameType {
   isEngine: boolean;
   isGolf: boolean;
   resultStrategy: string | null;
+  category: string;
 }
+
+// ── Static option tables ──────────────────────────────────────────────────────
+
+const CATEGORY_ORDER = ["golf", "card", "yard", "bar", "other"] as const;
+const CATEGORY_META: Record<string, { label: string; Icon: typeof Flag }> = {
+  golf: { label: "Golf", Icon: Flag },
+  card: { label: "Card", Icon: Spade },
+  yard: { label: "Yard", Icon: Target },
+  bar: { label: "Bar", Icon: Beer },
+  other: { label: "Other", Icon: Dices },
+};
+
+const COMP_FORMATS = [
+  { key: "head_to_head", label: "Head-to-Head / Match", desc: "One-off matchup, winner takes the points.", Icon: Swords },
+  { key: "bracket_se", label: "Bracket — Single Elimination", desc: "Lose once, you're out.", Icon: Trophy },
+  { key: "bracket_de", label: "Bracket — Double Elimination", desc: "Two lives — a losers' bracket.", Icon: Trophy },
+  { key: "best_of_n", label: "Best of N", desc: "First to win the majority of games.", Icon: Target },
+  { key: "live_results", label: "Live Results", desc: "A running tally that updates as it plays (e.g. Pick'em).", Icon: Radio },
+] as const;
+
+function formatLabel(key: string | null): string | null {
+  return COMP_FORMATS.find((f) => f.key === key)?.label ?? null;
+}
+
+/** Singles vs doubles for the match readout. Only singles exists today. */
+function matchFormatFor(gameTypeId: string | null): MatchFormat {
+  return gameTypeId === "gtt_match_play_doubles" ? "doubles" : "singles";
+}
+
+// ── Panel ─────────────────────────────────────────────────────────────────────
 
 export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props) {
   const [editing, setEditing] = useState<GameRow | null>(null);
   const [creating, setCreating] = useState(false);
 
-  const { data: allGames = [] } = trpc.games.listByTrip.useQuery(
-    { tripId },
-    { enabled: !!tripId }
-  );
+  const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { enabled: !!tripId });
   const { data: types = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: !!tripId });
 
   const games = useMemo(
@@ -83,12 +126,8 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
             <Trophy size={16} />
           </span>
           <div>
-            <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-              Games
-            </p>
-            <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-              {statusText}
-            </p>
+            <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>Games</p>
+            <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>{statusText}</p>
           </div>
         </div>
         {canEdit && (
@@ -118,7 +157,13 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
 
         <div className="space-y-2">
           {games.map((g) => (
-            <GameCard key={g.id} game={g} typeName={typeName(g.game_type_id)} canEdit={canEdit} onEdit={() => setEditing(g)} />
+            <GameCard
+              key={g.id}
+              game={g}
+              typeName={typeName(g.game_type_id)}
+              canEdit={canEdit}
+              onEdit={() => setEditing(g)}
+            />
           ))}
         </div>
 
@@ -128,6 +173,7 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
             competitionId={competitionId}
             game={editing}
             types={typesTyped}
+            canEdit={canEdit}
             onClose={() => {
               setCreating(false);
               setEditing(null);
@@ -139,34 +185,35 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
   );
 }
 
+// ── Game card (model-aware metadata) ──────────────────────────────────────────
+
 function GameCard({
-  game,
-  typeName,
-  canEdit,
-  onEdit,
+  game, typeName, canEdit, onEdit,
 }: {
-  game: GameRow;
-  typeName: string;
-  canEdit: boolean;
-  onEdit: () => void;
+  game: GameRow; typeName: string; canEdit: boolean; onEdit: () => void;
 }) {
   const dropped = game.status === "dropped";
   const dist = game.points_distribution;
 
-  let total = 0;
-  let distSummary: string | null = null;
+  // Model-aware points line: placement → "8 · 5│3│0"; match → "8 · 8 matches"
+  // (or "needs split"/"matches not set"); unallocated → "needs split".
+  let pointsLine: string | null = null;
   if (dist?.type === "placement") {
-    total = dist.values.reduce((a, b) => a + b, 0);
-    distSummary = dist.values.length > 0
-      ? dist.values.map((p, i) => `${ordinalShort(i + 1)}: ${p}`).join(" · ")
-      : null;
+    const total = game.points_total ?? dist.values.reduce((a, b) => a + b, 0);
+    pointsLine = dist.values.length > 0 ? `${fmtValue(total)} · ${dist.values.map(fmtValue).join("│")}` : `${fmtValue(total)} · needs split`;
   } else if (dist?.type === "per_match") {
-    distSummary = `${fmtValue(dist.value)} pt/match`;
+    pointsLine = `${fmtValue(dist.value)}/match`;
+  } else if (game.points_total != null) {
+    pointsLine = `${fmtValue(game.points_total)} · needs split`;
   }
+  const fmtLabel = formatLabel(game.competition_format);
 
   return (
-    <div
-      className="flex items-start gap-3 rounded-xl px-3 py-3"
+    <button
+      type="button"
+      onClick={canEdit ? onEdit : undefined}
+      disabled={!canEdit}
+      className="flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left disabled:cursor-default"
       style={{
         background: "var(--color-bt-card-raised)",
         border: "1px solid var(--color-bt-border)",
@@ -186,11 +233,6 @@ function GameCard({
           <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
             {game.name || "Untitled game"}
           </p>
-          {!dropped && dist?.type === "placement" && total > 0 && (
-            <span className="text-[11px] font-semibold tabular-nums" style={{ color: "var(--color-bt-accent)" }}>
-              {total} pt{total === 1 ? "" : "s"}
-            </span>
-          )}
           <span
             className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase"
             style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
@@ -206,116 +248,114 @@ function GameCard({
             </span>
           )}
         </div>
-        {distSummary && !dropped && (
-          <p className="mt-0.5 text-[10px] tabular-nums" style={{ color: "var(--color-bt-text-dim)" }}>
-            {distSummary}
-          </p>
-        )}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          {fmtLabel && <span>{fmtLabel}</span>}
+          {fmtLabel && pointsLine && <span aria-hidden>·</span>}
+          {pointsLine && <span className="tabular-nums">{pointsLine}</span>}
+        </div>
       </div>
 
-      {canEdit && (
-        <button
-          type="button"
-          onClick={onEdit}
-          aria-label={`Edit ${game.name ?? "game"}`}
-          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          <Pencil size={13} />
-        </button>
-      )}
-    </div>
+      {canEdit && <Pencil size={13} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />}
+    </button>
   );
 }
 
-// ── GameSheet (create / edit) ─────────────────────────────────────────────────
+// ── Two-tab Game sheet ────────────────────────────────────────────────────────
+
+type Tab = "game" | "config";
 
 function GameSheet({
-  tripId,
-  competitionId,
-  game,
-  types,
-  onClose,
+  tripId, competitionId, game, types, canEdit, onClose,
 }: {
   tripId: string;
   competitionId: string;
   game: GameRow | null;
   types: GameType[];
+  canEdit: boolean;
   onClose: () => void;
 }) {
   const isEdit = !!game;
   const utils = trpc.useUtils();
 
-  // Golf = engine golf types; Other = the non-engine manual type. Data-driven.
-  const golfTypes = types.filter((t) => t.isGolf);
-  const otherTypes = types.filter((t) => !t.isGolf);
   const initialType = types.find((t) => t.id === game?.game_type_id);
-  const [isGolf, setIsGolf] = useState(initialType ? initialType.isGolf : true);
+  const [category, setCategory] = useState<string>(initialType?.category ?? "golf");
   const [gameTypeId, setGameTypeId] = useState<string>(
-    game?.game_type_id ?? golfTypes[0]?.id ?? otherTypes[0]?.id ?? ""
+    game?.game_type_id ?? types.find((t) => t.category === "golf")?.id ?? types[0]?.id ?? ""
   );
   const [title, setTitle] = useState(game?.name ?? "");
-  // Placement-mode state
-  const [points, setPoints] = useState<number[]>(() => {
+  const [tab, setTab] = useState<Tab>("game");
+
+  // Placement: owner total (Game tab) + the place split (Config tab). 1st place
+  // initializes EMPTY (never 0) so "untouched" stays distinct from "entered 0".
+  const [total, setTotal] = useState<string>(
+    game?.points_total != null ? String(game.points_total) : ""
+  );
+  const [placeInputs, setPlaceInputs] = useState<string[]>(() => {
     const d = game?.points_distribution;
-    if (d?.type === "placement") return d.values.length > 0 ? [...d.values] : [0];
-    return [0];
+    if (d?.type === "placement" && d.values.length > 0) return d.values.map(String);
+    return [""];
   });
-  // Per-match-mode state
-  const [perMatchValue, setPerMatchValue] = useState<number>(() => {
+  // Match: per-match value (Game tab).
+  const [perMatchValue, setPerMatchValue] = useState<string>(() => {
     const d = game?.points_distribution;
-    if (d?.type === "per_match") return d.value;
-    return 1;
+    return d?.type === "per_match" ? String(d.value) : "1";
   });
+  const [compFormat, setCompFormat] = useState<string | null>(game?.competition_format ?? null);
+  const [formatSheetOpen, setFormatSheetOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const visibleTypes = isGolf ? golfTypes : otherTypes;
-  // Keep a valid selection when toggling Golf/Other.
-  const effectiveTypeId = visibleTypes.some((t) => t.id === gameTypeId) ? gameTypeId : visibleTypes[0]?.id ?? "";
+  const categoriesPresent = CATEGORY_ORDER.filter((c) => types.some((t) => t.category === c));
+  const categoryTypes = types.filter((t) => t.category === category);
+  const effectiveTypeId = categoryTypes.some((t) => t.id === gameTypeId) ? gameTypeId : categoryTypes[0]?.id ?? "";
   const selectedType = types.find((t) => t.id === effectiveTypeId);
-  const isMatchPlay = selectedType?.resultStrategy === "match_play_singles";
+  const isMatchPlay = selectedType?.resultStrategy === "match_play"; // FIX: was compared to a key
+  const isGolf = category === "golf";
 
-  // Projected total readout for match-play: team assignment counts.
-  const { data: teamCounts } = trpc.competitions.teamAssignmentCounts.useQuery(
-    { tripId, competitionId },
-    { enabled: isMatchPlay }
-  );
-  const projectedCap = useMemo(() => {
-    if (!teamCounts) return null;
-    const sizes = Object.values(teamCounts as Record<string, number>);
-    if (sizes.length === 0) return null;
-    return Math.min(...sizes);
-  }, [teamCounts]);
+  // Team headcounts drive the match readout + placement fit (members-with-teams).
+  const { data: teamCounts } = trpc.competitions.teamAssignmentCounts.useQuery({ tripId, competitionId });
+  const teamSizes = useMemo(() => Object.values((teamCounts as Record<string, number>) ?? {}), [teamCounts]);
+  const numTeams = teamSizes.length;
 
   const create = trpc.games.create.useMutation();
   const update = trpc.games.update.useMutation();
   const setDist = trpc.games.setPointsDistribution.useMutation();
+  const setTotalM = trpc.games.setPointsTotal.useMutation();
   const setStatus = trpc.games.setStatus.useMutation();
 
-  const placementTotal = points.reduce((a, b) => a + (b || 0), 0);
+  // Derived placement validation (the same pure fn the server uses).
+  const totalNum = Number(total) || 0;
+  const started = !isMatchPlay && (placeInputs[0]?.trim() ?? "") !== "";
+  const enteredValues = started ? placeInputs.map((s) => Number(s.trim() || "0")) : [];
+  const placement = validatePlacement(totalNum, enteredValues);
+  const pFit = placementFit(enteredValues, numTeams);
+  const mFit = matchFit(teamSizes, matchFormatFor(effectiveTypeId));
+  const readout = matchReadout(Number(perMatchValue) || 0, teamSizes, matchFormatFor(effectiveTypeId));
 
   function buildDistribution(): PointsDistribution | null {
-    if (isMatchPlay) {
-      return { type: "per_match", value: perMatchValue > 0 ? perMatchValue : 1 };
-    }
-    const values = points.filter((p) => p > 0);
-    return values.length > 0 ? { type: "placement", values: points.map((p) => p || 0) } : null;
+    if (isMatchPlay) return { type: "per_match", value: Number(perMatchValue) > 0 ? Number(perMatchValue) : 1 };
+    return started ? { type: "placement", values: enteredValues } : null;
   }
 
   async function persist(): Promise<boolean> {
     setError(null);
-    if (!title.trim()) {
-      setError("Title is required");
-      return false;
-    }
-    if (!effectiveTypeId) {
-      setError("Pick a format");
+    if (canEdit && !title.trim()) { setError("Title is required"); setTab("game"); return false; }
+    if (!effectiveTypeId) { setError("Pick a format"); setTab("game"); return false; }
+    if (canEdit && !isMatchPlay && totalNum <= 0) { setError("Set a point value on the Game tab"); setTab("game"); return false; }
+    if (!isMatchPlay && started && !placement.saveable) {
+      setError(`Points must total ${fmtValue(totalNum)} exactly — ${fmtValue(placement.allocated)} of ${fmtValue(totalNum)} placed`);
+      setTab("config");
       return false;
     }
     const distribution = buildDistribution();
     try {
       if (isEdit && game) {
-        await update.mutateAsync({ tripId, gameId: game.id, name: title.trim() });
+        if (canEdit) {
+          await update.mutateAsync({ tripId, gameId: game.id, name: title.trim(), competitionFormat: (compFormat as never) ?? null });
+          await setTotalM.mutateAsync({ tripId, gameId: game.id, total: isMatchPlay ? null : totalNum });
+        } else {
+          // Delegate: distribution + format only (can't touch name/total).
+          await update.mutateAsync({ tripId, gameId: game.id, competitionFormat: (compFormat as never) ?? null });
+        }
         await setDist.mutateAsync({ tripId, gameId: game.id, distribution });
       } else {
         const created = (await create.mutateAsync({
@@ -324,8 +364,9 @@ function GameSheet({
           name: title.trim(),
           competitionId,
           pointsDistribution: distribution,
+          pointsTotal: isMatchPlay ? null : totalNum,
         })) as { id: string };
-        void created;
+        if (compFormat) await update.mutateAsync({ tripId, gameId: created.id, competitionFormat: compFormat as never });
       }
       utils.games.listByTrip.invalidate({ tripId });
       utils.competitions.leaderboard.invalidate({ tripId, competitionId });
@@ -336,10 +377,7 @@ function GameSheet({
     }
   }
 
-  async function handleSaveClose() {
-    if (await persist()) onClose();
-  }
-  async function handleSaveConfigure() {
+  async function handleSave() {
     if (await persist()) onClose();
   }
 
@@ -351,7 +389,7 @@ function GameSheet({
     onClose();
   }
 
-  const busy = create.isPending || update.isPending || setDist.isPending;
+  const busy = create.isPending || update.isPending || setDist.isPending || setTotalM.isPending;
   const isDropped = game?.status === "dropped";
 
   return (
@@ -366,66 +404,70 @@ function GameSheet({
           style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
-            <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
-              {isEdit ? "Edit Game" : "Add Game"}
-            </h3>
-            <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
-              <X size={16} />
-            </button>
+          {/* Header + tabs */}
+          <div style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
+            <div className="flex items-center justify-between px-4 py-3">
+              <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
+                {isEdit ? "Edit Game" : "Add Game"}
+              </h3>
+              <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex px-4">
+              <TabButton active={tab === "game"} onClick={() => setTab("game")}>Game</TabButton>
+              <TabButton active={tab === "config"} onClick={() => setTab("config")}>Configuration</TabButton>
+            </div>
           </div>
 
           <div className="flex-1 space-y-4 overflow-y-auto p-4">
-            {!isEdit && (
-              <div className="grid grid-cols-2 gap-2">
-                <TypeChip active={isGolf} onClick={() => setIsGolf(true)} icon={<Flag size={18} />} label="Golf" />
-                <TypeChip active={!isGolf} onClick={() => setIsGolf(false)} icon={<Star size={18} />} label="Other" />
-              </div>
-            )}
-
-            {!isEdit && (
-              <Field label="Format" required>
-                <div className="flex flex-wrap gap-1.5">
-                  {visibleTypes.map((t) => (
-                    <Chip key={t.id} active={effectiveTypeId === t.id} onClick={() => setGameTypeId(t.id)}>
-                      {t.name}
-                    </Chip>
-                  ))}
-                </div>
-              </Field>
-            )}
-
-            <Field label="Title" required>
-              <input
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={isGolf ? "e.g. Day 1 Scramble" : "e.g. Poker Night, Cornhole"}
-                maxLength={200}
-                className="w-full rounded-lg px-3 py-2 text-sm outline-none"
-                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-              />
-            </Field>
-
-            {isMatchPlay ? (
-              <PerMatchEditor
-                value={perMatchValue}
-                onChange={setPerMatchValue}
-                projectedCap={projectedCap}
-                teamCountsLoaded={!!teamCounts}
+            {tab === "game" ? (
+              <GameTab
+                isEdit={isEdit}
+                canEdit={canEdit}
+                categoriesPresent={categoriesPresent}
+                category={category}
+                setCategory={(c) => { setCategory(c); const first = types.find((t) => t.category === c); if (first) setGameTypeId(first.id); }}
+                categoryTypes={categoryTypes}
+                effectiveTypeId={effectiveTypeId}
+                setGameTypeId={setGameTypeId}
+                selectedType={selectedType}
+                title={title}
+                setTitle={setTitle}
+                isGolf={isGolf}
+                courseId={game?.course_id ?? null}
+                isMatchPlay={isMatchPlay}
+                total={total}
+                setTotal={setTotal}
+                perMatchValue={perMatchValue}
+                setPerMatchValue={setPerMatchValue}
+                readout={readout}
               />
             ) : (
-              <PlacementEditor points={points} setPoints={setPoints} total={placementTotal} />
+              <ConfigTab
+                canEdit={canEdit}
+                tripId={tripId}
+                gameId={game?.id ?? null}
+                isMatchPlay={isMatchPlay}
+                totalNum={totalNum}
+                placeInputs={placeInputs}
+                setPlaceInputs={setPlaceInputs}
+                placement={placement}
+                pFit={pFit}
+                mFit={mFit}
+                readout={readout}
+                perMatchValue={perMatchValue}
+                compFormat={compFormat}
+                openFormatSheet={() => setFormatSheetOpen(true)}
+              />
             )}
 
-            {error && (
-              <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>
-                {error}
-              </p>
-            )}
+            {error && <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>{error}</p>}
           </div>
 
+          {/* Footer */}
           <div className="flex items-center gap-2 border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>
-            {isEdit && game && (
+            {isEdit && game && canEdit && (
               <button
                 type="button"
                 onClick={handleDrop}
@@ -438,172 +480,437 @@ function GameSheet({
                 {isDropped ? <RotateCcw size={15} /> : <Trash2 size={15} />}
               </button>
             )}
+            {tab === "game" && (
+              <button
+                type="button"
+                onClick={() => setTab("config")}
+                className="flex-1 rounded-xl py-3 text-sm font-semibold"
+                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+              >
+                Configuration ›
+              </button>
+            )}
             <button
               type="button"
-              onClick={handleSaveClose}
+              onClick={handleSave}
               disabled={busy}
-              className="flex-1 rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
-              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-            >
-              Save &amp; close
-            </button>
-            <button
-              type="button"
-              onClick={handleSaveConfigure}
-              disabled={busy}
+              data-testid="save-game"
               className="flex-1 rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
               style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
             >
-              Save &amp; configure ›
+              {isEdit ? "Save game" : "Add game"}
             </button>
           </div>
         </div>
       </div>
+
+      {formatSheetOpen && (
+        <FormatSheet
+          current={compFormat}
+          onPick={(k) => { setCompFormat(k); setFormatSheetOpen(false); }}
+          onClose={() => setFormatSheetOpen(false)}
+        />
+      )}
     </ScrollLock>
   );
 }
 
-// ── Per-match editor ──────────────────────────────────────────────────────────
+// ── Game tab ──────────────────────────────────────────────────────────────────
 
-function PerMatchEditor({
-  value,
-  onChange,
-  projectedCap,
-  teamCountsLoaded,
+function GameTab({
+  isEdit, canEdit, categoriesPresent, category, setCategory, categoryTypes, effectiveTypeId,
+  setGameTypeId, selectedType, title, setTitle, isGolf, courseId, isMatchPlay,
+  total, setTotal, perMatchValue, setPerMatchValue, readout,
 }: {
-  value: number;
-  onChange: (v: number) => void;
-  projectedCap: number | null;
-  teamCountsLoaded: boolean;
+  isEdit: boolean; canEdit: boolean; categoriesPresent: readonly string[]; category: string;
+  setCategory: (c: string) => void; categoryTypes: GameType[]; effectiveTypeId: string;
+  setGameTypeId: (id: string) => void; selectedType: GameType | undefined; title: string;
+  setTitle: (s: string) => void; isGolf: boolean; courseId: string | null; isMatchPlay: boolean;
+  total: string; setTotal: (s: string) => void; perMatchValue: string; setPerMatchValue: (s: string) => void;
+  readout: ReturnType<typeof matchReadout>;
 }) {
-  const projectedTotal = projectedCap != null ? value * projectedCap : null;
-
-  let totalLabel: string;
-  if (!teamCountsLoaded) {
-    totalLabel = "—";
-  } else if (projectedCap == null || projectedCap === 0) {
-    totalLabel = "— set teams";
-  } else {
-    totalLabel = `proj. ${fmtValue(projectedTotal!)} pts`;
-  }
-
+  const readOnly = !canEdit; // delegate: Game tab is the owner's, shown read-only
   return (
-    <Field label="Points per Match">
-      <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <input
-            type="number"
-            min={0.5}
-            step={0.5}
-            value={value}
-            onChange={(e) => {
-              const v = parseFloat(e.target.value);
-              if (!isNaN(v) && v > 0) onChange(v);
-            }}
-            className="w-24 rounded-lg px-2 py-1.5 text-sm outline-none"
-            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-          />
-          <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            pt per match · winner takes all, halve splits ½
-          </span>
-        </div>
-        <div className="flex items-center justify-between pt-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
-          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-            Projected total
-          </span>
-          <span
-            className="text-sm font-bold tabular-nums"
-            style={{ color: projectedTotal != null ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+    <>
+      {!isEdit && (
+        <Field label="Type" required>
+          <div className="grid grid-cols-5 gap-2">
+            {categoriesPresent.map((c) => {
+              const m = CATEGORY_META[c];
+              return <TypeChip key={c} active={category === c} onClick={() => setCategory(c)} icon={<m.Icon size={18} />} label={m.label} />;
+            })}
+          </div>
+        </Field>
+      )}
+
+      {!isEdit && (
+        <Field label="Format" required>
+          <div className="flex flex-wrap gap-1.5">
+            {categoryTypes.map((t) => (
+              <Chip key={t.id} active={effectiveTypeId === t.id} onClick={() => setGameTypeId(t.id)}>{t.name}</Chip>
+            ))}
+          </div>
+          {selectedType && !selectedType.isEngine && (
+            <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+              No built-in scoring engine for this type yet — name it below and enter the result by hand. Known games (Poker, Euchre…) get their own scoring later.
+            </p>
+          )}
+        </Field>
+      )}
+
+      <Field label="Title" required>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          readOnly={readOnly}
+          placeholder={isGolf ? "e.g. Day 1 Scramble" : "e.g. Poker Night, Cornhole"}
+          maxLength={200}
+          className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", opacity: readOnly ? 0.7 : 1 }}
+        />
+      </Field>
+
+      {isGolf && (
+        <Field label="Course">
+          <div
+            className="flex items-center justify-between rounded-lg px-3 py-2 text-sm"
+            style={{ background: "var(--color-bt-card-raised)", color: courseId ? "var(--color-bt-text)" : "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
           >
-            {totalLabel}
-          </span>
+            <span>{courseId ? "Course applied" : "No course yet"}</span>
+          </div>
+          <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            The golf course is optional, but required if you want to keep score.
+          </p>
+        </Field>
+      )}
+
+      {isMatchPlay ? (
+        <Field label="Points per match">
+          <div className="flex items-center gap-3">
+            <input
+              type="number" min={0.5} step={0.5} value={perMatchValue} readOnly={readOnly}
+              onChange={(e) => setPerMatchValue(e.target.value)}
+              className="w-24 rounded-lg px-2 py-1.5 text-sm outline-none"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+            />
+            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              per match · winner takes all, halve splits ½
+            </span>
+          </div>
+          <MatchReadoutLine readout={readout} />
+        </Field>
+      ) : (
+        <Field label="Point value" required>
+          <div className="flex items-center gap-3">
+            <input
+              type="number" min={0} step={1} value={total} readOnly={readOnly}
+              onChange={(e) => setTotal(e.target.value)}
+              placeholder="8"
+              className="w-24 rounded-lg px-2 py-1.5 text-sm outline-none"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+            />
+            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>points for this game</span>
+          </div>
+          <p className="mt-1.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            Split across finishing places on the Configuration tab ›
+          </p>
+        </Field>
+      )}
+    </>
+  );
+}
+
+function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout> }) {
+  return (
+    <div className="mt-2 flex items-center justify-between pt-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+      <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+        Points available
+      </span>
+      <span className="text-sm font-bold tabular-nums" style={{ color: readout.available != null ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>
+        {readout.available != null ? `${fmtValue(readout.available)} · ${readout.label}` : readout.label}
+      </span>
+    </div>
+  );
+}
+
+// ── Configuration tab ─────────────────────────────────────────────────────────
+
+function ConfigTab({
+  canEdit, tripId, gameId, isMatchPlay, totalNum, placeInputs, setPlaceInputs,
+  placement, pFit, mFit, readout, perMatchValue, compFormat, openFormatSheet,
+}: {
+  canEdit: boolean; tripId: string; gameId: string | null; isMatchPlay: boolean; totalNum: number;
+  placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
+  placement: ReturnType<typeof validatePlacement>; pFit: ReturnType<typeof placementFit>;
+  mFit: ReturnType<typeof matchFit>; readout: ReturnType<typeof matchReadout>;
+  perMatchValue: string; compFormat: string | null; openFormatSheet: () => void;
+}) {
+  return (
+    <>
+      <DelegationBlock canEdit={canEdit} tripId={tripId} gameId={gameId} />
+
+      {isMatchPlay ? (
+        <Field label="Point value">
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-black tabular-nums" style={{ color: "var(--color-bt-text)" }}>{fmtValue(Number(perMatchValue) || 0)}</span>
+            <span className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>/ match · set on Game tab</span>
+          </div>
+          <MatchReadoutLine readout={readout} />
+          <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+            A match game splits the per-match value across matches — no place table. The total lands once team sizes set the match count.
+          </p>
+        </Field>
+      ) : (
+        <PlacementEditor totalNum={totalNum} placeInputs={placeInputs} setPlaceInputs={setPlaceInputs} placement={placement} />
+      )}
+
+      {!isMatchPlay && pFit.state === "warn" && <FitWarning message={pFit.message!} />}
+      {isMatchPlay && mFit.state === "warn" && <FitWarning message={mFit.message!} />}
+
+      <Field label="Competition format">
+        <button
+          type="button"
+          onClick={openFormatSheet}
+          className="flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-sm"
+          style={{ background: "var(--color-bt-card-raised)", color: compFormat ? "var(--color-bt-text)" : "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <span>{formatLabel(compFormat) ?? "How's it played?"}</span>
+          <ChevronRight size={15} style={{ color: "var(--color-bt-text-dim)" }} />
+        </button>
+        <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          Sets the label on the leaderboard. Running it up in-app comes later — until then you enter results by hand.
+        </p>
+      </Field>
+    </>
+  );
+}
+
+function DelegationBlock({ canEdit, tripId, gameId }: { canEdit: boolean; tripId: string; gameId: string | null }) {
+  const utils = trpc.useUtils();
+  const [picking, setPicking] = useState(false);
+  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId }, { enabled: picking });
+  const { data: organizers = [] } = trpc.games.listOrganizers.useQuery(
+    { tripId, gameId: gameId ?? "" },
+    { enabled: !!gameId }
+  );
+  const addOrg = trpc.games.addOrganizer.useMutation();
+
+  if (!canEdit) {
+    return (
+      <div className="flex items-start gap-2.5 rounded-xl px-3 py-3" style={{ background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}>
+        <Users size={16} style={{ color: "var(--color-bt-accent)", flexShrink: 0, marginTop: 1 }} />
+        <div>
+          <p className="text-sm font-semibold" style={{ color: "var(--color-bt-accent)" }}>You've been asked to help set this up</p>
+          <p className="mt-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            Configure away. The owner keeps the basics (name, course, value) on the Game tab.
+          </p>
         </div>
       </div>
+    );
+  }
+
+  const orgCount = (organizers as { user_id: string }[]).length;
+  return (
+    <Field label="Delegate" >
+      {!gameId ? (
+        <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>Save the game first, then you can hand its setup to someone.</p>
+      ) : !picking ? (
+        <button
+          type="button"
+          onClick={() => setPicking(true)}
+          className="flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-sm"
+          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <Users size={15} style={{ color: "var(--color-bt-accent)" }} />
+          {orgCount > 0 ? `${orgCount} organizer${orgCount === 1 ? "" : "s"} · add another` : "Assign a game organizer"}
+        </button>
+      ) : (
+        <div className="space-y-1.5">
+          {(members as { memberId: string; displayName: string }[]).map((m) => (
+            <button
+              key={m.memberId}
+              type="button"
+              onClick={async () => {
+                await addOrg.mutateAsync({ tripId, gameId, userId: m.memberId });
+                utils.games.listOrganizers.invalidate({ tripId, gameId });
+                setPicking(false);
+              }}
+              className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+            >
+              <span>{m.displayName}</span>
+              <Plus size={13} style={{ color: "var(--color-bt-accent)" }} />
+            </button>
+          ))}
+        </div>
+      )}
+      <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        Hand this game's setup and running to someone — they get the game-organizer grant and their own Configuration tab.
+      </p>
     </Field>
   );
 }
 
-// ── Placement editor ──────────────────────────────────────────────────────────
+function FitWarning({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg px-3 py-2" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning)" }}>
+      <span className="text-[11px] leading-relaxed" style={{ color: "var(--color-bt-warning)" }}>{message}</span>
+    </div>
+  );
+}
+
+// ── Placement editor (distributes the owner total) ────────────────────────────
 
 function PlacementEditor({
-  points,
-  setPoints,
-  total,
+  totalNum, placeInputs, setPlaceInputs, placement,
 }: {
-  points: number[];
-  setPoints: (p: number[]) => void;
-  total: number;
+  totalNum: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
+  placement: ReturnType<typeof validatePlacement>;
 }) {
+  const started = (placeInputs[0]?.trim() ?? "") !== "";
   return (
-    <Field label="Points Distribution">
+    <Field label="Point distribution">
+      <p className="mb-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        The owner set this game at <span style={{ color: "var(--color-bt-text)" }}>{fmtValue(totalNum)} points</span>. Spread them across team places — the split must total {fmtValue(totalNum)} exactly.
+      </p>
       <div className="space-y-2">
-        {points.map((p, i) => (
+        {placeInputs.map((p, i) => (
           <div key={i} className="flex items-center gap-3">
             <span className="w-16 flex-shrink-0 text-xs font-semibold" style={{ color: "var(--color-bt-text)" }}>
               {ordinalShort(i + 1)} place
             </span>
             <input
-              type="number"
-              min={0}
-              value={p || ""}
-              onChange={(e) => {
-                const next = [...points];
-                next[i] = parseFloat(e.target.value) || 0;
-                setPoints(next);
-              }}
-              placeholder="0"
+              type="number" min={0} value={p}
+              onChange={(e) => { const next = [...placeInputs]; next[i] = e.target.value; setPlaceInputs(next); }}
+              placeholder="pts"
               className="w-20 rounded-lg px-2 py-1.5 text-sm outline-none"
               style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
             />
             <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>pts</span>
-            <button
-              type="button"
-              onClick={() => setPoints(points.filter((_, j) => j !== i))}
-              aria-label={`Remove ${ordinalShort(i + 1)} place`}
-              className="ml-auto flex h-6 w-6 items-center justify-center rounded-md"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              <X size={12} />
-            </button>
+            {placeInputs.length > 1 && (
+              <button
+                type="button"
+                onClick={() => setPlaceInputs(placeInputs.filter((_, j) => j !== i))}
+                aria-label={`Remove ${ordinalShort(i + 1)} place`}
+                className="ml-auto flex h-6 w-6 items-center justify-center rounded-md"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                <X size={12} />
+              </button>
+            )}
           </div>
         ))}
-        {(points.length === 0 || (points[points.length - 1] ?? 0) > 0) && (
+        {started && (
           <button
             type="button"
-            onClick={() => setPoints([...points, 0])}
+            onClick={() => setPlaceInputs([...placeInputs, ""])}
             className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium"
             style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
           >
             <Plus size={12} style={{ color: "var(--color-bt-accent)" }} />
-            Add {ordinalShort(points.length + 1)} place
+            Add {ordinalShort(placeInputs.length + 1)} place
           </button>
         )}
-        {points.length > 0 && (
-          <div className="mt-1 flex items-center justify-between pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
-            <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-              Total available
+        <div className="mt-1 flex items-center justify-between pt-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Allocated
+          </span>
+          {!started ? (
+            <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>0 of {fmtValue(totalNum)} pts · undistributed for now</span>
+          ) : placement.saveable ? (
+            <span className="flex items-center gap-1 text-sm font-bold tabular-nums" style={{ color: "var(--color-bt-accent)" }}>
+              <Check size={13} /> {fmtValue(placement.allocated)} of {fmtValue(totalNum)} pts
             </span>
-            <span
-              className="text-sm font-bold tabular-nums"
-              style={{ color: total > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
-            >
-              {total} pt{total === 1 ? "" : "s"}
+          ) : (
+            <span className="text-sm font-bold tabular-nums" style={{ color: "var(--color-bt-danger)" }}>
+              {fmtValue(placement.allocated)} of {fmtValue(totalNum)} pts
             </span>
-          </div>
+          )}
+        </div>
+        {started && !placement.saveable && (
+          <p className="text-[11px]" style={{ color: "var(--color-bt-danger)" }}>
+            {placement.remaining > 0 ? `${fmtValue(placement.remaining)} left to place` : `${fmtValue(-placement.remaining)} over — total must be ${fmtValue(totalNum)} to save`}
+          </p>
         )}
       </div>
     </Field>
   );
 }
 
+// ── "How's it played?" format sheet ───────────────────────────────────────────
+
+function FormatSheet({
+  current, onPick, onClose,
+}: {
+  current: string | null; onPick: (k: string) => void; onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-[60] flex items-end justify-center sm:items-center" style={{ background: "var(--color-bt-overlay)" }} onClick={onClose}>
+      <div
+        className="flex max-h-[80vh] w-full max-w-md flex-col rounded-t-2xl sm:rounded-2xl"
+        style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
+          <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>How's it played?</h3>
+          <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
+            <X size={16} />
+          </button>
+        </div>
+        <div className="flex-1 space-y-2 overflow-y-auto p-4">
+          {COMP_FORMATS.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => onPick(f.key)}
+              className="flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left"
+              style={{
+                background: current === f.key ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)",
+                border: `1px solid ${current === f.key ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}`,
+              }}
+            >
+              <f.Icon size={16} style={{ color: "var(--color-bt-accent)", flexShrink: 0, marginTop: 1 }} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>{f.label}</span>
+                  <span className="rounded px-1 py-0.5 text-[9px] font-bold uppercase" style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}>Manual</span>
+                  {current === f.key && <Check size={13} style={{ color: "var(--color-bt-accent)", marginLeft: "auto" }} />}
+                </div>
+                <p className="mt-0.5 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>{f.desc}</p>
+              </div>
+            </button>
+          ))}
+          <p className="px-1 pt-1 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+            However it runs, you can always enter the result by hand — picking a format never leaves you stuck on "coming soon."
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── small shared bits ─────────────────────────────────────────────────────────
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative px-3 py-2.5 text-sm font-semibold"
+      style={{ color: active ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}
+    >
+      {children}
+      {active && <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full" style={{ background: "var(--color-bt-accent)" }} />}
+    </button>
+  );
+}
 
 function TypeChip({ active, onClick, icon, label }: { active: boolean; onClick: () => void; icon: React.ReactNode; label: string }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex flex-col items-center gap-1.5 rounded-xl py-3 text-xs font-semibold"
+      className="flex flex-col items-center gap-1 rounded-xl py-2.5 text-[10px] font-semibold"
       style={
         active
           ? { background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)", border: "1.5px solid var(--color-bt-accent-border)" }
@@ -637,14 +944,8 @@ function Field({ label, required, children }: { label: string; required?: boolea
   return (
     <div>
       <div className="mb-1.5 flex items-baseline gap-1.5">
-        <label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-          {label}
-        </label>
-        {required && (
-          <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            required
-          </span>
-        )}
+        <label className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</label>
+        {required && <span className="text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>required</span>}
       </div>
       {children}
     </div>
@@ -657,7 +958,7 @@ function ordinalShort(n: number): string {
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
-/** Format a point value: whole numbers show as-is, 0.5 → "½", 1.5 → "1½". */
+/** Whole numbers as-is, halves as ½ (0.5 → "½", 1.5 → "1½"). */
 function fmtValue(n: number): string {
   const whole = Math.floor(n);
   const isHalf = Math.abs(n - whole - 0.5) < 0.001;

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -46,6 +46,7 @@ export interface GameRow {
   points_total: number | null;
   competition_format: string | null;
   rules_for_today: string | null;
+  modifiers: Record<string, Record<string, unknown>> | null;
   scorecard_schema: unknown | null;
   course_id: string | null;
   schedule_item_id: string | null;
@@ -60,6 +61,7 @@ interface GameType {
   isGolf: boolean;
   resultStrategy: string | null;
   category: string;
+  compatibleModifiers: string[];
 }
 
 interface Member { memberId: string; displayName: string }
@@ -86,6 +88,14 @@ const COMP_FORMATS = [
 function formatLabel(key: string | null): string | null {
   return COMP_FORMATS.find((f) => f.key === key)?.label ?? null;
 }
+
+/** Display metadata for the golf special-rule keys. Which rules are AVAILABLE
+ *  comes from the game type's model (compatibleModifiers); this is just the copy.
+ *  Per-rule configurability is deferred — each is on/off for now. */
+const SPECIAL_RULES: Record<string, { label: string; desc: string }> = {
+  moving_tees: { label: "Moving tees", desc: "The trailing team picks the tee box on the next hole." },
+  glorious_holes: { label: "Glorious finishing holes", desc: "The closing holes carry extra weight." },
+};
 
 /** Singles vs doubles for the match readout. Only singles exists today. */
 function matchFormatFor(gameTypeId: string | null): MatchFormat {
@@ -299,6 +309,8 @@ function GameSheet({
   });
   const [compFormat, setCompFormat] = useState<string | null>(game?.competition_format ?? null);
   const [rules, setRules] = useState<string>(game?.rules_for_today ?? "");
+  // Enabled special rules (golf) — keyed by modifier, value = per-rule config.
+  const [modifiers, setModifiers] = useState<Record<string, Record<string, unknown>>>(game?.modifiers ?? {});
   // Single delegate. undefined = not-yet-initialized from the existing grant.
   const [delegateId, setDelegateId] = useState<string | null | undefined>(game ? undefined : null);
   const [formatSheetOpen, setFormatSheetOpen] = useState(false);
@@ -373,10 +385,10 @@ function GameSheet({
       if (isEdit && game) {
         gameId = game.id;
         if (canEdit) {
-          await update.mutateAsync({ tripId, gameId, name: title.trim(), competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null });
+          await update.mutateAsync({ tripId, gameId, name: title.trim(), competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null, modifiers });
           await setTotalM.mutateAsync({ tripId, gameId, total: isMatchPlay ? null : total });
         } else {
-          await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null });
+          await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null, modifiers });
         }
         await setDist.mutateAsync({ tripId, gameId, distribution });
       } else {
@@ -385,8 +397,8 @@ function GameSheet({
           pointsDistribution: distribution, pointsTotal: isMatchPlay ? null : total,
         })) as { id: string };
         gameId = created.id;
-        if (compFormat || rules.trim()) {
-          await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null });
+        if (compFormat || rules.trim() || Object.keys(modifiers).length > 0) {
+          await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null, modifiers });
         }
       }
       if (canEdit) await reconcileDelegate(gameId);
@@ -483,6 +495,9 @@ function GameSheet({
                 perMatchValue={perMatchValue}
                 rules={rules}
                 setRules={setRules}
+                availableModifiers={selectedType?.compatibleModifiers ?? []}
+                modifiers={modifiers}
+                setModifiers={setModifiers}
                 compFormat={compFormat}
                 openFormatSheet={() => setFormatSheetOpen(true)}
               />
@@ -696,13 +711,16 @@ function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout
 
 function ConfigTab({
   canEdit, members, delegateId, setDelegateId, isMatchPlay, isGolf, courseId, total, placeInputs, setPlaceInputs,
-  placement, pFit, mFit, readout, perMatchValue, rules, setRules, compFormat, openFormatSheet,
+  placement, pFit, mFit, readout, perMatchValue, rules, setRules, availableModifiers, modifiers, setModifiers,
+  compFormat, openFormatSheet,
 }: {
   canEdit: boolean; members: Member[]; delegateId: string | null; setDelegateId: (id: string | null) => void;
   isMatchPlay: boolean; isGolf: boolean; courseId: string | null; total: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
   placement: ReturnType<typeof validatePlacement>; pFit: ReturnType<typeof placementFit>;
   mFit: ReturnType<typeof matchFit>; readout: ReturnType<typeof matchReadout>;
   perMatchValue: number; rules: string; setRules: (s: string) => void;
+  availableModifiers: string[]; modifiers: Record<string, Record<string, unknown>>;
+  setModifiers: (m: Record<string, Record<string, unknown>>) => void;
   compFormat: string | null; openFormatSheet: () => void;
 }) {
   return (
@@ -737,6 +755,10 @@ function ConfigTab({
           style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
         />
       </Field>
+
+      {isGolf && availableModifiers.length > 0 && (
+        <SpecialRules available={availableModifiers} modifiers={modifiers} setModifiers={setModifiers} />
+      )}
 
       <Field label="Competition format">
         <button
@@ -869,6 +891,72 @@ function DelegationBlock({
         Hand this game&rsquo;s setup and running to one person — they get their own Configuration tab.
       </p>
     </Field>
+  );
+}
+
+/**
+ * SPECIAL RULES — golf-only, model-driven optional rules (e.g. moving tees,
+ * glorious finishing holes). Which rules appear comes from the game type's
+ * `compatibleModifiers`; enabled ones are stored in `games.modifiers` keyed by
+ * rule, value = per-rule config (deferred — on/off for now).
+ */
+function SpecialRules({
+  available, modifiers, setModifiers,
+}: {
+  available: string[];
+  modifiers: Record<string, Record<string, unknown>>;
+  setModifiers: (m: Record<string, Record<string, unknown>>) => void;
+}) {
+  const toggle = (key: string) => {
+    const next = { ...modifiers };
+    if (next[key]) delete next[key];
+    else next[key] = {};
+    setModifiers(next);
+  };
+  return (
+    <Field label="Special rules">
+      <div className="space-y-1.5">
+        {available.map((key) => {
+          const meta = SPECIAL_RULES[key] ?? { label: key, desc: "" };
+          const on = !!modifiers[key];
+          return (
+            <div
+              key={key}
+              className="flex items-center justify-between gap-3 rounded-lg px-3 py-2.5"
+              style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>{meta.label}</p>
+                {meta.desc && <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>{meta.desc}</p>}
+              </div>
+              <Switch on={on} onClick={() => toggle(key)} label={meta.label} />
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        Optional. Fine-tuning each rule comes later — flip it on now to flag it for the day.
+      </p>
+    </Field>
+  );
+}
+
+function Switch({ on, onClick, label }: { on: boolean; onClick: () => void; label: string }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={label}
+      onClick={onClick}
+      className="relative h-6 w-10 flex-shrink-0 rounded-full transition-colors"
+      style={{ background: on ? "var(--color-bt-accent)" : "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+    >
+      <span
+        className="absolute top-0.5 h-4 w-4 rounded-full transition-all"
+        style={{ left: on ? "20px" : "2px", background: on ? "var(--color-bt-base)" : "var(--color-bt-text-dim)" }}
+      />
+    </button>
   );
 }
 

--- a/src/lib/competitionPlacement.ts
+++ b/src/lib/competitionPlacement.ts
@@ -33,6 +33,17 @@ export interface LiveGame {
   /** Per-team standings once results exist; empty before any are entered/computed. */
   standings: Standing[];
   direction: Direction;
+  /**
+   * Authoritative points in play for this game (Slice D): the owner-set total
+   * for placement, or value × matchCount for per_match. Drives points-available
+   * and the win number INDEPENDENTLY of whether the distribution/pairings are
+   * set — so the clinch number stays stable as games get configured across the
+   * week (§8). When omitted/null, falls back to awardedForGame(distribution,
+   * numTeams) — the pre-Slice-D behavior. A value of 0 means "in play but
+   * nothing yet" (e.g. match game whose teams aren't sized) and does NOT fall
+   * back.
+   */
+  pointsTotal?: number | null;
 }
 
 /** distribution[i] with out-of-range → 0 (teams beyond the distribution earn 0). */
@@ -165,7 +176,10 @@ export function rollUp(
   let pointsAvailable = 0;
 
   for (const g of liveGames) {
-    pointsAvailable += awardedForGame(g.distribution, g.numTeams);
+    // Available = the explicit per-game total when provided (Slice D stable
+    // clinch), else the pre-Slice-D awardable sum. `?? ` keeps an explicit 0
+    // (match game, teams not sized) from falling back.
+    pointsAvailable += g.pointsTotal ?? awardedForGame(g.distribution, g.numTeams);
     if (!g.distribution || g.standings.length === 0) continue;
     const pts = placementPoints(g.distribution, g.standings, g.direction);
     for (const [entityId, p] of pts) {

--- a/src/lib/gameConfig.test.ts
+++ b/src/lib/gameConfig.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveMatchCount,
+  validatePlacement,
+  matchReadout,
+  placementFit,
+  matchFit,
+} from "./gameConfig";
+
+/**
+ * Slice D add-game flow — pure validation/derivation (Stage 2). Each spec rule
+ * gets a case: untouched-saveable, partial-blocked, complete-valid, 0-lower-OK,
+ * match-count ready/not-set, fit warn-only-when-defined-incompatible +
+ * calm-pending + self-clear.
+ */
+
+describe("deriveMatchCount — the shared match-count primitive", () => {
+  it("singles = min(team sizes)", () => {
+    expect(deriveMatchCount([8, 8], "singles")).toBe(8);
+    expect(deriveMatchCount([8, 6], "singles")).toBe(6); // bounded by smaller
+    expect(deriveMatchCount([5, 7, 6], "singles")).toBe(5);
+  });
+
+  it("doubles = floor(min ÷ 2)", () => {
+    expect(deriveMatchCount([8, 8], "doubles")).toBe(4);
+    expect(deriveMatchCount([6, 8], "doubles")).toBe(3);
+    expect(deriveMatchCount([5, 8], "doubles")).toBe(2); // floor(5/2)
+  });
+
+  it("returns null (pending) when fewer than 2 teams are sized", () => {
+    expect(deriveMatchCount([], "singles")).toBeNull();
+    expect(deriveMatchCount([8], "singles")).toBeNull();
+    expect(deriveMatchCount([8, 0], "singles")).toBeNull(); // 0 = not sized
+  });
+});
+
+describe("validatePlacement — sum-to-total, nil-vs-entered", () => {
+  it("untouched (1st place nil / empty values) is SAVEABLE — the shell state", () => {
+    const v = validatePlacement(8, []);
+    expect(v.state).toBe("undistributed");
+    expect(v.saveable).toBe(true);
+    expect(v.remaining).toBe(8);
+  });
+
+  it("entered but sum < total is PARTIAL and blocked", () => {
+    const v = validatePlacement(8, [5]);
+    expect(v.state).toBe("partial");
+    expect(v.saveable).toBe(false);
+    expect(v.allocated).toBe(5);
+    expect(v.remaining).toBe(3);
+  });
+
+  it("entered but sum > total is PARTIAL and blocked", () => {
+    const v = validatePlacement(8, [5, 5]);
+    expect(v.state).toBe("partial");
+    expect(v.saveable).toBe(false);
+    expect(v.remaining).toBe(-2);
+  });
+
+  it("entered and summing to total is COMPLETE and saveable", () => {
+    const v = validatePlacement(8, [5, 3]);
+    expect(v.state).toBe("complete");
+    expect(v.saveable).toBe(true);
+    expect(v.remaining).toBe(0);
+  });
+
+  it("0-value LOWER place is valid when the sum still matches the total", () => {
+    const v = validatePlacement(8, [5, 3, 0]);
+    expect(v.state).toBe("complete");
+    expect(v.saveable).toBe(true);
+  });
+
+  it("a typed 0 in 1st place counts as STARTED (non-nil) — blocked unless sum matches", () => {
+    // total 8, 1st place typed as 0 → started, sum 0 ≠ 8 → partial.
+    const started0 = validatePlacement(8, [0]);
+    expect(started0.state).toBe("partial");
+    expect(started0.saveable).toBe(false);
+    // distinct from untouched (empty array), which is saveable.
+    expect(validatePlacement(8, []).saveable).toBe(true);
+  });
+});
+
+describe("matchReadout — concrete count, no 'projected'", () => {
+  it("teams sized → 'N matches ready' with available = value × count", () => {
+    const r = matchReadout(1, [8, 8], "singles");
+    expect(r.matchCount).toBe(8);
+    expect(r.available).toBe(8);
+    expect(r.label).toBe("8 matches ready");
+  });
+
+  it("doubles total uses floor(min/2)", () => {
+    const r = matchReadout(2, [8, 8], "doubles");
+    expect(r.matchCount).toBe(4);
+    expect(r.available).toBe(8); // 2 × 4
+  });
+
+  it("singular label for one match", () => {
+    expect(matchReadout(8, [1, 2], "singles").label).toBe("1 match ready");
+  });
+
+  it("teams not sized → 'matches not set', available null", () => {
+    const r = matchReadout(1, [8], "singles");
+    expect(r.matchCount).toBeNull();
+    expect(r.available).toBeNull();
+    expect(r.label).toBe("matches not set");
+  });
+});
+
+describe("placementFit — soft, defined-incompatible only", () => {
+  it("calm-PENDING when no teams defined (not a warning)", () => {
+    expect(placementFit([5, 3, 1], 0).state).toBe("pending");
+  });
+
+  it("WARNS when more places than teams (extra places unawardable)", () => {
+    const f = placementFit([5, 3, 1], 2);
+    expect(f.state).toBe("warn");
+    expect(f.message).toContain("3 places");
+  });
+
+  it("OK when places fit the teams", () => {
+    expect(placementFit([5, 3], 2).state).toBe("ok");
+    expect(placementFit([5, 3], 3).state).toBe("ok"); // fewer places than teams is fine
+  });
+
+  it("self-clears when the roster grows to fit (recompute)", () => {
+    expect(placementFit([5, 3, 1], 2).state).toBe("warn");
+    expect(placementFit([5, 3, 1], 3).state).toBe("ok"); // a team was added
+  });
+});
+
+describe("matchFit — doubles parity", () => {
+  it("calm-PENDING when fewer than 2 teams sized", () => {
+    expect(matchFit([8], "doubles").state).toBe("pending");
+    expect(matchFit([], "singles").state).toBe("pending");
+  });
+
+  it("doubles WARNS on an odd team", () => {
+    const f = matchFit([8, 7], "doubles");
+    expect(f.state).toBe("warn");
+    expect(f.message).toContain("odd");
+  });
+
+  it("doubles OK when both teams even", () => {
+    expect(matchFit([8, 6], "doubles").state).toBe("ok");
+  });
+
+  it("singles never warns on parity", () => {
+    expect(matchFit([8, 7], "singles").state).toBe("ok");
+  });
+
+  it("self-clears when the odd team becomes even (recompute)", () => {
+    expect(matchFit([8, 7], "doubles").state).toBe("warn");
+    expect(matchFit([8, 8], "doubles").state).toBe("ok");
+  });
+});

--- a/src/lib/gameConfig.ts
+++ b/src/lib/gameConfig.ts
@@ -1,0 +1,164 @@
+/**
+ * Game-configuration validation + derivation (Slice D add-game flow) — PURE,
+ * client-safe. No server/DB deps so the Configuration screen (client), the
+ * server enforcement (`games.setPointsDistribution`), and the leaderboard
+ * available-points (`competitionLeaderboard.ts`) all use the SAME primitives and
+ * can't diverge (CLAUDE.md enforced patterns #8/#9).
+ *
+ * Two points models, owner-set on the Game tab:
+ *  - PLACEMENT (golf placement, manual/generic): owner sets a TOTAL; the
+ *    Configuration tab distributes it across places (`points_distribution`
+ *    values) and MUST sum to the total once distribution begins.
+ *  - MATCH (singles/doubles match play): owner sets a PER-MATCH value; the
+ *    total is DERIVED = value × matchCount, where matchCount comes from team
+ *    SIZES (the smaller team bounds it) — knowable before pairings, so the
+ *    available total is stable across the week (#357/#358 model, kept).
+ *
+ * `deriveMatchCount` is the single match-count primitive — the UI readout AND
+ * the leaderboard available-points both call it (one derivation, two consumers).
+ */
+
+export type MatchFormat = "singles" | "doubles";
+
+/**
+ * Match count from team sizes — the cap bounded by the smaller team:
+ *   singles = min(sizes); doubles = floor(min(sizes) / 2).
+ * Needs ≥2 sized teams to cross the team line. Returns `null` when it can't be
+ * known yet (fewer than 2 teams have members) — the "matches not set" /
+ * calm-pending state. Zero-size teams are treated as not-yet-sized.
+ */
+export function deriveMatchCount(
+  teamSizes: number[],
+  format: MatchFormat
+): number | null {
+  const sized = teamSizes.filter((n) => n > 0);
+  if (sized.length < 2) return null; // not enough defined to know
+  const min = Math.min(...sized);
+  return format === "doubles" ? Math.floor(min / 2) : min;
+}
+
+// ── Placement distribution validation ────────────────────────────────────────
+
+export type PlacementState = "undistributed" | "partial" | "complete";
+
+export interface PlacementValidation {
+  state: PlacementState;
+  /** Sum of entered place values. */
+  allocated: number;
+  /** Owner-set total the split must reach. */
+  total: number;
+  /** total − allocated (how many points are left to place). */
+  remaining: number;
+  /** Saveable when undistributed (not started) OR complete (sum === total). */
+  saveable: boolean;
+}
+
+/**
+ * Validate a placement split against the owner-set total. The trigger is
+ * "distribution has begun" = `values` non-empty (1st place entered) — NOT
+ * "> 0", so a typed 0 still counts as started.
+ *
+ *  - values EMPTY (1st place nil / untouched)      → undistributed → saveable
+ *  - values non-empty, sum === total               → complete      → saveable
+ *  - values non-empty, sum !== total               → partial       → BLOCKED
+ *
+ * 0-value LOWER places are fine as long as the sum still equals the total
+ * (e.g. total 8 → [5,3,0] is complete). The caller maps "1st place empty" to an
+ * empty array; any entered value (incl. 0) yields a non-empty array.
+ */
+export function validatePlacement(
+  total: number,
+  values: number[]
+): PlacementValidation {
+  if (values.length === 0) {
+    return { state: "undistributed", allocated: 0, total, remaining: total, saveable: true };
+  }
+  const allocated = values.reduce((sum, v) => sum + (v || 0), 0);
+  const complete = allocated === total;
+  return {
+    state: complete ? "complete" : "partial",
+    allocated,
+    total,
+    remaining: total - allocated,
+    saveable: complete,
+  };
+}
+
+// ── Match readout (retires "projected") ──────────────────────────────────────
+
+export interface MatchReadout {
+  /** Derived match count, or null when teams aren't sized yet. */
+  matchCount: number | null;
+  /** value × matchCount, or null when the count is unknown. */
+  available: number | null;
+  /** "N matches ready" when known, else "matches not set". */
+  label: string;
+}
+
+/**
+ * The match-game points readout: the available total = per-match value ×
+ * matchCount, shown concretely ("8 matches ready") or pending ("matches not
+ * set"). Uses the SAME `deriveMatchCount` the leaderboard uses. No "projected".
+ */
+export function matchReadout(
+  value: number,
+  teamSizes: number[],
+  format: MatchFormat
+): MatchReadout {
+  const matchCount = deriveMatchCount(teamSizes, format);
+  if (matchCount == null) {
+    return { matchCount: null, available: null, label: "matches not set" };
+  }
+  return {
+    matchCount,
+    available: value * matchCount,
+    label: `${matchCount} match${matchCount === 1 ? "" : "es"} ready`,
+  };
+}
+
+// ── Fits-roster soft flag ─────────────────────────────────────────────────────
+
+export type FitState = "ok" | "warn" | "pending";
+
+export interface FitResult {
+  state: FitState;
+  /** Human-readable warning, null unless state === "warn". */
+  message: string | null;
+}
+
+const OK: FitResult = { state: "ok", message: null };
+const PENDING: FitResult = { state: "pending", message: null };
+
+/**
+ * Placement fit: warns when MORE places are configured than teams defined (the
+ * extra places can never be awarded). Calm-PENDING when no teams are defined yet
+ * (not enough to know). Self-clears as the roster/distribution changes to fit.
+ */
+export function placementFit(values: number[], numTeams: number): FitResult {
+  if (numTeams <= 0) return PENDING; // no teams yet — calm, not a warning
+  if (values.length > numTeams) {
+    const extra = values.length - numTeams;
+    return {
+      state: "warn",
+      message: `${values.length} places but ${numTeams} team${numTeams === 1 ? "" : "s"} — ${extra} place${extra === 1 ? "" : "s"} can't be awarded`,
+    };
+  }
+  return OK;
+}
+
+/**
+ * Match fit: doubles warns when a defined team has an ODD member count (someone
+ * can't be paired). Singles never warns on parity (min bounds it). Calm-PENDING
+ * when fewer than 2 teams are sized.
+ */
+export function matchFit(teamSizes: number[], format: MatchFormat): FitResult {
+  const sized = teamSizes.filter((n) => n > 0);
+  if (sized.length < 2) return PENDING; // not enough defined to know
+  if (format === "doubles" && sized.some((n) => n % 2 !== 0)) {
+    return {
+      state: "warn",
+      message: "Doubles needs even teams — a team has an odd number, so someone won't be paired",
+    };
+  }
+  return OK;
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,6 +1,13 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlacement";
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
+import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
+
+/** Singles vs doubles for matchCount. Only singles match play exists today; a
+ *  future doubles type slots in here without touching the caller. */
+function matchFormat(gameTypeId: string | null): MatchFormat {
+  return gameTypeId === "gtt_match_play_doubles" ? "doubles" : "singles";
+}
 
 /**
  * Server roll-up wrapper (Slice D1 §5/§6). The DB-read half of the CLAUDE.md #8
@@ -40,11 +47,25 @@ export async function computeCompetitionLeaderboard(
   // an "Abandoned" column, but only LIVE ones feed the roll-up / points-available.
   const { data: gameRows } = await supabase
     .from("games")
-    .select("id, name, points_distribution, status, game_type_id")
+    .select("id, name, points_distribution, points_total, status, game_type_id")
     .eq("competition_id", competitionId)
     .order("created_at", { ascending: true });
   const allGames = gameRows ?? [];
   const live = allGames.filter((g) => g.status !== "dropped");
+
+  // Team sizes (member headcount) drive the match-game total = value ×
+  // matchCount — derived from sizes, NOT pairings, so the per_match total is
+  // known once teams are populated and stays stable through the week (§8).
+  const { data: assignments } = await supabase
+    .from("team_assignments")
+    .select("team_id")
+    .eq("competition_id", competitionId);
+  const sizeByTeam = new Map<string, number>();
+  for (const a of assignments ?? []) {
+    const tid = a.team_id as string;
+    sizeByTeam.set(tid, (sizeByTeam.get(tid) ?? 0) + 1);
+  }
+  const teamSizes = teamIds.map((id) => sizeByTeam.get(id) ?? 0);
 
   const gameIds = live.map((g) => g.id as string);
   const { data: results } = gameIds.length
@@ -69,12 +90,16 @@ export async function computeCompetitionLeaderboard(
     const standings = standingsByGame.get(g.id as string) ?? [];
 
     if (isPerMatch(rawDist)) {
-      // Adapter (computeMatchPlayResults) writes raw_score per team. Build a
-      // synthetic distribution = sorted actual points so placementPoints passes
-      // them through unchanged (direction high_wins).
+      // Available (stable): value × matchCount from TEAM SIZES — known before
+      // pairings, so the clinch number doesn't move as matches are played (§8).
+      // 0 when teams aren't sized yet ("matches not set"). AWARDED teamTotals
+      // still come from the realized per-team match points (synthetic
+      // distribution below), so configuring/playing moves only awarded points.
+      const mc = deriveMatchCount(teamSizes, matchFormat(g.game_type_id as string | null));
+      const pointsTotal = mc != null ? rawDist.value * mc : 0;
       if (standings.length === 0) {
-        // No decided matches yet — no contribution to points-available or teamTotals.
-        return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "high_wins" as const };
+        // No decided matches yet — contributes its available pool, no awards.
+        return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "high_wins" as const, pointsTotal };
       }
       const sorted = [...standings].sort((a, b) => b.value - a.value);
       return {
@@ -83,21 +108,35 @@ export async function computeCompetitionLeaderboard(
         numTeams: teamIds.length,
         standings: sorted,
         direction: "high_wins" as const,
+        pointsTotal,
       };
     }
 
     if (isPlacement(rawDist)) {
+      // Available uses the owner-set total (counts even before distribution —
+      // stable clinch). A legacy game with no total (null) falls back to the
+      // distribution sum via rollUp's awardedForGame.
       return {
         id: g.id as string,
         distribution: rawDist.values,
         numTeams: teamIds.length,
         standings,
         direction: "low_wins" as const,
+        pointsTotal: (g.points_total as number | null) ?? undefined,
       };
     }
 
-    // null / unknown shape — contributes nothing
-    return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "low_wins" as const };
+    // null / unknown distribution shape: an undistributed placement SHELL still
+    // contributes its owner-set total (the Game-tab value saved before the
+    // Configuration-tab split exists). No total → contributes nothing.
+    return {
+      id: g.id as string,
+      distribution: null,
+      numTeams: teamIds.length,
+      standings: [],
+      direction: "low_wins" as const,
+      pointsTotal: (g.points_total as number | null) ?? undefined,
+    };
   });
 
   const roll = rollUp(liveGames, teamIds, { defendingTeamId: comp?.defending_team_id ?? null });

--- a/src/server/routers/competitions.d1followon.test.ts
+++ b/src/server/routers/competitions.d1followon.test.ts
@@ -27,12 +27,14 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  for (const id of gameIds) {
-    await ctx.admin.from("game_results").delete().eq("game_id", id);
-    await ctx.admin.from("games").delete().eq("id", id);
+  // Batch the deletes (one query each) — a per-game loop over the now-larger
+  // game set blows the default 10s hook timeout against the remote DB.
+  if (gameIds.length) {
+    await ctx.admin.from("game_results").delete().in("game_id", gameIds);
+    await ctx.admin.from("games").delete().in("id", gameIds);
   }
   await ctx.cleanup();
-});
+}, 30000);
 
 // ── §1: tagged shape persists and reads back ─────────────────────────────────
 
@@ -101,10 +103,17 @@ describe("§1 — tagged shape round-trips through the DB", () => {
 // ── §3/§5: roll-up parity — per_match team totals via synthetic distribution ─
 
 describe("§5 — roll-up parity: per_match game_results feed through competitionPlacement.ts", () => {
-  it("per_match game with team raw_score rows rolls up to correct leaderboard totals", async () => {
+  it("per_match available = value × matchCount (stable); teamTotals from realized points", async () => {
     const comp = await ctx.createCompetition(tripId, "PerMatch Rollup Comp");
     const ta = await ctx.createTeam(comp, "Blue", { shortName: "BLU" });
     const tb = await ctx.createTeam(comp, "Red", { shortName: "RED" });
+    // 2 members per team → singles matchCount = min(2,2) = 2 → available = 1×2.
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: ctx.getUser("owner").id, team_id: ta },
+      { competition_id: comp, user_id: ctx.getUser("planner").id, team_id: ta },
+      { competition_id: comp, user_id: ctx.getUser("member").id, team_id: tb },
+      { competition_id: comp, user_id: ctx.getUser("outsider").id, team_id: tb },
+    ]);
 
     const g = (await ctx.caller().games.create({
       tripId,
@@ -115,23 +124,20 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     })) as { id: string };
     gameIds.push(g.id);
 
-    // Inject team totals directly (simulating the adapter output).
-    // Blue won 7 matches, Red won 3.
+    // Realized awarded points (adapter output): Blue won both of the 2 matches.
     await ctx.admin.from("game_results").insert([
-      { id: crypto.randomUUID(), game_id: g.id, entity_id: ta, entity_type: "team", raw_score: 7, position: null, competition_points_earned: null },
-      { id: crypto.randomUUID(), game_id: g.id, entity_id: tb, entity_type: "team", raw_score: 3, position: null, competition_points_earned: null },
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: ta, entity_type: "team", raw_score: 2, position: null, competition_points_earned: null },
+      { id: crypto.randomUUID(), game_id: g.id, entity_id: tb, entity_type: "team", raw_score: 0, position: null, competition_points_earned: null },
     ]);
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
 
-    expect(lb.teamTotals[ta]).toBe(7);
-    expect(lb.teamTotals[tb]).toBe(3);
-    // pointsAvailable = synthetic sum = 7+3 = 10
-    expect(lb.pointsAvailable).toBe(10);
-    // winNumber = smallest > 5 = 5.5
-    expect(lb.winNumber).toBe(5.5);
-    // Blue clinched (7 >= 5.5)
-    expect(lb.pointsToClinch[ta]).toBeLessThanOrEqual(0);
+    expect(lb.teamTotals[ta]).toBe(2);
+    expect(lb.teamTotals[tb]).toBe(0);
+    // available = value × matchCount = 1 × 2 (NOT the realized sum) — stable.
+    expect(lb.pointsAvailable).toBe(2);
+    expect(lb.winNumber).toBe(1.5); // smallest > half of 2
+    expect(lb.pointsToClinch[ta]).toBeLessThanOrEqual(0); // 2 ≥ 1.5 → clinched
     expect(lb.pointsToClinch[tb]).toBeGreaterThan(0);
   });
 
@@ -139,6 +145,13 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     const comp = await ctx.createCompetition(tripId, "Halve Comp");
     const ta = await ctx.createTeam(comp, "A", { shortName: "A" });
     const tb = await ctx.createTeam(comp, "B", { shortName: "B" });
+    // 2 members per team → matchCount 2 → available = 1×2 = 2.
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: ctx.getUser("owner").id, team_id: ta },
+      { competition_id: comp, user_id: ctx.getUser("planner").id, team_id: ta },
+      { competition_id: comp, user_id: ctx.getUser("member").id, team_id: tb },
+      { competition_id: comp, user_id: ctx.getUser("outsider").id, team_id: tb },
+    ]);
 
     const g = (await ctx.caller().games.create({
       tripId,
@@ -158,9 +171,9 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
 
-    expect(lb.teamTotals[ta]).toBe(1.5);
+    expect(lb.teamTotals[ta]).toBe(1.5); // realized (the 0.5 halve survives numeric)
     expect(lb.teamTotals[tb]).toBe(0.5);
-    expect(lb.pointsAvailable).toBe(2); // 1.5+0.5
+    expect(lb.pointsAvailable).toBe(2); // value × matchCount = 1×2
   });
 
   it("per_match shell with no team results contributes 0 to pointsAvailable (no pairings)", async () => {
@@ -218,6 +231,66 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     // A is 1st (higher pts), B is 2nd
     expect(aCell!.place).toBe(1);
     expect(bCell!.place).toBe(2);
+  });
+});
+
+// ── Stage 4: stable clinch — owner-set total counts before configuration ─────
+
+describe("Stage 4 — available counts owner-set totals; configuring doesn't move it", () => {
+  it("an UNCONFIGURED placement game's owner-set total counts toward available", async () => {
+    const comp = await ctx.createCompetition(tripId, "Stable Placement Comp");
+    await ctx.createTeam(comp, "A");
+    await ctx.createTeam(comp, "B");
+    // Shell: total set on the Game tab, distribution NOT yet chosen.
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Unconfigured", competitionId: comp, pointsTotal: 8,
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.pointsAvailable).toBe(8); // total counts with no distribution yet
+    expect(lb.winNumber).toBe(4.5); // smallest > half of 8
+  });
+
+  it("configuring the distribution later does NOT move the available total", async () => {
+    const comp = await ctx.createCompetition(tripId, "Stable Config Comp");
+    await ctx.createTeam(comp, "A");
+    await ctx.createTeam(comp, "B");
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Config Later", competitionId: comp, pointsTotal: 8,
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    const before = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(before.pointsAvailable).toBe(8);
+
+    await ctx.caller().games.setPointsDistribution({
+      tripId, gameId: g.id, distribution: { type: "placement", values: [5, 3] },
+    });
+    const after = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(after.pointsAvailable).toBe(8); // unchanged — only awarded points move
+  });
+
+  it("per_match available is stable BEFORE any matches are scored", async () => {
+    const comp = await ctx.createCompetition(tripId, "Stable Match Comp");
+    const ta = await ctx.createTeam(comp, "A");
+    const tb = await ctx.createTeam(comp, "B");
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: ctx.getUser("owner").id, team_id: ta },
+      { competition_id: comp, user_id: ctx.getUser("planner").id, team_id: ta },
+      { competition_id: comp, user_id: ctx.getUser("member").id, team_id: tb },
+      { competition_id: comp, user_id: ctx.getUser("outsider").id, team_id: tb },
+    ]);
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MATCH_PLAY, name: "Future Cup", competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 1 },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    // No game_results yet — but matchCount from team sizes = 2 → available = 2.
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.pointsAvailable).toBe(2);
+    expect(lb.teamTotals[ta]).toBe(0); // nothing awarded yet
   });
 });
 

--- a/src/server/routers/games.d_addgame.test.ts
+++ b/src/server/routers/games.d_addgame.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Slice D add-game flow — Stage 3: sum-to-total server enforcement + the
+ * delegation boundary (owner sets the total; a game-delegate distributes within
+ * it but can't change it). The enforcement reuses the pure validatePlacement
+ * (gameConfig.ts), so the API rejects exactly what the UI blocks.
+ */
+
+const MANUAL = "gtt_manual";
+
+let ctx: TestContext;
+let tripId: string;
+let memberId: string;
+const gameIds: string[] = [];
+
+async function newGame(pointsTotal: number | null, name = "Placement Game") {
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId: MANUAL,
+    name,
+    pointsTotal,
+  })) as { id: string; points_total: number | null };
+  gameIds.push(g.id);
+  return g;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("D Add-Game Trip");
+  await ctx.addTripMember(tripId, "member", "Member"); // delegate target (plain Member)
+  memberId = ctx.getUser("member").id;
+});
+
+afterAll(async () => {
+  for (const id of gameIds) {
+    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("games").delete().eq("id", id);
+  }
+  await ctx.cleanup();
+});
+
+describe("Stage 3 — owner sets the total on the Game tab", () => {
+  it("create persists points_total", async () => {
+    const g = await newGame(8);
+    expect(g.points_total).toBe(8);
+  });
+
+  it("owner can change the total via setPointsTotal", async () => {
+    const g = await newGame(8);
+    await ctx.caller().games.setPointsTotal({ tripId, gameId: g.id, total: 10 });
+    const after = (await ctx.caller().games.getById({ tripId, gameId: g.id })) as { points_total: number | null };
+    expect(after.points_total).toBe(10);
+  });
+});
+
+describe("Stage 3 — sum-to-total enforcement (nil-vs-entered)", () => {
+  it("UNTOUCHED (empty values) distribution SAVES — the shell state", async () => {
+    const g = await newGame(8);
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [] },
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("COMPLETE distribution (sum === total) SAVES", async () => {
+    const g = await newGame(8);
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [5, 3] },
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("0-value lower place is fine when the sum matches", async () => {
+    const g = await newGame(8);
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [5, 3, 0] },
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("PARTIAL distribution (entered, sum < total) is REJECTED", async () => {
+    const g = await newGame(8);
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [5] },
+      })
+    ).rejects.toThrow(/must total 8/i);
+  });
+
+  it("OVER-allocation (sum > total) is REJECTED", async () => {
+    const g = await newGame(8);
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [5, 5] },
+      })
+    ).rejects.toThrow(/must total 8/i);
+  });
+
+  it("a legacy game with no total keeps free-form behavior (no enforcement)", async () => {
+    const g = await newGame(null);
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [9, 6, 4, 2] },
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("per_match distribution is not subject to sum-to-total", async () => {
+    const g = await newGame(null, "Match Game");
+    await expect(
+      ctx.caller().games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "per_match", value: 1 },
+      })
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe("Stage 3 — the delegation boundary", () => {
+  it("a delegate can distribute to the total but CANNOT change the total", async () => {
+    const g = await newGame(8, "Delegated Game");
+    await ctx.caller().games.addOrganizer({ tripId, gameId: g.id, userId: memberId });
+    const member = ctx.callerAs("member");
+
+    // Distribute within the total — allowed.
+    await expect(
+      member.games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [5, 3] },
+      })
+    ).resolves.toBeTruthy();
+
+    // Partial — blocked for the delegate too (server-side, not just UI).
+    await expect(
+      member.games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [5] },
+      })
+    ).rejects.toThrow(/must total 8/i);
+
+    // Changing the total — forbidden (Member-level, no Organizer role).
+    await expect(
+      member.games.setPointsTotal({ tripId, gameId: g.id, total: 12 })
+    ).rejects.toThrow();
+  });
+
+  it("a delegate exceeding the total is rejected", async () => {
+    const g = await newGame(8, "Delegated Game 2");
+    await ctx.caller().games.addOrganizer({ tripId, gameId: g.id, userId: memberId });
+    const member = ctx.callerAs("member");
+    await expect(
+      member.games.setPointsDistribution({
+        tripId, gameId: g.id, distribution: { type: "placement", values: [9, 9] },
+      })
+    ).rejects.toThrow(/must total 8/i);
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -6,6 +6,7 @@ import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
 import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema } from "@/lib/courseIndex";
+import { validatePlacement } from "@/lib/gameConfig";
 
 /**
  * games — the competition-engine spine (Slice A: individual stroke play).
@@ -37,6 +38,10 @@ export const gamesRouter = router({
           ])
           .nullable()
           .optional(),
+        // Owner-set TOTAL for placement games (Stage 3). NULL for match games
+        // (total derived = value × matchCount). Set here on create from the
+        // Game tab; changed later only via setPointsTotal (owner-only).
+        pointsTotal: z.number().min(0).nullable().optional(),
         // Optional, one-directional agenda link — never a gate. (§9)
         scheduleItemId: z.string().uuid().nullable().optional(),
       })
@@ -54,6 +59,7 @@ export const gamesRouter = router({
         name: input.name ?? null,
         tee_time: input.teeTime ?? null,
         points_distribution: input.pointsDistribution ?? null,
+        points_total: input.pointsTotal ?? null,
         schedule_item_id: input.scheduleItemId ?? null,
         status: "pending",
       });
@@ -371,8 +377,32 @@ export const gamesRouter = router({
       return { success: true };
     }),
 
-  // setPointsDistribution — game-edit gate. The competition-layer value
-  // (`[9,6,4,2]`). Editing it re-derives the leaderboard on next read (§5b/§6).
+  // setPointsTotal — Owner/Organizer ONLY (the delegation boundary, Stage 3).
+  // A game's TOTAL is owner-set; a game-delegate distributes WITHIN it but can't
+  // change it. requireTripRole("Organizer") blocks a Member-level delegate
+  // outright (a delegate has only a game_organizers grant, not Organizer role).
+  // NULL clears the total (match games, whose total is derived).
+  setPointsTotal: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), total: z.number().min(0).nullable() }))
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games").select("id").eq("id", input.gameId).eq("trip_id", ctx.tripId).maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      const { error } = await ctx.supabase
+        .from("games").update({ points_total: input.total }).eq("id", input.gameId).eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set total: ${error.message}` });
+      return { success: true };
+    }),
+
+  // setPointsDistribution — game-edit gate (owner OR game-delegate). The
+  // competition-layer split. Editing it re-derives the leaderboard on next read
+  // (§5b/§6). Stage 3 sum-to-total: a PLACEMENT split must equal the owner-set
+  // points_total once distribution has BEGUN (values non-empty). An empty
+  // (undistributed) split saves — the shell/delegate state; a PARTIAL one
+  // (entered ≠ total) is rejected. per_match carries no total relationship. Uses
+  // the SAME validatePlacement the client uses (CLAUDE.md #8), so the API can't
+  // accept what the UI blocks.
   setPointsDistribution: authedProcedure
     .input(
       z.object({
@@ -388,6 +418,23 @@ export const gamesRouter = router({
     )
     .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
+      if (input.distribution?.type === "placement") {
+        const { data: game } = await ctx.supabase
+          .from("games").select("points_total").eq("id", input.gameId).eq("trip_id", ctx.tripId).maybeSingle();
+        const total = (game?.points_total as number | null) ?? null;
+        // Only enforce when a total exists to enforce against. (A legacy game
+        // with no owner-set total keeps its pre-Slice-D free-form behavior.)
+        if (total != null) {
+          const check = validatePlacement(total, input.distribution.values);
+          if (!check.saveable) {
+            const over = check.remaining < 0;
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Points must total ${total} exactly — ${check.allocated} allocated, ${over ? `${-check.remaining} over` : `${check.remaining} left to place`}.`,
+            });
+          }
+        }
+      }
       const { error } = await ctx.supabase
         .from("games")
         .update({ points_distribution: input.distribution })

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -90,7 +90,7 @@ export const gamesRouter = router({
   listTypes: authedProcedure.query(async ({ ctx }) => {
     const { data, error } = await ctx.supabase
       .from("game_type_templates")
-      .select("id, key, name, description, result_strategy, scorecard_schema, sort_order")
+      .select("id, key, name, description, result_strategy, scorecard_schema, category, sort_order")
       .order("sort_order", { ascending: true });
     if (error) {
       throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to list game types: ${error.message}` });
@@ -104,6 +104,8 @@ export const gamesRouter = router({
       isEngine: t.result_strategy != null,
       isGolf: t.scorecard_schema != null, // golf engine types carry a scorecard
       resultStrategy: (t.result_strategy as string | null) ?? null,
+      // The creation Type tier (golf | card | yard | bar | other). Data-driven.
+      category: (t.category as string | null) ?? "other",
     }));
   }),
 
@@ -340,6 +342,11 @@ export const gamesRouter = router({
         name: z.string().max(200).nullable().optional(),
         teeTime: z.string().max(5).nullable().optional(),
         scheduleItemId: z.string().uuid().nullable().optional(),
+        // The "How's it played?" label (Configuration tab). Owner or delegate.
+        competitionFormat: z
+          .enum(["head_to_head", "bracket_se", "bracket_de", "best_of_n", "live_results"])
+          .nullable()
+          .optional(),
       })
     )
     .use(requireGameEdit())
@@ -348,6 +355,7 @@ export const gamesRouter = router({
       if (input.name !== undefined) patch.name = input.name;
       if (input.teeTime !== undefined) patch.tee_time = input.teeTime;
       if (input.scheduleItemId !== undefined) patch.schedule_item_id = input.scheduleItemId;
+      if (input.competitionFormat !== undefined) patch.competition_format = input.competitionFormat;
       if (Object.keys(patch).length === 0) return { success: true };
       const { error } = await ctx.supabase.from("games").update(patch).eq("id", input.gameId).eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to update game: ${error.message}` });

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -347,6 +347,8 @@ export const gamesRouter = router({
           .enum(["head_to_head", "bracket_se", "bracket_de", "best_of_n", "live_results"])
           .nullable()
           .optional(),
+        // Free-text "rules of the day" (Configuration tab). Owner or delegate.
+        rulesForToday: z.string().max(2000).nullable().optional(),
       })
     )
     .use(requireGameEdit())
@@ -356,6 +358,7 @@ export const gamesRouter = router({
       if (input.teeTime !== undefined) patch.tee_time = input.teeTime;
       if (input.scheduleItemId !== undefined) patch.schedule_item_id = input.scheduleItemId;
       if (input.competitionFormat !== undefined) patch.competition_format = input.competitionFormat;
+      if (input.rulesForToday !== undefined) patch.rules_for_today = input.rulesForToday;
       if (Object.keys(patch).length === 0) return { success: true };
       const { error } = await ctx.supabase.from("games").update(patch).eq("id", input.gameId).eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to update game: ${error.message}` });

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -90,7 +90,7 @@ export const gamesRouter = router({
   listTypes: authedProcedure.query(async ({ ctx }) => {
     const { data, error } = await ctx.supabase
       .from("game_type_templates")
-      .select("id, key, name, description, result_strategy, scorecard_schema, category, sort_order")
+      .select("id, key, name, description, result_strategy, scorecard_schema, category, compatible_modifiers, sort_order")
       .order("sort_order", { ascending: true });
     if (error) {
       throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to list game types: ${error.message}` });
@@ -106,6 +106,8 @@ export const gamesRouter = router({
       resultStrategy: (t.result_strategy as string | null) ?? null,
       // The creation Type tier (golf | card | yard | bar | other). Data-driven.
       category: (t.category as string | null) ?? "other",
+      // Optional special rules this format supports (SPECIAL RULES toggles).
+      compatibleModifiers: (t.compatible_modifiers as string[] | null) ?? [],
     }));
   }),
 
@@ -349,6 +351,9 @@ export const gamesRouter = router({
           .optional(),
         // Free-text "rules of the day" (Configuration tab). Owner or delegate.
         rulesForToday: z.string().max(2000).nullable().optional(),
+        // Enabled special rules + per-rule config, keyed by modifier (golf
+        // SPECIAL RULES). Presence of a key = enabled. Owner or delegate.
+        modifiers: z.record(z.string(), z.record(z.string(), z.unknown())).nullable().optional(),
       })
     )
     .use(requireGameEdit())
@@ -359,6 +364,7 @@ export const gamesRouter = router({
       if (input.scheduleItemId !== undefined) patch.schedule_item_id = input.scheduleItemId;
       if (input.competitionFormat !== undefined) patch.competition_format = input.competitionFormat;
       if (input.rulesForToday !== undefined) patch.rules_for_today = input.rulesForToday;
+      if (input.modifiers !== undefined) patch.modifiers = input.modifiers;
       if (Object.keys(patch).length === 0) return { success: true };
       const { error } = await ctx.supabase.from("games").update(patch).eq("id", input.gameId).eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to update game: ${error.message}` });

--- a/supabase/migrations/20260613130000_049_games_points_total.sql
+++ b/supabase/migrations/20260613130000_049_games_points_total.sql
@@ -1,0 +1,46 @@
+-- 049 — games.points_total (Slice D add-game flow, Stage 3)
+--
+-- The owner-set TOTAL points a game is worth, set on the Game tab. This is the
+-- delegation boundary made structural: the OWNER writes `points_total`
+-- (owner-only mutation); a DELEGATE distributes WITHIN it on the Configuration
+-- tab by writing `points_distribution` (the per-place split, which must sum to
+-- this total once distribution begins). Keeping the total in its own column
+-- (rather than reshaping the tagged `points_distribution` union again) gives a
+-- clean column-level permission split AND lets the total persist while the
+-- distribution is still empty — so an unconfigured game's owner-set total still
+-- counts toward the leaderboard's available points / clinch number (Stage 4),
+-- keeping the magic number stable across the week.
+--
+-- Model-aware:
+--   PLACEMENT games (golf placement, manual/generic) → points_total is the pool
+--     the `points_distribution.values` must sum to.
+--   MATCH games (singles/doubles) → points_total stays NULL; the total is
+--     DERIVED = per-match value × matchCount (matchCount from team sizes), so it
+--     must NOT be stored (it moves only with team sizes, never configuration).
+--
+-- numeric (not integer): averaged-tie placement points and per-match halves come
+-- in 0.5 steps, and a total may be set in halves. Idempotent.
+
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS points_total numeric;
+
+COMMENT ON COLUMN public.games.points_total IS
+  'Owner-set total points for a placement game (the pool the points_distribution '
+  'split must sum to). NULL for match games, whose total is derived = per-match '
+  'value × matchCount. Owner-only; delegates distribute within it.';
+
+-- Backfill existing PLACEMENT games: total = sum of their current place values,
+-- so the leaderboard available-points is unchanged for pre-Slice-D data. Only
+-- the 2026-06-06 reset's test-only data exists, so this is a clean reshape.
+-- per_match games keep points_total NULL.
+UPDATE public.games g
+SET points_total = sub.total
+FROM (
+  SELECT id,
+         (SELECT COALESCE(SUM(v::numeric), 0)
+            FROM jsonb_array_elements_text(points_distribution -> 'values') AS v) AS total
+    FROM public.games
+   WHERE points_distribution ->> 'type' = 'placement'
+) sub
+WHERE g.id = sub.id
+  AND g.points_distribution ->> 'type' = 'placement'
+  AND g.points_total IS NULL;

--- a/supabase/migrations/20260613140000_050_addgame_category_and_competition_format.sql
+++ b/supabase/migrations/20260613140000_050_addgame_category_and_competition_format.sql
@@ -1,0 +1,55 @@
+-- 050 — Slice D add-game flow, Stage 5 (UI data): type categories + per-game
+-- competition format.
+--
+-- 1. game_type_templates.category — the data-driven Type tier the creation page
+--    shows (Golf / Card / Yard / Bar / Other). Keeps the UI from hardcoding the
+--    type list (CLAUDE.md). Golf types carry an engine; the non-golf categories
+--    each offer a single "Generic <Type> Game" (no engine yet → results entered
+--    by hand; the manual-ness is implied, never a named "Manual" choice — §1).
+--
+-- 2. games.competition_format — the per-game "How's it played?" choice
+--    (head_to_head / bracket_se / bracket_de / best_of_n / live_results). It is a
+--    MANUAL label/how-it's-played descriptor that drives the leaderboard label;
+--    it never runs in-app (picking one never leaves you stuck on "coming soon").
+--    Nullable — unset until chosen on the Configuration tab.
+--
+-- Idempotent.
+
+-- ── 1. category ──────────────────────────────────────────────────────────────
+ALTER TABLE public.game_type_templates ADD COLUMN IF NOT EXISTS category text;
+
+COMMENT ON COLUMN public.game_type_templates.category IS
+  'Creation Type tier: golf | card | yard | bar | other. Golf types carry an '
+  'engine; non-golf categories offer a single generic (manual-scored) game.';
+
+UPDATE public.game_type_templates SET category = 'golf'
+ WHERE id IN ('gtt_stroke_play', 'gtt_match_play_singles', 'gtt_rack_n_stack');
+UPDATE public.game_type_templates SET category = 'other', name = 'Generic Game'
+ WHERE id = 'gtt_manual';
+
+-- Generic non-golf games — one per category, no engine, no scorecard.
+INSERT INTO public.game_type_templates (id, key, name, description, category, sort_order)
+VALUES
+  ('gtt_generic_card', 'generic_card', 'Generic Card Game',
+   'No built-in scoring engine — name it and enter the result by hand.', 'card', 90),
+  ('gtt_generic_yard', 'generic_yard', 'Generic Yard Game',
+   'No built-in scoring engine — name it and enter the result by hand.', 'yard', 91),
+  ('gtt_generic_bar',  'generic_bar',  'Generic Bar Game',
+   'No built-in scoring engine — name it and enter the result by hand.', 'bar',  92)
+ON CONFLICT (id) DO UPDATE
+  SET name = EXCLUDED.name, description = EXCLUDED.description,
+      category = EXCLUDED.category, sort_order = EXCLUDED.sort_order;
+
+-- ── 2. competition_format ────────────────────────────────────────────────────
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS competition_format text;
+
+DO $$ BEGIN
+  ALTER TABLE public.games ADD CONSTRAINT games_competition_format_check
+    CHECK (competition_format IS NULL OR competition_format IN
+      ('head_to_head', 'bracket_se', 'bracket_de', 'best_of_n', 'live_results'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+COMMENT ON COLUMN public.games.competition_format IS
+  'Per-game "How''s it played?" label (head_to_head | bracket_se | bracket_de | '
+  'best_of_n | live_results). A MANUAL descriptor that drives the leaderboard '
+  'label; it does not run in-app. NULL until chosen.';

--- a/supabase/migrations/20260613150000_051_seed_golf_special_rules.sql
+++ b/supabase/migrations/20260613150000_051_seed_golf_special_rules.sql
@@ -1,0 +1,19 @@
+-- 051 — Seed golf special rules into the game-type model (Slice D add-game).
+--
+-- The Configuration tab shows a SPECIAL RULES section for golf games, driven by
+-- the game type's model: `game_type_templates.compatible_modifiers` lists which
+-- optional rules apply to that format; the game stores the enabled ones (+ any
+-- per-rule config) in `games.modifiers`. Both columns already exist — this only
+-- seeds the available options (the per-rule configurability is intentionally
+-- deferred; for now each is a simple on/off).
+--
+-- Match/team formats can shift tees (trailing team picks the box); all golf can
+-- weight the closing holes. Idempotent.
+
+UPDATE public.game_type_templates
+   SET compatible_modifiers = ARRAY['moving_tees', 'glorious_holes']
+ WHERE id IN ('gtt_match_play_singles', 'gtt_rack_n_stack');
+
+UPDATE public.game_type_templates
+   SET compatible_modifiers = ARRAY['glorious_holes']
+ WHERE id = 'gtt_stroke_play';


### PR DESCRIPTION
Builds the two-tab Add Game page (Game · Configuration) + the game dashboard, on the revised CD mock. Staged logic-first per the spec — the three logic stages (which touch shipped, tested code) were done audit-first and verified **before** the UI.

## Stage 1 — Audit (findings drove the build)
- **Match-count derivation**: there was **no** shared function — only a singles-only UI `projectedCap` + a standalone `floor(players/2)`; the team-based cap was explicitly deferred to this slice. Stage 2 **creates** the shared primitive.
- **`competitionPlacement.ts` available-points**: counted only games with a distribution array → an unconfigured game contributed 0 → clinch jumped on configure. Stage 4 fixes this.
- **Points mutation**: no sum validation; gated by `requireGameEdit`. Stage 3 adds enforcement.
- **Type list**: data-driven (`game_type_templates`) but only 4 rows, no `category`. Stage 5 adds the tier. Also fixed a latent bug: `isMatchPlay` compared `result_strategy` to a *key* → PerMatchEditor never rendered.

## Stage 2 — Pure validation (`gameConfig.ts`, 22 tests)
`deriveMatchCount` (the one primitive feeding both UI readout and leaderboard), `validatePlacement` (nil-saveable / partial-blocked / complete, typed-0 counts as started), `matchReadout` (retires "projected"), `placementFit`/`matchFit` (warn only when defined-incompatible, calm-pending otherwise).

## Stage 3 — Server enforcement + delegation boundary (migration 049, 11 tests)
New owner-only `games.points_total` column (the placement total; NULL for match). `setPointsTotal` gated to Organizer; `setPointsDistribution` enforces sum-to-total via the shared `validatePlacement` (API rejects exactly what the UI blocks). Delegate distributes within the total but can't change it.

## Stage 4 — Stable clinch (`competitionPlacement.ts`, tests updated + added)
`LiveGame.pointsTotal?` drives available-points; placement → owner total (counts before distribution), per-match → `value × matchCount(teamSizes)` (known before pairings). Configuring/playing moves only *awarded* points, never the available pool. No warning state leaks into the lib.

## Stage 5 — Two-tab UI (migration 050)
- `game_type_templates.category` (data-driven Golf/Card/Yard/Bar/Other) + `games.competition_format`.
- Game tab: Type → format → title → course (golf) → owner-set point value. Generic non-golf games.
- Configuration tab: role-aware delegation; model-aware editor (placement sum-to-total / match readout); "How's it played?" format chooser (all MANUAL); soft fit-warnings here only. Single save.
- Dashboard rows: model-aware metadata. Fixed `isMatchPlay`.

## Verification
- **60 unit/integration tests green**; `tsc --noEmit` clean.
- Stage 5 UI **verified live against real production data** via the dev preview (two tabs, 5-way Type tier, placement editor with empty 1st place, "How's it played?" sheet, model-aware dashboard rows all confirmed).
- ⚠️ A route-mocked Playwright happy-path could **not** be added: the trip route is server-authed and the repo's existing route-mock E2E pattern redirects to login (`trip-detail.spec.ts` fails the same way today). This is a pre-existing infra gap — flagged separately.

## Migrations
049 (`points_total`) and 050 (`category` + `competition_format`) applied to remote via idempotent SQL; CI re-applies cleanly under the file timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)