### PR TITLE
feat(comp): extend per-game delegate gate to match/rack setup (§10)

### DIFF
--- a/src/server/routers/delegateSetupGate.test.ts
+++ b/src/server/routers/delegateSetupGate.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Per-game delegate gate, extended to the SETUP routers (§10).
+ *
+ * Migration 045 landed the delegate path (game_organizers / requireGameEdit) on
+ * games + game_results, but the setup mutations — matches (pairings / handicap /
+ * activate) and playGroups (foursomes / strokes) — were still gated
+ * requireTripRole("Organizer"). Stage 4 extends requireGameEdit() to them so a
+ * game's delegate can actually run it. These tests assert the new gate:
+ *   - a delegated member can run THEIR game's setup,
+ *   - a plain member with no grant cannot,
+ *   - the grant is game-isolated (delegate of A can't touch B).
+ */
+
+const MATCH = "gtt_match_play_singles";
+const RACK = "gtt_rack_n_stack";
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let memberId: string;
+const gameIds: string[] = [];
+
+async function newGame(gameTypeId: string, name: string) {
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId,
+    name,
+    competitionId,
+  })) as { id: string };
+  gameIds.push(g.id);
+  return g.id;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Delegate gate trip");
+  await ctx.addTripMember(tripId, "member", "Member"); // plain Member = delegate target
+  memberId = ctx.getUser("member").id;
+  competitionId = await ctx.createCompetition(tripId, "Delegate gate comp");
+});
+
+afterAll(async () => {
+  for (const id of gameIds) {
+    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("game_participants").delete().eq("game_id", id);
+    await ctx.admin.from("game_matches").delete().eq("game_id", id);
+    await ctx.admin.from("play_groups").delete().eq("game_id", id);
+    await ctx.admin.from("games").delete().eq("id", id);
+  }
+  await ctx.cleanup();
+});
+
+describe("matches setup gate admits the game delegate (§10)", () => {
+  it("delegate can set pairings on THEIR game; a non-delegate member cannot", async () => {
+    const mine = await newGame(MATCH, "Singles-BJ");
+    const other = await newGame(MATCH, "Singles-other");
+    await ctx.caller().games.addOrganizer({ tripId, gameId: mine, userId: memberId });
+
+    const member = ctx.callerAs("member");
+    const pairings = [{ sideA: null, sideB: null, matchNumber: 1 }];
+
+    // Delegate runs their game's setup…
+    await expect(
+      member.matches.setPairings({ tripId, gameId: mine, matches: pairings })
+    ).resolves.toBeTruthy();
+    // …activate too.
+    await expect(
+      member.matches.activate({ tripId, gameId: mine })
+    ).resolves.toBeTruthy();
+
+    // …but NOT another game (game-isolated).
+    await expect(
+      member.matches.setPairings({ tripId, gameId: other, matches: pairings })
+    ).rejects.toThrow(/Organizer|game-organizer/i);
+  });
+
+  it("a plain trip member with no grant cannot set pairings", async () => {
+    const g = await newGame(MATCH, "Singles-nogrant");
+    await expect(
+      ctx.callerAs("member").matches.setPairings({
+        tripId,
+        gameId: g,
+        matches: [{ sideA: null, sideB: null, matchNumber: 1 }],
+      })
+    ).rejects.toThrow(/Organizer|game-organizer/i);
+  });
+});
+
+describe("playGroups setup gate admits the game delegate (§10)", () => {
+  it("delegate can set foursomes on THEIR game; a non-delegate member cannot", async () => {
+    const mine = await newGame(RACK, "Rack-BJ");
+    const other = await newGame(RACK, "Rack-other");
+    await ctx.caller().games.addOrganizer({ tripId, gameId: mine, userId: memberId });
+
+    const member = ctx.callerAs("member");
+    const groups = [{ userIds: [memberId] }];
+
+    await expect(
+      member.playGroups.setFoursomes({ tripId, gameId: mine, groups })
+    ).resolves.toBeTruthy();
+
+    await expect(
+      member.playGroups.setFoursomes({ tripId, gameId: other, groups })
+    ).rejects.toThrow(/Organizer|game-organizer/i);
+  });
+
+  it("a plain trip member with no grant cannot set foursomes", async () => {
+    const g = await newGame(RACK, "Rack-nogrant");
+    await expect(
+      ctx.callerAs("member").playGroups.setFoursomes({
+        tripId,
+        gameId: g,
+        groups: [{ userIds: [memberId] }],
+      })
+    ).rejects.toThrow(/Organizer|game-organizer/i);
+  });
+});

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -1,16 +1,20 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole } from "../middleware";
+import { requireTripMember, requireGameEdit } from "../middleware";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 
 /**
  * matches — singles match-play setup + read (Slice B).
  *
- * Setup writes (pairings, handicap, reorder, activate) are Owner+Organizer
- * (`requireTripRole("Organizer")`), matching the competition-setup gate. Score
- * entry reuses Slice A's `scores.upsertEntry` (any member) — there is no score
- * procedure here. Result writes are server-side (`computeMatchPlayResults`).
+ * Setup writes (pairings, handicap, reorder, activate) are gated by
+ * `requireGameEdit()` — trip Owner/Organizer OR a delegated organizer of THIS
+ * game (game_organizers / migration 045). This extends the per-game delegate
+ * path (originally landed for games / game_results) to the match-setup router so
+ * a game's delegate can actually run it (§10), game-isolated: a delegate of one
+ * game can't touch another. Score entry reuses Slice A's `scores.upsertEntry`
+ * (any member) — there is no score procedure here. Result writes are
+ * server-side (`computeMatchPlayResults`).
  *
  * game-id-keyed procedures also take `tripId` so the standard trip middleware
  * gates them; we then verify the game belongs to that trip.
@@ -65,7 +69,7 @@ export const matchesRouter = router({
           .max(4),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
 
@@ -132,7 +136,7 @@ export const matchesRouter = router({
         userId: z.string().min(1),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
 
@@ -222,7 +226,7 @@ export const matchesRouter = router({
         strokes: z.number().int().min(0).max(36),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
 
@@ -274,7 +278,7 @@ export const matchesRouter = router({
         orderedMatchIds: z.array(z.string().min(1)).min(1).max(4),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
       for (let i = 0; i < input.orderedMatchIds.length; i++) {
@@ -291,7 +295,7 @@ export const matchesRouter = router({
   // Does NOT post to Notes (Slice F).
   activate: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
       const { error } = await ctx.supabase

--- a/src/server/routers/playGroups.ts
+++ b/src/server/routers/playGroups.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole } from "../middleware";
+import { requireTripMember, requireGameEdit } from "../middleware";
 import { clampStrokes } from "@/lib/handicap";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
@@ -17,7 +17,8 @@ import { computeRackNStackResults } from "../lib/rackNStack";
  * over score_entries; only the foursomes (entry units) persist.
  */
 export const playGroupsRouter = router({
-  // setFoursomes — Owner/Organizer. Replaces the game's foursomes + roster.
+  // setFoursomes — trip Owner/Organizer OR this game's delegate (requireGameEdit,
+  // §10). Replaces the game's foursomes + roster.
   setFoursomes: authedProcedure
     .input(
       z.object({
@@ -34,7 +35,7 @@ export const playGroupsRouter = router({
           .max(12),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
@@ -81,15 +82,15 @@ export const playGroupsRouter = router({
       return await readGroups(ctx.supabase, input.gameId);
     }),
 
-  // setHandicap — Owner/Organizer. Net strokes for one participant (null = 0).
-  // setParticipantStrokes — Owner/Organizer. The per-player ABSOLUTE handicap
+  // setParticipantStrokes — trip Owner/Organizer OR this game's delegate
+  // (requireGameEdit, §10). The per-player ABSOLUTE handicap
   // (Mode A), distinct from match play's relative one-side setHandicap. Server-
   // clamped to 0–18. Handicap is a scoring input, so the change re-derives the
   // game's in-progress results (CLAUDE.md "derived values recompute" pattern) —
   // a frozen/complete game is never rewritten.
   setParticipantStrokes: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string(), userId: z.string().min(1), strokes: z.number().int() }))
-    .use(requireTripRole("Organizer"))
+    .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")

--- a/supabase/migrations/20260614120000_053_delegate_setup_write_rls.sql
+++ b/supabase/migrations/20260614120000_053_delegate_setup_write_rls.sql
@@ -1,0 +1,39 @@
+-- 053 · Stage 4 (§10) — extend the per-game delegate path to the SETUP-write
+-- tables so a game's delegate can actually run it.
+--
+-- Migration 045 landed the delegate rule (is_game_organizer / requireGameEdit)
+-- on `games` (update) and `game_results` (all). But the match/rack SETUP
+-- mutations write three more tables — game_participants, play_groups,
+-- game_matches — whose write policies still require Owner/Organizer only. So
+-- once Stage 4 swapped the matches/playGroups routers to requireGameEdit(), a
+-- delegate cleared the server gate but then hit RLS on these tables. This
+-- finishes the delegate path (the CLAUDE.md "no twelve-call-site retrofit"
+-- lesson — land the rule on EVERY table the action writes).
+--
+-- These policies are PERMISSIVE, so they OR with the existing Owner/Organizer
+-- write policies (game_participants_write / play_groups_write /
+-- game_matches_write) — they ADD the delegate path, remove nothing. Idempotent.
+-- is_game_organizer(game) is defined in migration 045 (SECURITY DEFINER).
+
+-- game_participants: a delegate may add/clear the roster + handicaps for THEIR
+-- game (setPairings/assignPlayer/setFoursomes/setHandicap all write here).
+DROP POLICY IF EXISTS game_participants_delegate ON public.game_participants;
+CREATE POLICY game_participants_delegate ON public.game_participants
+  FOR ALL
+  USING (public.is_game_organizer(game_id))
+  WITH CHECK (public.is_game_organizer(game_id));
+
+-- play_groups: a delegate may rebuild the foursomes for THEIR game (setFoursomes).
+DROP POLICY IF EXISTS play_groups_delegate ON public.play_groups;
+CREATE POLICY play_groups_delegate ON public.play_groups
+  FOR ALL
+  USING (public.is_game_organizer(game_id))
+  WITH CHECK (public.is_game_organizer(game_id));
+
+-- game_matches: a delegate may set/reorder/activate the matchups for THEIR game
+-- (setPairings/assignPlayer/reorder/activate).
+DROP POLICY IF EXISTS game_matches_delegate ON public.game_matches;
+CREATE POLICY game_matches_delegate ON public.game_matches
+  FOR ALL
+  USING (public.is_game_organizer(game_id))
+  WITH CHECK (public.is_game_organizer(game_id));


### PR DESCRIPTION
## Why

The per-game **delegate** path (migration 045 — `game_organizers` / `requireGameEdit` / `is_game_organizer`) was landed on `games` + `game_results`, but the match/rack **setup** routers were never wired to it. So a game's delegate could configure points and post results, but **could not** set pairings, foursomes, handicaps, or activate the round — they'd clear the server gate elsewhere but the setup mutations were still `requireTripRole("Organizer")`. This finishes the delegate path so a delegate can genuinely *run* their game (Competition Face **Stage 4, §10**), game-isolated.

Split out as its own PR (your call: "full §10, gate as a separate PR first") so the server/permission change lands and is reviewed before the Stage 4 client work (board marking, delegate controls, member-not-ready message, teams structure-lock, status strip).

## Server gate
- `matches`: `setPairings` / `assignPlayer` / `setHandicap` / `reorder` / `activate` → `requireGameEdit()`.
- `playGroups`: `setFoursomes` / `setParticipantStrokes` → `requireGameEdit()`.
- `post` / `openCorrection` already admit the delegate (`requireGameRunAction`) — unchanged.

## DB row policies — migration 053
The server gate admits the delegate, but the underlying write tables still required Owner/Organizer at the **RLS** layer (so the delegate cleared the gate then hit RLS). Adds the permissive `is_game_organizer` policy to the three setup-write tables — `game_participants`, `play_groups`, `game_matches` — mirroring 045's `game_results` delegate policy. **PERMISSIVE**, so it ORs with the existing staff policies (adds the delegate path, removes nothing). Idempotent.

## Tests
`delegateSetupGate.test.ts`: a delegated member can run their game's `setPairings`/`activate` + `setFoursomes`; a plain member with no grant cannot; the grant is game-isolated (delegate of A can't touch B).

> **Verification:** local Docker/Supabase wasn't available, and the suite runs against the dev project. CI's `supabase db push` applies migration 053 before `vitest`, so the delegate tests are validated in CI on this PR. `tsc --noEmit` is clean locally. Please don't merge on red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)