### PR TITLE
feat(comp-face): Stage 2 — state-aware leaderboard rows + nav-model formalization

### DIFF
--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -21,6 +21,16 @@ interface LBGame {
   status: string;
   dropped: boolean;
   gameTypeId: string | null;
+  /** Points configured (scoring-ready). Drives the state-aware rows (§7). */
+  ready?: boolean;
+}
+
+/** The four leaderboard-row states (§7). */
+type RowState = "final" | "live" | "upcoming" | "unready";
+function rowStateOf(game: LBGame): RowState {
+  if (game.status === "complete") return "final";
+  if (game.status === "active") return "live";
+  return game.ready === false ? "unready" : "upcoming";
 }
 
 interface LBCell {
@@ -469,6 +479,10 @@ function SessionRow({
 }) {
   const href = gameHref(tripId, game.gameTypeId, game.id);
   const hasScores = cells && cells.size > 0;
+  const state = rowStateOf(game);
+  // Show the per-team result line only when there's a committed/in-progress
+  // result; otherwise a single status line — NEVER an empty "– / –" (0–0) row.
+  const showTeamLine = state === "final" || (state === "live" && hasScores);
 
   const inner = (
     <div className="flex flex-col gap-0.5 px-4 py-3">
@@ -480,39 +494,42 @@ function SessionRow({
           {game.name}
         </span>
         <div className="flex shrink-0 items-center gap-1.5">
-          <StatusBadge status={game.status} />
+          <RowBadge state={state} />
           {href && (
             <ChevronRight size={14} style={{ color: "var(--color-bt-text-dim)" }} />
           )}
         </div>
       </div>
 
-      {/* Per-team score line */}
-      <div className="flex flex-wrap gap-x-3 gap-y-0.5">
-        {teams.map((team) => {
-          const cell = cells?.get(team.id);
-          return (
-            <span
-              key={team.id}
-              className="flex items-center gap-1 text-[12px]"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
+      {showTeamLine ? (
+        <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+          {teams.map((team) => {
+            const cell = cells?.get(team.id);
+            return (
               <span
-                className="inline-block h-1.5 w-1.5 rounded-full"
-                style={{ background: team.color }}
-              />
-              <span style={{ color: hasScores ? team.color : "var(--color-bt-text-dim)" }}>
-                {team.short_name}
+                key={team.id}
+                className="flex items-center gap-1 text-[12px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: team.color }} />
+                <span style={{ color: team.color }}>{team.short_name}</span>
+                <span style={{ color: "var(--color-bt-text)" }}>{cell ? fmtPts(cell.points) : "–"}</span>
               </span>
-              {cell ? (
-                <span style={{ color: "var(--color-bt-text)" }}>{fmtPts(cell.points)}</span>
-              ) : (
-                <span style={{ color: "var(--color-bt-text-dim)" }}>–</span>
-              )}
-            </span>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      ) : (
+        <span
+          className="text-[12px]"
+          style={{ color: state === "unready" ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)" }}
+        >
+          {state === "live"
+            ? "Underway · scoring"
+            : state === "unready"
+              ? "Not scoring yet — still being set up"
+              : "Not started yet"}
+        </span>
+      )}
     </div>
   );
 
@@ -526,45 +543,33 @@ function SessionRow({
   return <div>{inner}</div>;
 }
 
-function StatusBadge({ status }: { status: string }) {
-  if (status === "complete") {
+function RowBadge({ state }: { state: RowState }) {
+  if (state === "final") {
     return (
-      <span
-        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          color: "var(--color-bt-text-dim)",
-        }}
-      >
+      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
         <Check size={9} />
         Final
       </span>
     );
   }
-  if (status === "in_progress") {
+  if (state === "live") {
     return (
-      <span
-        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
-        style={{
-          background: "var(--color-bt-accent-faint)",
-          color: "var(--color-bt-accent)",
-          border: "1px solid var(--color-bt-accent-border)",
-        }}
-      >
+      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)", border: "1px solid var(--color-bt-accent-border)" }}>
         <Radio size={9} />
         Live
       </span>
     );
   }
-  // pending / unknown
+  if (state === "unready") {
+    return (
+      <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}>
+        Needs setup
+      </span>
+    );
+  }
+  // upcoming
   return (
-    <span
-      className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
-      style={{
-        background: "var(--color-bt-card-raised)",
-        color: "var(--color-bt-text-dim)",
-      }}
-    >
+    <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
       Upcoming
     </span>
   );
@@ -661,7 +666,7 @@ function EarlyState({
                     {game.name}
                   </span>
                   <div className="flex items-center gap-1.5">
-                    <StatusBadge status={game.status} />
+                    <RowBadge state={rowStateOf(game)} />
                     {href && (
                       <ChevronRight
                         size={14}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -164,6 +164,10 @@ export async function computeCompetitionLeaderboard(
         status: g.status as string,
         dropped: g.status === "dropped",
         gameTypeId: (g.game_type_id as string | null) ?? null,
+        // "ready to score" = points are configured (a distribution shape or an
+        // owner-set total). Drives the state-aware leaderboard rows: an unready
+        // game reads "not scoring yet" instead of an empty/0–0 line (§7).
+        ready: !!rawDist || g.points_total != null,
       };
     }),
     cells,

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -52,12 +52,14 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  for (const id of gameIds) {
-    await ctx.admin.from("game_results").delete().eq("game_id", id);
-    await ctx.admin.from("games").delete().eq("id", id);
+  // Batch the deletes (one query each) — a per-game loop blows the 10s hook
+  // timeout as the game set grows.
+  if (gameIds.length) {
+    await ctx.admin.from("game_results").delete().in("game_id", gameIds);
+    await ctx.admin.from("games").delete().in("id", gameIds);
   }
   await ctx.cleanup();
-});
+}, 30000);
 
 describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
   let teamA: string;
@@ -301,11 +303,24 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
 
-    const game = lb.games.find((g2: { id: string }) => g2.id === g.id);
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { gameTypeId: string; ready: boolean };
     expect(game).toBeDefined();
     expect("gameTypeId" in game!).toBe(true);
     expect(game!.gameTypeId).toBe(MANUAL);
     expect("defendingTeamId" in lb).toBe(true);
+    // State-aware rows (§7): a configured game is scoring-ready.
+    expect(game!.ready).toBe(true);
+  });
+
+  it("a game with no points configured is NOT ready (drives the 'needs setup' row)", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 Unready Comp");
+    await ctx.createTeam(comp, "A", { shortName: "A" });
+    // Bare game — no distribution, no owner total.
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "Unready", competitionId: comp }) as { id: string };
+    gameIds.push(g.id);
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { ready: boolean };
+    expect(game!.ready).toBe(false);
   });
 
   it("reads competitionPlacement.ts — rollUp matches the endpoint's teamTotals", async () => {


### PR DESCRIPTION
Stage 2 of the Competition Face.

## Delivered — state-aware leaderboard rows (§7)
The leaderboard's game rows now read by **state** instead of a bare badge + empty score line:
- **final** → committed result (per-team points)
- **live** → "Live" + the score line, or "Underway · scoring" — **never** an empty "0–0" line (the §7 never-0–0 rule)
- **upcoming** → "Upcoming" + "Not started yet"
- **unready** → "Needs setup" + "Not scoring yet — still being set up"

`competitionLeaderboard.ts` exposes a per-game `ready` flag (points configured = a distribution or owner total) so the client can distinguish upcoming from unready (per-match games have a null client-side distribution, so the server has to say). Rows stay **display + navigate only** — no action buttons (§5). Also fixes a latent badge bug (checked `in_progress` but the status enum is `active`, so live games showed "Upcoming").

Tests: configured game is `ready`, bare game is not. Verified live (Final shows the result; Upcoming shows "Not started yet"; no 0–0). `tsc` clean, 28 leaderboard-suite tests green.

## Nav model — already satisfied by #363
The other Stage-2 verify items are already in from the game-running fixes:
- **tap a game → pushes its page** — the leaderboard's rows are `<Link>`s to the game page.
- **back → leaderboard (breadcrumb + browser agree)** — #363 switched the game-page back to `router.back()`, so both pop to the leaderboard you came from.

## Deferred to Stage 3 (pairs naturally with the two-state toggle)
- **Persistent Trip/Live bottom nav *on game pages*** — the game pages' active-scoring screens pin a stroke keypad to the bottom, so a `fixed bottom-0` nav there is a real layout conflict needing careful per-screen handling. And it's an *enhancement*, not a gap: #363's back already returns you to the leaderboard (which has the switcher), so you're never stranded.
- **"Leaderboard as face root" reconciliation** — today the face lives in the Competition tab (Stage 1) and `/leaderboard` is a separate route; unifying them is the same concern as Stage 3's setup↔leaderboard toggle + go-live default-flip, so it lands cleanest there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)