### PR TITLE
feat: rack-n-stack → per-match points + delete-game (L3-b)

### DIFF
--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -416,7 +416,10 @@ function GameSheet({
   const categoryTypes = types.filter((t) => t.category === category);
   const effectiveTypeId = categoryTypes.some((t) => t.id === gameTypeId) ? gameTypeId : categoryTypes[0]?.id ?? "";
   const selectedType = types.find((t) => t.id === effectiveTypeId);
-  const isMatchPlay = selectedType?.resultStrategy === "match_play";
+  // Per-match formats: 1v1 match play AND rack-n-stack (a set of rank-paired
+  // mini-matches) — both accumulate per-match points, not a placement total.
+  const isMatchPlay =
+    selectedType?.resultStrategy === "match_play" || selectedType?.resultStrategy === "rack_n_stack";
   const isGolf = category === "golf";
 
   // Members (for the delegate picker + name resolution) and the existing grant.

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -443,6 +443,7 @@ function GameSheet({
   const setDist = trpc.games.setPointsDistribution.useMutation();
   const setTotalM = trpc.games.setPointsTotal.useMutation();
   const setStatus = trpc.games.setStatus.useMutation();
+  const deleteGame = trpc.games.delete.useMutation();
   const addOrg = trpc.games.addOrganizer.useMutation();
   const removeOrg = trpc.games.removeOrganizer.useMutation();
 
@@ -517,6 +518,15 @@ function GameSheet({
   async function handleDrop() {
     if (!game) return;
     await setStatus.mutateAsync({ tripId, gameId: game.id, status: game.status === "dropped" ? "pending" : "dropped" });
+    utils.games.listByTrip.invalidate({ tripId });
+    utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+    onClose();
+  }
+
+  async function handleDelete() {
+    if (!game) return;
+    if (!window.confirm("Delete this game permanently? It and all its scores are removed — this can't be undone. (To keep it but hide it from the board, use Abandon instead.)")) return;
+    await deleteGame.mutateAsync({ tripId, gameId: game.id });
     utils.games.listByTrip.invalidate({ tripId });
     utils.competitions.leaderboard.invalidate({ tripId, competitionId });
     onClose();
@@ -603,6 +613,20 @@ function GameSheet({
             )}
 
             {error && <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>{error}</p>}
+
+            {isEdit && game && canEdit && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleteGame.isPending}
+                data-testid="delete-game"
+                className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs font-semibold disabled:opacity-50"
+                style={{ background: "transparent", color: "var(--color-bt-danger)", border: "1px solid var(--color-bt-border)" }}
+              >
+                <Trash2 size={12} />
+                Delete game permanently
+              </button>
+            )}
           </div>
 
           <div className="flex items-center gap-2 border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>

--- a/src/server/lib/rackNStack.ts
+++ b/src/server/lib/rackNStack.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { playerStats, computeRack, type RackPlayer, type Team } from "@/lib/rackNStack";
 import { effectiveStrokes } from "@/lib/handicap";
+import { isPerMatch } from "@/lib/pointsDistribution";
 
 /**
  * DB-persist side of rack-n-stack. Builds the SAME read-model the live client
@@ -10,9 +11,16 @@ import { effectiveStrokes } from "@/lib/handicap";
  * outcome is TEAM points (slot wins; halves = ½) distilled to `game_results`
  * (`entity_type='team'`). Slots are NOT persisted (derived read-model only).
  *
- * `competition_points_earned` stays null — Slice D maps team points to
- * competition points. Computed in 'current' mode (the canonical result; both
- * display modes converge at 18 holes).
+ * Rack is a set of rank-paired mini-matches, so it scores PER-MATCH (each slot
+ * won = the game's per-match value; a halve = ½). When the game is configured
+ * per_match (`{type:'per_match', value}`), we write the realized team points ×
+ * value as `raw_score` with `position=null` — the shape the competition
+ * leaderboard's per_match branch reads (value × matchCount available, awarded
+ * from raw_score). A legacy/unconfigured rack (no per_match distribution) keeps
+ * the placement shape (`position` = rank), so nothing already on a board breaks.
+ *
+ * `competition_points_earned` stays null. Computed in 'current' mode (the
+ * canonical result; both display modes converge at 18 holes).
  */
 
 export interface RackTeamOutcome {
@@ -31,10 +39,15 @@ export async function computeRackNStackResults(
 ): Promise<RackTeamOutcome[]> {
   const { data: game } = await supabase
     .from("games")
-    .select("scorecard_schema, game_type_id, competition_id")
+    .select("scorecard_schema, game_type_id, competition_id, points_distribution")
     .eq("id", gameId)
     .maybeSingle();
   if (!game?.competition_id) return []; // rack needs a competition (2 teams)
+
+  // Per-match scoring (each slot = `value` pts) when configured so; else the
+  // legacy placement shape (rank). value defaults to 1 (one point per slot won).
+  const perMatch = isPerMatch(game.points_distribution);
+  const value = perMatch ? (game.points_distribution as { value: number }).value : 1;
 
   // Effective par/index: the game's course snapshot, else its template default.
   let schema = game.scorecard_schema as SchemaShape | null;
@@ -108,9 +121,11 @@ export async function computeRackNStackResults(
     game_id: gameId,
     entity_id: teamId,
     entity_type: "team" as const,
-    raw_score: null,
+    // per_match: realized slot points × value as raw_score (no position) — the
+    // shape the leaderboard's per_match branch reads. placement: rank position.
+    raw_score: perMatch ? teamPoints[teamId] * value : null,
     points: teamPoints[teamId],
-    position: position(teamId),
+    position: perMatch ? null : position(teamId),
     competition_points_earned: null,
   }));
   if (rows.length > 0) await supabase.from("game_results").insert(rows);

--- a/src/server/routers/games.d_addgame.test.ts
+++ b/src/server/routers/games.d_addgame.test.ts
@@ -157,3 +157,14 @@ describe("Stage 3 — the delegation boundary", () => {
     ).rejects.toThrow(/must total 8/i);
   });
 });
+
+describe("delete — hard removal, Organizer-gated (L3-b)", () => {
+  it("owner deletes a game and it's gone; a plain Member cannot", async () => {
+    const g = await newGame(8, "To delete");
+    // Organizer-gated: a plain Member (even a would-be delegate) cannot delete.
+    await expect(ctx.callerAs("member").games.delete({ tripId, gameId: g.id })).rejects.toThrow();
+    // Owner hard-deletes → the game is gone.
+    await expect(ctx.caller().games.delete({ tripId, gameId: g.id })).resolves.toBeTruthy();
+    await expect(ctx.caller().games.getById({ tripId, gameId: g.id })).rejects.toThrow(/not found/i);
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -441,6 +441,24 @@ export const gamesRouter = router({
       return { success: true };
     }),
 
+  // delete — Owner/Organizer. HARD-delete a game; all dependent rows
+  // (participants, matches, play_groups, results, score_entries, organizers)
+  // cascade via ON DELETE CASCADE. Distinct from setStatus('dropped')
+  // ("Abandoned"), which is a reversible archive — this is a true removal (L3-b).
+  // requireTripRole("Organizer") gates it to trip staff (not a game-delegate).
+  delete: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripRole("Organizer"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games").select("id").eq("id", input.gameId).eq("trip_id", ctx.tripId).maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      const { error } = await ctx.supabase
+        .from("games").delete().eq("id", input.gameId).eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to delete game: ${error.message}` });
+      return { success: true };
+    }),
+
   // setPointsDistribution — game-edit gate (owner OR game-delegate). The
   // competition-layer split. Editing it re-derives the leaderboard on next read
   // (§5b/§6). Stage 3 sum-to-total: a PLACEMENT split must equal the owner-set

--- a/src/server/routers/rackNStack.test.ts
+++ b/src/server/routers/rackNStack.test.ts
@@ -132,3 +132,51 @@ describe("rack-n-stack — finish distills team points to game_results", () => {
     expect(teams.find((t) => t.teamId === teamB)!.points).toBe(0.5);
   });
 });
+
+describe("rack-n-stack — per-match points (Stage 3)", () => {
+  it("a per_match rack writes raw_score = slot points × value (position null) and rolls up", async () => {
+    // Isolated competition so the leaderboard reflects only this game.
+    const comp = await ctx.createCompetition(tripId, "Rack PM Cup");
+    const ta = await ctx.createTeam(comp, "Blue", { shortName: "B" });
+    const tb = await ctx.createTeam(comp, "Red", { shortName: "R" });
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: owner, team_id: ta },
+      { competition_id: comp, user_id: planner, team_id: ta },
+      { competition_id: comp, user_id: member, team_id: tb },
+      { competition_id: comp, user_id: outsider, team_id: tb },
+    ]);
+
+    const game = await ctx.caller().games.create({
+      tripId, gameTypeId: RACK, name: "PM Day", competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 2 },
+    });
+    const gameId = game.id as string;
+    await ctx.callerAs("planner").playGroups.setFoursomes({
+      tripId, gameId,
+      groups: [{ name: "G1", userIds: [owner, member] }, { name: "G2", userIds: [planner, outsider] }],
+    });
+    // Blue (both par) wins both rank slots over Red (both bogey) → 2 slots.
+    await enter(gameId, owner, PAR);
+    await enter(gameId, planner, PAR);
+    await enter(gameId, member, PAR.map((p) => p + 1));
+    await enter(gameId, outsider, PAR.map((p) => p + 1));
+    await ctx.caller().games.finish({ tripId, gameId });
+
+    // game_results: per_match shape — raw_score = slotPoints × value, no position.
+    const { data: rows } = await ctx.admin
+      .from("game_results")
+      .select("entity_id, raw_score, position")
+      .eq("game_id", gameId);
+    const blue = rows!.find((r) => r.entity_id === ta)!;
+    const red = rows!.find((r) => r.entity_id === tb)!;
+    expect(blue.raw_score).toBe(4); // 2 slots won × value 2
+    expect(red.raw_score).toBe(0);
+    expect(blue.position).toBeNull();
+
+    // Leaderboard: available = value(2) × matchCount(min team size 2) = 4; Blue takes all.
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.pointsAvailable).toBe(4);
+    expect(lb.teamTotals[ta]).toBe(4);
+    expect(lb.teamTotals[tb]).toBe(0);
+  });
+});


### PR DESCRIPTION
Follow-on to #363. Settles the rack points model and adds a real delete path.

## Stage 3 — Rack-n-stack scores per-match points (with engine tests)
Decision settled: rack is a set of rank-paired mini-matches, so each slot won = the game's per-match value (halve = ½) — it accumulates **per-match points**, not a placement/total.

- **Add-game editor:** include `rack_n_stack` on the per-match side (`isMatchPlay`), so rack gets the per-match value editor + "N matches ready" readout and stores `{type:'per_match', value}`.
- **Rack compute (`rackNStack.ts`)** branches on distribution type: `per_match` → write `raw_score = realized slot points × value` with `position=null` (the shape the leaderboard's per-match branch reads — available = `value × matchCount`, awarded from `raw_score`); a legacy/unconfigured rack keeps the placement shape (`position=rank`), so **nothing already on a board breaks. No data migration.**
- **No leaderboard change** — it already routes purely by distribution type (`isPerMatch`/`isPlacement`); rack's `matchCount = min(team sizes)` via the existing singles formula.
- **Engine tests:** a per-match rack writes `raw_score = slots × value` (`position=null`) and rolls up (available = `value × matchCount`, winner takes the slots). Existing placement rack tests stay green (back-compat). 15 rack tests pass.

## L3-b — Delete a game (hard removal)
The trash button only soft-drops to "Abandoned" (a reversible archive); there was no true remove path. Per the marching orders (bumped to near-term to clear a stray non-computing stroke game):
- `games.delete` (Organizer-gated) — dependents cascade via `ON DELETE CASCADE`.
- A deliberate "Delete game permanently" affordance in the GameSheet (with confirm), distinct from Abandon. Test: owner deletes, Member can't.

## Notes
- **Stroke-resume is intentionally NOT built** — raw stroke isn't a valid cup format (it's played as rack-n-stack in a cup). Captured as a testing guardrail + folded into the deferred competition-style chooser (DEFERRED update in #363).
- Independent of #363 (different files); both merge cleanly. **Reminder: #363 is still open** (despite the marching-orders doc saying merged) — merge it when ready.

`tsc --noEmit` clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)