### PR TITLE
feat(d): Run / Post Results + manual-placement entry

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -149,6 +149,8 @@ who's in, what they're called, what role they hold — is the Owner's.
 | Remove a team assignment | ✓ | — | — | `teamAssignments.remove` *(Owner)* |
 | **Edit / configure a game** (status incl. drop, points distribution, course, participants) | ✓ | ✓ | **game organizer of *that* game** | `games.update` / `setStatus` / `setPointsDistribution` / `applyCourse` / `addParticipants` |
 | **Enter a game's results** (manual placement; finish/compute) | ✓ | ✓ | **game organizer of *that* game** | `games.setManualResults` / `finish` |
+| **RUN: post results / open score correction** | ✓ | **—** | **game organizer of *that* game** | `games.post` / `openCorrection` *(Owner or game-delegate only — **not** a plain Organizer)* |
+| Enter a per-hole score (until posted) | ✓ | ✓ | ✓ | `scores.upsertEntry` / `deleteEntry` *(any member; **blocked** once the game is posted & not in correction)* |
 | Delegate / revoke a game organizer | ✓ | ✓ | — | `games.addOrganizer` / `removeOrganizer` *(trip staff only — a delegate can't sub-delegate)* |
 | View who runs a game | ✓ | ✓ | ✓ | `games.listOrganizers` |
 
@@ -159,6 +161,18 @@ who's in, what they're called, what role they hold — is the Owner's.
 > layers — the `requireGameEdit` tRPC middleware and the `is_game_organizer(game)`
 > RLS path on `games` (UPDATE) + `game_results` (migration 045). Granting is a
 > trip-staff act (`requireTripRole('Organizer')`).
+
+> **Competition RUN-actions are owner/game-delegate scoped — narrower than game
+> edit (Slice D Run/Post §5).** Posting results and opening score correction
+> (`games.post` / `games.openCorrection`) gate on **`isOwner || isGameOrganizer(gameId)`**
+> — the trip **Owner** or *that game's* delegate. A plain **Organizer (the trip
+> planner) is NOT a run-action** unless they're also the game's delegate: running
+> the competition is owner/delegate-scoped, distinct from trip-planner scope.
+> Enforced server-side by `requireGameRunAction`. "Post" publishes the current
+> standing and is **re-runnable** (Open → Posted ⇄ Correcting) — never a permanent
+> finalize. A posted game's scores are frozen (`scores.upsertEntry`/`deleteEntry`
+> return FORBIDDEN) until the owner/delegate opens correction; results stay
+> visible to everyone throughout.
 
 > **Scoring is Organizer+ today** (`setPlacements`). There is no member-facing
 > "enter your own score" path yet — the intent (see Resolved notes) is for any

