### PR TITLE
feat(comp-face): Stage A — competition face single boundary resolve (faceBootstrap)

### DIFF
--- a/src/app/trips/[tripId]/leaderboard/page.tsx
+++ b/src/app/trips/[tripId]/leaderboard/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Trophy } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { useTripRole } from "@/hooks/useTripRole";
 import { canAccessCompetition } from "@/lib/competitionAccess";
 import { useRealtimeCompetition } from "@/hooks/useRealtimeCompetition";
 import { useRealtimeMembers } from "@/hooks/useRealtimeMembers";
@@ -56,21 +55,57 @@ export default function LiveFacePage() {
     setNewsOpen((p) => !p);
   };
 
-  const { data: competition, isLoading: compLoading } =
-    trpc.competitions.getByTrip.useQuery({ tripId });
-  const { role, isOwner, canEdit, loading: roleLoading } = useTripRole(tripId);
-  const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+  const utils = trpc.useUtils();
 
-  // A game delegate is a BUILDER, not audience — they reach the competition in
-  // BOTH phases to configure their assigned game (setup happens pre-live, and
-  // delegates aren't always organizers). One competition per trip (MVP), so any
-  // delegated game ⇒ a delegate of this competition. Edit stays scoped to their
-  // game(s) by the edit gate; this is visibility only.
-  const { data: myDelegateGameIds = [], isLoading: delegateLoading } =
-    trpc.games.myDelegateGameIds.useQuery({ tripId }, { enabled: !!competition });
-  const amDelegate = (myDelegateGameIds as string[]).length > 0;
+  // ── The single boundary resolve (Stage A) ────────────────────────────────
+  // One round-trip for everything both face states need — no more 3-wave
+  // waterfall, no separate role / delegate fetches. Trip-coupling lives only in
+  // the bootstrap's server resolver; the client just reads what it returns.
+  const { data: boot, isLoading: loading } =
+    trpc.competitions.faceBootstrap.useQuery({ tripId });
 
