### PR TITLE
feat: competition game-running — resume match/rack from leaderboard + back-button fix

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -93,6 +93,50 @@ The heart of the event.
 - Moving tee boxes — available to any stroke-input scorecard; pop-up +
   per-cell visual cue; `tee_box_change` `game_live_events` (no September format requires it)
 
+### Competition-style chooser — style → format → points enforcement
+
+*Before launch (footgun prevention), NOT BBMI-blocking. Captured 2026-06-14,
+sharpened by the L2 triage audit.*
+
+**The gap:** a competition has no declared *style*, so nothing constrains which
+game formats are valid within it. This is what let rack-n-stack land on the wrong
+points path (placement/total) inside a match-play cup — nothing enforced
+compatibility.
+
+**The insight:** points shape is **downstream** of competition style, not a
+per-game free choice. The correct model is a dependency chain:
+
+> **competition style → constrains valid game formats → format determines points shape**
+
+- **2-team match-play cup (Ryder Cup):** every game must be match-play-friendly and
+  produce **per-match points** (singles/doubles match play, rack-n-stack-as-matches,
+  alternate-shot-as-match…). "First to 14½."
+- **Normal-scoring competition (2 or N teams):** other formats valid; points may be
+  placement/total or other shapes.
+
+Today points-distribution is set per-game and independently — the bug's root: you
+can put a placement game in a match-play cup.
+
+**What to build:** (1) a competition-style choice at competition creation
+(trip-planner / create-flow side — its own design conversation, "can get confusing
+depending on presentation"; likely 2-team match-play cup · 2-team normal · N-team
+normal); (2) add-game flow filters formats to those compatible with the style;
+(3) the model enforces it — points shape derives from format-within-style, no
+incompatible combos possible.
+
+**Why deferred (not BBMI-blocking):** BBMI 2026 is a 2-team match-play cup and all
+its games are match-play-friendly, so wiring everything to per-match (the
+game-running build) makes the real event work without the enforcement layer. The
+enforcement matters for *other users* and to prevent the footgun.
+
+**Design conversation needed:** how to present the style choice without confusion
+(2-team-match vs 2-team-normal vs N-team is subtle), where it lives in the create
+flow, how it interacts with the trip-planner side.
+
+**Effort:** medium-large. Touches competition creation, the add-game flow (format
+filtering), and the points model (derive shape from format-within-style). No new
+scoring engines — it constrains and routes existing ones.
+
 ### Post-BBMI engine work
 
 - `multi_team` competitions (3+ teams, placement points roll-up)

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -137,6 +137,26 @@ flow, how it interacts with the trip-planner side.
 filtering), and the points model (derive shape from format-within-style). No new
 scoring engines — it constrains and routes existing ones.
 
+**Update (2026-06-14) — the add-game format filter is PART of this chooser, not
+pulled forward.** The L2 work surfaced that the add-game modal offers all three
+built engines (Stroke Play, Alternate Shot, Rack-n-Stack) **unfiltered** — so you
+can add a raw Stroke Play game to a match-play cup, where it **won't compute**
+(placement/total, not per-match). Filtering the modal to style-compatible formats
+is the "add-game flow filters formats" item above — deliberately NOT built as a
+separate near-term patch.
+- A raw Stroke Play game is **addable but non-computing in a competition** — a
+  **known, accepted gap, not a bug** — until the chooser ships.
+- Near-term cost is only test confusion, handled by a standing testing instruction
+  (test competitions with match-play-friendly formats only; don't add raw stroke to
+  a cup). No interim filter built.
+- A stray non-computing stroke game already on a board gets removed once
+  **delete-game (L3-b)** ships (queued).
+- Reaffirmed framing: in a cup the valid formats are the match-play-friendly ones
+  (Alternate Shot, Rack-n-Stack — the latter being stroke-play-wrapped-as-matches).
+  Raw individual stroke play is a *normal-competition* format. "Stroke play in a
+  cup" isn't a separate event to design — in a cup, stroke-the-activity is played
+  as Rack-n-Stack.
+
 ### Post-BBMI engine work
 
 - `multi_team` competitions (3+ teams, placement points roll-up)

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -205,11 +205,13 @@ export default function NewMatchGamePage() {
     setNavStack((s) => [...s, screen]);
     setManualScreen(next);
   };