--- a/src/app/trips/[tripId]/tabs/CompTab.tsx
+++ b/src/app/trips/[tripId]/tabs/CompTab.tsx
@@ -164,6 +164,7 @@ function ExistingCompetitionView({
         competitionId={competition.id}
         tripId={tripId}
         canEdit={canEdit}
+        isOwner={isOwner}
       />
     </div>
   );

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Flag, Plus, Minus, Pencil, Star, Trash2, X, Trophy, RotateCcw,
-  Spade, Target, Beer, Dices, Swords, Radio, ChevronRight, Check, Users, Info, SlidersHorizontal,
+  Spade, Target, Beer, Dices, Swords, Radio, ChevronRight, ChevronUp, ChevronDown, Check, Users, Info, SlidersHorizontal,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
@@ -31,7 +31,21 @@ interface Props {
   competitionId: string;
   tripId: string;
   canEdit: boolean;
+  /** Trip Owner — gates the RUN actions (post / correct) in this view. The
+   *  server also admits a game-delegate, but their entry point is the per-game
+   *  tap-through, not this owner/organizer panel. */
+  isOwner?: boolean;
 }
+
+type RunState = "upcoming" | "open" | "posted" | "correcting";
+
+function runState(g: GameRow): RunState {
+  if (g.status === "complete") return g.corrections_open ? "correcting" : "posted";
+  if (g.status === "active") return "open";
+  return "upcoming";
+}
+
+interface LBTeamLite { id: string; name: string; short_name: string; color: string }
 
 /** Drag payload key for a game id — read by the agenda drop targets. */
 export const DND_GAME_KEY = "application/x-buddytrip-game-id";
@@ -50,6 +64,7 @@ export interface GameRow {
   scorecard_schema: unknown | null;
   course_id: string | null;
   schedule_item_id: string | null;
+  corrections_open: boolean;
 }
 
 interface GameType {
@@ -104,12 +119,14 @@ function matchFormatFor(gameTypeId: string | null): MatchFormat {
 
 // ── Panel ─────────────────────────────────────────────────────────────────────
 
-export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props) {
+export function CompetitionGamesPanel({ competitionId, tripId, canEdit, isOwner = false }: Props) {
   const [editing, setEditing] = useState<GameRow | null>(null);
   const [creating, setCreating] = useState(false);
+  const [running, setRunning] = useState<GameRow | null>(null); // game being posted/corrected
 
   const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { enabled: !!tripId });
   const { data: types = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: !!tripId });
+  const { data: lb } = trpc.competitions.leaderboard.useQuery({ tripId, competitionId }, { enabled: !!competitionId });
 
   const games = useMemo(
     () => (allGames as GameRow[]).filter((g) => g.competition_id === competitionId),
@@ -119,9 +136,20 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
   const typeName = (id: string | null) => typesTyped.find((t) => t.id === id)?.name ?? "Game";
 
   const live = games.filter((g) => g.status !== "dropped");
-  const statusText = `${live.length} game${live.length === 1 ? "" : "s"}${
-    games.length - live.length > 0 ? ` · ${games.length - live.length} abandoned` : ""
-  }`;
+  const postedCount = live.filter((g) => g.status === "complete").length;
+  const teams = (lb?.teams ?? []) as LBTeamLite[];
+  const pointsAvailable = lb?.pointsAvailable ?? 0;
+  const onBoard = Object.values((lb?.teamTotals ?? {}) as Record<string, number>).reduce((a, b) => a + b, 0);
+
+  // Seed the placement order for the run sheet: the posted finishing order (from
+  // the leaderboard cells) when correcting, else the roster order.
+  const runningOrder = useMemo(() => {
+    if (!running) return [];
+    const cells = ((lb?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
+      .filter((c) => c.gameId === running.id)
+      .sort((a, b) => a.place - b.place);
+    return cells.length ? cells.map((c) => c.teamId) : teams.map((t) => t.id);
+  }, [running, lb, teams]);
 
   return (
     <div
@@ -136,7 +164,9 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
           </span>
           <div>
             <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>Games</p>
-            <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>{statusText}</p>
+            <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              {postedCount} of {live.length} posted · {fmtValue(onBoard)} of {fmtValue(pointsAvailable)} pts on the board
+            </p>
           </div>
         </div>
         {canEdit && (
@@ -172,10 +202,18 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
               game={g}
               typeName={typeName(g.game_type_id)}
               canEdit={canEdit}
+              isOwner={isOwner}
               onEdit={() => setEditing(g)}
+              onRun={() => setRunning(g)}
             />
           ))}
         </div>
+
+        {live.length > 0 && postedCount < live.length && (
+          <p className="mt-3 text-center text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            When every game is posted, the cup has its winner.
+          </p>
+        )}
 
         {(creating || editing) && (
           <GameSheet
@@ -190,6 +228,18 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
             }}
           />
         )}
+
+        {running && (
+          <RunSheet
+            tripId={tripId}
+            competitionId={competitionId}
+            game={running}
+            teams={teams}
+            initialOrder={runningOrder}
+            isEngine={!!typesTyped.find((t) => t.id === running.game_type_id)?.isEngine}
+            onClose={() => setRunning(null)}
+          />
+        )}
       </div>
     </div>
   );
@@ -198,11 +248,12 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit }: Props)
 // ── Game card (model-aware metadata) ──────────────────────────────────────────
 
 function GameCard({
-  game, typeName, canEdit, onEdit,
+  game, typeName, canEdit, isOwner, onEdit, onRun,
 }: {
-  game: GameRow; typeName: string; canEdit: boolean; onEdit: () => void;
+  game: GameRow; typeName: string; canEdit: boolean; isOwner: boolean; onEdit: () => void; onRun: () => void;
 }) {
   const dropped = game.status === "dropped";
+  const state = runState(game);
   const dist = game.points_distribution;
 
   let pointsLine: string | null = null;
@@ -217,53 +268,98 @@ function GameCard({
   const fmtLabel = formatLabel(game.competition_format);
 
   return (
-    <button
-      type="button"
-      onClick={canEdit ? onEdit : undefined}
-      disabled={!canEdit}
-      className="flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left disabled:cursor-default"
-      style={{
-        background: "var(--color-bt-card-raised)",
-        border: "1px solid var(--color-bt-border)",
-        opacity: dropped ? 0.55 : 1,
-      }}
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", opacity: dropped ? 0.55 : 1 }}
       data-testid={`game-card-${game.id}`}
     >
-      <div
-        className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
-        style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }}
+      <button
+        type="button"
+        onClick={canEdit ? onEdit : undefined}
+        disabled={!canEdit}
+        className="flex w-full items-start gap-3 px-3 py-3 text-left disabled:cursor-default"
       >
-        {game.scorecard_schema ? <Flag size={15} /> : <Star size={15} />}
-      </div>
+        <div
+          className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
+          style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }}
+        >
+          {game.scorecard_schema ? <Flag size={15} /> : <Star size={15} />}
+        </div>
 
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-x-2">
-          <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            {game.name || "Untitled game"}
-          </p>
-          <span
-            className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase"
-            style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
-          >
-            {typeName}
-          </span>
-          {dropped && (
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {game.name || "Untitled game"}
+            </p>
             <span
               className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase"
-              style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}
+              style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
             >
-              Abandoned
+              {typeName}
             </span>
-          )}
+            {dropped ? (
+              <span className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase" style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}>
+                Abandoned
+              </span>
+            ) : (
+              <RunStateBadge state={state} />
+            )}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {fmtLabel && <span>{fmtLabel}</span>}
+            {fmtLabel && pointsLine && <span aria-hidden>·</span>}
+            {pointsLine && <span className="tabular-nums">{pointsLine}</span>}
+          </div>
         </div>
