### PR TITLE
fix(comp): enable card — one decline + a settings recovery valve

### DIFF
--- a/src/app/trips/[tripId]/components/setup-guide/CompetitionEnableCard.tsx
+++ b/src/app/trips/[tripId]/components/setup-guide/CompetitionEnableCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Trophy, X } from "lucide-react";
+import { Trophy } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 
 // ── CompetitionEnableCard ───────────────────────────────────────────────────
@@ -49,7 +49,7 @@ export function CompetitionEnableCard({ tripId }: { tripId: string }) {
 
   return (
     <div
-      className="relative mt-3 flex items-start gap-4 rounded-xl p-4"
+      className="mt-3 flex items-start gap-4 rounded-xl p-4"
       style={{
         background: "var(--color-bt-card)",
         border: "1px dashed var(--color-bt-border)",
@@ -105,15 +105,6 @@ export function CompetitionEnableCard({ tripId }: { tripId: string }) {
           </button>
         </div>
       </div>
-      <button
-        type="button"
-        onClick={dismiss}
-        aria-label="Dismiss"
-        className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-lg"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        <X size={15} />
-      </button>
     </div>
   );
 }

--- a/src/components/TripSettingsModal.tsx
+++ b/src/components/TripSettingsModal.tsx
@@ -14,6 +14,7 @@ import {
   MessageCircle,
   Trash2,
   AlertTriangle,
+  Trophy,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { useModalBackButton } from "@/hooks/useModalBackButton";
@@ -93,6 +94,11 @@ export function TripSettingsModal({
 
   const isOwner = viewerRole === "Owner";
   const canEditPlan = viewerRole === "Owner" || viewerRole === "Organizer";
+
+  // Competition existence drives the owner's "Enable competition" entry — the
+  // permanent creation/recovery path now that the enable card (the proactive
+  // prompt) can be dismissed. Deduped with the trip page's own query.
+  const { data: competition } = trpc.competitions.getByTrip.useQuery({ tripId });
 
   // ── Navigation ────────────────────────────────────────────────────────
   const [view, setView] = useState<View>("menu");
@@ -348,6 +354,31 @@ export function TripSettingsModal({
                           .filter(Boolean)
                           .join(" · ")}
                         onClick={openDetails}
+                      />
+                    </Section>
+                  )}
+
+                  {isOwner && (
+                    <Section label="Competition">
+                      <Row
+                        testId="settings-competition-row"
+                        icon={<Trophy size={17} />}
+                        title={competition ? "Competition" : "Enable competition"}
+                        subtitle={
+                          competition
+                            ? "Open the Live face to manage it"
+                            : "Teams, games, and a live leaderboard"
+                        }
+                        onClick={() => {
+                          // Same entry the enable card uses — the face hosts the
+                          // create flow (and the management surface once it
+                          // exists). One creation path, two entry points.
+                          // Navigate WITHOUT onClose() — the navigation unmounts
+                          // the modal, and (like the delete-trip row) skipping
+                          // onClose avoids useModalBackButton's cleanup
+                          // history.back() racing/cancelling the push.
+                          router.push(`/trips/${tripId}/leaderboard`);
+                        }}
                       />
                     </Section>
                   )}


### PR DESCRIPTION
Two small, related changes to the Stage-5 enable card (now the *only* way to create a competition).

## 1 · Drop the "X", keep "Not this trip"
The card had two functionally-identical dismisses. Kept the labeled button — unambiguous, deliberate (vs a reflexive corner-click), and consistent with the sibling setup-guide `StepCard`s (respond-to-it cards, no dismiss X). The card's stray X was the inconsistency. Decline stays visible as "Not this trip".

## 2 · "Enable competition" recovery entry in trip settings
Because the card is the sole creation prompt and "Not this trip" dismisses it, there's now a **permanent, owner-gated** entry in trip settings:
- **Reuses the same entry the card uses** — navigate to the competition face, which hosts the create flow. One creation path, two entry points (card = proactive prompt; settings = durable entry).
- Once a competition exists, the row reflects it ("Open the Live face to manage it") rather than offering a duplicate.
- Dismissing the card removes the *prompt*, never the *capability* — re-enabling is one click away in settings.

Navigates **without `onClose()`** (matching the delete-trip row) so `useModalBackButton`'s cleanup `history.back()` doesn't race/cancel the push — without this the navigation silently no-ops.

## Verify
- Settings → **Competition** row present (owner), shows the existing-competition state, and **navigates to the face** — confirmed in preview.
- Card renders only **Set it up / Not this trip** (no X).
- Recovery loop: dismiss card → settings "Enable competition" → face create flow (the same `/leaderboard` path Stage 5 verified). `tsc` clean.

> Note: both trips in the dev data already have competitions, so the *no-competition* renders (the card itself; the "Enable competition" label) couldn't be shown live — they're code-verified, and the settings→face navigation + the create flow are verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)