### PR TITLE
fix(comp): admit game delegates to the competition face pre-live

### DIFF
--- a/src/app/trips/[tripId]/leaderboard/page.tsx
+++ b/src/app/trips/[tripId]/leaderboard/page.tsx
@@ -60,7 +60,16 @@ export default function LiveFacePage() {
   const { role, isOwner, canEdit, loading: roleLoading } = useTripRole(tripId);
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
 
-  const loading = compLoading || roleLoading;
+  // A game delegate is a BUILDER, not audience — they reach the competition in
+  // BOTH phases to configure their assigned game (setup happens pre-live, and
+  // delegates aren't always organizers). One competition per trip (MVP), so any
+  // delegated game ⇒ a delegate of this competition. Edit stays scoped to their
+  // game(s) by the edit gate; this is visibility only.
+  const { data: myDelegateGameIds = [], isLoading: delegateLoading } =
+    trpc.games.myDelegateGameIds.useQuery({ tripId }, { enabled: !!competition });
+  const amDelegate = (myDelegateGameIds as string[]).length > 0;
+
+  const loading = compLoading || roleLoading || delegateLoading;
 
   let body: React.ReactNode;
   if (loading) {
@@ -87,9 +96,11 @@ export default function LiveFacePage() {
     } else {
       body = <NotSetUpEmptyState />;
     }
-  } else if (!canEdit && competition.status !== "active") {
-    // Members don't see the board until the owner flips Go Live (the
-    // visibility switch). Owners/organizers always get the full face.
+  } else if (!canEdit && !amDelegate && competition.status !== "active") {
+    // Plain members (no delegation) don't see the competition until Go Live
+    // (the visibility switch). Owners/organizers/co-admins AND game delegates
+    // (builders) always get the full face — a delegate needs pre-live access to
+    // set up their assigned game.
     body = <NotLiveEmptyState />;
   } else {
     body = (


### PR DESCRIPTION
## Bug

A **member-role delegate**, pre-live, hit the *"Competition isn't live yet"* wall and couldn't reach their assigned game to set it up — but configuration happens pre-live, and delegates aren't always organizers. That wall is correct for a **plain member** (audience), wrong for a **delegate** (builder).

## Fix

The leaderboard face's pre-live visibility gate admitted owner/organizer/co-admin only (`canEdit`). Now it also admits a user who delegates **any** game in the competition — via `games.myDelegateGameIds` (the same source the edit gate scopes by; one competition per trip in MVP, so any delegated game ⇒ this competition).

```
- } else if (!canEdit && competition.status !== "active") {
+ } else if (!canEdit && !amDelegate && competition.status !== "active") {
```

- **Plain members (no delegation):** still walled pre-live — unchanged.
- **Delegate:** sees the face in both phases; the board already marks their game **YOURS** (Stage 4) and the game page recognizes the delegate, so they tap in and configure. **Edit stays scoped to their game(s)** by the edit gate — unchanged (visibility-only fix).
- **Owner/organizer/co-admin:** unchanged.

## Verify
- `tsc` clean; owner path confirmed in preview (face renders, not walled, no console errors).
- The delegate-specific render isn't unit-testable (no RTL in repo), but its determinant — `myDelegateGameIds` returns the delegate's games and nothing for a non-delegate — is server-tested (`games.d1.test.ts`), as is delegate edit-scoping (`games.d1` / `delegateSetupGate` / `coAdminRole`). No server change, so no new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)