-        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-[10px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          {fmtLabel && <span>{fmtLabel}</span>}
-          {fmtLabel && pointsLine && <span aria-hidden>·</span>}
-          {pointsLine && <span className="tabular-nums">{pointsLine}</span>}
-        </div>
-      </div>
 
-      {canEdit && <Pencil size={13} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />}
+        {canEdit && <Pencil size={13} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />}
+      </button>
+
+      {isOwner && !dropped && (
+        <div className="flex items-center justify-between px-3 py-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {state === "posted" ? "Points are on the board" : state === "correcting" ? "Correcting — re-post to update" : "Not posted yet"}
+          </span>
+          <RunButton state={state} onClick={onRun} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RunStateBadge({ state }: { state: RunState }) {
+  const map: Record<RunState, { label: string; bg: string; fg: string }> = {
+    upcoming: { label: "Upcoming", bg: "var(--color-bt-card)", fg: "var(--color-bt-text-dim)" },
+    open: { label: "Open", bg: "var(--color-bt-accent-faint)", fg: "var(--color-bt-accent)" },
+    posted: { label: "Posted", bg: "var(--color-bt-accent-faint)", fg: "var(--color-bt-accent)" },
+    correcting: { label: "Correcting", bg: "var(--color-bt-warning-faint)", fg: "var(--color-bt-warning)" },
+  };
+  const m = map[state];
+  return (
+    <span className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase" style={{ background: m.bg, color: m.fg }}>
+      {m.label}
+    </span>
+  );
+}
+
+function RunButton({ state, onClick }: { state: RunState; onClick: () => void }) {
+  if (state === "posted") {
+    return (
+      <button type="button" onClick={onClick} className="rounded-lg px-3 py-1.5 text-xs font-semibold" style={{ background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}>
+        Correct
+      </button>
+    );
+  }
+  if (state === "correcting") {
+    return (
+      <button type="button" onClick={onClick} className="rounded-lg px-3 py-1.5 text-xs font-semibold" style={{ background: "var(--color-bt-warning)", color: "var(--color-bt-base)" }}>
+        Re-post
+      </button>
+    );
+  }
+  return (
+    <button type="button" onClick={onClick} data-testid={`post-${state}`} className="rounded-lg px-3 py-1.5 text-xs font-semibold" style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}>
+      Post
     </button>
   );
 }
@@ -1099,6 +1195,229 @@ function FormatSheet({
           </p>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ── Run sheet: post / score-correction (manual placement + engine post) ───────
+
+interface SchemaUnits { units?: { count?: number } }
+
+function RunSheet({
+  tripId, competitionId, game, teams, initialOrder, isEngine, onClose,
+}: {
+  tripId: string; competitionId: string; game: GameRow; teams: LBTeamLite[];
+  initialOrder: string[]; isEngine: boolean; onClose: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const state = runState(game);
+  const correcting = state === "posted" || state === "correcting";
+  const dist = game.points_distribution?.type === "placement" ? game.points_distribution.values : [];
+
+  const [order, setOrder] = useState<string[]>(initialOrder.length ? initialOrder : teams.map((t) => t.id));
+  const [confirmIncomplete, setConfirmIncomplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Engine incomplete-post guard (§4): name the gap, never block.
+  const { data: detail } = trpc.games.getById.useQuery({ tripId, gameId: game.id }, { enabled: isEngine });
+  const { data: scoreRows } = trpc.scores.listByGame.useQuery({ tripId, gameId: game.id }, { enabled: isEngine });
+  const participants = ((detail as { participants?: unknown[] } | undefined)?.participants ?? []) as unknown[];
+  const unitCount = ((game.scorecard_schema as SchemaUnits | null)?.units?.count) ?? 18;
+  const expected = participants.length * unitCount;
+  const entered = (scoreRows ?? []).filter((r) => (r as { value: number | null }).value != null).length;
+  const missing = Math.max(0, expected - entered);
+  const incomplete = isEngine && expected > 0 && missing > 0;
+
+  const post = trpc.games.post.useMutation();
+  const openCorrection = trpc.games.openCorrection.useMutation();
+  const busy = post.isPending || openCorrection.isPending;
+
+  function teamById(id: string) { return teams.find((t) => t.id === id); }
+  function move(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= order.length) return;
+    const next = [...order];
+    [next[i], next[j]] = [next[j], next[i]];
+    setOrder(next);
+  }
+
+  async function commit() {
+    setError(null);
+    if (isEngine && incomplete && !confirmIncomplete) { setConfirmIncomplete(true); return; }
+    try {
+      if (isEngine) {
+        await post.mutateAsync({ tripId, gameId: game.id });
+      } else {
+        await post.mutateAsync({ tripId, gameId: game.id, placements: order.map((id, i) => ({ entityId: id, position: i + 1 })) });
+      }
+      utils.games.listByTrip.invalidate({ tripId });
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to post");
+    }
+  }
+
+  async function unlockForCorrection() {
+    setError(null);
+    try {
+      await openCorrection.mutateAsync({ tripId, gameId: game.id });
+      utils.games.listByTrip.invalidate({ tripId });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to open correction");
+    }
+  }
+
+  const postLabel = correcting ? "Re-post" : "Post";
+  const postBg = correcting ? "var(--color-bt-warning)" : "var(--color-bt-accent)";
+
+  return (
+    <ScrollLock>
+      <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center" style={{ background: "var(--color-bt-overlay)" }} onClick={onClose}>
+        <div
+          className="flex max-h-[90vh] w-full max-w-md flex-col rounded-t-2xl sm:rounded-2xl"
+          style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
+            <div>
+              <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>{correcting ? "Score correction" : "Post results"}</h3>
+              <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>{game.name || "Game"}</p>
+            </div>
+            <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="flex-1 space-y-3 overflow-y-auto p-4">
+            {correcting && (
+              <div className="flex items-start gap-2 rounded-lg px-3 py-2.5" style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning)" }}>
+                <Info size={14} style={{ color: "var(--color-bt-warning)", flexShrink: 0, marginTop: 1 }} />
+                <span className="text-[11px] leading-relaxed" style={{ color: "var(--color-bt-warning)" }}>
+                  Correcting a posted round — re-posting recomputes the whole leaderboard.
+                </span>
+              </div>
+            )}
+
+            {isEngine ? (
+              <EngineReview
+                incomplete={incomplete}
+                missing={missing}
+                correcting={correcting}
+                onUnlock={unlockForCorrection}
+                unlocking={openCorrection.isPending}
+                scoresOpen={game.corrections_open}
+              />
+            ) : (
+              <ManualPlacementEditor order={order} teams={teams} dist={dist} teamById={teamById} move={move} />
+            )}
+
+            {error && <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>{error}</p>}
+          </div>
+
+          <div className="border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>
+            {confirmIncomplete ? (
+              <div className="space-y-2.5">
+                <p className="text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text)" }}>
+                  {missing} score{missing === 1 ? "" : "s"} are still blank. Rained out? Post the current standing now and correct it later — totally fine. Otherwise keep entering.
+                </p>
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => setConfirmIncomplete(false)} className="flex-1 rounded-xl py-2.5 text-sm font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}>
+                    Keep entering
+                  </button>
+                  <button type="button" onClick={commit} disabled={busy} className="flex-1 rounded-xl py-2.5 text-sm font-semibold disabled:opacity-50" style={{ background: postBg, color: "var(--color-bt-base)" }}>
+                    Post anyway
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={commit}
+                disabled={busy}
+                data-testid="run-post"
+                className="w-full rounded-xl py-3 text-sm font-bold disabled:opacity-50"
+                style={{ background: postBg, color: "var(--color-bt-base)" }}
+              >
+                {postLabel}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </ScrollLock>
+  );
+}
+
+/** Manual placement entry — order the teams 1st→last; PAYS shows the configured
+ *  distribution (the poster sets ORDER, never points). */
+function ManualPlacementEditor({
+  order, teams, dist, teamById, move,
+}: {
+  order: string[]; teams: LBTeamLite[]; dist: number[];
+  teamById: (id: string) => LBTeamLite | undefined; move: (i: number, dir: -1 | 1) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Finishing order</span>
+        <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Pays</span>
+      </div>
+      <div className="space-y-1.5">
+        {order.map((teamId, i) => {
+          const team = teamById(teamId);
+          const pays = dist[i] ?? 0;
+          return (
+            <div key={teamId} className="flex items-center gap-2 rounded-lg px-2.5 py-2" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}>
+              <span className="w-5 text-center text-sm font-bold tabular-nums" style={{ color: "var(--color-bt-text-dim)" }}>{i + 1}</span>
+              <span className="h-3 w-3 flex-shrink-0 rounded-full" style={{ background: team?.color ?? "var(--color-bt-text-dim)" }} />
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>{team?.name ?? "Team"}</span>
+              <span className="text-sm font-bold tabular-nums" style={{ color: pays > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>{fmtValue(pays)}</span>
+              <div className="ml-1 flex flex-col">
+                <button type="button" onClick={() => move(i, -1)} disabled={i === 0} aria-label="Move up" className="flex h-4 w-6 items-center justify-center rounded disabled:opacity-30" style={{ color: "var(--color-bt-text-dim)" }}>
+                  <ChevronUp size={13} />
+                </button>
+                <button type="button" onClick={() => move(i, 1)} disabled={i === order.length - 1} aria-label="Move down" className="flex h-4 w-6 items-center justify-center rounded disabled:opacity-30" style={{ color: "var(--color-bt-text-dim)" }}>
+                  <ChevronDown size={13} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        Order the teams by finish — points come from the game&rsquo;s configured distribution, so you set the order, not the points.
+      </p>
+    </div>
+  );
+}
+
+function EngineReview({
+  incomplete, missing, correcting, onUnlock, unlocking, scoresOpen,
+}: {
+  incomplete: boolean; missing: number; correcting: boolean; onUnlock: () => void; unlocking: boolean; scoresOpen: boolean;
+}) {
+  return (
+    <div className="space-y-2.5">
+      <p className="text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text)" }}>
+        {correcting
+          ? "This round is posted. Open score correction to edit the scorecard, then re-post to recompute the leaderboard."
+          : "Posting commits the computed result and publishes the current standing to the leaderboard."}
+      </p>
+      {correcting && !scoresOpen && (
+        <button type="button" onClick={onUnlock} disabled={unlocking} className="w-full rounded-lg py-2.5 text-sm font-semibold disabled:opacity-50" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}>
+          {unlocking ? "Opening…" : "Open score correction"}
+        </button>
+      )}
+      {correcting && scoresOpen && (
+        <p className="text-[11px]" style={{ color: "var(--color-bt-accent)" }}>Scores are open — edit on the scorecard, then re-post here.</p>
+      )}
+      {incomplete && (
+        <div className="flex items-start gap-2 rounded-lg px-3 py-2" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}>
+          <Info size={13} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0, marginTop: 1 }} />
+          <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>{missing} score{missing === 1 ? "" : "s"} still blank — you can post anyway.</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -139,6 +139,58 @@ export function requireGameEdit() {
 }
 
 // ---------------------------------------------------------------------------
+// requireGameRunAction (Slice D Run/Post §5)
+//
+// Competition RUN-actions (post results / open score correction) are NARROWER
+// than game edit: trip OWNER or THIS game's delegate only — NOT a plain
+// Organizer (the "trip planner"). Run-actions are owner/delegate-scoped, distinct
+// from trip-planner scope (PERMISSIONS.md). Enforced server-side so the controls
+// can't be reached by hiding the UI.
+// ---------------------------------------------------------------------------
+
+export function requireGameRunAction() {
+  return middleware(async ({ ctx, getRawInput, next }) => {
+    const raw = await getRawInput();
+    const parsed = z.object({ tripId: z.string(), gameId: z.string() }).safeParse(raw);
+    if (!parsed.success) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "tripId and gameId are required" });
+    }
+    const { tripId, gameId } = parsed.data;
+
+    const role = await resolveTripRole(ctx, tripId); // throws if not a trip member
+    let allowed = role === "Owner"; // Owner only — Organizers/planners excluded
+
+    if (!allowed) {
+      const { data } = await (
+        ctx.supabase.from("game_organizers") as unknown as {
+          select: (s: string) => {
+            eq: (c: string, v: string) => {
+              eq: (c: string, v: string) => {
+                maybeSingle: () => Promise<{ data: { game_id: string } | null }>;
+              };
+            };
+          };
+        }
+      )
+        .select("game_id")
+        .eq("game_id", gameId)
+        .eq("user_id", ctx.user!.id)
+        .maybeSingle();
+      allowed = !!data;
+    }
+
+    if (!allowed) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Posting and score corrections are limited to the trip owner or this game's delegate.",
+      });
+    }
+
+    return next({ ctx: { ...ctx, tripId, tripRole: role } });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // resolveTripRole — internal shared lookup with request-scoped cache.
 //
 // Every batched procedure that uses requireTripMember / requireTripRole

--- a/src/server/routers/games.runpost.test.ts
+++ b/src/server/routers/games.runpost.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Slice D Run/Post — post the current standing, score-lock, correction → re-post,
+ * and the owner/game-delegate permission boundary.
+ *
+ * Runs the whole cycle on a MANUAL game so the post/lock/correct logic is tested
+ * without engine-compute fixtures: posting a manual game writes the entered order
+ * and points come from the CONFIGURED distribution (poster sets order, not points).
+ */
+
+const MANUAL = "gtt_manual";
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let memberId: string;
+const gameIds: string[] = [];
+
+async function newManualGame(name = "Cornhole") {
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId: MANUAL,
+    name,
+    competitionId,
+    pointsDistribution: { type: "placement", values: [5, 3] },
+    pointsTotal: 8,
+  })) as { id: string };
+  gameIds.push(g.id);
+  return g.id;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Run/Post Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // a trip planner (NOT a run-action)
+  await ctx.addTripMember(tripId, "member", "Member"); // delegate candidate
+  memberId = ctx.getUser("member").id;
+  competitionId = await ctx.createCompetition(tripId, "Run Cup");
+  teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
+  teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
+});
+
+afterAll(async () => {
+  if (gameIds.length) {
+    await ctx.admin.from("score_entries").delete().in("game_id", gameIds);
+    await ctx.admin.from("game_results").delete().in("game_id", gameIds);
+    await ctx.admin.from("game_organizers").delete().in("game_id", gameIds);
+    await ctx.admin.from("games").delete().in("id", gameIds);
+  }
+  await ctx.cleanup();
+}, 30000);
+
+describe("post — commit current standing, points from configured distribution", () => {
+  it("manual post writes the entered ORDER; points come from the distribution", async () => {
+    const g = await newManualGame();
+    await ctx.caller().games.post({
+      tripId, gameId: g,
+      placements: [{ entityId: teamA, position: 1 }, { entityId: teamB, position: 2 }],
+    });
+
+    const game = (await ctx.caller().games.getById({ tripId, gameId: g })) as { status: string; corrections_open: boolean };
+    expect(game.status).toBe("complete"); // posted/locked
+    expect(game.corrections_open).toBe(false);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+    // Poster set positions 1,2 — points come from the configured [5,3].
+    expect(lb.teamTotals[teamA]).toBe(5);
+    expect(lb.teamTotals[teamB]).toBe(3);
+    expect(lb.pointsAvailable).toBe(8);
+  });
+
+  it("re-post is idempotent (re-commits current state)", async () => {
+    const g = await newManualGame("Re-post game");
+    const place = [{ entityId: teamA, position: 1 }, { entityId: teamB, position: 2 }];
+    await ctx.caller().games.post({ tripId, gameId: g, placements: place });
+    await ctx.caller().games.post({ tripId, gameId: g, placements: place });
+    const game = (await ctx.caller().games.getById({ tripId, gameId: g })) as { status: string };
+    expect(game.status).toBe("complete");
+  });
+});
+
+describe("score lock — posted scores frozen until correction", () => {
+  it("post → entry FORBIDDEN; openCorrection → entry allowed; re-post → FORBIDDEN", async () => {
+    const g = await newManualGame("Lock cycle");
+    const place = [{ entityId: teamA, position: 1 }, { entityId: teamB, position: 2 }];
+    const entry = { tripId, gameId: g, participantId: ctx.getUser("owner").id, unitLabel: "1", value: 4 };
+
+    await ctx.caller().games.post({ tripId, gameId: g, placements: place });
+    // Locked: score entry rejected while posted & not correcting.
+    await expect(ctx.caller().scores.upsertEntry(entry)).rejects.toThrow(/posted/i);
+
+    // Enter correction → entry re-opened.
+    await ctx.caller().games.openCorrection({ tripId, gameId: g });
+    const correcting = (await ctx.caller().games.getById({ tripId, gameId: g })) as { corrections_open: boolean };
+    expect(correcting.corrections_open).toBe(true);
+    await expect(ctx.caller().scores.upsertEntry(entry)).resolves.toBeTruthy();
+
+    // Re-post → re-locked.
+    await ctx.caller().games.post({ tripId, gameId: g, placements: place });
+    await expect(ctx.caller().scores.upsertEntry(entry)).rejects.toThrow(/posted/i);
+  });
+
+  it("openCorrection only applies to a POSTED game", async () => {
+    const g = await newManualGame("Not posted");
+    await expect(ctx.caller().games.openCorrection({ tripId, gameId: g })).rejects.toThrow(/posted/i);
+  });
+});
+
+describe("permissions — run-actions are owner / game-delegate only", () => {
+  it("owner can post", async () => {
+    const g = await newManualGame("Owner posts");
+    await expect(
+      ctx.caller().games.post({ tripId, gameId: g, placements: [{ entityId: teamA, position: 1 }] })
+    ).resolves.toBeTruthy();
+  });
+
+  it("a game-delegate can post; a plain Organizer (planner) and a Member cannot", async () => {
+    const g = await newManualGame("Delegate posts");
+    const place = [{ entityId: teamA, position: 1 }, { entityId: teamB, position: 2 }];
+
+    // Planner (trip Organizer, not this game's delegate) — blocked.
+    await expect(ctx.callerAs("planner").games.post({ tripId, gameId: g, placements: place }))
+      .rejects.toThrow(/owner or this game's delegate/i);
+    // Plain Member — blocked.
+    await expect(ctx.callerAs("member").games.post({ tripId, gameId: g, placements: place }))
+      .rejects.toThrow(/owner or this game's delegate/i);
+
+    // Grant the Member the game-delegate role → now allowed.
+    await ctx.caller().games.addOrganizer({ tripId, gameId: g, userId: memberId });
+    await expect(ctx.callerAs("member").games.post({ tripId, gameId: g, placements: place }))
+      .resolves.toBeTruthy();
+  });
+
+  it("an outsider (non-member) cannot post or correct", async () => {
+    const g = await newManualGame("Outsider blocked");
+    await ctx.caller().games.post({ tripId, gameId: g, placements: [{ entityId: teamA, position: 1 }] });
+    await expect(ctx.callerAs("outsider").games.post({ tripId, gameId: g, placements: [{ entityId: teamA, position: 1 }] })).rejects.toThrow();
+    await expect(ctx.callerAs("outsider").games.openCorrection({ tripId, gameId: g })).rejects.toThrow();
+  });
+
+  it("a planner cannot open correction either", async () => {
+    const g = await newManualGame("Planner correct blocked");
+    await ctx.caller().games.post({ tripId, gameId: g, placements: [{ entityId: teamA, position: 1 }] });
+    await expect(ctx.callerAs("planner").games.openCorrection({ tripId, gameId: g }))
+      .rejects.toThrow(/owner or this game's delegate/i);
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole, requireGameEdit } from "../middleware";
+import { requireTripMember, requireTripRole, requireGameEdit, requireGameRunAction } from "../middleware";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
@@ -17,6 +18,34 @@ import { validatePlacement } from "@/lib/gameConfig";
  * standard trip middleware can gate them — we then verify the game belongs to
  * that trip (defends against a gameId from another trip).
  */
+/**
+ * Shared manual-result write (Slice D §5a / Run-Post §2): replace a game's
+ * per-team finishing order in `game_results`. The ONE write path for entered
+ * placements — both `setManualResults` and the run `post` action use it, so
+ * there's no parallel commit. Placement POINTS stay derived (placementPoints);
+ * we store only the standing (position; raw_score mirrors it for low_wins).
+ */
+async function writeManualResults(
+  supabase: SupabaseClient,
+  gameId: string,
+  placements: { entityId: string; position: number }[]
+): Promise<number> {
+  const { error: delErr } = await supabase.from("game_results").delete().eq("game_id", gameId);
+  if (delErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to clear results: ${delErr.message}` });
+  if (placements.length === 0) return 0;
+  const rows = placements.map((p) => ({
+    id: crypto.randomUUID(),
+    game_id: gameId,
+    entity_id: p.entityId,
+    entity_type: "team",
+    position: p.position,
+    raw_score: p.position,
+  }));
+  const { error: insErr } = await supabase.from("game_results").insert(rows);
+  if (insErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to save results: ${insErr.message}` });
+  return rows.length;
+}
+
 export const gamesRouter = router({
   // create — Owner/Organizer. The Phase-1 shell (D1 §3): competition_id +
   // game_type + name + points_distribution + status is a FULLY VALID game; every
@@ -486,22 +515,99 @@ export const gamesRouter = router({
         .maybeSingle();
       if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
 
-      const { error: delErr } = await ctx.supabase.from("game_results").delete().eq("game_id", input.gameId);
-      if (delErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to clear results: ${delErr.message}` });
+      const count = await writeManualResults(ctx.supabase, input.gameId, input.placements);
+      return { success: true, count };
+    }),
 
-      if (input.placements.length === 0) return { success: true, count: 0 };
+  // post — RUN action (owner / game-delegate only). Publishes the game's current
+  // standing to the leaderboard. NOT "finalize": re-runnable. One action, two
+  // sources (Run-Post §2):
+  //   - manual game: the poster passes the entered finishing ORDER (placements);
+  //     POINTS come from the already-configured points_distribution at read time
+  //     (the poster never sets points). Committed via the shared writeManualResults.
+  //   - engine game: the result is COMPUTED from entered scores (same branch as
+  //     `finish`), writing game_results.
+  // Then locks: status='complete', corrections_open=false. The leaderboard
+  // recomputes on the next read (competitionPlacement.ts — the single reader);
+  // we do NOT recompute locally. Idempotent — re-post just re-commits. Never
+  // blocks an incomplete post (the rainout confirm is a UI guard, §4).
+  post: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        placements: z
+          .array(z.object({ entityId: z.string().min(1), position: z.number().int().min(1).max(99) }))
+          .max(64)
+          .optional(),
+      })
+    )
+    .use(requireGameRunAction())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, game_type_id")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
 
-      const rows = input.placements.map((p) => ({
-        id: crypto.randomUUID(),
-        game_id: input.gameId,
-        entity_id: p.entityId,
-        entity_type: "team",
-        position: p.position,
-        raw_score: p.position, // standing = finishing place (low_wins); points derived
-      }));
-      const { error: insErr } = await ctx.supabase.from("game_results").insert(rows);
-      if (insErr) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to save results: ${insErr.message}` });
-      return { success: true, count: rows.length };
+      const { data: template } = await ctx.supabase
+        .from("game_type_templates")
+        .select("result_strategy")
+        .eq("id", game.game_type_id as string)
+        .maybeSingle();
+      const strategy = (template?.result_strategy as string | null) ?? null;
+
+      if (strategy === null) {
+        // Manual: commit the entered finishing order (shared write path).
+        if (!input.placements) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "A manual game posts a finishing order." });
+        }
+        await writeManualResults(ctx.supabase, input.gameId, input.placements);
+      } else if (strategy === "match_play") {
+        await computeMatchPlayResults(ctx.supabase, input.gameId);
+      } else if (strategy === "rack_n_stack") {
+        await computeRackNStackResults(ctx.supabase, input.gameId);
+      } else {
+        await computeStrokePlayResults(ctx.supabase, input.gameId);
+      }
+
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ status: "complete", corrections_open: false })
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to post game: ${error.message}` });
+      return { success: true };
+    }),
+
+  // openCorrection — RUN action (owner / game-delegate only). Enters score-
+  // correction on a POSTED game: re-opens score entry (the scores router gates on
+  // status='complete' && !corrections_open) WITHOUT un-posting — the result stays
+  // visible on the board until Re-post (`post` again). A deliberate enter→re-post
+  // cycle, never a silent edit (§3).
+  openCorrection: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireGameRunAction())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("status")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      if (game.status !== "complete") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only a posted game can enter score correction." });
+      }
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ corrections_open: true })
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to open correction: ${error.message}` });
+      return { success: true };
     }),
 
   // addOrganizer — trip Owner/Organizer only (delegating is a trip-staff act; a

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -26,15 +26,25 @@ export const scoresRouter = router({
     )
     .use(requireTripMember)
     .mutation(async ({ ctx, input }) => {
-      // Confirm the game belongs to this trip (the middleware gated the trip).
+      // Confirm the game belongs to this trip (the middleware gated the trip),
+      // and that scores aren't locked. A POSTED game (status='complete' &&
+      // !corrections_open) has frozen scores — editing requires the owner/
+      // delegate to open score correction first (Run-Post §3). Results stay
+      // visible; only entry is closed.
       const { data: game } = await ctx.supabase
         .from("games")
-        .select("id")
+        .select("id, status, corrections_open")
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId)
         .maybeSingle();
       if (!game) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+      if (game.status === "complete" && !game.corrections_open) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "This round is posted — open score correction to edit it.",
+        });
       }
 
       // Deterministic id from the unique key so an upsert-on-conflict updates

