### PR TITLE
feat(comp-face): Stage B — server-render the initial competition state

### DIFF
--- a/src/app/trips/[tripId]/leaderboard/page.tsx
+++ b/src/app/trips/[tripId]/leaderboard/page.tsx
@@ -1,287 +1,42 @@
-"use client";
-
-import { useState, useMemo } from "react";
-import { useParams } from "next/navigation";
-import Link from "next/link";
-import { Trophy } from "lucide-react";
-import { trpc } from "@/lib/trpc-client";
-import { canAccessCompetition } from "@/lib/competitionAccess";
-import { useRealtimeCompetition } from "@/hooks/useRealtimeCompetition";
-import { useRealtimeMembers } from "@/hooks/useRealtimeMembers";
-import { TopNav } from "@/components/TopNav";
-import { TripBottomNav } from "@/components/BottomNav";
-import { FloatingChatPanel } from "@/components/FloatingChatPanel";
-import { NewsPanel, type NewsAuthorMeta } from "@/components/NewsPanel";
-import { CompetitionFace } from "@/components/competition/CompetitionFace";
-import { CompetitionIntroPanel } from "@/components/competition/CompetitionIntroPanel";
-import { CompetitionSetupPanel } from "@/components/competition/CompetitionSetupPanel";
+import { createSSRHelpers } from "@/server/trpc-ssr";
+import {
+  LiveFaceClient,
+  type FaceBootstrap,
+} from "@/components/competition/LiveFaceClient";
 
 /**
- * The Live face — the competition face's root (the "Live" bottom-nav
- * destination). Stage 3 escaped this off the trip's Competition tab: it's now
- * a clean face = global title bar (Band 1) + the competition header (Band 2) +
- * the bottom nav, with NO trip header and NO trip tab bar.
+ * The Live face route (Server Component) — Stage B.
  *
- * It hosts both states through CompetitionFace (setup guide ⇄ leaderboard) and
- * — as the interim entry point until Stage 5 — the pre-competition create flow
- * the Competition tab used to own inline.
+ * Resolves the competition face's single boundary resolve
+ * (competitions.faceBootstrap) on the server and hands it to the client face as
+ * initialData, so the initial competition state ships WITH the page: the
+ * board/guide render populated in the server HTML (zero client round-trip for
+ * first paint), and the client reads it as fresh under the 60s staleTime — no
+ * mount refetch (one resolve per load, B4). It is the SAME resolver as Stage A,
+ * just called server-side via the SSR helpers (B2).
  *
- * Role gating:
- *   - editor, no competition      → intro → create form
- *   - non-editor, no competition  → "not set up yet"
- *   - non-editor, not live        → "not live yet" (go-live reveals the board)
- *   - otherwise                   → the two-state CompetitionFace
+ * Interactivity (toggle, controls, go-live) + realtime subscriptions live in
+ * LiveFaceClient as client components over this server-rendered initial state
+ * (B1) — the natural foundation for the live realtime board (B3).
+ *
+ * Resolve failures are swallowed (mirrors the trip layout): an unauthed/early
+ * request hands down `null`, and the client falls back to its own fetch +
+ * loading state rather than tripping the route error boundary.
  */
