### PR TITLE
fix(comp): refresh delegate grant after save in the game config modal

### DIFF
--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -503,6 +503,10 @@ function GameSheet({
       }
       if (canEdit) await reconcileDelegate(gameId);
       utils.games.listByTrip.invalidate({ tripId });
+      // Refresh the per-game organizer grant too — without this the
+      // listOrganizers cache stays stale, so reopening the modal shows the old
+      // delegate until a hard refresh.
+      utils.games.listOrganizers.invalidate({ tripId, gameId });
       utils.competitions.leaderboard.invalidate({ tripId, competitionId });
       return true;
     } catch (e) {

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -501,11 +501,23 @@ function GameSheet({
           await update.mutateAsync({ tripId, gameId, competitionFormat: (compFormat as never) ?? null, rulesForToday: rules.trim() || null, modifiers });
         }
       }
-      if (canEdit) await reconcileDelegate(gameId);
+      if (canEdit) {
+        await reconcileDelegate(gameId);
+        // Write the new grant straight into the listOrganizers cache. The
+        // mutations above already succeeded, so this is server truth — and
+        // unlike invalidate() (which only schedules a refetch) it's synchronous,
+        // so an IMMEDIATE reopen of the modal seeds from the correct value
+        // instead of racing the refetch against the dialog close.
+        utils.games.listOrganizers.setData(
+          { tripId, gameId },
+          desiredDelegate
+            ? ([{ user_id: desiredDelegate, granted_by: null, created_at: null }] as never)
+            : []
+        );
+      }
       utils.games.listByTrip.invalidate({ tripId });
-      // Refresh the per-game organizer grant too — without this the
-      // listOrganizers cache stays stale, so reopening the modal shows the old
-      // delegate until a hard refresh.
+      // Background reconcile (eventual consistency) — the setData above is what
+      // makes the immediate reopen correct.
       utils.games.listOrganizers.invalidate({ tripId, gameId });
       utils.competitions.leaderboard.invalidate({ tripId, competitionId });
       return true;


### PR DESCRIPTION
## Bug

Assigning or changing a game's **delegate** in the Configuration tab (Manage games → tap a game → Configuration) didn't show until you closed the modal, **hard-refreshed the page**, and reopened.

## Cause

`persist()` reconciled the grant (`addOrganizer`/`removeOrganizer`) and invalidated `games.listByTrip` + `competitions.leaderboard`, but **never invalidated `games.listOrganizers`**. So the organizer cache stayed stale and the reopened modal seeded its delegate state from the old value until a refresh.

## Fix

Invalidate `games.listOrganizers({ tripId, gameId })` alongside the other post-save invalidations.

## Verification (preview)

Remove the delegate → Save → reopen (no refresh) → correctly shows the cleared "Assign a game organizer" state. Reassigning + reopening shows the new delegate. No console errors. `tsc --noEmit` clean.

> No unit test added — this is client-side cache wiring (the repo has no RTL/jsdom; presentational React is validated via the data layer + preview, consistent with the Stage 1–3 comp-face work). The underlying `addOrganizer`/`removeOrganizer`/`listOrganizers` procedures are already covered.

Independent of #368 (delegate setup gate) — pre-existing bug in the assignment UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)