### PR TITLE
feat(comp-face): Stage 5 — the cord-cut (competition off the trip tab structure)

### DIFF
--- a/src/app/trips/[tripId]/components/setup-guide/CompetitionEnableCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/CompetitionEnableCard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trophy, X } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+
+// ── CompetitionEnableCard ───────────────────────────────────────────────────
+//
+// The optional "Running a competition?" card at the foot of trip Home's setup
+// guide — the create entry point for a competition now that the Competition tab
+// is gone (Stage 5 cord-cut). The trip CREATES the competition here; the
+// competition face MANAGES it from its own gear thereafter.
+//
+//   - No competition + not dismissed → the prompt ("Set it up" / "Not this trip").
+//   - "Set it up"  → the competition face, where the create flow lives. Once a
+//                    competition exists the "Live" bottom-nav entry appears and
+//                    becomes the entry point — so this card hides itself.
+//   - "Not this trip" → dismissed (per-trip, localStorage), card hidden.
+//
+// Owner-only by virtue of living inside the owner-only FreshTripGuide.
+
+const KEY = (tripId: string) => `bt-trip-${tripId}-comp-card-dismissed`;
+
+export function CompetitionEnableCard({ tripId }: { tripId: string }) {
+  const router = useRouter();
+  const { data: competition } = trpc.competitions.getByTrip.useQuery({ tripId });
+
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(KEY(tripId)) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  // Once enabled, the "Live" nav entry is the way in — the card's job is done.
+  if (competition || dismissed) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(KEY(tripId), "1");
+    } catch {
+      // best-effort; state still flips in memory
+    }
+  };
+
+  return (
+    <div
+      className="relative mt-3 flex items-start gap-4 rounded-xl p-4"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px dashed var(--color-bt-border)",
+      }}
+      data-testid="comp-enable-card"
+    >
+      <div
+        className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl"
+        style={{
+          background: "var(--color-bt-accent-faint)",
+          color: "var(--color-bt-accent)",
+        }}
+        aria-hidden
+      >
+        <Trophy size={20} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p
+          className="text-[15px] font-semibold leading-tight"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          Running a competition?
+        </p>
+        <p
+          className="mt-1 text-[13px] leading-snug"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          Teams, games, and a live leaderboard the crew follows along. Optional —
+          most trips don&rsquo;t need one.
+        </p>
+        <div className="mt-3 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => router.push(`/trips/${tripId}/leaderboard`)}
+            className="inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-[13px] font-semibold"
+            style={{
+              background: "var(--color-bt-accent)",
+              color: "var(--color-bt-on-accent, #0d1f1a)",
+            }}
+            data-testid="comp-enable-setup"
+          >
+            <Trophy size={14} strokeWidth={2.4} />
+            Set it up
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            className="rounded-lg px-3 py-2 text-[13px] font-medium"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="comp-enable-dismiss"
+          >
+            Not this trip
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-lg"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        <X size={15} />
+      </button>
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/FreshTripGuide.tsx
@@ -5,6 +5,7 @@ import { Building2, Check, Flag, UserPlus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { StepCard } from "./StepCard";
 import { SetDatesFlipCard } from "./SetDatesFlipCard";
+import { CompetitionEnableCard } from "./CompetitionEnableCard";
 import { DatePollCard } from "../../tabs/components/DatePollCard";
 import {
   LodgingThumbnail,
@@ -253,6 +254,11 @@ export function FreshTripGuide({
           />
         </div>
       )}
+
+      {/* Optional last card — enable a competition (the create entry point now
+          that the Competition tab is gone). Self-hides once one exists or is
+          dismissed. */}
+      {!pollMode && <CompetitionEnableCard tripId={tripId} />}
 
       {/* Commit bar — appears once there's enough to go; switches Home to the
           itinerary (the guide stays reopenable via the left pill). */}

--- a/src/app/trips/[tripId]/leaderboard/page.tsx
+++ b/src/app/trips/[tripId]/leaderboard/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Trophy } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useTripRole } from "@/hooks/useTripRole";
+import { canAccessCompetition } from "@/lib/competitionAccess";
 import { useRealtimeCompetition } from "@/hooks/useRealtimeCompetition";
 import { useRealtimeMembers } from "@/hooks/useRealtimeMembers";
 import { TopNav } from "@/components/TopNav";
@@ -96,11 +97,12 @@ export default function LiveFacePage() {
     } else {
       body = <NotSetUpEmptyState />;
     }