-export default function LiveFacePage() {
-  const { tripId } = useParams<{ tripId: string }>();
+export default async function LiveFacePage({
+  params,
+}: {
+  params: Promise<{ tripId: string }>;
+}) {
+  const { tripId } = await params;
 
-  // Push competition (Go Live, name, tagline) + membership changes live so the
-  // face re-resolves without a manual refresh.
-  useRealtimeCompetition(tripId);
-  useRealtimeMembers(tripId);
-
-  const [chatOpen, setChatOpen] = useState(false);
-  const [newsOpen, setNewsOpen] = useState(false);
-  // Editor has tapped "Enable Competition Mode" — swaps the intro panel for the
-  // create form. Reset when the competition is deleted so the intro reappears.
-  const [unlocked, setUnlocked] = useState(false);
-
-  const openChat = () => {
-    setNewsOpen(false);
-    setChatOpen((p) => !p);
-  };
-  const openNews = () => {
-    setChatOpen(false);
-    setNewsOpen((p) => !p);
-  };
-
-  const utils = trpc.useUtils();
-
-  // ── The single boundary resolve (Stage A) ────────────────────────────────
-  // One round-trip for everything both face states need — no more 3-wave
-  // waterfall, no separate role / delegate fetches. Trip-coupling lives only in
-  // the bootstrap's server resolver; the client just reads what it returns.
-  const { data: boot, isLoading: loading } =
-    trpc.competitions.faceBootstrap.useQuery({ tripId });
-
-  const competition = boot?.competition ?? null;
-  // Competition role (owner / co_admin / member), live-derived server-side.
-  const role = boot?.myCompetitionRole ?? null;
-  const canEdit = role === "owner" || role === "co_admin";
-  const isOwner = role === "owner";
-  // A delegate is a BUILDER — reaches the competition in both phases to set up
-  // their assigned game (canAccessCompetition admits them). Edit stays scoped to
-  // their game by the edit gate; this is visibility only.
-  const amDelegate = (boot?.myDelegateGameIds.length ?? 0) > 0;
-
-  // Seed the child caches from the one bootstrap so the board/guide — and the
-  // setup↔leaderboard toggle, and the sub-views — render from cache with NO
-  // extra round-trips. The global 60s staleTime keeps the seed fresh, so the
-  // children's own useQuery calls don't re-fetch. Keyed on `boot` so it runs
-  // exactly once per resolve, synchronously DURING render — before the face's
-  // children mount and fire their queries (an effect runs too late: child
-  // mount-effects fire before the parent's, so they'd re-fetch first).
-  useMemo(() => {
-    if (!boot) return;
-    utils.competitions.getByTrip.setData({ tripId }, boot.competition as never);
-    utils.games.myDelegateGameIds.setData({ tripId }, boot.myDelegateGameIds);
-    if (boot.competition) {
-      const cid = boot.competition.id as string;
-      utils.competitions.leaderboard.setData(
-        { tripId, competitionId: cid },
-        boot.leaderboard as never,
-      );
-      utils.games.listByTrip.setData({ tripId }, boot.games as never);
-      utils.teams.list.setData({ tripId, competitionId: cid }, boot.teams as never);
-      utils.teamAssignments.list.setData(
-        { tripId, competitionId: cid },
-        boot.assignments as never,
-      );
-    }
-  }, [boot, tripId, utils]);
-
-  // Crew names (for chat/news authors) are container-provided and NOT needed to
-  // render the face — fetch lazily, only when a panel opens (A4: chat/news off
-  // the load critical path).
-  const { data: members = [] } = trpc.tripMembers.list.useQuery(
-    { tripId },
-    { enabled: chatOpen || newsOpen },
-  );
-
-  let body: React.ReactNode;
-  if (loading) {
-    body = (
-      <div className="flex min-h-[40vh] items-center justify-center">
-        <div
-          className="h-8 w-8 animate-spin rounded-full border-2"
-          style={{
-            borderColor: "var(--color-bt-accent)",
-            borderTopColor: "transparent",
-          }}
-        />
-      </div>
-    );
-  } else if (!competition) {
-    // No competition row yet. Editors get the create flow (the interim entry
-    // point); everyone else gets a calm placeholder.
-    if (canEdit) {
-      body = unlocked ? (
-        <CompetitionSetupPanel tripId={tripId} />
-      ) : (
-        <CompetitionIntroPanel onEnable={() => setUnlocked(true)} />
-      );
-    } else {
-      body = <NotSetUpEmptyState />;
-    }
-  } else if (
-    !canAccessCompetition({ canEdit, amDelegate, status: competition.status })
-  ) {
-    // Plain members (no delegation) don't see the competition until Go Live.
-    // Builders (owner / organizer / co-admin / delegate) always get the full
-    // face. Same predicate as the "Live" nav entry — they can't disagree.
-    body = <NotLiveEmptyState />;
-  } else {
-    body = (
-      <CompetitionFace
-        tripId={tripId}
-        competition={competition}
-        canEdit={canEdit}
-        isOwner={isOwner}
-        onCompetitionDeleted={() => setUnlocked(false)}
-      />
-    );
+  let initialBoot: FaceBootstrap | null = null;
+  try {
+    const helpers = await createSSRHelpers();
+    initialBoot = await helpers.competitions.faceBootstrap.fetch({ tripId });
+  } catch {
+    // Auth/membership not ready — the client falls back to its own fetch.
   }
 
-  return (
-    <div
-      className="min-h-screen"
-      style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text)" }}
-    >
-      {/* Band 1 — the global title bar, identical to the trip face (§2). */}
-      <TopNav
-        tripId={tripId}
-        onOpenChat={openChat}
-        chatOpen={chatOpen}
-        onOpenNews={openNews}
-        newsOpen={newsOpen}
-        onDismissPanels={() => {
-          setChatOpen(false);
-          setNewsOpen(false);
-        }}
-      />
-
-      <main className="mx-auto max-w-[1024px] px-4 pt-4 pb-32">{body}</main>
-
-      {/* Bottom nav persists on the face so you can always cross back to the
-          trip (§11). Live is the current destination. */}
-      <TripBottomNav tripId={tripId} showComp={true} />
-
-      {/* Chat / News overlay any surface (§11). */}
-      <FloatingChatPanel
-        tripId={tripId}
-        isOpen={chatOpen}
-        onClose={() => setChatOpen(false)}
-        memberNames={Object.fromEntries(
-          members.map(
-            (m: {
-              user_id: string | null;
-              memberId: string;
-              displayName: string;
-            }) => [m.user_id ?? m.memberId, m.displayName]
-          )
-        )}
-      />
-      <NewsPanel
-        tripId={tripId}
-        isOpen={newsOpen}
-        onClose={() => setNewsOpen(false)}
-        canPost={canEdit}
-        authors={Object.fromEntries(
-          members.map(
-            (m: {
-              user_id: string | null;
-              memberId: string;
-              displayName: string;
-              role: NewsAuthorMeta["role"];
-              user: { avatar_icon: string | null } | null;
-            }) => [
-              m.user_id ?? m.memberId,
-              {
-                name: m.displayName,
-                role: m.role,
-                avatarIcon: m.user?.avatar_icon ?? null,
-              },
-            ]
-          )
-        )}
-      />
-    </div>
-  );
-}
-
-// ── Empty states ────────────────────────────────────────────────────────────
-
-function NotSetUpEmptyState() {
-  return (
-    <EmptyState
-      title="Competition hasn't been set up yet"
-      body="The owner will set this up before the trip."
-    />
-  );
-}
-
-function NotLiveEmptyState() {
-  return (
-    <EmptyState
-      title="Competition isn't live yet"
-      body="The organizer hasn't flipped this to live. The leaderboard appears here once they hit Go Live."
-    />
-  );
-}
-
-function EmptyState({ title, body }: { title: string; body: string }) {
-  const { tripId } = useParams<{ tripId: string }>();
-  return (
-    <div
-      className="mt-6 flex flex-col items-center justify-center rounded-xl px-6 py-16 text-center"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-      data-testid="comp-face-empty"
-    >
-      <div
-        className="flex h-16 w-16 items-center justify-center rounded-2xl"
-        style={{
-          background: "var(--color-bt-accent-faint)",
-          color: "var(--color-bt-accent)",
-        }}
-      >
-        <Trophy size={28} />
-      </div>
-      <h2
-        className="mt-4 text-lg font-semibold"
-        style={{ color: "var(--color-bt-text)" }}
-      >
-        {title}
-      </h2>
-      <p
-        className="mt-2 max-w-xs text-sm leading-relaxed"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        {body}
-      </p>
-      <Link
-        href={`/trips/${tripId}`}
-        className="mt-5 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-semibold"
-        style={{
-          background: "var(--color-bt-card-raised)",
-          color: "var(--color-bt-text)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        Back to trip
-      </Link>
-    </div>
-  );
+  return <LiveFaceClient initialBoot={initialBoot} />;
 }

--- a/src/components/competition/LiveFaceClient.tsx
+++ b/src/components/competition/LiveFaceClient.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { Trophy } from "lucide-react";
+import type { inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "@/server/router";
+import { trpc } from "@/lib/trpc-client";
+import { canAccessCompetition } from "@/lib/competitionAccess";
+import { useRealtimeCompetition } from "@/hooks/useRealtimeCompetition";
+import { useRealtimeMembers } from "@/hooks/useRealtimeMembers";
+import { TopNav } from "@/components/TopNav";
+import { TripBottomNav } from "@/components/BottomNav";
+import { FloatingChatPanel } from "@/components/FloatingChatPanel";
+import { NewsPanel, type NewsAuthorMeta } from "@/components/NewsPanel";
+import { CompetitionFace } from "@/components/competition/CompetitionFace";
+import { CompetitionIntroPanel } from "@/components/competition/CompetitionIntroPanel";
+import { CompetitionSetupPanel } from "@/components/competition/CompetitionSetupPanel";
+
+/**
+ * The Live face — the competition face's client root (the "Live" bottom-nav
+ * destination). Stage 3 escaped this off the trip's Competition tab: it's a
+ * clean face = global title bar (Band 1) + the competition header (Band 2) +
+ * the bottom nav, with NO trip header and NO trip tab bar.
+ *
+ * It hosts both states through CompetitionFace (setup guide ⇄ leaderboard) and
+ * — as the interim entry point until Stage 5 — the pre-competition create flow
+ * the Competition tab used to own inline.
+ *
+ * Stage B: this is the CLIENT half of the face. The server route (page.tsx)
+ * prefetches the same competitions.faceBootstrap resolve and ships it in the
+ * dehydrated cache, so the useQuery below reads it during SSR (the board/guide
+ * render populated on first paint) and on hydration finds it fresh (60s
+ * staleTime) — no client round-trip for first paint. Interactivity + realtime
+ * live here (client) over that server-rendered initial state. If the server
+ * prefetch was skipped (unauthed/early), this falls back to its own fetch +
+ * the loading state below.
+ *
+ * Role gating:
+ *   - editor, no competition      → intro → create form
+ *   - non-editor, no competition  → "not set up yet"
+ *   - non-editor, not live        → "not live yet" (go-live reveals the board)
+ *   - otherwise                   → the two-state CompetitionFace
+ */
+/** The competitions.faceBootstrap output — the server-resolved initial state. */
+export type FaceBootstrap =
+  inferRouterOutputs<AppRouter>["competitions"]["faceBootstrap"];
+
+export function LiveFaceClient({
+  initialBoot,
+}: {
+  /** Server-prefetched bootstrap (Stage B). null when the server prefetch was
+   *  skipped (unauthed/early) — the client then fetches + shows the spinner. */
+  initialBoot: FaceBootstrap | null;
+}) {
+  const { tripId } = useParams<{ tripId: string }>();
+
+  // Push competition (Go Live, name, tagline) + membership changes live so the
+  // face re-resolves without a manual refresh.
+  useRealtimeCompetition(tripId);
+  useRealtimeMembers(tripId);
+
+  const [chatOpen, setChatOpen] = useState(false);
+  const [newsOpen, setNewsOpen] = useState(false);
+  // Editor has tapped "Enable Competition Mode" — swaps the intro panel for the
+  // create form. Reset when the competition is deleted so the intro reappears.
+  const [unlocked, setUnlocked] = useState(false);
+
+  const openChat = () => {
+    setNewsOpen(false);
+    setChatOpen((p) => !p);
+  };
+  const openNews = () => {
+    setChatOpen(false);
+    setNewsOpen((p) => !p);
+  };
+
+  const utils = trpc.useUtils();
+
+  // ── The single boundary resolve (Stage A) ────────────────────────────────
+  // One round-trip for everything both face states need — no more 3-wave
+  // waterfall, no separate role / delegate fetches. Trip-coupling lives only in
+  // the bootstrap's server resolver; the client just reads what it returns.
+  //
+  // Stage B: the server route resolves this and hands it down as initialData, so
+  // `boot` is defined on the very first (SSR) render — the board/guide render
+  // populated in the server HTML, zero client round-trip for first paint. We
+  // stamp initialDataUpdatedAt = now so the freshly-resolved data counts as
+  // fresh under the 60s staleTime → no redundant refetch on mount (one resolve
+  // per load). Realtime + the leaderboard's own refetchInterval keep it live;
+  // soft navigation re-runs the server component for a fresh resolve.
+  const { data: boot, isLoading: loading } =
+    trpc.competitions.faceBootstrap.useQuery(
+      { tripId },
+      initialBoot
+        ? { initialData: initialBoot, initialDataUpdatedAt: () => Date.now() }
+        : undefined,
+    );
+
+  const competition = boot?.competition ?? null;
+  // Competition role (owner / co_admin / member), live-derived server-side.
+  const role = boot?.myCompetitionRole ?? null;
+  const canEdit = role === "owner" || role === "co_admin";
+  const isOwner = role === "owner";
+  // A delegate is a BUILDER — reaches the competition in both phases to set up
+  // their assigned game (canAccessCompetition admits them). Edit stays scoped to
+  // their game by the edit gate; this is visibility only.
+  const amDelegate = (boot?.myDelegateGameIds.length ?? 0) > 0;
+
+  // Seed the child caches from the one bootstrap so the board/guide — and the
+  // setup↔leaderboard toggle, and the sub-views — render from cache with NO
+  // extra round-trips. The global 60s staleTime keeps the seed fresh, so the
+  // children's own useQuery calls don't re-fetch. Keyed on `boot` so it runs
+  // exactly once per resolve, synchronously DURING render — before the face's
+  // children mount and fire their queries (an effect runs too late: child
+  // mount-effects fire before the parent's, so they'd re-fetch first). This
+  // also runs during the SSR render pass, so the children render populated in
+  // the server HTML (Stage B first paint).
+  useMemo(() => {
+    if (!boot) return;
+    utils.competitions.getByTrip.setData({ tripId }, boot.competition as never);
+    utils.games.myDelegateGameIds.setData({ tripId }, boot.myDelegateGameIds);
+    if (boot.competition) {
+      const cid = boot.competition.id as string;
+      utils.competitions.leaderboard.setData(
+        { tripId, competitionId: cid },
+        boot.leaderboard as never,
+      );
+      utils.games.listByTrip.setData({ tripId }, boot.games as never);
+      utils.teams.list.setData({ tripId, competitionId: cid }, boot.teams as never);
+      utils.teamAssignments.list.setData(
+        { tripId, competitionId: cid },
+        boot.assignments as never,
+      );
+    }
+  }, [boot, tripId, utils]);
+
+  // Crew names (for chat/news authors) are container-provided and NOT needed to
+  // render the face — fetch lazily, only when a panel opens (A4: chat/news off
+  // the load critical path).
+  const { data: members = [] } = trpc.tripMembers.list.useQuery(
+    { tripId },
+    { enabled: chatOpen || newsOpen },
+  );
+
+  let body: React.ReactNode;
+  if (loading) {
+    body = (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <div
+          className="h-8 w-8 animate-spin rounded-full border-2"
+          style={{
+            borderColor: "var(--color-bt-accent)",
+            borderTopColor: "transparent",
+          }}
+        />
+      </div>
+    );
+  } else if (!competition) {
+    // No competition row yet. Editors get the create flow (the interim entry
+    // point); everyone else gets a calm placeholder.
+    if (canEdit) {
+      body = unlocked ? (
+        <CompetitionSetupPanel tripId={tripId} />
+      ) : (
+        <CompetitionIntroPanel onEnable={() => setUnlocked(true)} />
+      );
+    } else {
+      body = <NotSetUpEmptyState />;
+    }
+  } else if (
+    !canAccessCompetition({ canEdit, amDelegate, status: competition.status })
+  ) {
+    // Plain members (no delegation) don't see the competition until Go Live.
+    // Builders (owner / organizer / co-admin / delegate) always get the full
+    // face. Same predicate as the "Live" nav entry — they can't disagree.
+    body = <NotLiveEmptyState />;
+  } else {
+    body = (
+      <CompetitionFace
+        tripId={tripId}
+        competition={competition}
+        canEdit={canEdit}
+        isOwner={isOwner}
+        onCompetitionDeleted={() => setUnlocked(false)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text)" }}
+    >
+      {/* Band 1 — the global title bar, identical to the trip face (§2). */}
+      <TopNav
+        tripId={tripId}
+        onOpenChat={openChat}
+        chatOpen={chatOpen}
+        onOpenNews={openNews}
+        newsOpen={newsOpen}
+        onDismissPanels={() => {
+          setChatOpen(false);
+          setNewsOpen(false);
+        }}
+      />
+
+      <main className="mx-auto max-w-[1024px] px-4 pt-4 pb-32">{body}</main>
+
+      {/* Bottom nav persists on the face so you can always cross back to the
+          trip (§11). Live is the current destination. */}
+      <TripBottomNav tripId={tripId} showComp={true} />
+
+      {/* Chat / News overlay any surface (§11). */}
+      <FloatingChatPanel
+        tripId={tripId}
+        isOpen={chatOpen}
+        onClose={() => setChatOpen(false)}
+        memberNames={Object.fromEntries(
+          members.map(
+            (m: {
+              user_id: string | null;
+              memberId: string;
+              displayName: string;
+            }) => [m.user_id ?? m.memberId, m.displayName]
+          )
+        )}
+      />
+      <NewsPanel
+        tripId={tripId}
+        isOpen={newsOpen}
+        onClose={() => setNewsOpen(false)}
+        canPost={canEdit}
+        authors={Object.fromEntries(
+          members.map(
+            (m: {
+              user_id: string | null;
+              memberId: string;
+              displayName: string;
+              role: NewsAuthorMeta["role"];
+              user: { avatar_icon: string | null } | null;
+            }) => [
+              m.user_id ?? m.memberId,
+              {
+                name: m.displayName,
+                role: m.role,
+                avatarIcon: m.user?.avatar_icon ?? null,
+              },
+            ]
+          )
+        )}
+      />
+    </div>
+  );
+}
+
+// ── Empty states ────────────────────────────────────────────────────────────
+
+function NotSetUpEmptyState() {
+  return (
+    <EmptyState
+      title="Competition hasn't been set up yet"
+      body="The owner will set this up before the trip."
+    />
+  );
+}
+
+function NotLiveEmptyState() {
+  return (
+    <EmptyState
+      title="Competition isn't live yet"
+      body="The organizer hasn't flipped this to live. The leaderboard appears here once they hit Go Live."
+    />
+  );
+}
+
+function EmptyState({ title, body }: { title: string; body: string }) {
+  const { tripId } = useParams<{ tripId: string }>();
+  return (
+    <div
+      className="mt-6 flex flex-col items-center justify-center rounded-xl px-6 py-16 text-center"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      data-testid="comp-face-empty"
+    >
+      <div
+        className="flex h-16 w-16 items-center justify-center rounded-2xl"
+        style={{
+          background: "var(--color-bt-accent-faint)",
+          color: "var(--color-bt-accent)",
+        }}
+      >
+        <Trophy size={28} />
+      </div>
+      <h2
+        className="mt-4 text-lg font-semibold"
+        style={{ color: "var(--color-bt-text)" }}
+      >
+        {title}
+      </h2>
+      <p
+        className="mt-2 max-w-xs text-sm leading-relaxed"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {body}
+      </p>
+      <Link
+        href={`/trips/${tripId}`}
+        className="mt-5 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-semibold"
+        style={{
+          background: "var(--color-bt-card-raised)",
+          color: "var(--color-bt-text)",
+          border: "1px solid var(--color-bt-border)",
+        }}
+      >
+        Back to trip
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Stage B — Server-render the initial competition state

The committed follow-on to [Stage A (#376)](https://github.com/zgrether/buddytrip/pull/376). Stage A collapsed the 3-wave client waterfall into one parallel `faceBootstrap` resolve and made the toggle instant from cache — but first paint still showed a spinner while the client fetched. Stage B moves that resolve to the **server**, so the initial competition state arrives **rendered with the page**.

### What changed
- **`leaderboard/page.tsx` is now a Server Component.** It resolves `competitions.faceBootstrap` server-side via `createSSRHelpers().competitions.faceBootstrap.fetch({ tripId })` and hands the result to the client face as `initialBoot`. Resolve failures are swallowed (mirrors the trip layout) — an unauthed/early request hands down `null` and the client falls back to its own fetch + loading state, never tripping the route error boundary.
- **New `LiveFaceClient` (`"use client"`)** holds everything interactive + realtime — the setup↔leaderboard toggle, go-live/edit controls, chat/news, `useRealtime*` subscriptions — rendering **over** the server-resolved initial state. It feeds the bootstrap into `useQuery` as `initialData` (stamped `initialDataUpdatedAt = now`, so it's fresh under the 60s `staleTime` → no mount refetch) and seeds the child caches from the same bootstrap during the SSR render, so the board **and** the setup guide both ship populated.

### How it maps to the spec
- **B0** — re-verified the render structure first (mapped which components are client, where the server/client line fell: `page.tsx` was `"use client"`, whole tree below it client; the trip `layout.tsx` already used `createSSRHelpers` + `HydrationBoundary` as precedent).
- **B1** — the server/client **seam is the `initialBoot` prop**: server resolves + renders initial state; client takes over for interactivity + realtime.
- **B2** — reuses Stage A's resolver unchanged; only *where* it's called moved (server fetch vs. client fetch).
- **B3** — server-render-initial + client-subscribe shape is realtime-ready; no realtime built here.
- **B4** — one resolve per load: the server resolve, with no client `faceBootstrap` round-trip.

### Verified live (owner path)
- ✅ Board is in the initial **SSR HTML** — `<main>` contains the rendered standings (FAL/CON, "½ to clinch", "No pts yet"), **zero spinners in `<main>`**.
- ✅ **No client `faceBootstrap` round-trip** — `performance` resource timing shows only TopNav chrome (`news.unreadCount`/`messages`/`users.getMe`/`trips.list`) + lazy `tripMembers`; competition data is server-only. One resolve per load (B4).
- ✅ Setup↔leaderboard **toggle works post-hydration** with no spinner (client took over over SSR state; renders from seeded cache).
- ✅ No hydration/console errors (the transient `server-only` HMR errors were a stale dev module graph from the client→server flip — cleared on dev-server restart; `LiveFaceClient`'s only `@/server/*` imports are `import type`, erased from the client bundle).
- ✅ `tsc --noEmit` clean; `next lint` clean (the rule that failed Stage A's build).
- ℹ️ Role is still **live-derived per request** server-side; `faceBootstrap.test.ts` (from Stage A) covers owner/co_admin/member + delegate derivation. Member/delegate live paths can't be exercised in the single-user preview, but they flow through the identical resolver.

The competition face is now a high-performance, decouple-clean, realtime-ready surface: first paint is server-rendered, in-session toggles/navigation are instant, and the resolver stays the single trip-coupling boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
