### PR TITLE
feat(games): 2v2 match play — engine foundation (Stage 1, server)

### DIFF
--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -40,7 +40,7 @@ interface GameResultRow {
   id: string;
   game_id: string;
   entity_id: string;
-  entity_type: "user";
+  entity_type: "user" | "play_group";
   raw_score: null;
   position: number;
   competition_points_earned: null;
@@ -64,22 +64,34 @@ export async function computeMatchPlayResults(
   // → `buildDecided` uses the sequential fallback (the no-course path).
   const { strokeIndex, holeCount } = await loadStrokeIndex(supabase, gameId);
 
-  // user_id → handicap strokes (null = 0).
+  // Side handicaps, keyed by SIDE id. A 1v1 side is a user (handicap on
+  // game_participants); a 2v2 side is a pair = a play_group (handicap on
+  // play_groups). Read both so one compute serves both formats — the id spaces
+  // don't collide and a game only ever looks up its own side type's ids.
+  const hcap = new Map<string, number>();
   const { data: parts } = await supabase
     .from("game_participants")
     .select("user_id, handicap_strokes")
     .eq("game_id", gameId);
-  const hcap = new Map<string, number>();
   for (const p of parts ?? []) {
     hcap.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
   }
+  const { data: pgroups } = await supabase
+    .from("play_groups")
+    .select("id, handicap_strokes")
+    .eq("game_id", gameId);
+  for (const pg of pgroups ?? []) {
+    hcap.set(pg.id as string, effectiveStrokes(pg as { handicap_strokes: number | null }));
+  }
 
-  // user_id → { unit_label → gross }.
+  // Side gross, keyed by SIDE id → { unit_label → gross }. 1v1 records one entry
+  // per user (participant_type='user'); 2v2 records one entry per side
+  // (participant_type='play_group'). Read both and merge by id.
   const { data: entries } = await supabase
     .from("score_entries")
     .select("participant_id, unit_label, value")
     .eq("game_id", gameId)
-    .eq("participant_type", "user");
+    .in("participant_type", ["user", "play_group"]);
   // Nothing scored yet → nothing to derive. Skips the wasted recompute that the
   // setup-time setHandicap calls would otherwise trigger (no results to write).
   if ((entries ?? []).length === 0) return [];
@@ -134,9 +146,10 @@ export async function computeMatchPlayResults(
     // play has no aggregate. Reflects current standing live and final on finish.
     const aTrailing = st.up > 0 && st.leader === "B";
     const bTrailing = st.up > 0 && st.leader === "A";
+    // entity_type follows the side type: 'user' (1v1) or 'play_group' (2v2).
     resultRows.push(
-      mkResult(gameId, a.id, aTrailing ? 2 : 1),
-      mkResult(gameId, b.id, bTrailing ? 2 : 1)
+      mkResult(gameId, a.id, aTrailing ? 2 : 1, a.type),
+      mkResult(gameId, b.id, bTrailing ? 2 : 1, b.type)
     );
   }
 
@@ -194,12 +207,19 @@ async function loadStrokeIndex(
   return { strokeIndex: schema?.units?.metadata?.handicap_index, holeCount: schema?.units?.count };
 }
 
-function mkResult(gameId: string, entityId: string, position: number): GameResultRow {
+function mkResult(
+  gameId: string,
+  entityId: string,
+  position: number,
+  sideType: string
+): GameResultRow {
   return {
     id: crypto.randomUUID(),
     game_id: gameId,
     entity_id: entityId,
-    entity_type: "user",
+    // Normalize the side ref's type to the entity_type column's domain; a 1v1
+    // side ('user') and a 2v2 side ('play_group') are the only cases.
+    entity_type: sideType === "play_group" ? "play_group" : "user",
     raw_score: null,
     position,
     competition_points_earned: null,
@@ -240,6 +260,23 @@ async function writeTeamMatchPoints(
     userTeam.set(a.user_id as string, a.team_id as string);
   }
 
+  // play_group → team (2v2): a side is a pair, so resolve its team via a member.
+  // Both partners are on the same team in a two-team competition. Empty for 1v1.
+  const { data: pgMembers } = await supabase
+    .from("game_participants")
+    .select("user_id, play_group_id")
+    .eq("game_id", gameId);
+  const pgTeam = new Map<string, string>();
+  for (const gp of pgMembers ?? []) {
+    const pg = gp.play_group_id as string | null;
+    if (!pg || pgTeam.has(pg)) continue;
+    const team = userTeam.get(gp.user_id as string);
+    if (team) pgTeam.set(pg, team);
+  }
+  // A side resolves to its team via the user map (1v1) or the play_group map (2v2).
+  const sideTeam = (s: SideRef): string | undefined =>
+    s.type === "play_group" ? pgTeam.get(s.id) : userTeam.get(s.id);
+
   const teamPoints = new Map<string, number>();
   for (const m of allMatches) {
     const result = resultByMatch.get(m.id as string);
@@ -247,8 +284,8 @@ async function writeTeamMatchPoints(
     const a = m.side_a as SideRef | null;
     const b = m.side_b as SideRef | null;
     if (!a?.id || !b?.id) continue;
-    const aTeam = userTeam.get(a.id);
-    const bTeam = userTeam.get(b.id);
+    const aTeam = sideTeam(a);
+    const bTeam = sideTeam(b);
     if (!aTeam || !bTeam) continue;
 
     if (result === "a_win") {

--- a/src/server/routers/matches.doubles.test.ts
+++ b/src/server/routers/matches.doubles.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * 2v2 / doubles match play (Slice C). The side is a PAIR (a play_group), one
+ * score is recorded per side per hole, and the SAME match engine
+ * (computeMatchPlayResults) resolves the head-to-head — just with play_group
+ * sides instead of user sides. These tests prove the sided path end-to-end:
+ * pairings create the two sides, scoring is per side, and the result distills to
+ * game_results with entity_type='play_group'.
+ */
+
+const DOUBLES = "gtt_match_play_doubles";
+
+type Side = { type: string; id: string } | null;
+interface MatchRow {
+  id: string;
+  side_a: Side;
+  side_b: Side;
+  result: string | null;
+  margin: string | null;
+  status: string;
+}
+
+let ctx: TestContext;
+let tripId: string;
+let owner: string, planner: string, member: string, outsider: string;
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Doubles Match Play Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer");
+  await ctx.addTripMember(tripId, "member", "Member");
+  await ctx.addTripMember(tripId, "outsider", "Member");
+  owner = ctx.user.id;
+  planner = ctx.getUser("planner").id;
+  member = ctx.getUser("member").id;
+  outsider = ctx.getUser("outsider").id;
+});
+
+afterAll(async () => {
+  await ctx.cleanup();
+});
+
+/** Enter one score per SIDE per hole (participant_type='play_group'). */
+async function enterSides(
+  gameId: string,
+  pgA: string,
+  pgB: string,
+  scoreA: Record<number, number>,
+  scoreB: Record<number, number>
+) {
+  const caller = ctx.caller();
+  for (const [h, v] of Object.entries(scoreA)) {
+    await caller.scores.upsertEntry({ tripId, gameId, participantId: pgA, unitLabel: h, value: v, participantType: "play_group" });
+  }
+  for (const [h, v] of Object.entries(scoreB)) {
+    await caller.scores.upsertEntry({ tripId, gameId, participantId: pgB, unitLabel: h, value: v, participantType: "play_group" });
+  }
+}
+
+async function freshGame(name: string) {
+  const game = await ctx.caller().games.create({ tripId, gameTypeId: DOUBLES, name });
+  return game.id;
+}
+
+/** Pair (owner+planner) vs (member+outsider). Returns the two play_group ids. */
+async function pairUp(gameId: string): Promise<{ pgA: string; pgB: string; matchId: string }> {
+  const matches = (await ctx.caller().matches.setDoublesPairings({
+    tripId,
+    gameId,
+    matches: [
+      {
+        sideA: { members: [owner, planner] },
+        sideB: { members: [member, outsider] },
+        matchNumber: 1,
+      },
+    ],
+  })) as MatchRow[];
+  const m = matches[0];
+  return { pgA: m.side_a!.id, pgB: m.side_b!.id, matchId: m.id };
+}
+
+describe("doubles setup — sides are play_groups", () => {
+  it("setDoublesPairings creates a play_group per side with its two members", async () => {
+    const gameId = await freshGame("Pairing");
+    const { pgA, pgB } = await pairUp(gameId);
+
+    // Two distinct play_groups, both anchored to this game.
+    const { data: pgs } = await ctx.admin.from("play_groups").select("id").eq("game_id", gameId);
+    expect((pgs as { id: string }[]).map((p) => p.id).sort()).toEqual([pgA, pgB].sort());
+
+    // Four participants, two on each side (play_group_id set).
+    const { data: parts } = await ctx.admin
+      .from("game_participants")
+      .select("user_id, play_group_id")
+      .eq("game_id", gameId);
+    const rows = parts as { user_id: string; play_group_id: string | null }[];
+    expect(rows).toHaveLength(4);
+    const sideOf = (u: string) => rows.find((r) => r.user_id === u)?.play_group_id;
+    expect(sideOf(owner)).toBe(pgA);
+    expect(sideOf(planner)).toBe(pgA);
+    expect(sideOf(member)).toBe(pgB);
+    expect(sideOf(outsider)).toBe(pgB);
+
+    // The match references the two play-group sides.
+    const { data: matches } = await ctx.admin.from("game_matches").select("side_a, side_b").eq("game_id", gameId);
+    const m = (matches as { side_a: Side; side_b: Side }[])[0];
+    expect(m.side_a?.type).toBe("play_group");
+    expect(m.side_b?.type).toBe("play_group");
+  });
+
+  it("setDoublesHandicap stores the side handicap on play_groups (recipient n, other 0)", async () => {
+    const gameId = await freshGame("Side handicap");
+    const { pgA, pgB, matchId } = await pairUp(gameId);
+    await ctx.callerAs("planner").matches.setDoublesHandicap({
+      tripId,
+      gameId,
+      matchId,
+      recipientPlayGroupId: pgB,
+      strokes: 2,
+    });
+    const { data } = await ctx.admin.from("play_groups").select("id, handicap_strokes").eq("game_id", gameId);
+    const hcap = Object.fromEntries(
+      (data as { id: string; handicap_strokes: number | null }[]).map((p) => [p.id, p.handicap_strokes])
+    );
+    expect(hcap[pgB]).toBe(2);
+    expect(hcap[pgA]).toBe(0);
+  });
+
+  it("a plain Member cannot set doubles pairings", async () => {
+    const gameId = await freshGame("Gate");
+    await expect(
+      ctx.callerAs("member").matches.setDoublesPairings({
+        tripId,
+        gameId,
+        matches: [
+          { sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 },
+        ],
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("doubles results — one score per side, match engine reused", () => {
+  it("closed-out 3&2 → a_win with game_results rows of entity_type='play_group'", async () => {
+    const gameId = await freshGame("Close 3&2");
+    const { pgA, pgB } = await pairUp(gameId);
+    // Side A wins 1-3, halves 4-16 → +3 frozen at hole 16 = 3&2.
+    const aHalf: Record<number, number> = {};
+    const bHalf: Record<number, number> = {};
+    for (let h = 4; h <= 16; h++) {
+      aHalf[h] = 4;
+      bHalf[h] = 4;
+    }
+    await enterSides(gameId, pgA, pgB, { 1: 4, 2: 4, 3: 4, ...aHalf }, { 1: 5, 2: 5, 3: 5, ...bHalf });
+
+    const { matches } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ result: "a_win", margin: "3&2", status: "complete" });
+
+    const { data: results } = await ctx.admin
+      .from("game_results")
+      .select("entity_id, entity_type, position, raw_score")
+      .eq("game_id", gameId);
+    const rows = results as { entity_id: string; entity_type: string; position: number; raw_score: number | null }[];
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.entity_type === "play_group")).toBe(true);
+    expect(rows.find((r) => r.entity_id === pgA)?.position).toBe(1);
+    expect(rows.find((r) => r.entity_id === pgB)?.position).toBe(2);
+    expect(rows.every((r) => r.raw_score === null)).toBe(true);
+  });
+
+  it("a received side stroke flips a hole (net), same as 1v1", async () => {
+    const gameId = await freshGame("Side net");
+    const { pgA, pgB, matchId } = await pairUp(gameId);
+    // Side B gets 1 stroke → fallback puts it on hole 1.
+    await ctx.caller().matches.setDoublesHandicap({ tripId, gameId, matchId, recipientPlayGroupId: pgB, strokes: 1 });
+    // Hole 1: A gross 4, B gross 5 → B net 4 → halved, not an A win.
+    await enterSides(gameId, pgA, pgB, { 1: 4 }, { 1: 5 });
+
+    const { matches } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(matches[0].result).toBeNull(); // one halved hole, match not over
+    const { data: results } = await ctx.admin
+      .from("game_results")
+      .select("entity_id, position")
+      .eq("game_id", gameId);
+    const rows = results as { entity_id: string; position: number }[];
+    expect(rows.find((r) => r.entity_id === pgA)?.position).toBe(1);
+    expect(rows.find((r) => r.entity_id === pgB)?.position).toBe(1);
+  });
+});

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -24,6 +24,10 @@ import { computeMatchPlayResults } from "../lib/matchPlay";
  */
 
 const sideSchema = z.object({ type: z.literal("user"), id: z.string().min(1) });
+// 2v2 (doubles): a side is a PAIR of users. setDoublesPairings creates a
+// play_group per side and stores side_a/side_b as {"type":"play_group","id":pgId}
+// — the SAME match engine as singles, with the side being a pair.
+const doublesSideSchema = z.object({ members: z.array(z.string().min(1)).length(2) });
 
 async function assertGameInTrip(
   ctx: { supabase: { from: (t: string) => unknown } },
@@ -269,6 +273,160 @@ export const matchesRouter = router({
       return { ok: true };
     }),
 
+  // ── 2v2 / doubles (Slice C) ────────────────────────────────────────────────
+  // The side is a PAIR (a play_group), the score is one entry per side per hole.
+  // These are the doubles analogues of setPairings / setHandicap; the singles
+  // procedures above are untouched, and the result math (computeMatchPlayResults)
+  // is shared — it resolves a side by id whether the id is a user or a play_group.
+
+  // setDoublesPairings — Owner/Organizer. Clean-replace the game's matches:
+  // create a play_group per side (its 2 members → game_participants), and one
+  // game_match between the two play-group sides. Mirrors setPairings' clean
+  // re-save (setup-time; before scores exist).
+  setDoublesPairings: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        matches: z
+          .array(
+            z.object({
+              sideA: doublesSideSchema.nullable(),
+              sideB: doublesSideSchema.nullable(),
+              matchNumber: z.number().int().min(1),
+            })
+          )
+          .min(1)
+          .max(4),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
+
+      // Clean replace (setup-time, before scoring — mirrors setPairings). Order
+      // matters: matches reference play_groups (SET NULL), participants reference
+      // play_groups (SET NULL); clear children then the play_groups.
+      await ctx.supabase.from("game_matches").delete().eq("game_id", input.gameId);
+      await ctx.supabase.from("game_participants").delete().eq("game_id", input.gameId);
+      await ctx.supabase.from("play_groups").delete().eq("game_id", input.gameId);
+
+      const pgRows: { id: string; game_id: string; display_name: null }[] = [];
+      const partRows: {
+        id: string;
+        game_id: string;
+        user_id: string;
+        play_group_id: string;
+        team_id: null;
+      }[] = [];
+      const matchRows = input.matches.map((m, i) => {
+        const mkSide = (side: { members: string[] } | null) => {
+          if (!side) return null;
+          const pgId = crypto.randomUUID();
+          pgRows.push({ id: pgId, game_id: input.gameId, display_name: null });
+          for (const uid of side.members) {
+            partRows.push({
+              id: crypto.randomUUID(),
+              game_id: input.gameId,
+              user_id: uid,
+              play_group_id: pgId,
+              team_id: null,
+            });
+          }
+          return { type: "play_group" as const, id: pgId };
+        };
+        return {
+          id: crypto.randomUUID(),
+          game_id: input.gameId,
+          play_group_id: null,
+          match_number: m.matchNumber,
+          display_order: i,
+          side_a: mkSide(m.sideA),
+          side_b: mkSide(m.sideB),
+          status: "pending",
+        };
+      });
+
+      if (pgRows.length > 0) {
+        const { error } = await ctx.supabase.from("play_groups").insert(pgRows);
+        if (error) {
+          throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to create sides: ${error.message}` });
+        }
+      }
+      if (partRows.length > 0) {
+        // One row per user per game (UNIQUE game_id,user_id) — a player is on one side.
+        const { error } = await ctx.supabase
+          .from("game_participants")
+          .upsert(partRows, { onConflict: "game_id,user_id" });
+        if (error) {
+          throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to seed players: ${error.message}` });
+        }
+      }
+      const { error } = await ctx.supabase.from("game_matches").insert(matchRows);
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set pairings: ${error.message}` });
+      }
+
+      const { data } = await ctx.supabase
+        .from("game_matches")
+        .select("*")
+        .eq("game_id", input.gameId)
+        .order("display_order", { ascending: true });
+      return data ?? [];
+    }),
+
+  // setDoublesHandicap — Owner/Organizer. The recipient SIDE (a play_group) gets
+  // `strokes`, the other side 0 — never split. The side handicap lives on
+  // play_groups.handicap_strokes (the doubles analogue of game_participants).
+  setDoublesHandicap: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        matchId: z.string().min(1),
+        recipientPlayGroupId: z.string().min(1),
+        strokes: z.number().int().min(0).max(36),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
+
+      const { data: match } = await ctx.supabase
+        .from("game_matches")
+        .select("side_a, side_b")
+        .eq("id", input.matchId)
+        .eq("game_id", input.gameId)
+        .maybeSingle();
+      if (!match) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
+      }
+      const sides = [
+        (match.side_a as { id: string } | null)?.id,
+        (match.side_b as { id: string } | null)?.id,
+      ].filter((x): x is string => !!x);
+      if (!sides.includes(input.recipientPlayGroupId)) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Recipient is not a side in this match" });
+      }
+      const other = sides.find((id) => id !== input.recipientPlayGroupId);
+
+      await ctx.supabase
+        .from("play_groups")
+        .update({ handicap_strokes: input.strokes })
+        .eq("id", input.recipientPlayGroupId)
+        .eq("game_id", input.gameId);
+      if (other) {
+        await ctx.supabase
+          .from("play_groups")
+          .update({ handicap_strokes: 0 })
+          .eq("id", other)
+          .eq("game_id", input.gameId);
+      }
+      // Handicap is a recompute input — re-derive in-progress matches (#9 freeze).
+      await computeMatchPlayResults(ctx.supabase, input.gameId, { skipComplete: true });
+      return { ok: true };
+    }),
+
   // reorder — Owner/Organizer. Persist display_order from the given order.
   reorder: authedProcedure
     .input(
@@ -335,7 +493,7 @@ export const matchesRouter = router({
       const published = !!game.pairings_published_at;
 
       if (ctx.tripRole === "Member" && !published) {
-        return { published: false, matches: [], participants: [] };
+        return { published: false, matches: [], participants: [], playGroups: [] };
       }
 
       const { data: matches } = await ctx.supabase
@@ -347,7 +505,19 @@ export const matchesRouter = router({
         .from("game_participants")
         .select("user_id, handicap_strokes, play_group_id")
         .eq("game_id", input.gameId);
+      // The sides (pairs) for 2v2 — their handicap + display name. Empty for 1v1
+      // (no play_groups created). The client maps a play_group side to its two
+      // members via `participants.play_group_id`.
+      const { data: playGroups } = await ctx.supabase
+        .from("play_groups")
+        .select("id, display_name, handicap_strokes")
+        .eq("game_id", input.gameId);
 
-      return { published, matches: matches ?? [], participants: participants ?? [] };
+      return {
+        published,
+        matches: matches ?? [],
+        participants: participants ?? [],
+        playGroups: playGroups ?? [],
+      };
     }),
 });

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -19,9 +19,12 @@ export const scoresRouter = router({
       z.object({
         tripId: z.string(),
         gameId: z.string(),
-        participantId: z.string().min(1), // user_id in Slice A
+        participantId: z.string().min(1), // user_id (1v1/stroke) | play_group_id (2v2)
         unitLabel: z.string().min(1).max(16), // "1".."18"
         value: z.number().int().min(1).max(99).nullable(),
+        // The scoring unit. Defaults to 'user' (singles/stroke — unchanged); a
+        // 2v2 side records one entry per play_group.
+        participantType: z.enum(["user", "play_group"]).optional(),
       })
     )
     .use(requireTripMember)
@@ -55,7 +58,7 @@ export const scoresRouter = router({
           id,
           game_id: input.gameId,
           participant_id: input.participantId,
-          participant_type: "user",
+          participant_type: input.participantType ?? "user",
           unit_label: input.unitLabel,
           value: input.value,
           submitted_by: ctx.user!.id,
@@ -131,11 +134,13 @@ export const scoresRouter = router({
       if (!game) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
       }
+      // Both scoring units: 'user' (1v1/stroke) and 'play_group' (2v2 sides).
+      // Singles games have only 'user' rows, so this is unchanged for them.
       const { data, error } = await ctx.supabase
         .from("score_entries")
         .select("participant_id, unit_label, value")
         .eq("game_id", input.gameId)
-        .eq("participant_type", "user");
+        .in("participant_type", ["user", "play_group"]);
       if (error) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",

--- a/supabase/migrations/20260615130000_055_match_play_doubles.sql
+++ b/supabase/migrations/20260615130000_055_match_play_doubles.sql
@@ -1,0 +1,78 @@
+-- 055 — 2v2 match play (doubles): side-handicap column + game type template
+--
+-- BBMI's remaining events (2-Man Scramble, Alt-Shot, Best-Ball) are all 2v2
+-- match play. The engine is 1v1's match_play, with the SIDE being a pair
+-- (a `play_group`) instead of a user, and ONE score recorded per side per hole
+-- (`group_holes`) instead of per user. `game_matches`, `play_groups`,
+-- `score_entries` (participant_type IN ('user','play_group')) and `game_results`
+-- (entity_type IN ('user','team','play_group')) already support this shape — see
+-- COMPETITION_ENGINE.md. Idempotent.
+
+-- ── 1. Side handicap ─────────────────────────────────────────────────────────
+-- 1v1 stores a match's handicap strokes on `game_participants.handicap_strokes`
+-- (per user). A 2v2 side is a PAIR (a play_group), so its per-match handicap
+-- lives on the play_group. computeMatchPlayResults reads from here when a side
+-- is a play_group, and from game_participants when a side is a user.
+ALTER TABLE public.play_groups ADD COLUMN IF NOT EXISTS handicap_strokes integer;
+
+COMMENT ON COLUMN public.play_groups.handicap_strokes IS
+  'Match-play handicap strokes this side (pair) receives, for 2v2/doubles where '
+  'the play_group is the scoring side. Null = 0. Mirrors '
+  'game_participants.handicap_strokes (which is per user, for 1v1 sides).';
+
+-- ── 2. gtt_match_play_doubles ────────────────────────────────────────────────
+-- Same engine as singles (result_strategy='match_play'), but entry is one ball
+-- per SIDE per hole (entry_schema='group_holes') and a side holds two players
+-- (max_players_per_side=2). The three BBMI presets (Scramble / Alt-Shot /
+-- Best-Ball) are NOT separate engines — they are this one type with a name +
+-- Rules Explainer + default modifier toggles, set client-side. compatible
+-- modifiers match singles (moving_tees + glorious_holes — the preset defaults).
+INSERT INTO public.game_type_templates (
+  id, key, name, description, sort_order,
+  entry_schema, result_strategy,
+  supports_free_for_all, supports_sides, requires_sides, max_players_per_side,
+  compatible_competition_formats, compatible_modifiers, category,
+  config_schema, scorecard_schema
+)
+VALUES (
+  'gtt_match_play_doubles', 'match_play_doubles', '2v2 Match Play',
+  '2v2 match play — one score per side per hole, low net wins each hole; the match resolves W/H/L hole-by-hole between two pairs. Scramble / Alt-Shot / Best-Ball are presets over this one engine.', 2,
+  'group_holes', 'match_play',
+  false, true, true, 2,
+  ARRAY['ryder_cup']::text[], ARRAY['moving_tees', 'glorious_holes']::text[], 'golf',
+  '{}'::jsonb,
+  '{
+    "units": {
+      "type": "holes", "count": 18, "ordered": true,
+      "labels": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18"],
+      "metadata": { "par": [4,5,3,4,4,3,5,4,4,4,3,5,4,4,3,4,5,4] }
+    },
+    "entry": { "value_type": "integer", "value_label": "Strokes", "min": 1, "max": null },
+    "scoring": {
+      "strategy": "match_play", "direction": "low_wins", "aggregation": "match",
+      "sections": [
+        { "name": "Front 9", "units": ["1","2","3","4","5","6","7","8","9"] },
+        { "name": "Back 9", "units": ["10","11","12","13","14","15","16","17","18"] }
+      ],
+      "tiebreaker": "shared"
+    },
+    "participants": { "min": 4, "max": 8, "participant_type": "side", "players_per_side": 2, "assigned_pairings": true },
+    "interaction": { "model": "simultaneous", "entry_timing": "per_unit" }
+  }'::jsonb
+)
+ON CONFLICT (id) DO UPDATE SET
+  key = EXCLUDED.key,
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  sort_order = EXCLUDED.sort_order,
+  entry_schema = EXCLUDED.entry_schema,
+  result_strategy = EXCLUDED.result_strategy,
+  supports_free_for_all = EXCLUDED.supports_free_for_all,
+  supports_sides = EXCLUDED.supports_sides,
+  requires_sides = EXCLUDED.requires_sides,
+  max_players_per_side = EXCLUDED.max_players_per_side,
+  compatible_competition_formats = EXCLUDED.compatible_competition_formats,
+  compatible_modifiers = EXCLUDED.compatible_modifiers,
+  category = EXCLUDED.category,
+  config_schema = EXCLUDED.config_schema,
+  scorecard_schema = EXCLUDED.scorecard_schema;


### PR DESCRIPTION
## What & why

BBMI's remaining events (2-Man Scramble, Alt-Shot, Best-Ball) are all **2v2 match play**. 2v2 *is* the 1v1 match engine with the side being a **pair** (a `play_group`) and **one score per side per hole** — the schema already supports it (`score_entries.participant_type` and `game_results.entity_type` both allow `'play_group'`; the match math is type-agnostic). Built **additively** so the singles path is byte-for-byte unchanged.

This is **Stage 1 of 2** (engine first, per the agreed staging). Stage 2 is the client (generalize the match page for sided entry + the three presets).

## Changes

- **Migration 055** — seed `gtt_match_play_doubles` (entry `group_holes`, result `match_play`, `requires_sides`, `max_players_per_side: 2`, modifiers `moving_tees` + `glorious_holes`, `category: golf`); add `play_groups.handicap_strokes` (a pair's per-match handicap — the doubles analogue of `game_participants.handicap_strokes`).
- **`computeMatchPlayResults`** now resolves a side by id whether it's a **user** (1v1) or a **play_group** (2v2): reads gross + handicap keyed by side id from both sources, writes `game_results` with `entity_type` following the side type, and maps a play_group side → team for the `per_match` points adapter the competition leaderboard rolls up.
- **`scores.upsertEntry`** gains optional `participantType` (default `'user'`); **`listByGame`** returns `'play_group'` entries too.
- **`matches`** — new `setDoublesPairings` (creates the two play-group pairs + one match) and `setDoublesHandicap` (side handicap). Singles procedures untouched; `listByGame` also returns `playGroups`.
- **`matches.doubles.test.ts`** — sided pairings, per-side scoring, closed-out 3&2 → `a_win` with `entity_type='play_group'`, side net stroke flip, role gate.

## Singles is unchanged
Every change is additive — new procedures, plus branches that no-op without play_group sides/entries. The 1v1 server path is byte-for-byte. **Enforcing "1v1 works exactly as before" is the first gate in Stage 2** when the page itself is generalized.

## Verification
- `tsc --noEmit`, `next lint`, `next build` all green locally.
- `matches.doubles.test.ts` runs against Supabase in CI (not runnable in the build sandbox).
- Migration 055 applies via CI's `supabase db push`.

## How to test
There's **no doubles UI yet** (that's Stage 2), so end-to-end play isn't clickable from this PR. What you *can* verify here: CI goes green (the doubles Vitest + migration push), and the singles match flow still behaves exactly as before (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149txQDUCGi4F5htP9awR9V)_