### PR TITLE
fix(nav): Trip Home / Live bottom nav — current-trip + hierarchical back

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -160,20 +160,16 @@ export const TripBottomNav: FC<TripBottomNavProps> = ({
             data-testid={`nav-${id}`}
             onClick={() => {
               if (pathname === href) return; // already here
-              const onTripHome = pathname === `/trips/${tripId}`;
+              // Live is a CHILD of trip home (hierarchical, not flat tabs):
+              //  - Trip Home: replace → return to THIS trip's home in place.
+              //    Deterministic — never router.back(), which could pop to a
+              //    previously-visited trip; never push, which would stack a
+              //    duplicate home.
+              //  - Live: push → browser-back from Live returns to the trip
+              //    home you came from (not the previous trip).
               const goingToTripHome = href === `/trips/${tripId}`;
-              if (goingToTripHome) {
-                // Trip home is already in history (we pushed when we left it).
-                // Use back() to return to that entry instead of creating a
-                // duplicate trip-home entry via replace.
-                router.back();
-              } else if (onTripHome) {
-                // Leaving trip home — push so it stays in history for back nav.
-                router.push(href);
-              } else {
-                // Sub-page → sub-page — replace to avoid stacking.
-                router.replace(href);
-              }
+              if (goingToTripHome) router.replace(href);
+              else router.push(href);
             }}
             className="relative flex flex-1 flex-col items-center justify-center gap-1 py-2 transition-colors"
             style={{ color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}


### PR DESCRIPTION
## Bugs (two, same root: history mishandling)

1. **"Trip Home" used `router.back()`** — popped browser history, so after trip-switching or arriving via "Live" it landed on a *previously-visited* trip's home (or the dashboard), not the current trip's.
2. After a first attempt fixed (1) with **replace-both**, going trip home → Live then pressing **browser-back skipped trip home and went to the previous trip** — `replace` had swapped trip home *out* of history.

## Fix — Live is a child of trip home (hierarchical, not flat tabs)

- **Live → `router.push(href)`** — browser-back from Live returns to the trip home you came from (not the previous trip).
- **Trip Home → `router.replace(href)`** — return to *this* trip's home in place; deterministic, never `router.back()` (can't pop to another trip), never a duplicate-home push.

```
const goingToTripHome = href === `/trips/${tripId}`;
if (goingToTripHome) router.replace(href); // this trip's home, in place
else router.push(href);                    // Live as a child → back returns home
```

## Verify (preview)

- dashboard → trip home → **Live** → **mouse-back** → lands on the **current trip's home** (replace-both had gone to the dashboard / previous trip). ✓
- **Trip Home** button from Live → current trip's home (never a previously-visited trip). ✓
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)