### PR TITLE
feat(comp): competition co-admin role (container-granted, live-derived)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -108,7 +108,9 @@ export function CompetitionFace({
       isOwner={isOwner}
       compact={isLive}
       onToggleLive={
-        isOwner && competition.status !== "completed" ? toggleLive : undefined
+        // Go-live is operational (owner-minus-destructive) — co-admins flip it
+        // too. canEdit = owner OR co-admin (trip organizer).
+        canEdit && competition.status !== "completed" ? toggleLive : undefined
       }
       togglePending={setStatus.isPending}
       onDeleted={onCompetitionDeleted}
@@ -190,7 +192,6 @@ export function CompetitionFace({
           competitionId={competition.id}
           tripId={tripId}
           canEdit={canEdit}
-          isOwner={isOwner}
           structureLocked={isLive}
         />
       )}

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -315,7 +315,9 @@ function GameCard({
         {canEdit && <Pencil size={13} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />}
       </button>
 
-      {isOwner && !dropped && (
+      {canEdit && !dropped && (
+        // Posting/correcting is operational (owner-minus-destructive) — owner &
+        // co-admins both run it. canEdit = owner OR co-admin.
         <div className="flex items-center justify-between px-3 py-2" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
           <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
             {state === "posted" ? "Points are on the board" : state === "correcting" ? "Correcting — re-post to update" : "Not posted yet"}

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -21,7 +21,6 @@ interface Props {
   competitionId: string;
   tripId: string;
   canEdit: boolean;
-  isOwner?: boolean;
   /** When provided, the parent (CompTab) drives create state via the
    *  CompetitionHeader's +Team button. Local state is used as a
    *  fallback so this panel still works standalone. */
@@ -197,7 +196,6 @@ export function TeamsPanel({
   competitionId,
   tripId,
   canEdit,
-  isOwner,
   creating: creatingProp,
   onCreatingChange,
   structureLocked = false,
@@ -337,7 +335,6 @@ export function TeamsPanel({
                   members={members as Member[]}
                   assignments={assignments as Assignment[]}
                   canEdit={canEdit}
-                  isOwner={!!isOwner}
                   onEdit={() => setEditingTeam(team)}
                   tripId={tripId}
                   competitionId={competitionId}
@@ -354,7 +351,6 @@ export function TeamsPanel({
           tripId={tripId}
           competitionId={competitionId}
           team={editingTeam}
-          isOwner={!!isOwner}
           structureLocked={structureLocked}
           existingTeamNames={teamsTyped.map((t) => t.name.toLowerCase())}
           onClose={() => {
@@ -431,7 +427,6 @@ function TeamCard({
   members,
   assignments,
   canEdit,
-  isOwner,
   onEdit,
   tripId,
   competitionId,
@@ -440,7 +435,6 @@ function TeamCard({
   members: Member[];
   assignments: Assignment[];
   canEdit: boolean;
-  isOwner: boolean;
   onEdit: () => void;
   tripId: string;
   competitionId: string;
@@ -578,7 +572,9 @@ function TeamCard({
                   : undefined
               }
               onRemove={
-                isOwner
+                // Swapping/unassigning a player is co-admin team-editing, not
+                // competition-destructive — owner & co-admins both do it.
+                canEdit
                   ? () => remove.mutate({ tripId, competitionId, userId: id })
                   : undefined
               }
@@ -947,7 +943,6 @@ function TeamSheet({
   tripId,
   competitionId,
   team,
-  isOwner,
   structureLocked = false,
   existingTeamNames,
   onClose,
@@ -955,9 +950,6 @@ function TeamSheet({
   tripId: string;
   competitionId: string;
   team: Team | null;
-  /** Only owners can delete the team — controls visibility of the
-   *  delete affordance in edit mode. */
-  isOwner: boolean;
   /** Live structure-lock (§9): hide the delete-team affordance (rename stays). */
   structureLocked?: boolean;
   /** Lowercased names of teams already in this competition — used to skip
@@ -984,7 +976,7 @@ function TeamSheet({
   // Snapshot member count for the confirm dialog before delete fires.
   const { data: assignments = [] } = trpc.teamAssignments.list.useQuery(
     { tripId, competitionId },
-    { enabled: isEdit && isOwner }
+    { enabled: isEdit && !structureLocked }
   );
   const memberCount = team
     ? (assignments as Assignment[]).filter((a) => a.team_id === team.id).length
@@ -1220,9 +1212,9 @@ function TeamSheet({
           )}
 
           <div className="flex items-center gap-2">
-            {isEdit && isOwner && !structureLocked && team && (
-              // Secondary destructive action — sits next to Save so it's
-              // reachable but doesn't compete with the primary CTA. Hidden once
+            {isEdit && !structureLocked && team && (
+              // Delete-team is co-admin team-editing (reaching this sheet already
+              // requires edit access) — not competition-destructive. Hidden once
               // live: removing a team is a structure change (§9).
               <button
                 type="button"

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -84,12 +84,86 @@ export function requireTripRole(minRole: TripRole) {
 }
 
 // ---------------------------------------------------------------------------
-// requireGameEdit (Slice D1 §8)
+// Competition roles — the competition's OWN role model (container-independent).
 //
-// The per-game edit gate: passes if the user is trip Owner/Organizer (canEdit)
-// OR a delegated organizer of THIS game (game_organizers row). Game-isolated —
-// a pick'em delegate cannot touch the scramble. Mirror of the DB rule in
-// migration 045 (is_game_organizer); both must agree.
+// The competition gate honors EXACTLY these roles and nothing else; it must
+// NEVER reach up and check trip roles directly. Instead the CONTAINER grants
+// competition roles: `resolveCompetitionRole` is the container's trip→competition
+// mapping (its implementation of "who are my co-admins"), and it is LIVE —
+// derived fresh from current trip membership on every check, never snapshotted.
+// Demote a trip organizer and their co-admin access is gone on the NEXT check
+// (no stale grant to leak). This is the same live-derivation discipline as the
+// roster seed reading team_assignments at pairing time.
+//
+//   co-admin = owner-minus-destructive: configure any game, edit teams, post any
+//   result, go-live — but NOT delete the competition / transfer ownership.
+//
+// Container mapping (trip-attached): Owner→owner, Organizer→co_admin, else member.
+// Standalone / Circle are FUTURE container mappings — they swap this derivation,
+// not the gate. The gate below only ever asks for the competition role.
+// ---------------------------------------------------------------------------
+
+export type CompetitionRole = "owner" | "co_admin" | "member";
+
+const COMP_ROLE_LEVEL: Record<CompetitionRole, number> = {
+  owner: 3,
+  co_admin: 2,
+  member: 1,
+};
+
+async function resolveCompetitionRole(
+  ctx: {
+    supabase: { from: (t: string) => unknown };
+    user: { id: string } | null;
+    membershipCache: Map<string, TripRole>;
+  },
+  tripId: string
+): Promise<CompetitionRole> {
+  // The ONLY place the trip role is consulted for competition authority — the
+  // container mapping, live-derived (resolveTripRole reads current membership).
+  const tripRole = await resolveTripRole(ctx, tripId);
+  if (tripRole === "Owner") return "owner";
+  if (tripRole === "Organizer") return "co_admin";
+  return "member";
+}
+
+// requireCompetitionRole(minRole) — competition-level gate (go-live, delete,
+// team edits). Checks the COMPETITION role granted by the container, never the
+// trip role. Reads tripId from rawInput; chain AFTER authedProcedure.
+export function requireCompetitionRole(minRole: CompetitionRole) {
+  return middleware(async ({ ctx, getRawInput, next }) => {
+    const raw = await getRawInput();
+    const parsed = z.object({ tripId: z.string() }).safeParse(raw);
+    if (!parsed.success) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "tripId is required" });
+    }
+    const { tripId } = parsed.data;
+    const role = await resolveCompetitionRole(ctx, tripId);
+    if (COMP_ROLE_LEVEL[role] < COMP_ROLE_LEVEL[minRole]) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          minRole === "owner"
+            ? "Only the competition owner can do this."
+            : "Requires competition co-admin access.",
+      });
+    }
+    return next({ ctx: { ...ctx, tripId } });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// requireGameEdit (Slice D1 §8; co-admin role-model)
+//
+// The per-game edit gate: passes if the user is a competition owner/co-admin
+// (granted by the container) OR a delegated organizer of THIS game
+// (game_organizers row). Game-isolated — a pick'em delegate cannot touch the
+// scramble. Mirror of the DB rule in migration 045 (is_game_organizer).
+//
+// Authority is the COMPETITION role, not the trip role — the trip→co-admin
+// mapping lives in resolveCompetitionRole (the container), so this gate stays
+// container-independent (standalone / Circle just change the mapping). Phase-
+// independent: there is no competition-status condition here, by design.
 //
 // Reads tripId + gameId from rawInput. Chain AFTER authedProcedure. Use on every
 // game-EDIT mutation (configure / enter-results); game CREATE stays trip-role
@@ -105,10 +179,13 @@ export function requireGameEdit() {
     }
     const { tripId, gameId } = parsed.data;
 
-    const role = await resolveTripRole(ctx, tripId); // throws if not a trip member
-    let allowed = ROLE_LEVEL[role] >= ROLE_LEVEL.Organizer;
+    // Competition role first (owner/co-admin edit any game) — the container
+    // grants it; this gate never checks the trip role itself.
+    const compRole = await resolveCompetitionRole(ctx, tripId); // throws if not a member
+    let allowed = COMP_ROLE_LEVEL[compRole] >= COMP_ROLE_LEVEL.co_admin;
 
     if (!allowed) {
+      // …otherwise a delegated organizer of THIS game (game-isolated).
       const { data } = await (
         ctx.supabase.from("game_organizers") as unknown as {
           select: (s: string) => {
@@ -130,21 +207,22 @@ export function requireGameEdit() {
     if (!allowed) {
       throw new TRPCError({
         code: "FORBIDDEN",
-        message: "Requires trip Organizer role or a game-organizer grant for this game",
+        message: "Requires competition co-admin access or a game-organizer grant for this game",
       });
     }
 
-    return next({ ctx: { ...ctx, tripId, tripRole: role } });
+    return next({ ctx: { ...ctx, tripId } });
   });
 }
 
 // ---------------------------------------------------------------------------
-// requireGameRunAction (Slice D Run/Post §5)
+// requireGameRunAction (Slice D Run/Post §5; co-admin role-model)
 //
-// Competition RUN-actions (post results / open score correction) are NARROWER
-// than game edit: trip OWNER or THIS game's delegate only — NOT a plain
-// Organizer (the "trip planner"). Run-actions are owner/delegate-scoped, distinct
-// from trip-planner scope (PERMISSIONS.md). Enforced server-side so the controls
+// Competition RUN-actions (post results / open score correction): a competition
+// owner/co-admin (granted by the container) OR THIS game's delegate. Co-admin is
+// owner-minus-destructive, and posting a result is operational, not destructive —
+// so co-admins post (the game-day redundancy this role exists for). Authority is
+// the COMPETITION role, never the trip role; enforced server-side so the controls
 // can't be reached by hiding the UI.
 // ---------------------------------------------------------------------------
 
@@ -157,8 +235,8 @@ export function requireGameRunAction() {
     }
     const { tripId, gameId } = parsed.data;
 
-    const role = await resolveTripRole(ctx, tripId); // throws if not a trip member
-    let allowed = role === "Owner"; // Owner only — Organizers/planners excluded
+    const compRole = await resolveCompetitionRole(ctx, tripId); // throws if not a member
+    let allowed = COMP_ROLE_LEVEL[compRole] >= COMP_ROLE_LEVEL.co_admin;
 
     if (!allowed) {
       const { data } = await (
@@ -182,11 +260,11 @@ export function requireGameRunAction() {
     if (!allowed) {
       throw new TRPCError({
         code: "FORBIDDEN",
-        message: "Posting and score corrections are limited to the trip owner or this game's delegate.",
+        message: "Posting and score corrections are limited to a competition owner/co-admin or this game's delegate.",
       });
     }
 
-    return next({ ctx: { ...ctx, tripId, tripRole: role } });
+    return next({ ctx: { ...ctx, tripId } });
   });
 }
 

--- a/src/server/routers/coAdminRole.test.ts
+++ b/src/server/routers/coAdminRole.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Competition co-admin role — the container grants it, the gate honors it.
+ *
+ * A trip ORGANIZER is granted competition co-admin (owner-minus-destructive) by
+ * the container mapping (resolveCompetitionRole), LIVE-derived from current trip
+ * membership. We assert the matrix in BOTH phases and — the critical one —
+ * that demoting the organizer pulls co-admin access on the next check, with no
+ * re-save of the competition (no snapshot to go stale).
+ */
+
+const MANUAL = "gtt_manual";
+const DIST = { type: "placement" as const, values: [9, 6] };
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let plannerId: string;
+const gameIds: string[] = [];
+
+async function newManualGame(name: string) {
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId: MANUAL,
+    name,
+    competitionId,
+    pointsDistribution: DIST,
+  })) as { id: string };
+  gameIds.push(g.id);
+  return g.id;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Co-admin trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // → competition co-admin
+  await ctx.addTripMember(tripId, "member", "Member");
+  plannerId = ctx.getUser("planner").id;
+  competitionId = await ctx.createCompetition(tripId, "Co-admin Cup");
+  teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
+  teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
+});
+
+afterAll(async () => {
+  for (const id of gameIds) {
+    await ctx.admin.from("game_results").delete().eq("game_id", id);
+    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("games").delete().eq("id", id);
+  }
+  // Restore the organizer role in case a live-derivation test left it demoted.
+  await ctx.admin
+    .from("trip_members")
+    .update({ role: "Organizer" })
+    .eq("trip_id", tripId)
+    .eq("user_id", plannerId);
+  await ctx.cleanup();
+});
+
+describe("co-admin = owner-minus-destructive (both phases)", () => {
+  it("a trip organizer edits + posts + goes live — pre-live AND post-live", async () => {
+    const coadmin = ctx.callerAs("planner");
+
+    // PRE-LIVE (competition still "upcoming"): configure a game (requireGameEdit).
+    const g1 = await newManualGame("Pre-live game");
+    await expect(
+      coadmin.games.setStatus({ tripId, gameId: g1, status: "active" })
+    ).resolves.toBeTruthy();
+
+    // Post a result (requireGameRunAction — co-admin, not just owner/delegate).
+    await expect(
+      coadmin.games.post({
+        tripId,
+        gameId: g1,
+        placements: [
+          { entityId: teamA, position: 1 },
+          { entityId: teamB, position: 2 },
+        ],
+      })
+    ).resolves.toBeTruthy();
+
+    // Go live (competitions.update status — operational, co-admin allowed).
+    await expect(
+      coadmin.competitions.update({ tripId, competitionId, status: "active" })
+    ).resolves.toBeTruthy();
+
+    // POST-LIVE: edit authority is phase-independent — still edits.
+    const g2 = await newManualGame("Post-live game");
+    await expect(
+      coadmin.games.setStatus({ tripId, gameId: g2, status: "active" })
+    ).resolves.toBeTruthy();
+  });
+
+  it("co-admin can edit teams but CANNOT delete the competition (destructive = owner only)", async () => {
+    const coadmin = ctx.callerAs("planner");
+
+    // Edit teams — co-admin work.
+    const t = await coadmin.teams.create({
+      tripId,
+      competitionId,
+      name: "Green",
+      shortName: "GRN",
+      color: "#22c55e",
+      colorDim: "#0a2a0f",
+    });
+    expect(t).toBeTruthy();
+    // Delete team (end-to-end: co_admin gate + migration 054 RLS).
+    await expect(
+      coadmin.teams.delete({ tripId, teamId: (t as { id: string }).id })
+    ).resolves.toBeTruthy();
+    const teams = await coadmin.teams.list({ tripId, competitionId });
+    expect((teams as { name: string }[]).some((x) => x.name === "Green")).toBe(false);
+
+    // Destructive: delete the competition — owner only.
+    await expect(
+      coadmin.competitions.delete({ tripId, competitionId })
+    ).rejects.toThrow(/owner/i);
+  });
+});
+
+describe("members have no co-admin access (either phase)", () => {
+  it("a plain trip member cannot edit, post, or go live", async () => {
+    const member = ctx.callerAs("member");
+    const g = await newManualGame("Member-blocked game");
+    await expect(
+      member.games.setStatus({ tripId, gameId: g, status: "active" })
+    ).rejects.toThrow(/co-admin|organizer|owner/i);
+    await expect(
+      member.games.post({
+        tripId,
+        gameId: g,
+        placements: [{ entityId: teamA, position: 1 }],
+      })
+    ).rejects.toThrow(/co-admin|organizer|owner|delegate/i);
+    await expect(
+      member.competitions.update({ tripId, competitionId, status: "active" })
+    ).rejects.toThrow(/co-admin|organizer|owner/i);
+  });
+});
+
+describe("co-admin is LIVE-derived, never snapshotted", () => {
+  it("demoting the organizer pulls co-admin access on the next check (no competition re-save)", async () => {
+    const g = await newManualGame("Live-derivation game");
+
+    // Organizer → co-admin → can edit.
+    await expect(
+      ctx.callerAs("planner").games.setStatus({ tripId, gameId: g, status: "active" })
+    ).resolves.toBeTruthy();
+
+    // Demote to Member at the container layer — NOTHING re-saves the competition.
+    await ctx.admin
+      .from("trip_members")
+      .update({ role: "Member" })
+      .eq("trip_id", tripId)
+      .eq("user_id", plannerId);
+
+    // Next check (fresh caller / fresh role cache): access is gone immediately.
+    await expect(
+      ctx.callerAs("planner").games.setStatus({ tripId, gameId: g, status: "pending" })
+    ).rejects.toThrow(/co-admin|organizer|owner/i);
+
+    // Re-promote → co-admin returns, again with no competition re-save.
+    await ctx.admin
+      .from("trip_members")
+      .update({ role: "Organizer" })
+      .eq("trip_id", tripId)
+      .eq("user_id", plannerId);
+    await expect(
+      ctx.callerAs("planner").games.setStatus({ tripId, gameId: g, status: "active" })
+    ).resolves.toBeTruthy();
+  });
+});

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole } from "../middleware";
+import { requireTripMember, requireTripRole, requireCompetitionRole } from "../middleware";
 import { computeCompetitionLeaderboard } from "../lib/competitionLeaderboard";
 
 const SCOREBOARD_STYLES = [
@@ -143,7 +143,8 @@ export const competitionsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // update — edit metadata (canEdit)
+  // update — edit metadata + go-live (owner/co-admin). Go-live is operational,
+  // not destructive, so co-admins can flip it.
   // -----------------------------------------------------------------------
   update: authedProcedure
     .input(
@@ -156,7 +157,7 @@ export const competitionsRouter = router({
         scoreboardStyle: z.enum(SCOREBOARD_STYLES).optional(),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireCompetitionRole("co_admin"))
     .mutation(async ({ ctx, input }) => {
       const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
       if (input.name !== undefined) patch.name = input.name;
@@ -183,11 +184,12 @@ export const competitionsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // delete — remove a competition (Owner only)
+  // delete — remove a competition. DESTRUCTIVE → competition owner only
+  // (co-admins are owner-minus-destructive).
   // -----------------------------------------------------------------------
   delete: authedProcedure
     .input(z.object({ tripId: z.string(), competitionId: z.string() }))
-    .use(requireTripRole("Owner"))
+    .use(requireCompetitionRole("owner"))
     .mutation(async ({ ctx, input }) => {
       const { error } = await ctx.supabase
         .from("competitions")

--- a/src/server/routers/games.runpost.test.ts
+++ b/src/server/routers/games.runpost.test.ts
@@ -110,7 +110,7 @@ describe("score lock — posted scores frozen until correction", () => {
   });
 });
 
-describe("permissions — run-actions are owner / game-delegate only", () => {
+describe("permissions — run-actions: owner / co-admin / game-delegate", () => {
   it("owner can post", async () => {
     const g = await newManualGame("Owner posts");
     await expect(
@@ -118,16 +118,17 @@ describe("permissions — run-actions are owner / game-delegate only", () => {
     ).resolves.toBeTruthy();
   });
 
-  it("a game-delegate can post; a plain Organizer (planner) and a Member cannot", async () => {
-    const g = await newManualGame("Delegate posts");
+  it("a co-admin (trip Organizer) and a game-delegate can post; a plain Member cannot", async () => {
+    const g = await newManualGame("Co-admin + delegate post");
     const place = [{ entityId: teamA, position: 1 }, { entityId: teamB, position: 2 }];
 
-    // Planner (trip Organizer, not this game's delegate) — blocked.
+    // Co-admin (trip Organizer) — posting is operational (owner-minus-destructive),
+    // so co-admins post now (the game-day redundancy this role exists for).
     await expect(ctx.callerAs("planner").games.post({ tripId, gameId: g, placements: place }))
-      .rejects.toThrow(/owner or this game's delegate/i);
-    // Plain Member — blocked.
+      .resolves.toBeTruthy();
+    // Plain Member — blocked (not co-admin, not this game's delegate).
     await expect(ctx.callerAs("member").games.post({ tripId, gameId: g, placements: place }))
-      .rejects.toThrow(/owner or this game's delegate/i);
+      .rejects.toThrow(/co-admin|delegate/i);
 
     // Grant the Member the game-delegate role → now allowed.
     await ctx.caller().games.addOrganizer({ tripId, gameId: g, userId: memberId });
@@ -142,10 +143,10 @@ describe("permissions — run-actions are owner / game-delegate only", () => {
     await expect(ctx.callerAs("outsider").games.openCorrection({ tripId, gameId: g })).rejects.toThrow();
   });
 
-  it("a planner cannot open correction either", async () => {
-    const g = await newManualGame("Planner correct blocked");
+  it("a co-admin (trip Organizer) can open correction", async () => {
+    const g = await newManualGame("Co-admin corrects");
     await ctx.caller().games.post({ tripId, gameId: g, placements: [{ entityId: teamA, position: 1 }] });
     await expect(ctx.callerAs("planner").games.openCorrection({ tripId, gameId: g }))
-      .rejects.toThrow(/owner or this game's delegate/i);
+      .resolves.toBeTruthy();
   });
 });

--- a/src/server/routers/teams.test.ts
+++ b/src/server/routers/teams.test.ts
@@ -64,17 +64,19 @@ describe("teams router", () => {
     expect(updated.name).toBe("Team Hammer 2.0");
   });
 
-  it("delete — only owner can delete a team", async () => {
-    const plannerCaller = ctx.callerAs("planner");
-    const teams = await plannerCaller.teams.list({ tripId, competitionId });
-    const target = teams[0];
-
+  it("delete — a co-admin (trip Organizer) can delete a team; a member cannot", async () => {
+    // Member is gated out at the co_admin boundary.
+    const memberCaller = ctx.callerAs("member");
+    const memberTeams = await memberCaller.teams.list({ tripId, competitionId });
     await expect(
-      plannerCaller.teams.delete({ tripId, teamId: target.id })
+      memberCaller.teams.delete({ tripId, teamId: memberTeams[0].id })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
-    const ownerCaller = ctx.caller();
-    const result = await ownerCaller.teams.delete({ tripId, teamId: target.id });
+    // Co-admin (planner) can — editing teams is owner-minus-destructive
+    // (deleting a TEAM isn't a competition-destructive action).
+    const plannerCaller = ctx.callerAs("planner");
+    const teams = await plannerCaller.teams.list({ tripId, competitionId });
+    const result = await plannerCaller.teams.delete({ tripId, teamId: teams[0].id });
     expect(result).toEqual({ success: true });
   });
 });

--- a/src/server/routers/teams.ts
+++ b/src/server/routers/teams.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole } from "../middleware";
+import { requireTripMember, requireCompetitionRole } from "../middleware";
 
 /**
  * teams — competition-scoped teams.
@@ -52,7 +52,7 @@ export const teamsRouter = router({
         colorDim: z.string().min(1).max(20),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireCompetitionRole("co_admin"))
     .mutation(async ({ ctx, input }) => {
       const { data: inserted, error: insertErr } = await ctx.supabase
         .from("teams")
@@ -103,7 +103,7 @@ export const teamsRouter = router({
         colorDim: z.string().min(1).max(20).optional(),
       })
     )
-    .use(requireTripRole("Organizer"))
+    .use(requireCompetitionRole("co_admin"))
     .mutation(async ({ ctx, input }) => {
       const patch: Record<string, unknown> = {};
       if (input.name !== undefined) patch.name = input.name;
@@ -129,11 +129,12 @@ export const teamsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // delete — remove a team (Owner only). Cascades clear assignments.
+  // delete — remove a team (owner/co-admin). Editing teams is co-admin work
+  // (not competition-destructive). Cascades clear assignments.
   // -----------------------------------------------------------------------
   delete: authedProcedure
     .input(z.object({ tripId: z.string(), teamId: z.string() }))
-    .use(requireTripRole("Owner"))
+    .use(requireCompetitionRole("co_admin"))
     .mutation(async ({ ctx, input }) => {
       const { error } = await ctx.supabase
         .from("teams")

--- a/supabase/migrations/20260615120000_054_teams_delete_coadmin.sql
+++ b/supabase/migrations/20260615120000_054_teams_delete_coadmin.sql
@@ -1,0 +1,20 @@
+-- 054 · Competition co-admin — let co-admins delete teams.
+--
+-- Co-admin = owner-minus-destructive, where the destructive set is exactly
+-- {delete the competition, transfer ownership}. Deleting a TEAM is ordinary
+-- team-editing (co-admin work), not competition-destructive. The co_admin tRPC
+-- gate now admits trip organizers for teams.delete; widen the RLS to match so
+-- the gate isn't blocked at the row layer (the migration-053 lesson — land the
+-- rule on the table the action writes).
+--
+-- teams_delete was Owner-only (migration 001 / 029); widen to Owner+Organizer,
+-- mirroring the existing teams_update / teams_insert policies. Idempotent.
+DROP POLICY IF EXISTS teams_delete ON public.teams;
+CREATE POLICY teams_delete ON public.teams FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.competitions c
+      WHERE c.id = teams.competition_id
+        AND has_trip_role(c.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+    )
+  );


### PR DESCRIPTION
## Why

On game day the owner is often unreachable (mid-round, beer in hand). **Co-admin is operational redundancy** — a second/third person who can do admin lifting. It's the inebriation principle one level up: the *competition* shouldn't depend on any one person being reachable.

## Role model (the competition's OWN roles — container-independent)

| Role | Authority |
|---|---|
| **owner** | full control incl. destructive (delete competition / transfer ownership) |
| **co_admin** | configure any game, edit teams, post any result, go-live — **owner-minus-destructive** |
| **delegate** | their assigned game(s) only |
| **member** | read-only (post-reveal) |

## The architecture (the decouple-clean core)

- **`resolveCompetitionRole(ctx, tripId)`** — the **container** mapping (trip→competition), the *only* place a trip role is consulted for competition authority. **LIVE-derived** from current trip membership on every check, **never snapshotted** — demote a trip organizer and co-admin access is gone on the *next* check (no stale grant to leak). Standalone/Circle are future mappings; the gate is unchanged.
- **`requireGameEdit` + `requireGameRunAction`** now check the **competition role** (owner/co_admin) **OR** this game's delegate — no inline trip-role check. New **`requireCompetitionRole(min)`** gates competition-level actions.
- `competitions.update` (go-live) → co_admin · `competitions.delete` → **owner** (destructive) · `teams.create/update/delete` → co_admin. **Migration 054** widens `teams_delete` RLS Owner→Owner+Organizer to match the co_admin gate (the migration-053 lesson — land the rule on the table the action writes). `competitions.create` stays trip-role (bootstrap).

## Client

Co-admins see the owner's admin controls **minus destructive** — go-live toggle, post/correct, team edit/delete all gate on `canEdit` (owner OR co-admin); delete-competition stays `isOwner`. Removed the now-dead `isOwner` threading through `TeamsPanel`.

## Tests

`coAdminRole.test.ts` asserts the matrix in **both phases** + the **critical live-derivation** (demote → loses access on the next check, no competition re-save; re-promote → regains). Updated `games.runpost.test.ts` to the new policy (co-admins post + correct). All 26 affected existing tests pass locally; the new suite is 3/4 locally — the `teams.delete` end-to-end assertion needs migration 054, which CI's `supabase db push` applies before `vitest` (the #368/053 pattern). `tsc` clean.

> Note: builds on the already-role-based, phase-independent edit gate (the phase-gating fix's prerequisite was already satisfied — see prior investigation). This PR refactors that gate from trip-role to competition-role and adds co-admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)