-  } else if (!canEdit && !amDelegate && competition.status !== "active") {
-    // Plain members (no delegation) don't see the competition until Go Live
-    // (the visibility switch). Owners/organizers/co-admins AND game delegates
-    // (builders) always get the full face — a delegate needs pre-live access to
-    // set up their assigned game.
+  } else if (
+    !canAccessCompetition({ canEdit, amDelegate, status: competition.status })
+  ) {
+    // Plain members (no delegation) don't see the competition until Go Live.
+    // Builders (owner / organizer / co-admin / delegate) always get the full
+    // face. Same predicate as the "Live" nav entry — they can't disagree.
     body = <NotLiveEmptyState />;
   } else {
     body = (

--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -28,6 +28,7 @@ import { LodgingTab } from "./tabs/LodgingTab";
 import { ExpensesTab } from "./tabs/ExpensesTab";
 import { formatDateRangeCompact } from "@/lib/dates";
 import { isReadOnly as checkReadOnly } from "@/lib/tripStatus";
+import { canAccessCompetition } from "@/lib/competitionAccess";
 import { DatesSheet } from "./components/DatesSheet";
 
 // ── TripDetailPage ────────────────────────────────────────────────────────
@@ -105,6 +106,16 @@ function TripDetailBody({ tripId }: { tripId: string }) {
   // leaderboard is rebuilt against the new model.
   const { data: competition, isLoading: competitionLoading } =
     trpc.competitions.getByTrip.useQuery({ tripId });
+
+  // Drives the "Live" bottom-nav entry's visibility — a game delegate (even a
+  // member-role one) is a builder who can reach the competition pre-live, so the
+  // entry must show for them too. Same predicate as the leaderboard's pre-live
+  // wall (canAccessCompetition) so nav-visibility and wall-visibility can't
+  // disagree.
+  const { data: myDelegateGameIds = [] } = trpc.games.myDelegateGameIds.useQuery(
+    { tripId },
+    { enabled: !!competition }
+  );
 
   // schedule + logistics ARE gated: they feed the home itinerary (ItineraryView
   // / FreshTripGuide query them by tripId) which is the default surface on a
@@ -541,9 +552,12 @@ function TripDetailBody({ tripId }: { tripId: string }) {
       {/* Bottom nav appears once the owner flips the competition to
           "active" (Go Live button in CompetitionHeader). Stays hidden
           during setup so we don't surface an empty leaderboard. */}
-      {competition?.status === "active" && (
-        <TripBottomNav tripId={tripId} showComp={true} />
-      )}
+      {competition &&
+        canAccessCompetition({
+          canEdit,
+          amDelegate: (myDelegateGameIds as string[]).length > 0,
+          status: competition.status,
+        }) && <TripBottomNav tripId={tripId} showComp={true} />}
 
       {/* ── Settings modal ────────────────────────────────────────────────── */}
       {showSettings && role && (

--- a/src/components/TripTabBar.test.tsx
+++ b/src/components/TripTabBar.test.tsx
@@ -8,26 +8,17 @@ import { describe, it, expect } from "vitest";
  */
 
 describe("TripTabBar — tab configuration", () => {
-  // Per SPEC 2: always show 4 tabs (Home, Schedule, Crew, Competition)
-  const TABS = [
-    { id: "home", label: "Home" },
-    { id: "schedule", label: "Schedule" },
-    { id: "crew", label: "Crew" },
-    { id: "comp", label: "Competition" },
-  ];
+  // Post Stage-5 cord-cut: the tab bar is PURE TRIP CONTENT — no Competition
+  // tab. The competition is a face (created from trip Home's enable card,
+  // entered via the "Live" bottom-nav entry), not a tab.
+  const TAB_IDS = ["home", "crew", "lodging", "schedule", "expenses"];
 
-  it("has exactly 4 tabs", () => {
-    expect(TABS).toHaveLength(4);
+  it("is pure trip content — no Competition tab", () => {
+    expect(TAB_IDS).not.toContain("comp");
   });
 
-  it("includes Home, Schedule, Crew, Competition", () => {
-    const ids = TABS.map((t) => t.id);
-    expect(ids).toEqual(["home", "schedule", "crew", "comp"]);
-  });
-
-  it("does NOT include More tab", () => {
-    const ids = TABS.map((t) => t.id);
-    expect(ids).not.toContain("more");
+  it("includes the five trip tabs", () => {
+    expect(TAB_IDS).toEqual(["home", "crew", "lodging", "schedule", "expenses"]);
   });
 });
 
@@ -82,33 +73,17 @@ describe("TripBottomNav — back navigation contract", () => {
 // ── Tab-filtering tests ────────────────────────────────────────────────
 
 describe("Tab bar — tab filtering", () => {
-  const ALL_TAB_IDS = ["home", "crew", "schedule", "expenses", "comp"];
+  // No Competition tab anymore (Stage 5 cord-cut). The tab bar is pure trip
+  // content for everyone; the competition is reached via the "Live" bottom-nav
+  // entry, not a tab.
+  const ALL_TAB_IDS = ["home", "crew", "lodging", "schedule", "expenses"];
 
-  // Competition is an owner/organizer-only authoring surface: the tab shows
-  // iff the viewer can edit (Owner or Organizer), independent of stage or
-  // whether a competition row exists. Members reach a live competition via
-  // the bottom-nav "Live" entry instead.
-  function getVisibleTabs(canEdit: boolean) {
-    return ALL_TAB_IDS.filter((id) => {
-      if (id === "comp") return canEdit;
-      return true;
-    });
-  }
-
-  it("hides Competition tab from members (non-editors)", () => {
-    const tabs = getVisibleTabs(false);
-    expect(tabs).not.toContain("comp");
-    expect(tabs).toEqual(["home", "crew", "schedule", "expenses"]);
+  it("never includes a Competition tab (it's a face, not a tab)", () => {
+    expect(ALL_TAB_IDS).not.toContain("comp");
   });
 
-  it("shows Competition tab for owners/organizers (editors)", () => {
-    const tabs = getVisibleTabs(true);
-    expect(tabs).toContain("comp");
-  });
-
-  it("Expenses tab is always present in tab list (disabled state handled at click level)", () => {
-    const tabs = getVisibleTabs(true);
-    expect(tabs).toContain("expenses");
+  it("Expenses tab is present in the tab list", () => {
+    expect(ALL_TAB_IDS).toContain("expenses");
   });
 });
 

--- a/src/components/TripTabBar.tsx
+++ b/src/components/TripTabBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, type FC } from "react";
-import { House, Users, Hotel, Calendar, DollarSign, Trophy, type LucideIcon } from "lucide-react";
+import { House, Users, Hotel, Calendar, DollarSign, type LucideIcon } from "lucide-react";
 import type { TabId } from "./BottomNav";
 import { DOMAIN_COLORS, TAB_DOMAIN } from "@/lib/domainColors";
 
@@ -11,13 +11,16 @@ interface TabDef {
   Icon: LucideIcon;
 }
 
+// The Competition tab is gone (Stage 5 cord-cut) — the competition is a face,
+// not a tab. It's created from trip Home's enable card, managed from the
+// competition header gear, and entered via the "Live" bottom-nav entry. The
+// trip tab bar is pure trip content.
 const ALL_TABS: TabDef[] = [
   { id: "home",     label: "Home",        Icon: House       },
   { id: "crew",     label: "Crew",        Icon: Users       },
   { id: "lodging",  label: "Lodging",     Icon: Hotel       },
   { id: "schedule", label: "Agenda",      Icon: Calendar    },
   { id: "expenses", label: "Receipts",    Icon: DollarSign  },
-  { id: "comp",     label: "Competition", Icon: Trophy      },
 ];
 
 interface TripTabBarProps {
@@ -49,12 +52,6 @@ export const TripTabBar: FC<TripTabBarProps> = ({
   const [iconMode, setIconMode] = useState(false);
 
   const tabs = ALL_TABS.filter((t) => {
-    if (t.id === "comp") {
-      // Competition is an owner/organizer-only authoring surface. Members
-      // never see the tab — they follow a *live* competition through the
-      // bottom nav's "Live" entry (the leaderboard route) instead.
-      return canEdit;
-    }
     // Lodging and Expenses are only meaningful once a destination is locked
     // in — keep them out of the idea phase. Every later phase shows all five
     // primary tabs (Home, Crew, Lodging, Agenda, Receipts).

--- a/src/lib/competitionAccess.test.ts
+++ b/src/lib/competitionAccess.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { canAccessCompetition } from "./competitionAccess";
+
+/**
+ * canAccessCompetition — the ONE predicate behind both the "Live" nav entry
+ * (shown when true) and the pre-live wall (shown when false). These tests pin
+ * the Stage-5 access matrix in both phases so nav and wall can't diverge.
+ */
+describe("canAccessCompetition", () => {
+  const upcoming = "upcoming";
+  const active = "active";
+
+  it("owner / co-admin (canEdit) can access in BOTH phases", () => {
+    expect(canAccessCompetition({ canEdit: true, amDelegate: false, status: upcoming })).toBe(true);
+    expect(canAccessCompetition({ canEdit: true, amDelegate: false, status: active })).toBe(true);
+  });
+
+  it("a delegate (member-role, builder) can access in BOTH phases", () => {
+    expect(canAccessCompetition({ canEdit: false, amDelegate: true, status: upcoming })).toBe(true);
+    expect(canAccessCompetition({ canEdit: false, amDelegate: true, status: active })).toBe(true);
+  });
+
+  it("a plain member is WALLED pre-live, admitted once live (go-live reveals)", () => {
+    expect(canAccessCompetition({ canEdit: false, amDelegate: false, status: upcoming })).toBe(false);
+    expect(canAccessCompetition({ canEdit: false, amDelegate: false, status: active })).toBe(true);
+  });
+
+  it("a plain member cannot access a completed competition pre-reveal states", () => {
+    expect(canAccessCompetition({ canEdit: false, amDelegate: false, status: "completed" })).toBe(false);
+    expect(canAccessCompetition({ canEdit: false, amDelegate: false, status: null })).toBe(false);
+  });
+
+  it("nav-visibility and wall-visibility are exact complements (can't disagree)", () => {
+    for (const canEdit of [true, false]) {
+      for (const amDelegate of [true, false]) {
+        for (const status of [upcoming, active, "completed", null]) {
+          const navShows = canAccessCompetition({ canEdit, amDelegate, status });
+          const wallShows = !canAccessCompetition({ canEdit, amDelegate, status });
+          expect(navShows).toBe(!wallShows);
+        }
+      }
+    }
+  });
+});

--- a/src/lib/competitionAccess.ts
+++ b/src/lib/competitionAccess.ts
@@ -1,0 +1,31 @@
+// ── Competition access predicate ───────────────────────────────────────────
+//
+// THE single "can this user access the competition right now?" check. It drives
+// two things that must never disagree:
+//   - the "Live" bottom-nav entry — shown when this is TRUE
+//   - the pre-live "Competition isn't live yet" wall — shown when this is FALSE
+// Computing them from one predicate makes the failure mode (nav shows but wall
+// also shows, or vice-versa) impossible.
+//
+// A competition is accessible to its BUILDERS at all times (owner / organizer /
+// co-admin via `canEdit`; a game delegate via `amDelegate`) and to EVERYONE once
+// it's live (`status === "active"` — go-live is what reveals it to plain crew).
+// Callers gate on the competition EXISTING separately (no competition ⇒ nothing
+// to access, "Live" hidden for everyone).
+
+export interface CompetitionAccessInput {
+  /** Trip Owner/Organizer → competition owner/co-admin. */
+  canEdit: boolean;
+  /** Delegates any game in the competition (a builder, even if member-role). */
+  amDelegate: boolean;
+  /** competition.status — "upcoming" | "active" | "completed" (or null). */
+  status: string | null | undefined;
+}
+
+export function canAccessCompetition({
+  canEdit,
+  amDelegate,
+  status,
+}: CompetitionAccessInput): boolean {
+  return canEdit || amDelegate || status === "active";
+}


### PR DESCRIPTION
## Stage 5 — the cord-cut

The competition becomes **purely a face**: born from trip Home, entered via the **"Live"** bottom-nav entry, with **no presence in the trip tab bar**. Built in the mandated order — replacements first, deletion last.

### 1 · Replacements (before the tab is removed)
- **Enable-competition card** (`CompetitionEnableCard`) — the last optional card in trip Home's setup guide (`FreshTripGuide`). "Set it up" → the face's create flow (the same IntroPanel/SetupPanel the tab hosted); "Not this trip" dismisses (per-trip, localStorage). **Self-hides** once a competition exists (the "Live" nav becomes the entry) or is dismissed. Owner-only (lives in the owner-only guide).
- **Settings** already live on the face's Band-2 header gear (rename / tagline / delete) — no move needed.

### 2 · "Live" nav ↔ pre-live wall — one shared predicate
New **`canAccessCompetition({canEdit, amDelegate, status})`** = `canEdit || amDelegate || status === "active"`.
- Trip-page **"Live"** entry shows when a competition **exists && canAccess**.
- Leaderboard **wall** shows when **!canAccess**.
- Deriving both from the one predicate makes nav/wall disagreement impossible (the spec's hard requirement).

| Role | Pre-live | Post-live |
|---|---|---|
| owner / organizer / co-admin | Live ✓ | ✓ |
| delegate (incl. member-role) | Live ✓ | ✓ |
| plain member | **hidden** | ✓ (go-live reveals) |
| *(no competition)* | hidden for all | — |

### 3 · The cut
**Deleted the Competition tab** from `TripTabBar` — the tab bar is pure trip content (home/crew/lodging/agenda/receipts). Stale `?tab=comp` deep links still redirect onto the face (the Stage 3 effect).

## Tests / verification
- `competitionAccess.test.ts` pins the matrix in both phases + proves nav/wall are exact complements. `TripTabBar.test.ts` updated (no comp tab). `tsc` clean.
- Verified live (owner): **no Competition tab**; **"Live" shows pre-live**; face + wall intact; no console errors. The enable card's *show* path wasn't reproducible live (both existing trips already have competitions, and mature trips dismiss the guide) — the hide-path is verified and the create flow reuses existing surfaces.

This is the final comp-face stage — the competition is a face, not a tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)