### PR TITLE
feat(connectivity): Layer 1 — score saves visible + retried, never silently lost

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useTripRole } from "@/hooks/useTripRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
@@ -82,8 +83,11 @@ export default function NewMatchGamePage() {
   // Back-stack: forward transitions push the screen they left; Back pops to it.
   // Empty stack means we arrived directly (derived screen) → leave to trip home.
   const [navStack, setNavStack] = useState<Screen[]>([]);
-  // Scoring
-  const [values, setValues] = useState<ScoreValues>({});
+  // Scoring — the connectivity-resilient saver owns `values` + `saveStatus`:
+  // optimistic value, retry-with-backoff, per-cell status, kept-and-flagged
+  // (never rolled back) on failure.
+  const { values, setValues, saveStatus, onChange, onClear, retryCell } =
+    useScoreSaver(tripId, gameId);
   const [view, setView] = useState<"entry" | "grid">("entry");
   const [currentHole, setCurrentHole] = useState(1);
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
@@ -112,9 +116,13 @@ export default function NewMatchGamePage() {
   const setPairings = trpc.matches.setPairings.useMutation();
   const setHandicap = trpc.matches.setHandicap.useMutation();
   const activate = trpc.matches.activate.useMutation();
-  const upsertEntry = trpc.scores.upsertEntry.useMutation();
-  const deleteEntry = trpc.scores.deleteEntry.useMutation();
-  const finishGame = trpc.games.finish.useMutation();
+  // Finishing retries (idempotent recompute); a failure stays on the overview
+  // and surfaces via the global error toast — loud + retryable, not a silent
+  // stall. Score writes go through useScoreSaver (above).
+  const finishGame = trpc.games.finish.useMutation({
+    retry: 4,
+    retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 8000),
+  });
 
   const nameOf = useMemo(() => {
     const m = new Map<string, string>();
@@ -342,27 +350,16 @@ export default function NewMatchGamePage() {
     go("overview");
   }
 
-  function handleChange(participantId: string, unitLabel: string, value: number) {
-    if (!tripId || !gameId) return;
-    const prev = values;
-    setValues((v) => ({ ...v, [participantId]: { ...(v[participantId] ?? {}), [unitLabel]: value } }));
-    upsertEntry.mutate({ tripId, gameId, participantId, unitLabel, value }, { onError: () => setValues(prev) });
-  }
-  function handleClear(participantId: string, unitLabel: string) {
-    if (!tripId || !gameId) return;
-    const prev = values;
-    setValues((v) => {
-      const row = { ...(v[participantId] ?? {}) };
-      delete row[unitLabel];
-      return { ...v, [participantId]: row };
-    });
-    deleteEntry.mutate({ tripId, gameId, participantId, unitLabel }, { onError: () => setValues(prev) });
-  }
   async function handleFinish() {
     if (!tripId || !gameId) return;
-    await finishGame.mutateAsync({ tripId, gameId });
-    await Promise.all([gameQ.refetch(), matchesQ.refetch(), scoresQ.refetch()]);
-    go("overview");
+    try {
+      await finishGame.mutateAsync({ tripId, gameId });
+      await Promise.all([gameQ.refetch(), matchesQ.refetch(), scoresQ.refetch()]);
+      go("overview");
+    } catch {
+      // Stay put (no silent advance). The global error toast surfaces the
+      // failure; Finish stays tappable to retry (the recompute is idempotent).
+    }
   }
 
   // Scoreable groups (fully-paired matches) for the entry view + grid.
@@ -427,6 +424,7 @@ export default function NewMatchGamePage() {
                 values={values}
                 direction="low_wins"
                 pips={entryPips}
+                saveStatus={saveStatus}
                 onCellTap={(label) => {
                   setCurrentHole(Number(label) || 1);
                   setView("entry");
@@ -443,8 +441,10 @@ export default function NewMatchGamePage() {
             values={values}
             currentHole={currentHole}
             onHoleChange={setCurrentHole}
-            onChange={handleChange}
-            onClear={handleClear}
+            onChange={onChange}
+            onClear={onClear}
+            saveStatus={saveStatus}
+            onRetryCell={retryCell}
             onBack={goBack}
             onOpenGrid={() => setView("grid")}
             onFinish={goBack}

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -3,12 +3,13 @@
 import { useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
+import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { FinalStandings } from "@/components/games/FinalStandings";
 import type { StrokeStanding } from "@/lib/strokePlay";
 import { STROKE_PLAY_UNITS, PLAYER_COLORS, initialsOf } from "@/lib/strokePlayConfig";
-import type { Participant, ScoreValues } from "@/components/games/types";
+import type { Participant } from "@/components/games/types";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const STROKE_PLAY = "gtt_stroke_play";
@@ -33,16 +34,24 @@ export default function NewGamePage() {
 
   const [selected, setSelected] = useState<string[]>([]);
   const [game, setGame] = useState<{ id: string; participants: Participant[] } | null>(null);
-  const [values, setValues] = useState<ScoreValues>({});
   const [view, setView] = useState<"entry" | "grid" | "final">("entry");
   const [currentHole, setCurrentHole] = useState(1);
   const [standings, setStandings] = useState<StrokeStanding[]>([]);
 
   const createGame = trpc.games.create.useMutation();
   const addParticipants = trpc.games.addParticipants.useMutation();
-  const upsertEntry = trpc.scores.upsertEntry.useMutation();
-  const deleteEntry = trpc.scores.deleteEntry.useMutation();
-  const finishGame = trpc.games.finish.useMutation();
+  // Score writes go through the connectivity-resilient saver: optimistic value,
+  // retry-with-backoff, per-cell save status, kept-and-flagged (never rolled
+  // back) on failure. Owns `values` + `saveStatus` for this game.
+  const { values, setValues, saveStatus, onChange, onClear, retryCell } =
+    useScoreSaver(tripId, game?.id);
+  // Finishing also retries (idempotent — recomputes from the same scores); a
+  // failure stays on the entry view and surfaces via the global error toast,
+  // so it's loud + retryable instead of a silent stall.
+  const finishGame = trpc.games.finish.useMutation({
+    retry: 4,
+    retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 8000),
+  });
 
   const memberById = useMemo(() => {
     const m = new Map<string, { id: string; name: string }>();
@@ -72,35 +81,6 @@ export default function NewGamePage() {
     setGame({ id: g.id, participants });
   }
 
-  function handleChange(participantId: string, unitLabel: string, value: number) {
-    if (!tripId || !game) return;
-    const prev = values;
-    setValues((v) => ({
-      ...v,
-      [participantId]: { ...(v[participantId] ?? {}), [unitLabel]: value },
-    }));
-    upsertEntry.mutate(
-      { tripId, gameId: game.id, participantId, unitLabel, value },
-      {
-        onError: () => setValues(prev), // rollback
-      }
-    );
-  }
-
-  function handleClear(participantId: string, unitLabel: string) {
-    if (!tripId || !game) return;
-    const prev = values;
-    setValues((v) => {
-      const row = { ...(v[participantId] ?? {}) };
-      delete row[unitLabel];
-      return { ...v, [participantId]: row };
-    });
-    deleteEntry.mutate(
-      { tripId, gameId: game.id, participantId, unitLabel },
-      { onError: () => setValues(prev) }
-    );
-  }
-
   if (!tripId) {
     return (
       <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--color-bt-base)" }}>
@@ -111,9 +91,15 @@ export default function NewGamePage() {
 
   async function handleFinish() {
     if (!tripId || !game) return;
-    const res = await finishGame.mutateAsync({ tripId, gameId: game.id });
-    setStandings(res.standings);
-    setView("final");
+    try {
+      const res = await finishGame.mutateAsync({ tripId, gameId: game.id });
+      setStandings(res.standings);
+      setView("final");
+    } catch {
+      // Stay on the entry view (no silent advance). The global error toast
+      // surfaces the failure; the Finish CTA stays tappable to retry (the
+      // recompute is idempotent).
+    }
   }
 
   function playAgain() {
@@ -150,6 +136,7 @@ export default function NewGamePage() {
                 participants={game.participants}
                 values={values}
                 direction="low_wins"
+                saveStatus={saveStatus}
                 onCellTap={(label) => {
                   setCurrentHole(Number(label) || 1);
                   setView("entry");
@@ -166,8 +153,10 @@ export default function NewGamePage() {
             direction="low_wins"
             currentHole={currentHole}
             onHoleChange={setCurrentHole}
-            onChange={handleChange}
-            onClear={handleClear}
+            onChange={onChange}
+            onClear={onClear}
+            saveStatus={saveStatus}
+            onRetryCell={retryCell}
             onBack={() => router.back()}
             onOpenGrid={() => setView("grid")}
             onFinish={handleFinish}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CloudOff } from "lucide-react";
+import { subscribeToasts, dismissToast, type ToastItem } from "@/lib/toast";
+
+/**
+ * Toaster — renders the connectivity toast stack (Connectivity Layer 1).
+ *
+ * Bottom-center, above the bottom nav. Auto-dismisses; tap to dismiss early.
+ * Mounted once at the provider root so any mutation failure can surface here.
+ */
+export function Toaster() {
+  const [items, setItems] = useState<ToastItem[]>([]);
+
+  useEffect(() => subscribeToasts(setItems), []);
+
+  useEffect(() => {
+    if (items.length === 0) return;
+    const timers = items.map((t) =>
+      setTimeout(() => dismissToast(t.id), 4500),
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [items]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className="fixed inset-x-0 z-[100] flex flex-col items-center gap-2 px-4"
+      style={{ bottom: 88, pointerEvents: "none" }}
+    >
+      {items.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          onClick={() => dismissToast(t.id)}
+          role="alert"
+          className="flex max-w-sm items-center gap-2 shadow-lg"
+          style={{
+            pointerEvents: "auto",
+            padding: "10px 14px",
+            borderRadius: 12,
+            background: "var(--color-bt-card-float)",
+            border: `1px solid ${
+              t.tone === "error"
+                ? "var(--color-bt-danger-border)"
+                : "var(--color-bt-border)"
+            }`,
+            color: "var(--color-bt-text)",
+            fontSize: 14,
+            fontWeight: 500,
+          }}
+        >
+          {t.tone === "error" && (
+            <CloudOff size={16} style={{ color: "var(--color-bt-danger)", flexShrink: 0 }} />
+          )}
+          {t.message}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { ChevronRight, Check, Radio, Trophy } from "lucide-react";
+import { ChevronRight, Check, Radio, Trophy, CloudOff, RefreshCw } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -86,7 +86,7 @@ interface Props {
 }
 
 export function CompetitionLeaderboard({ competitionId, tripId }: Props) {
-  const { data: lb, isLoading } = trpc.competitions.leaderboard.useQuery(
+  const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
       enabled: !!competitionId,
@@ -148,7 +148,15 @@ export function CompetitionLeaderboard({ competitionId, tripId }: Props) {
     [utils, tripId],
   );
 
-  if (isLoading || !data) return null;
+  // Never blank-on-error (Connectivity Layer 1). TanStack keeps the last `data`
+  // through a failed refetch, so a flaky poll keeps showing the board. Only when
+  // there's NO data yet do we branch: a spinner while the first load is in
+  // flight, or a clear retryable card if it failed — never a confusing blank.
+  if (!data) {
+    if (isError) return <LeaderboardLoadError onRetry={() => void refetch()} />;
+    if (isLoading) return <LeaderboardLoading />;
+    return null;
+  }
 
   const { teams, teamTotals, pointsAvailable, winNumber, pointsToClinch, defendingTeamId } = data;
 
@@ -840,6 +848,69 @@ function NoTeamsState() {
       >
         Add teams and games in the Competition tab to see standings here.
       </p>
+    </div>
+  );
+}
+
+/** First-load spinner — only shown when there's NO cached board yet (a warm
+ *  board keeps rendering through refetches). Never a blank. */
+function LeaderboardLoading() {
+  return (
+    <div
+      className="flex min-h-[30vh] items-center justify-center"
+      data-testid="competition-leaderboard"
+    >
+      <div
+        className="h-7 w-7 animate-spin rounded-full border-2"
+        style={{
+          borderColor: "var(--color-bt-accent)",
+          borderTopColor: "transparent",
+        }}
+      />
+    </div>
+  );
+}
+
+/** Couldn't load the board AND nothing cached to fall back to — a clear,
+ *  retryable card instead of a confusing blank (Connectivity Layer 1). */
+function LeaderboardLoadError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 rounded-xl px-4 py-10 text-center"
+      style={{
+        background: "var(--color-bt-card)",
+        border: "1px solid var(--color-bt-border)",
+      }}
+      data-testid="competition-leaderboard"
+    >
+      <CloudOff size={24} style={{ color: "var(--color-bt-text-dim)" }} />
+      <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+        Couldn&apos;t load the leaderboard
+      </p>
+      <p
+        className="max-w-xs text-[12px] leading-relaxed"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Check your connection — the board will be here when you&apos;re back.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="flex items-center gap-1.5"
+        style={{
+          marginTop: 4,
+          padding: "6px 14px",
+          borderRadius: 9999,
+          background: "var(--color-bt-card-raised)",
+          border: "1px solid var(--color-bt-border)",
+          color: "var(--color-bt-text)",
+          fontSize: 13,
+          fontWeight: 600,
+        }}
+      >
+        <RefreshCw size={13} strokeWidth={2.5} />
+        Try again
+      </button>
     </div>
   );
 }

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -8,8 +8,18 @@ import { MatchCard } from "./MatchCard";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
 import { Avatar } from "@/components/Avatar";
 import { GolfChip } from "./GolfChip";
+import { ScoreSaveBadge } from "./ScoreSaveBadge";
+import { UnsavedScoresBanner } from "./UnsavedScoresBanner";
 import { golfWord } from "./golfScore";
-import type { ScoreUnit, Participant, ScoreValues } from "./types";
+import {
+  parseScoreCellKey,
+  scoreCellKey,
+  type ScoreUnit,
+  type Participant,
+  type ScoreValues,
+  type CellSaveState,
+  type SaveStatusMap,
+} from "./types";
 
 /**
  * MatchEntryView — the per-hole entry surface for singles match play (Slice B).
@@ -52,6 +62,11 @@ interface MatchEntryViewProps {
   finishSubtext?: string;
   /** Current user's id — appends "(you)" to their name on the board + rows. */
   meId?: string;
+  /** Per-cell save state (Connectivity Layer 1) — drives the cell badges + the
+   *  unsaved-scores banner. Keyed by `${participantId}:${unitLabel}`. */
+  saveStatus?: SaveStatusMap;
+  /** Re-fire the save for a flagged cell. */
+  onRetryCell?: (participantId: string, unitLabel: string) => void;
 }
 
 export function MatchEntryView({
@@ -70,6 +85,8 @@ export function MatchEntryView({
   finishLabel = "Finish",
   finishSubtext = "Saves results · shows final standings",
   meId,
+  saveStatus = {},
+  onRetryCell,
 }: MatchEntryViewProps) {
   const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
   const hole = currentHole ?? holeInternal;
@@ -129,6 +146,16 @@ export function MatchEntryView({
       : (interactiveHere.find((p) => valueFor(p.id, label) == null)?.id ?? null);
   const activeParticipant = allParticipants.find((p) => p.id === activePid) ?? null;
   const isCorrection = activePid != null && valueFor(activePid, label) != null;
+
+  // ── Save status (Connectivity Layer 1) ────────────────────────────────
+  const errorCount = Object.values(saveStatus).filter((s) => s === "error").length;
+  const retryAll = () => {
+    for (const [k, s] of Object.entries(saveStatus)) {
+      if (s !== "error") continue;
+      const { participantId, unitLabel } = parseScoreCellKey(k);
+      onRetryCell?.(participantId, unitLabel);
+    }
+  };
 
   // The board reflects a hole only once it's confirmed: while the keypad is open
   // on the current hole (activePid set), exclude that hole from the match-state
@@ -192,6 +219,9 @@ export function MatchEntryView({
           <Grid3x3 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
         </button>
       </header>
+
+      {/* Unsaved-scores safety net (Connectivity Layer 1) */}
+      <UnsavedScoresBanner count={errorCount} onRetry={retryAll} />
 
       {/* Match board(s) — pinned at the top, above the hole selector */}
       <div className="shrink-0" style={{ padding: "12px 12px 0" }}>
@@ -293,6 +323,8 @@ export function MatchEntryView({
                 isMe={!!meId && m.a.id === meId}
                 par={par}
                 celebrate={lastCommit?.pid === m.a.id && lastCommit?.hole === hole}
+                saveState={saveStatus[scoreCellKey(m.a.id, label)]}
+                onRetry={() => onRetryCell?.(m.a.id, label)}
               />
               <PlayerRow
                 group={g}
@@ -307,6 +339,8 @@ export function MatchEntryView({
                 isMe={!!meId && m.b.id === meId}
                 par={par}
                 celebrate={lastCommit?.pid === m.b.id && lastCommit?.hole === hole}
+                saveState={saveStatus[scoreCellKey(m.b.id, label)]}
+                onRetry={() => onRetryCell?.(m.b.id, label)}
                 last
               />
             </div>
@@ -362,6 +396,8 @@ function PlayerRow({
   par,
   celebrate,
   last,
+  saveState,
+  onRetry,
 }: {
   group: { st: ReturnType<typeof matchState>; strokeHolesA: Set<number>; strokeHolesB: Set<number> };
   player: Participant;
@@ -376,6 +412,8 @@ function PlayerRow({
   par?: number;
   celebrate?: boolean;
   last?: boolean;
+  saveState?: CellSaveState;
+  onRetry?: () => void;
 }) {
   const v = valueFor(player.id, label);
   const stroked = (isA ? group.strokeHolesA : group.strokeHolesB).has(hole);
@@ -398,13 +436,18 @@ function PlayerRow({
   }
 
   return (
-    <button
+    // role=button (not <button>) so the per-cell Retry button can nest without
+    // invalid button-in-button markup.
+    <div
+      role="button"
+      tabIndex={dead ? -1 : 0}
+      aria-disabled={dead}
       onClick={dead ? undefined : onTap}
-      disabled={dead}
       className="flex w-full items-center gap-3 text-left"
       style={{
         height: 62,
         padding: "0 14px 0 0",
+        cursor: dead ? "default" : "pointer",
         opacity: dead ? 0.55 : 1,
         background: active ? "var(--color-bt-accent-faint)" : "var(--color-bt-card)",
         borderTop: last ? "1px solid var(--color-bt-subtle-border)" : undefined,
@@ -420,8 +463,9 @@ function PlayerRow({
         </span>
         <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
       </div>
+      <ScoreSaveBadge state={saveState} onRetry={onRetry} />
       <MatchScoreCell value={v} active={active} stroked={stroked} par={par} celebrate={celebrate} />
-    </button>
+    </div>
   );
 }
 

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -6,8 +6,18 @@ import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import { StrokeKeypad } from "./StrokeKeypad";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
 import { GolfChip } from "./GolfChip";
+import { ScoreSaveBadge } from "./ScoreSaveBadge";
+import { UnsavedScoresBanner } from "./UnsavedScoresBanner";
 import { golfWord, golfResult, GOLF_STYLE } from "./golfScore";
-import type { ScoreUnit, Participant, ScoreValues, ScoreDirection } from "./types";
+import {
+  parseScoreCellKey,
+  scoreCellKey,
+  type ScoreUnit,
+  type Participant,
+  type ScoreValues,
+  type ScoreDirection,
+  type SaveStatusMap,
+} from "./types";
 
 /**
  * ScoreEntryView — the per-unit (hole-by-hole) score-entry surface (Slice A,
@@ -34,6 +44,11 @@ interface ScoreEntryViewProps {
   onFinish?: () => void;
   onBack?: () => void;
   onOpenGrid?: () => void;
+  /** Per-cell save state (Connectivity Layer 1) — drives the cell badges + the
+   *  unsaved-scores banner. Keyed by `${participantId}:${unitLabel}`. */
+  saveStatus?: SaveStatusMap;
+  /** Re-fire the save for a flagged cell. */
+  onRetryCell?: (participantId: string, unitLabel: string) => void;
 }
 
 export function ScoreEntryView({
@@ -48,6 +63,8 @@ export function ScoreEntryView({
   onFinish,
   onBack,
   onOpenGrid,
+  saveStatus = {},
+  onRetryCell,
 }: ScoreEntryViewProps) {
   const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
   const hole = currentHole ?? holeInternal;
@@ -132,6 +149,16 @@ export function ScoreEntryView({
   const activeParticipant = participants.find((p) => p.id === activePid) ?? null;
   const isCorrection = activePid != null && valueFor(activePid, label) != null;
 
+  // ── Save status (Connectivity Layer 1) ────────────────────────────────
+  const errorCount = Object.values(saveStatus).filter((s) => s === "error").length;
+  const retryAll = () => {
+    for (const [k, s] of Object.entries(saveStatus)) {
+      if (s !== "error") continue;
+      const { participantId, unitLabel } = parseScoreCellKey(k);
+      onRetryCell?.(participantId, unitLabel);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
       {/* ── App bar ── */}
@@ -158,6 +185,9 @@ export function ScoreEntryView({
           <Grid3x3 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
         </button>
       </header>
+
+      {/* ── Unsaved-scores safety net (Connectivity Layer 1) ── */}
+      <UnsavedScoresBanner count={errorCount} onRetry={retryAll} />
 
       {/* ── Standings strip ── */}
       <div
@@ -247,9 +277,13 @@ export function ScoreEntryView({
           const done = doneCount(p.id) === units.length;
           return (
             <div key={p.id}>
-              <button
+              {/* role=button (not <button>) so the per-cell Retry button can
+                  nest without invalid button-in-button markup. */}
+              <div
+                role="button"
+                tabIndex={0}
                 onClick={() => setOverride({ hole, pid: p.id })}
-                className="flex w-full items-center gap-3 text-left"
+                className="flex w-full cursor-pointer items-center gap-3 text-left"
                 style={{
                   height: 62,
                   padding: "0 16px 0 0",
@@ -316,8 +350,12 @@ export function ScoreEntryView({
                           : `${total} total`}
                   </div>
                 </div>
+                <ScoreSaveBadge
+                  state={saveStatus[scoreCellKey(p.id, label)]}
+                  onRetry={() => onRetryCell?.(p.id, label)}
+                />
                 <ScoreCell value={v} active={active} par={par} celebrate={lastCommit?.pid === p.id && lastCommit?.hole === hole} />
-              </button>
+              </div>
               {active && isCorrection && (
                 <div
                   className="flex items-center gap-1.5"

--- a/src/components/games/ScoreSaveBadge.tsx
+++ b/src/components/games/ScoreSaveBadge.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Check, RefreshCw } from "lucide-react";
+import type { CellSaveState } from "./types";
+
+/**
+ * ScoreSaveBadge — the per-cell save indicator (Connectivity Layer 1).
+ *
+ * Renders next to a score cell to show whether the write behind the optimistic
+ * value landed: a quiet pending dot while saving, a brief check once saved, and
+ * — the one that matters on the course — a clear, tappable "Retry" when it
+ * couldn't save. `error` cells keep their number; this badge is how the user
+ * knows it needs attention instead of trusting a silent (possibly lost) save.
+ *
+ * Presentational only — `onRetry` is wired by the parent's score saver.
+ */
+export function ScoreSaveBadge({
+  state,
+  onRetry,
+}: {
+  state?: CellSaveState;
+  onRetry?: () => void;
+}) {
+  if (!state) return null;
+
+  if (state === "saving") {
+    return (
+      <span
+        role="status"
+        aria-label="Saving"
+        className="inline-flex shrink-0 items-center justify-center"
+        style={{ width: 16, height: 16 }}
+      >
+        <span
+          className="animate-spin rounded-full"
+          style={{
+            width: 12,
+            height: 12,
+            border: "2px solid var(--color-bt-text-dim)",
+            borderTopColor: "transparent",
+            opacity: 0.7,
+          }}
+        />
+      </span>
+    );
+  }
+
+  if (state === "saved") {
+    return (
+      <span
+        role="status"
+        aria-label="Saved"
+        className="inline-flex shrink-0 items-center justify-center"
+        style={{ width: 16, height: 16, color: "var(--color-bt-accent)", opacity: 0.8 }}
+      >
+        <Check size={14} strokeWidth={3} />
+      </span>
+    );
+  }
+
+  // error — clear and actionable. Stops propagation so it doesn't also trigger
+  // the row's player-select tap.
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onRetry?.();
+      }}
+      aria-label="Couldn't save — tap to retry"
+      className="inline-flex shrink-0 items-center gap-1"
+      style={{
+        padding: "2px 7px",
+        borderRadius: 9999,
+        background: "var(--color-bt-danger-faint)",
+        border: "1px solid var(--color-bt-danger-border)",
+        color: "var(--color-bt-danger)",
+        fontSize: 11,
+        fontWeight: 700,
+      }}
+    >
+      <RefreshCw size={11} strokeWidth={2.5} />
+      Retry
+    </button>
+  );
+}

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -2,7 +2,14 @@
 
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import { GolfChip } from "./GolfChip";
-import type { ScoreUnit, Participant, ScoreValues, ScoreDirection } from "./types";
+import {
+  scoreCellKey,
+  type ScoreUnit,
+  type Participant,
+  type ScoreValues,
+  type ScoreDirection,
+  type SaveStatusMap,
+} from "./types";
 
 /**
  * StandardGrid — the review / spot-correction scorecard (Slice A, Task 7).
@@ -32,6 +39,13 @@ interface StandardGridProps {
    * pip on each cell they receive a handicap stroke on. Omit for Slice A.
    */
   pips?: Record<string, Set<string>>;
+  /**
+   * Per-cell save state (Connectivity Layer 1). Errored cells get a danger ring
+   * so the whole card can be scanned for unsaved scores; tapping the cell jumps
+   * to that hole's entry view where the per-cell Retry lives. Keyed by
+   * `${participantId}:${unitLabel}`.
+   */
+  saveStatus?: SaveStatusMap;
 }
 
 const NAME_W = 124;
@@ -39,7 +53,7 @@ const HOLE_W = 30;
 const SUB_W = 44;
 const TOTAL_W = 50;
 
-export function StandardGrid({ units, participants, values, onCellTap, pips }: StandardGridProps) {
+export function StandardGrid({ units, participants, values, onCellTap, pips, saveStatus }: StandardGridProps) {
   const front = units.filter((u) => u.section === "front");
   const back = units.filter((u) => u.section === "back");
   const hasSections = front.length > 0 && back.length > 0;
@@ -194,15 +208,28 @@ export function StandardGrid({ units, participants, values, onCellTap, pips }: S
                   const v = valOf(p.id, u.label);
                   const hasPip = pips?.[p.id]?.has(u.label);
                   const colored = v != null && hasPar && u.par != null;
+                  const errored = saveStatus?.[scoreCellKey(p.id, u.label)] === "error";
                   return (
                     <button
                       key={u.label}
                       onClick={() => onCellTap?.(u.label)}
                       className="relative flex items-center justify-center"
-                      style={{ ...cellBase, height: 44, ...divider(u.label), fontSize: 13, fontWeight: 500, color: v != null ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}
+                      style={{
+                        ...cellBase,
+                        height: 44,
+                        ...divider(u.label),
+                        fontSize: 13,
+                        fontWeight: 500,
+                        color: v != null ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+                        // Unsaved → danger ring so it's scannable across the card.
+                        ...(errored
+                          ? { boxShadow: "inset 0 0 0 2px var(--color-bt-danger)" }
+                          : {}),
+                      }}
                     >
                       {colored ? <GolfChip value={v!} par={u.par!} size={26} fontSize={13} /> : (v ?? "—")}
                       {hasPip && <StrokePip />}
+                      {errored && <UnsavedDot />}
                     </button>
                   );
                 })}
@@ -248,6 +275,25 @@ function Legend() {
         </span>
       ))}
     </div>
+  );
+}
+
+/** Unsaved marker — a danger dot in the cell's lower-left corner, paired with
+ *  the danger ring, so an unsaved score reads at a glance on the review grid. */
+function UnsavedDot() {
+  return (
+    <span
+      aria-label="Not saved"
+      style={{
+        position: "absolute",
+        bottom: 5,
+        left: 5,
+        width: 6,
+        height: 6,
+        borderRadius: "50%",
+        background: "var(--color-bt-danger)",
+      }}
+    />
   );
 }
 

--- a/src/components/games/UnsavedScoresBanner.tsx
+++ b/src/components/games/UnsavedScoresBanner.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { CloudOff, RefreshCw } from "lucide-react";
+
+/**
+ * UnsavedScoresBanner — the always-visible safety net (Connectivity Layer 1).
+ *
+ * Per-cell badges flag failures, but the entry view shows one hole at a time —
+ * a save that failed on a hole you've since navigated away from would be out of
+ * sight. This banner sits at the top of the entry surface whenever ANY cell is
+ * unsaved, so the user can never lose track that something didn't save, and can
+ * retry every flagged cell at once. Hidden when nothing is pending.
+ */
+export function UnsavedScoresBanner({
+  count,
+  onRetry,
+}: {
+  count: number;
+  onRetry: () => void;
+}) {
+  if (count <= 0) return null;
+  return (
+    <div
+      role="alert"
+      className="flex shrink-0 items-center justify-between gap-3"
+      style={{
+        padding: "8px 14px",
+        background: "var(--color-bt-danger-faint)",
+        borderBottom: "1px solid var(--color-bt-danger-border)",
+      }}
+    >
+      <span
+        className="flex items-center gap-2"
+        style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-danger)" }}
+      >
+        <CloudOff size={15} />
+        {count} {count === 1 ? "score" : "scores"} didn&apos;t save
+      </span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="flex items-center gap-1.5"
+        style={{
+          padding: "4px 12px",
+          borderRadius: 9999,
+          background: "var(--color-bt-card)",
+          border: "1px solid var(--color-bt-danger-border)",
+          color: "var(--color-bt-danger)",
+          fontSize: 12,
+          fontWeight: 700,
+        }}
+      >
+        <RefreshCw size={12} strokeWidth={2.5} />
+        Retry{count > 1 ? " all" : ""}
+      </button>
+    </div>
+  );
+}

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -35,3 +35,31 @@ export type ScoreValues = Record<string, Record<string, number>>;
 
 /** Slice A is always low_wins; typed so later strategies can extend. */
 export type ScoreDirection = "low_wins";
+
+/**
+ * Per-cell save lifecycle (Connectivity Layer 1). A score lives optimistically
+ * in local state the instant it's tapped; this tracks whether the WRITE behind
+ * it landed, so a failed save is VISIBLE on the cell instead of silently
+ * vanishing. `error` cells keep their entered value — flagged, retryable, never
+ * rolled back to blank.
+ */
+export type CellSaveState = "saving" | "saved" | "error";
+
+/** { [scoreCellKey]: state } — keyed by `${participantId}:${unitLabel}`. */
+export type SaveStatusMap = Record<string, CellSaveState>;
+
+/** Cell key for SaveStatusMap. participantIds are uuids and unit labels never
+ *  contain a colon, so a colon join is unambiguous and round-trips. */
+export function scoreCellKey(participantId: string, unitLabel: string): string {
+  return `${participantId}:${unitLabel}`;
+}
+
+/** Inverse of {@link scoreCellKey} — split on the FIRST colon (the uuid side
+ *  has none, so this is safe). */
+export function parseScoreCellKey(key: string): {
+  participantId: string;
+  unitLabel: string;
+} {
+  const i = key.indexOf(":");
+  return { participantId: key.slice(0, i), unitLabel: key.slice(i + 1) };
+}

--- a/src/hooks/useRealtimeCompetition.ts
+++ b/src/hooks/useRealtimeCompetition.ts
@@ -23,6 +23,9 @@ export function useRealtimeCompetition(tripId: string | null) {
     if (!tripId) return;
 
     const supabase = getRealtimeClient();
+    const refresh = () => {
+      utils.competitions.getByTrip.invalidate({ tripId });
+    };
     const channel = supabase
       .channel(`competition:${tripId}`)
       .on(
@@ -33,11 +36,14 @@ export function useRealtimeCompetition(tripId: string | null) {
           table: "competitions",
           filter: `trip_id=eq.${tripId}`,
         },
-        () => {
-          utils.competitions.getByTrip.invalidate({ tripId });
-        }
+        refresh
       )
-      .subscribe();
+      // Backfill on (re)connect: a dead zone drops the socket, so any change
+      // during it would otherwise sit stale up to the 60s staleTime. Refetching
+      // on the SUBSCRIBED tick self-heals on reconnect (mirrors useRealtimeChat).
+      .subscribe((status) => {
+        if (status === "SUBSCRIBED") refresh();
+      });
 
     return () => {
       supabase.removeChannel(channel);

--- a/src/hooks/useRealtimeMembers.ts
+++ b/src/hooks/useRealtimeMembers.ts
@@ -30,6 +30,9 @@ export function useRealtimeMembers(tripId: string | null) {
     if (!tripId) return;
 
     const supabase = getRealtimeClient();
+    const refresh = () => {
+      utils.tripMembers.list.invalidate({ tripId });
+    };
     const channel = supabase
       .channel(`members:${tripId}`)
       .on(
@@ -40,11 +43,14 @@ export function useRealtimeMembers(tripId: string | null) {
           table: "trip_members",
           filter: `trip_id=eq.${tripId}`,
         },
-        () => {
-          utils.tripMembers.list.invalidate({ tripId });
-        }
+        refresh
       )
-      .subscribe();
+      // Backfill on (re)connect: a role change during a dead zone would
+      // otherwise stay stale up to the 60s staleTime. Refetching on the
+      // SUBSCRIBED tick self-heals on reconnect (mirrors useRealtimeChat).
+      .subscribe((status) => {
+        if (status === "SUBSCRIBED") refresh();
+      });
 
     return () => {
       supabase.removeChannel(channel);

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { trpc } from "@/lib/trpc-client";
+import {
+  scoreCellKey,
+  type CellSaveState,
+  type SaveStatusMap,
+  type ScoreValues,
+} from "@/components/games/types";
+
+/**
+ * useScoreSaver — the score-entry write path (Connectivity Layer 1).
+ *
+ * The on-course problem: a score posted at 1–2 bars used to fire-and-forget,
+ * and on failure silently roll back to blank with no retry — the score just
+ * vanished. This hook makes every save VISIBLE and RETRIED:
+ *
+ *  - Optimistic: the value lands in local state the instant it's tapped.
+ *  - Retried: the upsert/delete mutations carry exponential backoff over a short
+ *    window, so brief blips ("walked behind a tree") self-heal with no user
+ *    action. The writes are idempotent (deterministic id
+ *    `gameId:participantId:unitLabel`, upsert/onConflict), so a retry — or a
+ *    double-tap — is always safe.
+ *  - Visible on failure: when retries are exhausted, the entered value STAYS on
+ *    screen and the cell is flagged `error` (never rolled back to blank), with a
+ *    per-cell retry. Visible-and-flagged beats rolled-back-and-gone.
+ *
+ * CRITICAL: this never consults `navigator.onLine`. That flag lies at 1 bar
+ * (reports online when requests will fail), so every write is simply attempted
+ * and retried regardless — retry-everything beats trust-the-online-flag.
+ *
+ * Persistence lives here (the parent page hook), NOT inside the persistence-
+ * agnostic scorecard components — they receive `values` + `saveStatus` as props
+ * and emit through `onChange`/`onClear`/`onRetryCell`.
+ *
+ * This is Layer 1 (visibility + retry). It deliberately does NOT persist the
+ * mutation across an app-kill or flush a queue on reconnect — that is Layer 2
+ * (the persisted write-queue), a separate follow-on.
+ */
+
+const MAX_RETRIES = 4;
+/** 0.5s, 1s, 2s, 4s … capped at 8s — a few attempts over ~15s, then surface. */
+const retryDelay = (attempt: number) => Math.min(500 * 2 ** attempt, 8000);
+
+export function useScoreSaver(
+  tripId: string | undefined,
+  gameId: string | null | undefined,
+) {
+  const [values, setValues] = useState<ScoreValues>({});
+  const [saveStatus, setSaveStatus] = useState<SaveStatusMap>({});
+
+  const upsertEntry = trpc.scores.upsertEntry.useMutation({
+    retry: MAX_RETRIES,
+    retryDelay,
+  });
+  const deleteEntry = trpc.scores.deleteEntry.useMutation({
+    retry: MAX_RETRIES,
+    retryDelay,
+  });
+
+  const mark = useCallback((key: string, state: CellSaveState | null) => {
+    setSaveStatus((s) => {
+      if (state === null) {
+        if (!(key in s)) return s;
+        const next = { ...s };
+        delete next[key];
+        return next;
+      }
+      if (s[key] === state) return s;
+      return { ...s, [key]: state };
+    });
+  }, []);
+
+  const onChange = useCallback(
+    (participantId: string, unitLabel: string, value: number) => {
+      if (!tripId || !gameId) return;
+      const key = scoreCellKey(participantId, unitLabel);
+      // Optimistic: show the number immediately.
+      setValues((v) => ({
+        ...v,
+        [participantId]: { ...(v[participantId] ?? {}), [unitLabel]: value },
+      }));
+      mark(key, "saving");
+      upsertEntry.mutate(
+        { tripId, gameId, participantId, unitLabel, value },
+        {
+          onSuccess: () => mark(key, "saved"),
+          // KEEP the optimistic value — flag it, never roll back to blank.
+          onError: () => mark(key, "error"),
+        },
+      );
+    },
+    [tripId, gameId, upsertEntry, mark],
+  );
+
+  const onClear = useCallback(
+    (participantId: string, unitLabel: string) => {
+      if (!tripId || !gameId) return;
+      const key = scoreCellKey(participantId, unitLabel);
+      const prevValue = values[participantId]?.[unitLabel];
+      // Optimistic removal.
+      setValues((v) => {
+        const row = { ...(v[participantId] ?? {}) };
+        delete row[unitLabel];
+        return { ...v, [participantId]: row };
+      });
+      mark(key, null);
+      deleteEntry.mutate(
+        { tripId, gameId, participantId, unitLabel },
+        {
+          // A failed delete means the value is still on the server — restore it
+          // (accurate) and flag it so the user knows the clear didn't take.
+          onError: () => {
+            if (prevValue != null) {
+              setValues((v) => ({
+                ...v,
+                [participantId]: {
+                  ...(v[participantId] ?? {}),
+                  [unitLabel]: prevValue,
+                },
+              }));
+              mark(key, "error");
+            }
+          },
+        },
+      );
+    },
+    [tripId, gameId, values, deleteEntry, mark],
+  );
+
+  /** Re-fire the save for a flagged cell using its current value. */
+  const retryCell = useCallback(
+    (participantId: string, unitLabel: string) => {
+      const value = values[participantId]?.[unitLabel];
+      if (value == null) return;
+      onChange(participantId, unitLabel, value);
+    },
+    [values, onChange],
+  );
+
+  const errorCount = Object.values(saveStatus).filter(
+    (s) => s === "error",
+  ).length;
+
+  return {
+    values,
+    setValues,
+    saveStatus,
+    errorCount,
+    onChange,
+    onClear,
+    retryCell,
+  };
+}

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -50,13 +50,17 @@ export function useScoreSaver(
   const [values, setValues] = useState<ScoreValues>({});
   const [saveStatus, setSaveStatus] = useState<SaveStatusMap>({});
 
+  // suppressErrorToast: these own per-cell save UI (badge + banner), so the
+  // global connectivity toast would double-signal — opt out of it.
   const upsertEntry = trpc.scores.upsertEntry.useMutation({
     retry: MAX_RETRIES,
     retryDelay,
+    meta: { suppressErrorToast: true },
   });
   const deleteEntry = trpc.scores.deleteEntry.useMutation({
     retry: MAX_RETRIES,
     retryDelay,
+    meta: { suppressErrorToast: true },
   });
 
   const mark = useCallback((key: string, state: CellSaveState | null) => {

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -1,12 +1,40 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  MutationCache,
+} from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import { useState } from "react";
 import superjson from "superjson";
 import { ThemeProvider } from "next-themes";
 import { trpc } from "@/lib/trpc-client";
 import { AuthProvider } from "@/lib/auth-context";
+import { Toaster } from "@/components/Toaster";
+import { showToast } from "@/lib/toast";
+
+/**
+ * A mutation failed because the request never reached a server (dead zone / bad
+ * signal), NOT because the server rejected it. A transport failure has no HTTP
+ * status; a real server response (validation/conflict/500) does and is handled
+ * where it's raised, so we don't hijack it with a connectivity toast.
+ */
+function isConnectivityError(error: unknown): boolean {
+  const httpStatus = (error as { data?: { httpStatus?: number } } | null)?.data
+    ?.httpStatus;
+  if (typeof httpStatus === "number" && httpStatus > 0) return false;
+  const msg = (
+    error instanceof Error ? error.message : String(error)
+  ).toLowerCase();
+  return (
+    msg.includes("fetch") ||
+    msg.includes("network") ||
+    msg.includes("load failed") ||
+    msg.includes("failed to fetch") ||
+    httpStatus === undefined
+  );
+}
 
 function getBaseUrl() {
   if (typeof window !== "undefined") return "";
@@ -21,6 +49,22 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
+        // Surface connectivity failures (Layer 1): any mutation whose request
+        // never reached the server gets a "couldn't save" toast — UNLESS it
+        // opts out via meta.suppressErrorToast (score writes do, since they
+        // own per-cell save UI). Server-rejected mutations are handled at their
+        // call sites, so they're left alone.
+        mutationCache: new MutationCache({
+          onError: (error, _vars, _ctx, mutation) => {
+            const suppressed = (
+              mutation.meta as { suppressErrorToast?: boolean } | undefined
+            )?.suppressErrorToast;
+            if (suppressed) return;
+            if (isConnectivityError(error)) {
+              showToast("Couldn't save — check your connection. We'll keep your data.");
+            }
+          },
+        }),
         defaultOptions: {
           queries: {
             staleTime: 60_000,
@@ -53,7 +97,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <ThemeProvider attribute="class" defaultTheme="dark" forcedTheme="dark">
       <AuthProvider queryClient={queryClient}>
         <trpc.Provider client={trpcClient} queryClient={queryClient}>
-          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+          <QueryClientProvider client={queryClient}>
+            {children}
+            <Toaster />
+          </QueryClientProvider>
         </trpc.Provider>
       </AuthProvider>
     </ThemeProvider>

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,49 @@
+/**
+ * Minimal toast pub/sub (Connectivity Layer 1).
+ *
+ * A dependency-free notification channel so connectivity failures are SEEN
+ * instead of failing silently. The QueryClient's mutationCache.onError pushes
+ * here; <Toaster> subscribes and renders. Deliberately tiny — not a general
+ * design-system toast, just enough to surface "couldn't save".
+ */
+
+export type ToastTone = "error" | "info";
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  tone: ToastTone;
+}
+
+type Listener = (toasts: ToastItem[]) => void;
+
+let toasts: ToastItem[] = [];
+let nextId = 1;
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l(toasts);
+}
+
+export function subscribeToasts(listener: Listener): () => void {
+  listeners.add(listener);
+  listener(toasts);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function showToast(message: string, tone: ToastTone = "error"): number {
+  const id = nextId++;
+  // Collapse duplicate consecutive messages (a flurry of failed writes on a
+  // dead connection shouldn't stack identical toasts).
+  if (toasts.some((t) => t.message === message)) return id;
+  toasts = [...toasts, { id, message, tone }];
+  emit();
+  return id;
+}
+
+export function dismissToast(id: number) {
+  toasts = toasts.filter((t) => t.id !== id);
+  emit();
+}


### PR DESCRIPTION
## Connectivity Layer 1 — make failures VISIBLE and RETRIED

From the low-connectivity diagnostic: today you **cannot reliably enter a score at 1–2 bars** — a posted score fires, times out, silently rolls back to blank with no retry, and is gone. This layer attacks the *silent* in "silent score loss." It does **not** build the persisted write-queue (Layer 2) or the offline shell (Layer 3).

### The cardinal rule
**Nothing here consults `navigator.onLine`** — it lies at 1 bar (reports online when requests fail). Every write is simply attempted and retried regardless; retry-everything beats trust-the-online-flag.

### What changed

**1. Score writes are visible + retried (the headline)** — new `useScoreSaver` hook owns the write path for both game pages:
- Optimistic local value the instant you tap.
- **Retry with exponential backoff** (~0.5/1/2/4s) on the upsert/delete mutations — brief blips ("walked behind a tree") self-heal with no user action. Idempotent (deterministic-id upserts), so retries + double-taps are safe.
- On sustained failure the entered value **stays on screen, flagged `error`** — never rolled back to blank.
- Per-cell `ScoreSaveBadge` (saving / saved / **couldn't-save → tap to retry**) + an always-visible `UnsavedScoresBanner` ("N scores didn't save — Retry all") so a failure on a hole you've left is never out of sight. The review grid rings unsaved cells. (Player rows became `role="button"` so the per-cell Retry can nest validly.)

**2. Finish-game is loud + retryable** — `mutateAsync` was unwrapped (a blip = unhandled rejection, user stranded). Now retried + try/catch on both pages: stays on the entry view (no silent advance), surfaces via the toast, CTA stays tappable.

**3. Global connectivity toast** — a `mutationCache.onError` fires "Couldn't save — check your connection" on transport failures (no HTTP status). Score writes opt out (`meta.suppressErrorToast`) since they own per-cell UI; server-rejected mutations are left to their call sites.

**4. Realtime board self-heals on reconnect** — `useRealtimeCompetition` / `useRealtimeMembers` now refetch on the `SUBSCRIBED` tick (the pattern `useRealtimeChat` already used), so a change during a dead zone catches up on reconnect instead of waiting out the 60s staleTime.

**5. Leaderboard never blank-on-error** — `if (isLoading || !data) return null` became a spinner (first load) / a retryable "couldn't load" card (error). A warm board is untouched (TanStack keeps last data through failed refetches).

### Verified in preview (simulated dead zone via failed POSTs)
- ✅ Enter a score → fails → retries → on sustained failure stays on screen flagged "couldn't save" + banner ("1 score didn't save") — **the value never vanishes**.
- ✅ Tap Retry on reconnect → saves, badge → saved, banner clears, value preserved throughout.
- ✅ Happy path shows a "saved" confirmation.
- ✅ Failing a create-game mutation shows the global toast.
- ✅ No `navigator.onLine` gates any save/retry. `tsc` + `next lint` clean; no console errors.

### Deferred (explicitly out of scope)
- **Layer 2** — persisted write-queue (survive app-kill, flush on reconnect).
- **Layer 3** — offline app shell / service worker + query persistence (read-path cold-start).
- No offline-first / local-first DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
