### PR TITLE
fix(comp-face): invalidate bootstrap-seeded caches on setup-data mutations

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -88,7 +88,14 @@ export function CompetitionFace({
         utils.competitions.getByTrip.setData({ tripId }, ctx.previous);
       }
     },
-    onSettled: () => utils.competitions.getByTrip.invalidate({ tripId }),
+    onSettled: () => {
+      utils.competitions.getByTrip.invalidate({ tripId });
+      // The header reads status from the faceBootstrap snapshot (boot.competition),
+      // not getByTrip — re-resolve it so the chrome-shrink (and the crew's board
+      // reveal at go-live) lands without a hard refresh. Optimism above keeps the
+      // toggle/view switch instant.
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+    },
   });
 
   const toggleLive = () => {

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1308,6 +1308,10 @@ function RunSheet({
     try {
       await openCorrection.mutateAsync({ tripId, gameId: game.id });
       utils.games.listByTrip.invalidate({ tripId });
+      // Reopening flips the game complete → active, which changes its leaderboard
+      // row state (Final → Live) — invalidate the board's cache too, matching the
+      // post/commit path above, so the leaderboard isn't stale until a refresh.
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to open correction");
     }

--- a/src/components/competition/CompetitionHeader.tsx
+++ b/src/components/competition/CompetitionHeader.tsx
@@ -144,6 +144,10 @@ export function CompetitionHeader({
   const deleteComp = trpc.competitions.delete.useMutation({
     onSettled: () => {
       utils.competitions.getByTrip.invalidate({ tripId });
+      // The Live face renders from the faceBootstrap snapshot (boot.competition),
+      // not getByTrip — re-resolve it so the face returns to the empty/intro
+      // state without a hard refresh.
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     },
     onSuccess: () => {
       setConfirming(false);
@@ -409,6 +413,9 @@ function CompetitionEditModal({
     },
     onSettled: () => {
       utils.competitions.getByTrip.invalidate({ tripId });
+      // The face header reads name/tagline from the faceBootstrap snapshot —
+      // re-resolve it so the rename shows without a hard refresh.
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     },
     onSuccess: () => onClose(),
   });

--- a/src/components/competition/CompetitionSetupPanel.tsx
+++ b/src/components/competition/CompetitionSetupPanel.tsx
@@ -45,6 +45,11 @@ export function CompetitionSetupPanel({ tripId, competition, onSuccess, onCancel
     onError: (e) => setError(e.message ?? "Failed to create competition"),
     onSettled: () => {
       utils.competitions.getByTrip.invalidate({ tripId });
+      // The Live face renders from the faceBootstrap snapshot (boot.competition),
+      // not getByTrip — re-resolve it so the face swaps the create form for the
+      // setup guide (and seeds the new competition's child caches) without a
+      // hard refresh.
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     },
   });
 
@@ -69,6 +74,9 @@ export function CompetitionSetupPanel({ tripId, competition, onSuccess, onCancel
     },
     onSettled: () => {
       utils.competitions.getByTrip.invalidate({ tripId });
+      // The face header reads name/tagline from the faceBootstrap snapshot —
+      // re-resolve it so the rename shows without a hard refresh.
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     },
   });
 

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -166,7 +166,14 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
         utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
       }
     },
-    onSettled: () => utils.teamAssignments.list.invalidate(queryKey),
+    onSettled: () => {
+      utils.teamAssignments.list.invalidate(queryKey);
+      // The leaderboard roll-up derives per_match points from TEAM SIZES, so a
+      // (re)assignment moves pointsAvailable / winNumber. The board reads the
+      // bootstrap-seeded competitions.leaderboard cache — invalidate it too so
+      // the leaderboard reflects the change without a hard refresh.
+      utils.competitions.leaderboard.invalidate(queryKey);
+    },
   });
 
   const remove = trpc.teamAssignments.remove.useMutation({
@@ -184,7 +191,12 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
         utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
       }
     },
-    onSettled: () => utils.teamAssignments.list.invalidate(queryKey),
+    onSettled: () => {
+      utils.teamAssignments.list.invalidate(queryKey);
+      // Removing a player changes team sizes → the leaderboard roll-up's
+      // per_match points. Refresh the board's seeded cache (see `assign`).
+      utils.competitions.leaderboard.invalidate(queryKey);
+    },
   });
 
   return { assign, remove };
@@ -982,16 +994,28 @@ function TeamSheet({
     ? (assignments as Assignment[]).filter((a) => a.team_id === team.id).length
     : 0;
 
+  // The leaderboard roll-up (competitions.leaderboard) bakes in each team's
+  // color / name / short_name, and the board renders from that bootstrap-seeded
+  // cache — NOT teams.list. So every team mutation must invalidate the
+  // leaderboard too, or the board shows stale colors/names until a hard refresh
+  // (the reported bug). teams.list stays invalidated for the teams panel + guide.
   const create = trpc.teams.create.useMutation({
-    onSettled: () => utils.teams.list.invalidate({ tripId, competitionId }),
+    onSettled: () => {
+      utils.teams.list.invalidate({ tripId, competitionId });
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+    },
   });
   const update = trpc.teams.update.useMutation({
-    onSettled: () => utils.teams.list.invalidate({ tripId, competitionId }),
+    onSettled: () => {
+      utils.teams.list.invalidate({ tripId, competitionId });
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+    },
   });
   const deleteTeam = trpc.teams.delete.useMutation({
     onSettled: () => {
       utils.teams.list.invalidate({ tripId, competitionId });
       utils.teamAssignments.list.invalidate({ tripId, competitionId });
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
     },
     onSuccess: () => {
       setConfirmingDelete(false);


### PR DESCRIPTION
The competition face renders its leaderboard from the bootstrap-seeded
competitions.leaderboard roll-up (team color/name/short_name + team-size-
derived points baked in) and its header from boot.competition directly.
Setup-data mutations wired before the faceBootstrap snapshot existed only
invalidated teams.list / teamAssignments.list / getByTrip, so the board and
header stayed stale until a hard refresh.

Close the stale-until-refresh class:
- teams create/update/delete + teamAssignments assign/remove now invalidate
  competitions.leaderboard (the seeded child the board reads), matching the
  already-correct games/score path. Fixes the reported team-color bug.
- competitions create/update(name,tagline)/delete + go-live status toggle now
  invalidate competitions.faceBootstrap, so the face header (which reads
  boot.competition) reflects renames / create / delete / go-live without a
  refresh.
- games.openCorrection now invalidates competitions.leaderboard (reopening
  flips a game Final -> Live on the board), matching the post/commit path.

Optimistic updates left intact; invalidation is additive. Games and score
paths already invalidated competitions.leaderboard and are unchanged.