--- a/supabase/migrations/20260613160000_052_games_corrections_open.sql
+++ b/supabase/migrations/20260613160000_052_games_corrections_open.sql
@@ -1,0 +1,23 @@
+-- 052 — games.corrections_open (Slice D Run/Post: the posted→correcting sub-state)
+--
+-- The run state model is Open → Posted/Locked ⇄ Correcting. It maps onto the
+-- existing `status` plus this one boolean — NOT a new status (audit Stage 2):
+--
+--   OPEN        status pending|active                    (never posted)
+--   POSTED      status complete, corrections_open=false  (scores frozen, on board)
+--   CORRECTING  status complete, corrections_open=true   (result still on the
+--                                                          board; score entry
+--                                                          re-opened for edits)
+--
+-- "Posting" publishes the current standing (re-runnable) — it is NOT a permanent
+-- finalize. Re-post just re-commits and clears corrections_open. Score entry is
+-- gated when status='complete' AND NOT corrections_open (server-enforced in the
+-- scores router); a posted game stays fully VISIBLE — only editing is closed.
+-- Idempotent.
+
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS corrections_open boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.games.corrections_open IS
+  'Run state sub-flag: with status=complete, true means the posted game is in '
+  'score-correction mode (entry re-opened). Cleared on (re-)post. A posted game '
+  'is complete + corrections_open=false.';