-  // Back step: pop to the previous workflow screen, or leave to the trip home
-  // when there's nothing to pop (we arrived directly at a derived screen).
+  // Back step: pop to the previous workflow screen, or leave the page when
+  // there's nothing to pop — router.back() returns to wherever we came from
+  // (the leaderboard, when launched from it), so breadcrumb and browser-back
+  // agree instead of disagreeing (one to trip home, one to the leaderboard).
   const goBack = () => {
     if (navStack.length === 0) {
-      router.push(`/trips/${param}`);
+      router.back();
       return;
     }
     setManualScreen(navStack[navStack.length - 1]);

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -59,6 +59,16 @@ export default function NewMatchGamePage() {
   const me = useCurrentUser();
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { enabled: !!tripId });
 
+  // Competition roster (Slice D): a competition game pairs from the players
+  // assigned to its teams, not the whole trip crew. Names still resolve from
+  // crew (the roster is a subset of trip members).
+  const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const competitionId = competition.data?.id as string | undefined;
+  const assignQ = trpc.teamAssignments.list.useQuery(
+    { tripId: tripId!, competitionId: competitionId! },
+    { enabled: !!tripId && !!competitionId }
+  );
+
   const [gameId, setGameId] = useState<string | null>(search.get("game"));
   const [manualScreen, setManualScreen] = useState<Screen | null>(null);
 
@@ -123,6 +133,20 @@ export default function NewMatchGamePage() {
   // line — generally min team size across teams — which is Slice D's concern.
   const crewCount = crew.data?.length ?? 0;
   const maxMatches = Math.max(1, Math.floor(crewCount / 2));
+
+  // Competition roster + the singles match cap = min(teamA, teamB). Used to seed
+  // a resumed competition game's pairings and to scope the player picker.
+  const gameCompId = (gameQ.data?.competition_id as string | null) ?? null;
+  const rosterIds = useMemo(
+    () => [...new Set((assignQ.data ?? []).map((a) => a.user_id as string))],
+    [assignQ.data]
+  );
+  const compMatchCount = useMemo(() => {
+    const sizes = new Map<string, number>();
+    for (const a of assignQ.data ?? []) sizes.set(a.team_id as string, (sizes.get(a.team_id as string) ?? 0) + 1);
+    const counts = [...sizes.values()];
+    return counts.length >= 2 ? Math.max(1, Math.min(...counts)) : 0;
+  }, [assignQ.data]);
 
   const status = gameQ.data?.status as string | undefined;
   const published = matchesQ.data?.published ?? false;
@@ -223,10 +247,18 @@ export default function NewMatchGamePage() {
   // draft is empty. Create + Edit also seed via their handlers; this covers a
   // direct/derived landing.
   useEffect(() => {
-    if (screen === "setup" && draft.length === 0 && serverMatches.length > 0) {
+    if (screen !== "setup" || draft.length > 0) return;
+    if (serverMatches.length > 0) {
       setDraft(serverDraftFrom(serverMatches, handicapOf));
+      return;
     }
-  }, [screen, draft.length, serverMatches, handicapOf]);
+    // Resume-into-empty: a competition game tapped from the leaderboard arrives
+    // with no game_matches, so the derived "setup" landing had an empty draft and
+    // a disabled CTA. Seed blank pairing cards from the roster's match cap (or the
+    // crew cap for a standalone game) so setup is fillable.
+    const n = compMatchCount || maxMatches;
+    if (n > 0) setDraft(Array.from({ length: n }, (_, i) => ({ matchNumber: i + 1, a: null, b: null, handicap: 0 })));
+  }, [screen, draft.length, serverMatches, handicapOf, compMatchCount, maxMatches]);
 
   // ── Actions ──────────────────────────────────────────────────────────
   async function handleCreate() {
@@ -503,7 +535,7 @@ export default function NewMatchGamePage() {
           matchIdx={selector.matchIdx}
           slot={selector.slot}
           draft={draft}
-          crew={(crew.data ?? []).map((c) => c.user_id)}
+          crew={gameCompId && rosterIds.length > 0 ? rosterIds : (crew.data ?? []).map((c) => c.user_id)}
           nameOf={nameOf}
           avatarIconOf={avatarIconOf}
           onPick={(userId) => {

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -168,7 +168,7 @@ export default function NewGamePage() {
             onHoleChange={setCurrentHole}
             onChange={handleChange}
             onClear={handleClear}
-            onBack={() => router.push(`/trips/${param}`)}
+            onBack={() => router.back()}
             onOpenGrid={() => setView("grid")}
             onFinish={handleFinish}
           />

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -207,12 +207,22 @@ export default function RackNStackPage() {
   );
 
   // ── Handlers ─────────────────────────────────────────────────────────
+  // Seed the rack's structure from the competition roster. Two entry points,
+  // ONE path: a brand-new game (no gid → create it first), or an existing
+  // competition game tapped from the leaderboard that has no foursomes yet
+  // (gid set, groups empty → seed onto it, don't mint a new game).
   async function startRack() {
     if (!tripId || !competitionId) return;
-    const g = await createGame.mutateAsync({ tripId, gameTypeId: RACK, name: "Rack-n-Stack", competitionId });
+    let gameId: string;
+    if (gid) {
+      gameId = gid;
+    } else {
+      const g = await createGame.mutateAsync({ tripId, gameTypeId: RACK, name: "Rack-n-Stack", competitionId });
+      gameId = g.id as string;
+    }
     if (pendingCourse) {
       try {
-        await applyCourse.mutateAsync({ tripId, gameId: g.id, courseId: pendingCourse.id });
+        await applyCourse.mutateAsync({ tripId, gameId, courseId: pendingCourse.id });
       } catch {
         /* template default par/index still applies */
       }
@@ -224,8 +234,9 @@ export default function RackNStackPage() {
       userIds,
       teeTime: firstTee ? addMinutes(firstTee, i * 10) : null,
     }));
-    await setFoursomes.mutateAsync({ tripId, gameId: g.id, groups });
-    setGameId(g.id);
+    await setFoursomes.mutateAsync({ tripId, gameId, groups });
+    await utils.playGroups.listByGame.invalidate({ tripId, gameId });
+    setGameId(gameId);
     setShowHandicaps(true); // Pairings ✓ → Handicaps step
   }
 
@@ -261,8 +272,17 @@ export default function RackNStackPage() {
     await utils.games.getById.invalidate({ tripId, gameId: gid });
   }
 
+  // A resumed competition game (gid set from ?game=) may have NO foursomes yet
+  // (created as a bare games row by add-game). Route it to the setup step instead
+  // of the empty play screen — startRack seeds onto the existing game.
+  const needsSetup = !!gid && groupsQ.isSuccess && (groupsQ.data?.groups?.length ?? 0) === 0;
+
   // ── Render ───────────────────────────────────────────────────────────
   if (!tripId || roleLoading || crew.isLoading || competition.isLoading) {
+    return <Center>Loading…</Center>;
+  }
+  // gid set but groups still loading → wait, don't flash an empty play screen.
+  if (gid && groupsQ.isLoading) {
     return <Center>Loading…</Center>;
   }
 
@@ -327,8 +347,8 @@ export default function RackNStackPage() {
     );
   }
 
-  // No game yet → setup.
-  if (!gid) {
+  // No game yet, or a resumed game with no foursomes → setup.
+  if (!gid || needsSetup) {
     return (
       <Shell onBack={() => router.back()} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
         <div className="w-full px-4 py-5">

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -268,7 +268,7 @@ export default function RackNStackPage() {
 
   if (!hasCompetition) {
     return (
-      <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack">
+      <Shell onBack={() => router.back()} title="Rack-n-Stack">
         <div className="flex flex-col items-center text-center" style={{ paddingTop: 72 }}>
           <div className="flex items-center justify-center" style={{ width: 56, height: 56, borderRadius: 16, background: "var(--color-bt-card-raised)", marginBottom: 16 }}>
             <Users size={24} style={{ color: "var(--color-bt-text-dim)" }} />
@@ -330,7 +330,7 @@ export default function RackNStackPage() {
   // No game yet → setup.
   if (!gid) {
     return (
-      <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
+      <Shell onBack={() => router.back()} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
         <div className="w-full px-4 py-5">
           <div className="flex flex-col gap-3.5">
             <div>
@@ -361,7 +361,7 @@ export default function RackNStackPage() {
   const final = gameQ.data?.status === "complete";
   const allThru18 = rack.slots.length > 0 && rack.slots.every((s) => s.a.thru >= scUnits.length && s.b.thru >= scUnits.length);
   return (
-    <Shell onBack={() => router.push(`/trips/${param}`)} title="Rack-n-Stack" subtitle={final ? "Net stroke play · final" : "Net stroke play · standings"}>
+    <Shell onBack={() => router.back()} title="Rack-n-Stack" subtitle={final ? "Net stroke play · final" : "Net stroke play · standings"}>
       <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
       {canEdit && !final && (


### PR DESCRIPTION
Keystone fixes from the L2 triage audit. Re-verifying the audit map before building (per the spec's gate) **materially changed the picture** — the resume surfaces are largely built and roster-wired; the real gap is **routing a structure-less resumed game past its own setup step**, not a missing surface. So the fix is surgical, not a from-scratch rebuild. Done with the owner's confirmation (surgical approach; match sources from the competition roster).

## Map correction (flagged before building)
- **Rack** is fully wired (reads `?game=`, sources teams from `teamAssignments`, has setup→foursomes→handicaps→scoring) — it just skipped the `!gid` setup screen for a resumed game with no foursomes.
- **Match** is fully wired too — a resumed pending game derived `screen="setup"` with an empty draft because the blank-seed path lived only on the create screen.
- **Stroke** is genuinely create-only (matches the audit) — see Remaining.

## What's in this PR (verified live)
1. **Back button (L1-b):** stroke/match/rack page-exit back → `router.back()` instead of hardcoded trip home, so breadcrumb and browser-back agree (both pop to the leaderboard).
2. **Match resume (L2-b):** seeds blank pairing cards on the resume-into-empty-setup landing, sized by `min(teamA, teamB)` from the competition roster; player picker scoped to the roster (was the whole trip crew). *Verified: "Alternate Shot" → Set Pairings with 3 cards + the 6 BBMI roster players in the picker.*
3. **Rack resume (L2-c):** routes a resumed game with no foursomes to the setup step and seeds foursomes onto the **existing** game (was: minted a new one). *Verified: "test 2" → "Start the rack · 6 players across Condors & Falcons".*
4. **DEFERRED:** competition-style chooser entry (style → format → points enforcement; before-launch footgun prevention).

`tsc --noEmit` clean after each commit.

## Remaining (deliberately not in this PR — large / needs care)
- **Stage 2c — Stroke resume:** `games/new/page.tsx` is create-only (ignores `?game=`). Wiring resume is moderate, BUT **flag:** stroke play is an individual 2–4-player format and `addParticipants` caps at 4 — seeding a 6-player competition roster into one stroke game doesn't fit. Stroke-in-a-2-team-cup is semantically odd; worth a quick product decision before building (player-picker-scoped-to-roster vs. is stroke even a competition game here?).
- **Stage 3 — Rack → per-match points:** a real scoring-engine change (`rackNStack.ts` to write per-team slot points, `competitionLeaderboard.ts` to treat rack as per-match not placement, the add-game editor to give rack the per-match value control). Touches tested code; deserves its own focused pass **with engine tests** rather than a rushed change. Premise confirmed (rack does use placement/total today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)