### PR TITLE
docs(deferred): point value as competition-level weighting

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -103,6 +103,52 @@ The heart of the event.
 - Full top-20 golf format matrix fill-out (validated against the taxonomy in
   `COMPETITION_ENGINE.md`, built on demand)
 
+### Point value as competition-level weighting (+ defined/weighted readiness split)
+
+*Captured 2026-06-14. Not launch-blocking — the current per-game point value is
+functional; this is a model/UX improvement. When: after the competition face
+ships and the add-game flow is stable.*
+
+**Today:** a game's point value is set on the add-game flow's **Game tab (tab 1)**
+— a per-game field, set when you create the game.
+
+**The insight:** point value isn't really a property of the *game* — it's a
+property of the game's *relationship to the other games*. "How much is Day 1
+Scramble worth" only has a sensible answer once you know what it's worth
+*relative to* Singles, Cornhole, Euchre. It's a **competition-level weighting
+decision**, not a game-level fact like name/format/course. You can't sensibly
+weight a game until the whole slate of games exists.
+
+**The change:** move point value off the per-game tab and into a
+**competition-level "balance the points" step** that shows **all games together**
+— "Scramble 8 · Singles 8 · Cornhole 8 · Euchre 4 — 28 in play, feel right?" That's
+the decision the owner is actually making (relative weighting), shown where it
+makes sense (all games side by side, the balance visible). Much truer than poking
+a number into each game's config in isolation.
+
+**The consequence — "ready" splits into two readinesses:**
+
+- **Defined** — per-game, set early, any order: type, format, name, course,
+  pairings/handicaps. (Tab 1 + most of tab 2.)
+- **Weighted** — competition-level, set late, all games at once: the point balance.
+
+**Go-live requires both:** every game *defined* AND the points *balanced*. The
+existing "Cornhole needs points" state becomes a **competition-level "you haven't
+balanced the points yet"** rather than a per-game nag — more honest (points aren't
+missing on Cornhole specifically; the cup's weighting isn't done).
+
+**Forward-design discipline (cheap insurance, do now even though the build is
+deferred):** point-value-on-tab-1 works for now and can stay. But **don't
+hard-wire "ready = has points"** as load-bearing logic, in either the build or the
+mocks — present/compute readiness so it survives the coming defined/weighted split.
+Build nothing yet, but don't build something that *blocks* the split.
+
+**Effort:** medium. Touches the add-game flow (remove point value from tab 1), a
+new competition-level balance surface, and the readiness/go-live logic (split
+defined vs. weighted). No schema change expected — point value already lives on the
+game (`games.points_total`); this is where/when it's *edited* and how readiness is
+*computed*.
+
 ---
 
 ## v2 / Circle Era


### PR DESCRIPTION
Adds a DEFERRED.md entry (under Active — Competition & Gaming Engine → Post-BBMI engine work) capturing the insight that a game's **point value is a competition-level relative-weighting decision**, not a per-game fact.

- Move point value off the add-game Game tab into a competition-level "balance the points" step that shows all games together.
- Splits go-live readiness into **Defined** (per-game: type/format/name/course/pairings) vs **Weighted** (competition-level: the point balance) — both required to go live.
- Not launch-blocking; the current per-game `games.points_total` is functional. Forward-design note: don't hard-wire "ready = has points" so the future split isn't blocked.

Doc-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)