-  const loading = compLoading || roleLoading || delegateLoading;
+  const competition = boot?.competition ?? null;
+  // Competition role (owner / co_admin / member), live-derived server-side.
+  const role = boot?.myCompetitionRole ?? null;
+  const canEdit = role === "owner" || role === "co_admin";
+  const isOwner = role === "owner";
+  // A delegate is a BUILDER — reaches the competition in both phases to set up
+  // their assigned game (canAccessCompetition admits them). Edit stays scoped to
+  // their game by the edit gate; this is visibility only.
+  const amDelegate = (boot?.myDelegateGameIds.length ?? 0) > 0;
+
+  // Seed the child caches from the one bootstrap so the board/guide — and the
+  // setup↔leaderboard toggle, and the sub-views — render from cache with NO
+  // extra round-trips. The global 60s staleTime keeps the seed fresh, so the
+  // children's own useQuery calls don't re-fetch. Seeded once per bootstrap, in
+  // render before the face mounts (ref-guarded) so children read a warm cache.
+  const seededFor = useRef<unknown>(null);
+  if (boot && seededFor.current !== boot) {
+    seededFor.current = boot;
+    utils.competitions.getByTrip.setData({ tripId }, boot.competition as never);
+    utils.games.myDelegateGameIds.setData({ tripId }, boot.myDelegateGameIds);
+    if (boot.competition) {
+      const cid = boot.competition.id as string;
+      utils.competitions.leaderboard.setData(
+        { tripId, competitionId: cid },
+        boot.leaderboard as never,
+      );
+      utils.games.listByTrip.setData({ tripId }, boot.games as never);
+      utils.teams.list.setData({ tripId, competitionId: cid }, boot.teams as never);
+      utils.teamAssignments.list.setData(
+        { tripId, competitionId: cid },
+        boot.assignments as never,
+      );
+    }
+  }
+
+  // Crew names (for chat/news authors) are container-provided and NOT needed to
+  // render the face — fetch lazily, only when a panel opens (A4: chat/news off
+  // the load critical path).
+  const { data: members = [] } = trpc.tripMembers.list.useQuery(
+    { tripId },
+    { enabled: chatOpen || newsOpen },
+  );
 
   let body: React.ReactNode;
   if (loading) {
@@ -159,7 +194,7 @@ export default function LiveFacePage() {
         tripId={tripId}
         isOpen={newsOpen}
         onClose={() => setNewsOpen(false)}
-        canPost={role === "Owner" || role === "Organizer"}
+        canPost={canEdit}
         authors={Object.fromEntries(
           members.map(
             (m: {

--- a/src/app/trips/[tripId]/leaderboard/page.tsx
+++ b/src/app/trips/[tripId]/leaderboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Trophy } from "lucide-react";
@@ -77,11 +77,12 @@ export default function LiveFacePage() {
   // Seed the child caches from the one bootstrap so the board/guide — and the
   // setup↔leaderboard toggle, and the sub-views — render from cache with NO
   // extra round-trips. The global 60s staleTime keeps the seed fresh, so the
-  // children's own useQuery calls don't re-fetch. Seeded once per bootstrap, in
-  // render before the face mounts (ref-guarded) so children read a warm cache.
-  const seededFor = useRef<unknown>(null);
-  if (boot && seededFor.current !== boot) {
-    seededFor.current = boot;
+  // children's own useQuery calls don't re-fetch. Keyed on `boot` so it runs
+  // exactly once per resolve, synchronously DURING render — before the face's
+  // children mount and fire their queries (an effect runs too late: child
+  // mount-effects fire before the parent's, so they'd re-fetch first).
+  useMemo(() => {
+    if (!boot) return;
     utils.competitions.getByTrip.setData({ tripId }, boot.competition as never);
     utils.games.myDelegateGameIds.setData({ tripId }, boot.myDelegateGameIds);
     if (boot.competition) {
@@ -97,7 +98,7 @@ export default function LiveFacePage() {
         boot.assignments as never,
       );
     }
-  }
+  }, [boot, tripId, utils]);
 
   // Crew names (for chat/news authors) are container-provided and NOT needed to
   // render the face — fetch lazily, only when a panel opens (A4: chat/news off

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -31,35 +31,40 @@ export async function computeCompetitionLeaderboard(
   supabase: SupabaseClient,
   competitionId: string
 ) {
-  const { data: teams } = await supabase
-    .from("teams")
-    .select("id, name, short_name, color")
-    .eq("competition_id", competitionId);
+  // These four reads are independent — run them in parallel (one round-trip's
+  // worth of latency instead of four stacked). `game_results` alone depends on
+  // the game ids, so it waits below. (Was 5 serial queries — the profiling's
+  // server-side mini-waterfall; this is fix #3.)
+  const [teamsRes, compRes, gameRowsRes, assignmentsRes] = await Promise.all([
+    supabase
+      .from("teams")
+      .select("id, name, short_name, color")
+      .eq("competition_id", competitionId),
+    supabase
+      .from("competitions")
+      .select("defending_team_id")
+      .eq("id", competitionId)
+      .maybeSingle(),
+    // Games of this competition. We fetch ALL (incl. dropped) so the grid can
+    // show an "Abandoned" column, but only LIVE ones feed the roll-up.
+    supabase
+      .from("games")
+      .select("id, name, points_distribution, points_total, status, game_type_id")
+      .eq("competition_id", competitionId)
+      .order("created_at", { ascending: true }),
+    // Team sizes (member headcount) drive the match-game total = value ×
+    // matchCount — derived from sizes, NOT pairings (§8).
+    supabase
+      .from("team_assignments")
+      .select("team_id")
+      .eq("competition_id", competitionId),
+  ]);
+  const teams = teamsRes.data;
   const teamIds = (teams ?? []).map((t) => t.id as string);
-
-  const { data: comp } = await supabase
-    .from("competitions")
-    .select("defending_team_id")
-    .eq("id", competitionId)
-    .maybeSingle();
-
-  // Games of this competition. We fetch ALL (incl. dropped) so the grid can show
-  // an "Abandoned" column, but only LIVE ones feed the roll-up / points-available.
-  const { data: gameRows } = await supabase
-    .from("games")
-    .select("id, name, points_distribution, points_total, status, game_type_id")
-    .eq("competition_id", competitionId)
-    .order("created_at", { ascending: true });
-  const allGames = gameRows ?? [];
+  const comp = compRes.data;
+  const allGames = gameRowsRes.data ?? [];
   const live = allGames.filter((g) => g.status !== "dropped");
-
-  // Team sizes (member headcount) drive the match-game total = value ×
-  // matchCount — derived from sizes, NOT pairings, so the per_match total is
-  // known once teams are populated and stays stable through the week (§8).
-  const { data: assignments } = await supabase
-    .from("team_assignments")
-    .select("team_id")
-    .eq("competition_id", competitionId);
+  const assignments = assignmentsRes.data;
   const sizeByTeam = new Map<string, number>();
   for (const a of assignments ?? []) {
     const tid = a.team_id as string;

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -59,6 +59,99 @@ export const competitionsRouter = router({
     .query(({ ctx, input }) => computeCompetitionLeaderboard(ctx.supabase, input.competitionId)),
 
   // -----------------------------------------------------------------------
+  // faceBootstrap — the competition face's single boundary resolve (Stage A).
+  //
+  // ONE round-trip that returns everything BOTH face states need: the shared
+  // base (competition + teams + games + assignments) plus the leaderboard
+  // roll-up (board) and the raw games rows the setup guide reads for per-game
+  // config status. Collapses the old 3-wave client waterfall into one parallel
+  // fetch, and serves both states so flipping setup↔leaderboard never re-fetches.
+  //
+  // It is the ONE place trip-coupling lives: the viewer's competition role is
+  // live-derived from THIS request's trip role (resolved fresh by
+  // requireTripMember — no cross-request cache, so demoting an organizer revokes
+  // co-admin on the next load). Standalone later swaps only this resolve.
+  //
+  // Shapes match the individual procedures (getByTrip / teams.list /
+  // teamAssignments.list / games.listByTrip / myDelegateGameIds / leaderboard)
+  // so the client can seed those caches from one call.
+  // -----------------------------------------------------------------------
+  faceBootstrap: authedProcedure
+    .input(z.object({ tripId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx }) => {
+      const tripId = ctx.tripId;
+      const myCompetitionRole =
+        ctx.tripRole === "Owner"
+          ? "owner"
+          : ctx.tripRole === "Organizer"
+            ? "co_admin"
+            : "member";
+
+      const { data: competition } = await ctx.supabase
+        .from("competitions")
+        .select("*")
+        .eq("trip_id", tripId)
+        .order("created_at", { ascending: true })
+        .limit(1)
+        .maybeSingle();
+
+      if (!competition) {
+        // Clean no-competition state — the face renders the enable/empty state.
+        return {
+          competition: null,
+          myCompetitionRole,
+          myDelegateGameIds: [] as string[],
+          teams: [] as unknown[],
+          assignments: [] as unknown[],
+          games: [] as unknown[],
+          leaderboard: null,
+        };
+      }
+      const competitionId = competition.id as string;
+
+      // All independent — one round-trip, parallel DB work. `leaderboard` is the
+      // SAME compute competitions.leaderboard runs (parallelized internally), so
+      // its shape matches for cache-seeding.
+      const [teams, assignments, games, myDelegateGameIds, leaderboard] =
+        await Promise.all([
+          ctx.supabase
+            .from("teams")
+            .select("*")
+            .eq("competition_id", competitionId)
+            .order("created_at", { ascending: true })
+            .then((r) => r.data ?? []),
+          ctx.supabase
+            .from("team_assignments")
+            .select("*")
+            .eq("competition_id", competitionId)
+            .then((r) => r.data ?? []),
+          ctx.supabase
+            .from("games")
+            .select("*")
+            .eq("trip_id", tripId)
+            .order("created_at", { ascending: false })
+            .then((r) => r.data ?? []),
+          ctx.supabase
+            .from("game_organizers")
+            .select("game_id")
+            .eq("user_id", ctx.user!.id)
+            .then((r) => (r.data ?? []).map((x) => x.game_id as string)),
+          computeCompetitionLeaderboard(ctx.supabase, competitionId),
+        ]);
+
+      return {
+        competition,
+        myCompetitionRole,
+        myDelegateGameIds,
+        teams,
+        assignments,
+        games,
+        leaderboard,
+      };
+    }),
+
+  // -----------------------------------------------------------------------
   // teamAssignmentCounts — per-team member headcount for this competition.
   // Used by GameSheet to project per_match total before pairings exist:
   // projected cap = min(...counts), projected total = value × cap.

--- a/src/server/routers/faceBootstrap.test.ts
+++ b/src/server/routers/faceBootstrap.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * competitions.faceBootstrap — the Stage-A single boundary resolve.
+ *
+ * One call returns everything both face states need: the shared base
+ * (competition + teams + games + assignments), the leaderboard roll-up, the
+ * viewer's live-derived competition role, and their delegated game ids. These
+ * tests assert both states' data is present, the no-competition case is clean,
+ * and the role is derived in both directions (owner/co-admin/member).
+ */
+
+const MANUAL = "gtt_manual";
+const DIST = { type: "placement" as const, values: [9, 6] };
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let gameId: string;
+let memberId: string;
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Bootstrap trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // → co_admin
+  await ctx.addTripMember(tripId, "member", "Member");
+  memberId = ctx.getUser("member").id;
+  competitionId = await ctx.createCompetition(tripId, "Bootstrap Cup");
+  await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
+  await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
+  const g = (await ctx.caller().games.create({
+    tripId,
+    gameTypeId: MANUAL,
+    name: "Pickem",
+    competitionId,
+    pointsDistribution: DIST,
+  })) as { id: string };
+  gameId = g.id;
+});
+
+afterAll(async () => {
+  await ctx.admin.from("game_organizers").delete().eq("game_id", gameId);
+  await ctx.admin.from("game_results").delete().eq("game_id", gameId);
+  await ctx.admin.from("games").delete().eq("id", gameId);
+  await ctx.cleanup();
+});
+
+describe("faceBootstrap — both states in one resolve", () => {
+  it("returns the shared base + leaderboard for the owner", async () => {
+    const boot = await ctx.caller().competitions.faceBootstrap({ tripId });
+    expect(boot.competition?.id).toBe(competitionId);
+    expect(boot.myCompetitionRole).toBe("owner");
+    expect(boot.teams.length).toBe(2); // shared base (setup guide + board)
+    expect((boot.games as { id: string }[]).some((g) => g.id === gameId)).toBe(true);
+    // Leaderboard roll-up present (the board state) — same shape as the
+    // competitions.leaderboard endpoint.
+    expect(boot.leaderboard).not.toBeNull();
+    expect(boot.leaderboard!.teams.length).toBe(2);
+    expect(boot.leaderboard!.pointsAvailable).toBeGreaterThan(0);
+  });
+
+  it("derives the competition role in both directions (live, per request)", async () => {
+    const asPlanner = await ctx.callerAs("planner").competitions.faceBootstrap({ tripId });
+    expect(asPlanner.myCompetitionRole).toBe("co_admin");
+
+    const asMember = await ctx.callerAs("member").competitions.faceBootstrap({ tripId });
+    expect(asMember.myCompetitionRole).toBe("member");
+    expect(asMember.myDelegateGameIds).not.toContain(gameId); // not a delegate yet
+  });
+
+  it("surfaces the viewer's delegated games (drives the 'Yours' marking)", async () => {
+    await ctx.caller().games.addOrganizer({ tripId, gameId, userId: memberId });
+    const asMember = await ctx.callerAs("member").competitions.faceBootstrap({ tripId });
+    expect(asMember.myDelegateGameIds).toContain(gameId);
+    // still a member-role competition role — delegate ≠ co-admin
+    expect(asMember.myCompetitionRole).toBe("member");
+  });
+});
+
+describe("faceBootstrap — no-competition trip is a clean state, not an error", () => {
+  it("returns a null competition + empty base without throwing", async () => {
+    const noCompTrip = await ctx.createTrip("No-comp trip");
+    const boot = await ctx.caller().competitions.faceBootstrap({ tripId: noCompTrip });
+    expect(boot.competition).toBeNull();
+    expect(boot.leaderboard).toBeNull();
+    expect(boot.teams).toEqual([]);
+    expect(boot.games).toEqual([]);
+    expect(boot.myDelegateGameIds).toEqual([]);
+    expect(boot.myCompetitionRole).toBe("owner"); // role still resolves
+  });
+});


### PR DESCRIPTION
## Stage A — Competition face: one boundary resolve

Turns the profiling pass's two fixes into architecture. Collapses the competition face's **3-wave serial tRPC waterfall** into **one parallel server resolve**, and parallelizes the leaderboard's internal queries.

### Server (commit 1)
- **`computeCompetitionLeaderboard`** — the 4 independent reads (teams, competition, game rows, assignments) now run via `Promise.all`; only `game_results` stays dependent (needs the live game ids). Was 5 serial queries — the profiling's server-side mini-waterfall (fix #3).
- **`competitions.faceBootstrap`** — one round-trip returning everything **both** face states need: the shared base (competition + teams + games + assignments), the leaderboard roll-up, the viewer's **live-derived** competition role, and their delegated game ids. Shapes match the individual procedures so the client can seed those caches. Handles the no-competition trip as a clean null state, not an error. It is the **one** place trip-coupling lives (the role is derived from *this* request's trip role — no cross-request cache, so demoting an organizer revokes co-admin on the next load); standalone later swaps only this resolve.
- `faceBootstrap.test.ts` — 4 tests: both states present for owner; role derived both directions (owner/co_admin/member); delegated games surfaced; no-competition trip returns a clean null state.

### Client (commit 2)
- The Live face fires the **single** `faceBootstrap` query and derives `role` / `canEdit` / `amDelegate` from its server fields — no client `useTripRole`, and the self-inflicted delegate render-gate is gone.
- Seeds the child caches (`getByTrip` / `leaderboard` / `listByTrip` / `teams` / `assignments` / `myDelegateGameIds`) from that one call. The global 60s `staleTime` keeps the seed fresh, so the board, the setup guide, and the **setup↔leaderboard toggle** render from cache with no extra round-trips and no spinner past the first open.
- Chat/news crew names go **lazy** (fetch only when a panel opens), off the load critical path. News `canPost` now follows `canEdit` (owner/co-admin).

### Verification
- ✅ A competition load fires **one** bootstrap round-trip for the core data (down from 3 waves) — confirmed in the network panel; no separate leaderboard/teams/assignments/listByTrip/myDelegateGameIds queries.
- ✅ Flipping setup↔leaderboard shows **no spinner** — both states render from the seeded cache (verified in preview: setup guide showed "2 teams · 7 assigned" instantly).
- ✅ Board renders real data; first open (empty cache) is the only loading moment.
- ✅ No-comp trip renders the enable/empty state cleanly via `faceBootstrap` (covered by test).
- ✅ Live-derivation intact (no role cached across requests).
- ✅ `tsc --noEmit` clean; bootstrap tests pass (4/4).

Stage B (server-component render so initial state ships with the page; realtime-ready server-render-initial + client-subscribe) is a separate follow-on, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