### PR DESCRIPTION
Builds the RUN movement of the competition — how a game's results get posted to the leaderboard, the posted→correction→re-post loop, and the owner/delegate run-management view. **Closes the deferred manual-placement entry** (non-engine games). Staged audit-first; logic before UI.

## Stage 1 — Audit
- **Recompute is read-time**: `competitions.leaderboard` → `computeCompetitionLeaderboard` → `competitionPlacement.ts` is the single reader. Posting commits results + invalidates the query → recompute. **No change to `competitionPlacement.ts`** (lower risk).
- **Status**: `complete` = posted; the correcting sub-state maps to a new boolean `corrections_open` (not a new status).
- `setManualResults` exists/tested; `points_distribution`/`points_total` readable at post.
- **Gap closed**: `scores.upsertEntry/deleteEntry` had no status gate — the lock adds one.

## Stages 2–3 — Post / correction state model (migration 052)
- `games.post` (one action, two sources): manual posts the entered **order** (points come from the configured distribution via the shared `writeManualResults` — no parallel commit path); engine computes via the `finish` branch. Then locks (`complete`, `corrections_open=false`). Idempotent re-post.
- `games.openCorrection`: re-opens score entry on a posted game without un-posting; result stays on the board until Re-post.
- `scores.upsert/delete` reject edits when `complete && !corrections_open` — posted scores frozen, results still visible.

## Stage 4 — Incomplete-post guard
Server never blocks; the UI names the gap ("N scores still blank — Keep entering / Post anyway").

## Stage 5 — Permissions (server-enforced)
`requireGameRunAction` = **Owner or the game's delegate** — **not** a plain Organizer (planner). `PERMISSIONS.md` updated. Run-actions are owner/delegate-scoped, distinct from trip-planner scope.

## Stage 6 — UI (6 surfaces)
Run-phase list (progress + state badges + Post/Correct/Re-post), manual placement entry (order + PAYS = configured distribution), engine post + incomplete guard, posted/locked, score-correction mode (amber Re-post + flag).

## Verification
- **47 tests green** (8 new run/post: manual post → distribution points; lock cycle post→correct→re-post; openCorrection-only-when-posted; owner/delegate yes, planner/member/outsider no). `tsc` clean.
- **Verified live** against the real BBMI competition: engine post → recompute (header "1 of 5 posted · 8 of 35 pts") → Posted → correction (amber Re-post + flag); manual post → order maps to [5,3] on the leaderboard. (Test artifacts cleaned up.)

## Edge cases (flagged per spec)
- **Manual ties/halves**: `setManualResults` accepts shared positions and `placementPoints` averages them (engine halve rule), but the up/down order UI expresses strict ranking only — **deferred** (most manual games have a clean winner).
- **Skill-prize side events** (Closest to Pin): per-individual, doesn't map to team placement — **flagged** as a separate contest kind to model later, not built here.

Note: the manual placement UI uses up/down reordering rather than literal drag-and-drop (more robust/accessible; functionally identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)