### PR TITLE
feat(games): dynamic match count (1v1 + 2v2) — add/remove matches, live recompute

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -33,6 +33,8 @@ function formatTee(t: string | null | undefined): string {
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MATCH_PLAY = "gtt_match_play_singles";
 const MATCH_PLAY_DOUBLES = "gtt_match_play_doubles";
+// Mirrors the server cap (matches router). Dynamic match count grows up to here.
+const MAX_MATCHES = 24;
 
 // A server match side: a user (1v1) or a play_group (2v2). The editable draft
 // holds each side as a list of member user ids — length ≤1 for singles, ≤2 for
@@ -86,8 +88,9 @@ export default function NewMatchGamePage() {
   const [gameId, setGameId] = useState<string | null>(search.get("game"));
   const [manualScreen, setManualScreen] = useState<Screen | null>(null);
 
-  // New-game form
-  const [matchCount, setMatchCount] = useState(2);
+  // New-game form. Dynamic match count: start at 1 (a single default match) and
+  // grow one at a time — never force the full suggested count up front.
+  const [matchCount, setMatchCount] = useState(1);
   const [teeTime, setTeeTime] = useState(""); // "HH:MM" 24h
   // Setup editing state
   const [draft, setDraft] = useState<DraftMatch[]>([]);
@@ -140,6 +143,11 @@ export default function NewMatchGamePage() {
   const setDoublesPairings = trpc.matches.setDoublesPairings.useMutation();
   const setDoublesHandicap = trpc.matches.setDoublesHandicap.useMutation();
   const activate = trpc.matches.activate.useMutation();
+  // Dynamic match count (+1 / −1). Each changes the game's configured match
+  // count → the clinch goalpost (value × count) on the competition board, so
+  // both refresh the board after (see refreshAfterMatchCountChange).
+  const addMatch = trpc.matches.addMatch.useMutation();
+  const removeMatch = trpc.matches.removeMatch.useMutation();
   // Finishing retries (idempotent recompute); a failure stays on the overview
   // and surfaces via the global error toast — loud + retryable, not a silent
   // stall. Score writes go through useScoreSaver (above).
@@ -392,6 +400,20 @@ export default function NewMatchGamePage() {
     if (n > 0) setDraft(Array.from({ length: n }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
   }, [screen, draft.length, serverMatches, handicapOf, membersOfSide, sided, compMatchCount, maxMatches]);
 
+  // After a +1/−1 (or initial create): re-pull the game's matches AND refresh
+  // the competition board so "first to XX" / "X of Y" recompute ON SCREEN. The
+  // board has no realtime sub (only a 30s poll) and re-seeds competitions.
+  // leaderboard FROM faceBootstrap on mount, so invalidate BOTH (CLAUDE.md #10),
+  // else the goalpost reads stale until the poll.
+  async function refreshAfterMatchCountChange() {
+    await Promise.all([gameQ.refetch(), matchesQ.refetch(), scoresQ.refetch()]);
+    if (competitionId) {
+      utils.competitions.leaderboard.invalidate({ tripId: tripId!, competitionId });
+      utils.games.listByTrip.invalidate({ tripId: tripId! });
+      utils.competitions.faceBootstrap.invalidate({ tripId: tripId! });
+    }
+  }
+
   // ── Actions ──────────────────────────────────────────────────────────
   async function handleCreate() {
     if (!tripId) return;
@@ -411,6 +433,13 @@ export default function NewMatchGamePage() {
       }
     }
     const count = Math.min(Math.max(1, matchCount), maxMatches);
+    // Persist the configured matches as rows NOW (empty) so the game has ≥1
+    // configured match from creation — the board's clinch goalpost (value ×
+    // count) is live immediately, not 0 until tee-off.
+    const emptyMatches = Array.from({ length: count }, (_, i) => ({ sideA: null, sideB: null, matchNumber: i + 1 }));
+    if (sided) await setDoublesPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
+    else await setPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
+    await refreshAfterMatchCountChange();
     setDraft(Array.from({ length: count }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
     go("setup");
   }
@@ -473,8 +502,32 @@ export default function NewMatchGamePage() {
       });
       await Promise.all([...handicapWrites, activate.mutateAsync({ tripId, gameId })]);
     }
-    await Promise.all([gameQ.refetch(), matchesQ.refetch(), scoresQ.refetch()]);
+    // Saving setup changes the configured match count → refresh the board so
+    // "first to XX" reflects it on screen.
+    await refreshAfterMatchCountChange();
     go("overview");
+  }
+
+  // Dynamic match count — mid-life +1 / −1 (the explicit "arm with 1, add a 2nd
+  // mid-life" path). Each persists incrementally (NOT a bulk re-save, so
+  // in-progress matches are untouched) and refreshes the board reactively.
+  async function handleAddMatch() {
+    if (!tripId || !gameId) return;
+    try {
+      await addMatch.mutateAsync({ tripId, gameId });
+      await refreshAfterMatchCountChange();
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+  async function handleRemoveMatch(matchId: string) {
+    if (!tripId || !gameId) return;
+    try {
+      await removeMatch.mutateAsync({ tripId, gameId, matchId });
+      await refreshAfterMatchCountChange();
+    } catch {
+      // surfaced via the global error toast
+    }
   }
 
   async function handleFinish() {
@@ -704,6 +757,14 @@ export default function NewMatchGamePage() {
             setView(locked ? "grid" : "entry");
             go("score");
           }}
+          // +1 mid-life: persist an empty match (board recomputes immediately),
+          // then land on setup to pick its players (assignment is the same flow).
+          onAddMatch={async () => {
+            await handleAddMatch();
+            go("setup");
+          }}
+          onRemoveMatch={handleRemoveMatch}
+          mutatingCount={addMatch.isPending || removeMatch.isPending}
         />
       )}
       </div>
@@ -1078,16 +1139,32 @@ function MatchSetup({
               )}
               <div className="flex items-center justify-between" style={{ marginBottom: 10 }}>
                 <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>Match {i + 1}</span>
-                <span
-                  onMouseDown={() => setArmedIdx(i)}
-                  onMouseUp={() => setArmedIdx(null)}
-                  title="Drag to reorder"
-                  aria-label="Drag to reorder"
-                  className="flex cursor-grab items-center justify-center active:cursor-grabbing"
-                  style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)", touchAction: "none" }}
-                >
-                  <GripVertical size={16} />
-                </span>
+                <div className="flex items-center gap-1">
+                  {/* Remove this match (down to the minimum of 1). Pre-tee-off
+                      draft has no persisted scores, so removal is free here. */}
+                  {draft.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setDraft((prev) => prev.filter((_, j) => j !== i))}
+                      title="Remove match"
+                      aria-label={`Remove match ${i + 1}`}
+                      className="flex items-center justify-center"
+                      style={{ width: 24, height: 24, color: "var(--color-bt-danger)" }}
+                    >
+                      <Minus size={16} />
+                    </button>
+                  )}
+                  <span
+                    onMouseDown={() => setArmedIdx(i)}
+                    onMouseUp={() => setArmedIdx(null)}
+                    title="Drag to reorder"
+                    aria-label="Drag to reorder"
+                    className="flex cursor-grab items-center justify-center active:cursor-grabbing"
+                    style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)", touchAction: "none" }}
+                  >
+                    <GripVertical size={16} />
+                  </span>
+                </div>
               </div>
               {/* Grid with minmax(0,1fr) columns → the two slots are always
                   equal width regardless of name length, vs stays centered. */}
@@ -1110,6 +1187,19 @@ function MatchSetup({
           );
         })}
       </div>
+
+      {/* Add another match — dynamic count grows one at a time (up to the cap). */}
+      {draft.length < MAX_MATCHES && (
+        <button
+          type="button"
+          onClick={() => setDraft((prev) => [...prev, { matchNumber: prev.length + 1, a: [], b: [], handicap: 0 }])}
+          className="mt-3 flex w-full items-center justify-center gap-1.5"
+          style={{ height: 46, borderRadius: 12, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
+        >
+          <Plus size={16} />
+          Add match
+        </button>
+      )}
 
       <PrimaryButton
         label={saving ? "Setting up…" : "Ready to tee off"}
@@ -1142,6 +1232,9 @@ function Overview({
   onCorrect,
   correctingPending,
   onOpenMatch,
+  onAddMatch,
+  onRemoveMatch,
+  mutatingCount,
 }: {
   groups: MatchGroupData[];
   myId: string | undefined;
@@ -1160,6 +1253,10 @@ function Overview({
   onCorrect: () => void;
   correctingPending: boolean;
   onOpenMatch: (matchId: string) => void;
+  /** Dynamic match count — mid-life +1 / −1. */
+  onAddMatch: () => void;
+  onRemoveMatch: (matchId: string) => void;
+  mutatingCount: boolean;
 }) {
   if (!published) return <MemberNotReady gameName={gameName} />;
   const decideds = groups.map(decidedFor);
@@ -1184,20 +1281,57 @@ function Overview({
 
       <div className="flex flex-col gap-2.5">
         {groups.map((g, i) => (
-          <MatchCard
-            key={g.matchId}
-            a={g.a}
-            b={g.b}
-            results={decideds[i]}
-            label={`Match ${i + 1}`}
-            youId={myId}
-            leftColor={g.leftColor}
-            rightColor={g.rightColor}
-            hideFormat
-            onClick={() => onOpenMatch(g.matchId)}
-          />
+          <div key={g.matchId} className="flex items-center gap-2">
+            <div className="min-w-0 flex-1">
+              <MatchCard
+                a={g.a}
+                b={g.b}
+                results={decideds[i]}
+                label={`Match ${i + 1}`}
+                youId={myId}
+                leftColor={g.leftColor}
+                rightColor={g.rightColor}
+                hideFormat
+                onClick={() => onOpenMatch(g.matchId)}
+              />
+            </div>
+            {/* −1: remove this match (live count). Warn first if it has scores —
+                never silently drop entry. Down to the minimum of 1. */}
+            {canEdit && !complete && groups.length > 1 && (
+              <button
+                type="button"
+                onClick={() => {
+                  const scored = decideds[i].length > 0;
+                  if (scored && !window.confirm(`Match ${i + 1} has scores entered. Remove it and discard them?`)) return;
+                  onRemoveMatch(g.matchId);
+                }}
+                disabled={mutatingCount}
+                title="Remove match"
+                aria-label={`Remove match ${i + 1}`}
+                className="flex shrink-0 items-center justify-center disabled:opacity-40"
+                style={{ width: 34, height: 34, borderRadius: 9999, color: "var(--color-bt-danger)", border: "1px solid var(--color-bt-danger-border)" }}
+              >
+                <Minus size={16} />
+              </button>
+            )}
+          </div>
         ))}
       </div>
+
+      {/* +1: add another match mid-life (lands on setup to pick its players).
+          The board's "first to XX" jumps by one × value immediately. */}
+      {canEdit && !complete && groups.length < MAX_MATCHES && (
+        <button
+          type="button"
+          onClick={onAddMatch}
+          disabled={mutatingCount}
+          className="mt-3 flex w-full items-center justify-center gap-1.5 disabled:opacity-40"
+          style={{ height: 46, borderRadius: 12, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
+        >
+          <Plus size={16} />
+          Add match
+        </button>
+      )}
 
       <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", margin: "12px 0 0 2px" }}>
         {complete
@@ -1205,8 +1339,8 @@ function Overview({
             ? "Tap a match to fix a score."
             : "Tap a match to view the scorecard."
           : underway
-            ? "Tap a match to keep scoring."
-            : "Tap a match to enter scores — the round starts on your first score."}
+            ? `${groups.length} ${groups.length === 1 ? "match" : "matches"} · tap one to keep scoring.`
+            : `${groups.length} ${groups.length === 1 ? "match" : "matches"} · tap one to enter scores — the round starts on your first score.`}
       </p>
 
       {canEdit && !complete && allOver && (

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,6 +1,15 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlacement";
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
+import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
+
+const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
+
+/** Singles vs doubles head-to-head sizing for the team-size-derived formats
+ *  (rack-n-stack). Match play itself counts its configured rows instead. */
+function matchFormat(gameTypeId: string | null): MatchFormat {
+  return gameTypeId === "gtt_match_play_doubles" ? "doubles" : "singles";
+}
 
 /**
  * Server roll-up wrapper (Slice D1 §5/§6). The DB-read half of the CLAUDE.md #8
@@ -24,10 +33,10 @@ export async function computeCompetitionLeaderboard(
   supabase: SupabaseClient,
   competitionId: string
 ) {
-  // These three reads are independent — run them in parallel (one round-trip's
-  // worth of latency instead of stacked). `game_results` + the match counts
-  // alone depend on the game ids, so they wait below.
-  const [teamsRes, compRes, gameRowsRes] = await Promise.all([
+  // These reads are independent — run them in parallel (one round-trip's worth
+  // of latency instead of stacked). `game_results` + the match counts alone
+  // depend on the game ids, so they wait below.
+  const [teamsRes, compRes, gameRowsRes, assignmentsRes] = await Promise.all([
     supabase
       .from("teams")
       .select("id, name, short_name, color")
@@ -44,12 +53,24 @@ export async function computeCompetitionLeaderboard(
       .select("id, name, points_distribution, points_total, status, game_type_id")
       .eq("competition_id", competitionId)
       .order("created_at", { ascending: true }),
+    // Team sizes drive the team-size-derived per_match formats (rack-n-stack):
+    // value × min team size. Match play instead counts its configured rows.
+    supabase
+      .from("team_assignments")
+      .select("team_id")
+      .eq("competition_id", competitionId),
   ]);
   const teams = teamsRes.data;
   const teamIds = (teams ?? []).map((t) => t.id as string);
   const comp = compRes.data;
   const allGames = gameRowsRes.data ?? [];
   const live = allGames.filter((g) => g.status !== "dropped");
+  const sizeByTeam = new Map<string, number>();
+  for (const a of assignmentsRes.data ?? []) {
+    const tid = a.team_id as string;
+    sizeByTeam.set(tid, (sizeByTeam.get(tid) ?? 0) + 1);
+  }
+  const teamSizes = teamIds.map((id) => sizeByTeam.get(id) ?? 0);
 
   const gameIds = live.map((g) => g.id as string);
   // game_results (awarded) + the per-game match COUNT (available). Both depend on
@@ -92,12 +113,17 @@ export async function computeCompetitionLeaderboard(
     const standings = standingsByGame.get(g.id as string) ?? [];
 
     if (isPerMatch(rawDist)) {
-      // Available = value × the game's CONFIGURED match count (its game_matches
-      // rows), regardless of pairing — the live clinch goalpost. Pairing/playing
-      // a match doesn't change it; adding/removing one does. AWARDED teamTotals
-      // still come from the realized per-team match points (synthetic
-      // distribution below), so playing moves only awarded points.
-      const mc = matchCountByGame.get(g.id as string) ?? 0;
+      const typeId = g.game_type_id as string | null;
+      // Match play (singles/doubles): available = value × the game's CONFIGURED
+      // match count (its game_matches rows), regardless of pairing — the live
+      // clinch goalpost that add/remove moves (dynamic match count). Other
+      // per_match formats (rack-n-stack) DON'T use game_matches; their count is
+      // the team-size-derived head-to-head sizing (unchanged stable model) — so
+      // counting rows there would zero them out.
+      const mc =
+        typeId && MATCH_PLAY_TYPES.has(typeId)
+          ? matchCountByGame.get(g.id as string) ?? 0
+          : deriveMatchCount(teamSizes, matchFormat(typeId)) ?? 0;
       const pointsTotal = rawDist.value * mc;
       if (standings.length === 0) {
         // No decided matches yet — contributes its available pool, no awards.

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,13 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlacement";
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
-import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
-
-/** Singles vs doubles for matchCount. Only singles match play exists today; a
- *  future doubles type slots in here without touching the caller. */
-function matchFormat(gameTypeId: string | null): MatchFormat {
-  return gameTypeId === "gtt_match_play_doubles" ? "doubles" : "singles";
-}
 
 /**
  * Server roll-up wrapper (Slice D1 §5/§6). The DB-read half of the CLAUDE.md #8
@@ -31,11 +24,10 @@ export async function computeCompetitionLeaderboard(
   supabase: SupabaseClient,
   competitionId: string
 ) {
-  // These four reads are independent — run them in parallel (one round-trip's
-  // worth of latency instead of four stacked). `game_results` alone depends on
-  // the game ids, so it waits below. (Was 5 serial queries — the profiling's
-  // server-side mini-waterfall; this is fix #3.)
-  const [teamsRes, compRes, gameRowsRes, assignmentsRes] = await Promise.all([
+  // These three reads are independent — run them in parallel (one round-trip's
+  // worth of latency instead of stacked). `game_results` + the match counts
+  // alone depend on the game ids, so they wait below.
+  const [teamsRes, compRes, gameRowsRes] = await Promise.all([
     supabase
       .from("teams")
       .select("id, name, short_name, color")
@@ -52,34 +44,39 @@ export async function computeCompetitionLeaderboard(
       .select("id, name, points_distribution, points_total, status, game_type_id")
       .eq("competition_id", competitionId)
       .order("created_at", { ascending: true }),
-    // Team sizes (member headcount) drive the match-game total = value ×
-    // matchCount — derived from sizes, NOT pairings (§8).
-    supabase
-      .from("team_assignments")
-      .select("team_id")
-      .eq("competition_id", competitionId),
   ]);
   const teams = teamsRes.data;
   const teamIds = (teams ?? []).map((t) => t.id as string);
   const comp = compRes.data;
   const allGames = gameRowsRes.data ?? [];
   const live = allGames.filter((g) => g.status !== "dropped");
-  const assignments = assignmentsRes.data;
-  const sizeByTeam = new Map<string, number>();
-  for (const a of assignments ?? []) {
-    const tid = a.team_id as string;
-    sizeByTeam.set(tid, (sizeByTeam.get(tid) ?? 0) + 1);
-  }
-  const teamSizes = teamIds.map((id) => sizeByTeam.get(id) ?? 0);
 
   const gameIds = live.map((g) => g.id as string);
-  const { data: results } = gameIds.length
-    ? await supabase
-        .from("game_results")
-        .select("game_id, entity_id, position, raw_score")
-        .in("game_id", gameIds)
-        .eq("entity_type", "team")
-    : { data: [] as { game_id: string; entity_id: string; position: number | null; raw_score: number | null }[] };
+  // game_results (awarded) + the per-game match COUNT (available). Both depend on
+  // the live game ids; run them together.
+  const [resultsRes, matchRowsRes] = await Promise.all([
+    gameIds.length
+      ? supabase
+          .from("game_results")
+          .select("game_id, entity_id, position, raw_score")
+          .in("game_id", gameIds)
+          .eq("entity_type", "team")
+      : Promise.resolve({ data: [] as { game_id: string; entity_id: string; position: number | null; raw_score: number | null }[] }),
+    gameIds.length
+      ? supabase.from("game_matches").select("game_id").in("game_id", gameIds)
+      : Promise.resolve({ data: [] as { game_id: string }[] }),
+  ]);
+  const results = resultsRes.data;
+  // A match game's available points = value × the number of matches it is
+  // CONFIGURED to have (its game_matches rows), counted regardless of whether
+  // they're paired yet — the configured count, ≥1 from creation. Adding/removing
+  // a match moves this (the live clinch target); pairing or playing does not.
+  // (Was value × deriveMatchCount(teamSizes) — the stable §8 estimate; the
+  // dynamic-match-count build moves the goalpost to the live configured count.)
+  const matchCountByGame = new Map<string, number>();
+  for (const r of (matchRowsRes.data ?? []) as { game_id: string }[]) {
+    matchCountByGame.set(r.game_id, (matchCountByGame.get(r.game_id) ?? 0) + 1);
+  }
 
   // For placement games: value = position (lower wins).
   // For per_match games: value = raw_score (match points, higher wins).
@@ -95,13 +92,13 @@ export async function computeCompetitionLeaderboard(
     const standings = standingsByGame.get(g.id as string) ?? [];
 
     if (isPerMatch(rawDist)) {
-      // Available (stable): value × matchCount from TEAM SIZES — known before
-      // pairings, so the clinch number doesn't move as matches are played (§8).
-      // 0 when teams aren't sized yet ("matches not set"). AWARDED teamTotals
+      // Available = value × the game's CONFIGURED match count (its game_matches
+      // rows), regardless of pairing — the live clinch goalpost. Pairing/playing
+      // a match doesn't change it; adding/removing one does. AWARDED teamTotals
       // still come from the realized per-team match points (synthetic
-      // distribution below), so configuring/playing moves only awarded points.
-      const mc = deriveMatchCount(teamSizes, matchFormat(g.game_type_id as string | null));
-      const pointsTotal = mc != null ? rawDist.value * mc : 0;
+      // distribution below), so playing moves only awarded points.
+      const mc = matchCountByGame.get(g.id as string) ?? 0;
+      const pointsTotal = rawDist.value * mc;
       if (standings.length === 0) {
         // No decided matches yet — contributes its available pool, no awards.
         return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "high_wins" as const, pointsTotal };

--- a/src/server/routers/competitions.d1followon.test.ts
+++ b/src/server/routers/competitions.d1followon.test.ts
@@ -124,6 +124,13 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     })) as { id: string };
     gameIds.push(g.id);
 
+    // Configured to have 2 matches (rows) → available = value × 2. (Dynamic
+    // match count derives available from the match rows, not team sizes.)
+    await ctx.admin.from("game_matches").insert([
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: null, side_b: null, status: "active" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: null, side_b: null, status: "active" },
+    ]);
+
     // Realized awarded points (adapter output): Blue won both of the 2 matches.
     await ctx.admin.from("game_results").insert([
       { id: crypto.randomUUID(), game_id: g.id, entity_id: ta, entity_type: "team", raw_score: 2, position: null, competition_points_earned: null },
@@ -134,7 +141,7 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
 
     expect(lb.teamTotals[ta]).toBe(2);
     expect(lb.teamTotals[tb]).toBe(0);
-    // available = value × matchCount = 1 × 2 (NOT the realized sum) — stable.
+    // available = value × match-row count = 1 × 2 (NOT the realized sum).
     expect(lb.pointsAvailable).toBe(2);
     expect(lb.winNumber).toBe(1.5); // smallest > half of 2
     expect(lb.pointsToClinch[ta]).toBeLessThanOrEqual(0); // 2 ≥ 1.5 → clinched
@@ -162,6 +169,13 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     })) as { id: string };
     gameIds.push(g.id);
 
+    // Configured to have 2 matches (rows) → available = value × 2 = 2. (Dynamic
+    // match count: available derives from the match ROWS, not team sizes.)
+    await ctx.admin.from("game_matches").insert([
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: null, side_b: null, status: "active" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: null, side_b: null, status: "active" },
+    ]);
+
     // 2 matches played: 1 halve (each gets 0.5) + A wins 1 (A gets 1).
     // A total = 1.5, B total = 0.5.
     await ctx.admin.from("game_results").insert([
@@ -173,7 +187,7 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
 
     expect(lb.teamTotals[ta]).toBe(1.5); // realized (the 0.5 halve survives numeric)
     expect(lb.teamTotals[tb]).toBe(0.5);
-    expect(lb.pointsAvailable).toBe(2); // value × matchCount = 1×2
+    expect(lb.pointsAvailable).toBe(2); // value × match-row count = 1×2
   });
 
   it("per_match shell with no team results contributes 0 to pointsAvailable (no pairings)", async () => {
@@ -271,25 +285,27 @@ describe("Stage 4 — available counts owner-set totals; configuring doesn't mov
     expect(after.pointsAvailable).toBe(8); // unchanged — only awarded points move
   });
 
-  it("per_match available is stable BEFORE any matches are scored", async () => {
+  it("per_match available = value × configured match count (the rows), before any scoring", async () => {
     const comp = await ctx.createCompetition(tripId, "Stable Match Comp");
     const ta = await ctx.createTeam(comp, "A");
-    const tb = await ctx.createTeam(comp, "B");
-    await ctx.admin.from("team_assignments").insert([
-      { competition_id: comp, user_id: ctx.getUser("owner").id, team_id: ta },
-      { competition_id: comp, user_id: ctx.getUser("planner").id, team_id: ta },
-      { competition_id: comp, user_id: ctx.getUser("member").id, team_id: tb },
-      { competition_id: comp, user_id: ctx.getUser("outsider").id, team_id: tb },
-    ]);
+    await ctx.createTeam(comp, "B");
     const g = (await ctx.caller().games.create({
       tripId, gameTypeId: MATCH_PLAY, name: "Future Cup", competitionId: comp,
       pointsDistribution: { type: "per_match", value: 1 },
     })) as { id: string };
     gameIds.push(g.id);
 
-    // No game_results yet — but matchCount from team sizes = 2 → available = 2.
+    // Dynamic match count: available derives from the matches the game is
+    // CONFIGURED to have (its rows, ≥1 from creation), NOT a team-size estimate.
+    // 3 configured matches → available = value × 3 = 3, even unpaired/unscored.
+    await ctx.admin.from("game_matches").insert([
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: null, side_b: null, status: "pending" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: null, side_b: null, status: "pending" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 3, display_order: 2, side_a: null, side_b: null, status: "pending" },
+    ]);
+
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
-    expect(lb.pointsAvailable).toBe(2);
+    expect(lb.pointsAvailable).toBe(3);
     expect(lb.teamTotals[ta]).toBe(0); // nothing awarded yet
   });
 });

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -23,6 +23,10 @@ import { computeMatchPlayResults } from "../lib/matchPlay";
  * other `0`) — never split, never in `games.modifiers.buddy_rules` (Slice F).
  */
 
+// Match count is dynamic (start at 1, add as foursomes are set). The cap is a
+// generous ceiling — far above any realistic field — not the old fixed 4.
+const MAX_MATCHES = 24;
+
 const sideSchema = z.object({ type: z.literal("user"), id: z.string().min(1) });
 // 2v2 (doubles): a side is a PAIR of users. setDoublesPairings creates a
 // play_group per side and stores side_a/side_b as {"type":"play_group","id":pgId}
@@ -70,7 +74,7 @@ export const matchesRouter = router({
             })
           )
           .min(1)
-          .max(4),
+          .max(MAX_MATCHES),
       })
     )
     .use(requireGameEdit())
@@ -297,7 +301,7 @@ export const matchesRouter = router({
             })
           )
           .min(1)
-          .max(4),
+          .max(MAX_MATCHES),
       })
     )
     .use(requireGameEdit())
@@ -456,13 +460,130 @@ export const matchesRouter = router({
       return { ok: true };
     }),
 
+  // addMatch — Owner/Organizer/delegate. Append ONE empty match (the dynamic
+  // "+1"). The configured match count = game_matches rows, so a new row raises
+  // the clinch goalpost (value × count) immediately, paired or not. Sides get
+  // filled after via assignPlayer (1v1) / the doubles assignment flow. A match
+  // added to an already-active game is itself active (scoreable now); on a
+  // pending game it stays pending until activate. Refuses past the cap.
+  addMatch: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
+
+      const { data: existing } = await ctx.supabase
+        .from("game_matches")
+        .select("match_number, display_order")
+        .eq("game_id", input.gameId);
+      const rows = (existing ?? []) as { match_number: number; display_order: number }[];
+      if (rows.length >= MAX_MATCHES) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: `A game can have at most ${MAX_MATCHES} matches` });
+      }
+      const nextNumber = rows.reduce((mx, r) => Math.max(mx, r.match_number ?? 0), 0) + 1;
+      const nextOrder = rows.reduce((mx, r) => Math.max(mx, r.display_order ?? -1), -1) + 1;
+
+      // Active game → the new match is immediately scoreable; pending → pending.
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("status")
+        .eq("id", input.gameId)
+        .maybeSingle();
+      const status = (game?.status as string | undefined) === "active" ? "active" : "pending";
+
+      const { error } = await ctx.supabase.from("game_matches").insert({
+        id: crypto.randomUUID(),
+        game_id: input.gameId,
+        play_group_id: null,
+        match_number: nextNumber,
+        display_order: nextOrder,
+        side_a: null,
+        side_b: null,
+        status,
+      });
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to add match: ${error.message}` });
+      }
+
+      const { data } = await ctx.supabase
+        .from("game_matches")
+        .select("*")
+        .eq("game_id", input.gameId)
+        .order("display_order", { ascending: true });
+      return data ?? [];
+    }),
+
+  // removeMatch — Owner/Organizer/delegate. Delete ONE match (the dynamic "-1"),
+  // lowering the clinch goalpost by one × value. Hard-deletes the match, its
+  // sides' participants/play_groups, and ANY entered scores + side results for
+  // those sides (a player/pair is in exactly one match) — then recomputes the
+  // rest. The CLIENT confirms first when the match has scores (don't silently
+  // drop entry); the server still cleans up fully. Refuses to drop below 1 (a
+  // match game always keeps ≥1 configured match).
+  removeMatch: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), matchId: z.string().min(1) }))
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
+
+      const { data: all } = await ctx.supabase
+        .from("game_matches")
+        .select("id, side_a, side_b")
+        .eq("game_id", input.gameId);
+      type Side = { type: string; id: string } | null;
+      const rows = (all ?? []) as { id: string; side_a: Side; side_b: Side }[];
+      if (rows.length <= 1) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "A match game must keep at least one match" });
+      }
+      const target = rows.find((r) => r.id === input.matchId);
+      if (!target) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
+      }
+
+      const sides = [target.side_a, target.side_b].filter(
+        (s): s is { type: string; id: string } => !!s?.id
+      );
+      const userSideIds = sides.filter((s) => s.type === "user").map((s) => s.id);
+      const pgSideIds = sides.filter((s) => s.type === "play_group").map((s) => s.id);
+      // The side id IS the score key (score_entries.participant_id) and the
+      // side-level result key (game_results.entity_id) — a user for 1v1, a
+      // play_group for 2v2.
+      const sideKeyIds = [...userSideIds, ...pgSideIds];
+
+      // Drop the match first so the recompute below sees the reduced set.
+      await ctx.supabase.from("game_matches").delete().eq("id", input.matchId);
+
+      if (sideKeyIds.length > 0) {
+        await ctx.supabase.from("score_entries").delete().eq("game_id", input.gameId).in("participant_id", sideKeyIds);
+        await ctx.supabase.from("game_results").delete().eq("game_id", input.gameId).in("entity_id", sideKeyIds);
+      }
+      if (userSideIds.length > 0) {
+        await ctx.supabase.from("game_participants").delete().eq("game_id", input.gameId).in("user_id", userSideIds);
+      }
+      if (pgSideIds.length > 0) {
+        await ctx.supabase.from("game_participants").delete().eq("game_id", input.gameId).in("play_group_id", pgSideIds);
+        await ctx.supabase.from("play_groups").delete().eq("game_id", input.gameId).in("id", pgSideIds);
+      }
+
+      // Recompute remaining in-progress matches — rebuilds the per-team totals so
+      // the board reflects the drop (a frozen/complete match is left alone).
+      await computeMatchPlayResults(ctx.supabase, input.gameId, { skipComplete: true });
+
+      const { data } = await ctx.supabase
+        .from("game_matches")
+        .select("*")
+        .eq("game_id", input.gameId)
+        .order("display_order", { ascending: true });
+      return data ?? [];
+    }),
+
   // reorder — Owner/Organizer. Persist display_order from the given order.
   reorder: authedProcedure
     .input(
       z.object({
         tripId: z.string(),
         gameId: z.string(),
-        orderedMatchIds: z.array(z.string().min(1)).min(1).max(4),
+        orderedMatchIds: z.array(z.string().min(1)).min(1).max(MAX_MATCHES),
       })
     )
     .use(requireGameEdit())

--- a/supabase/manual/20260617_backfill_default_match_row.sql
+++ b/supabase/manual/20260617_backfill_default_match_row.sql
@@ -1,0 +1,26 @@
+-- ONE-TIME, PRODUCTION-ONLY data backfill — applied OUT-OF-BAND on 2026-06-17
+-- (via the Supabase SQL path, NOT a migration). Do NOT add to migrations/.
+--
+-- Why out-of-band, not a migration: this corrects LEGACY production rows only.
+-- A fresh DB (CI test DB, a new environment) never needs it — new match-play
+-- games get a default match row at creation (the dynamic-match-count flow), and
+-- the test suite creates its own rows. Putting it in a migration would make
+-- every DB run a data backfill it doesn't need.
+--
+-- Context: dynamic match count made the competition leaderboard derive a match
+-- game's available points from its CONFIGURED match count (its game_matches
+-- rows) instead of the team-size estimate. Legacy match-play games created
+-- before the "≥1 row from creation" invariant had 0 rows and would silently
+-- contribute 0 to "first to XX". This gives each such game a single default
+-- (empty) match so it contributes value × 1 instead of 0. Idempotent
+-- (NOT EXISTS) — safe to re-run. Scoped to match play ONLY; rack-n-stack and
+-- other per_match formats don't use game_matches (they keep team-size sizing).
+--
+-- Affected on 2026-06-17: 5 pending match-play games (incl. BBMI "Teams").
+
+insert into game_matches (id, game_id, play_group_id, match_number, display_order, side_a, side_b, status)
+select gen_random_uuid(), g.id, null, 1, 0, null, null,
+       case when g.status = 'active' then 'active' else 'pending' end
+from games g
+where g.game_type_id in ('gtt_match_play_singles', 'gtt_match_play_doubles')
+  and not exists (select 1 from game_matches m where m.game_id = g.id);


### PR DESCRIPTION
## Dynamic match count (1v1 + 2v2)

Match-play games start at **1 match** and grow one at a time (and shrink), instead of fixing the count up front. Every value derived from match count — "first to XX wins", the "N matches" count, clinch math — now recomputes from the **live count**.

### Model (per the spec + clarification)
Points available for a match game = `value × the number of matches it's CONFIGURED to have` (its `game_matches` rows), counted **regardless of pairing**, ≥1 from creation. Pairing/playing a match doesn't move it; **adding/removing one does**. This intentionally supersedes §8's stable-from-team-sizes behavior for match play.

### Server (`93907acb`, `167ee975`)
- Leaderboard derivation: match-play (`gtt_match_play_singles/doubles`) → `value × game_matches row count`. **Scoped to match play only** — `gtt_rack_n_stack` is *also* `per_match` but doesn't use `game_matches`, so it **keeps the team-size derivation** (counting rows there would zero out every rack game, including completed ones — caught during live verification).
- New `matches.addMatch` / `matches.removeMatch` (incremental, no bulk re-save → in-progress matches untouched; `removeMatch` cleans up the dropped match's participants/play_groups/scores/side-results then recomputes; refuses below 1). Bulk caps 4 → 24.
- §8 per-match available tests moved to the new row-count model.

### Client (`93192815`)
- Default **1** match; persists configured matches as rows **at creation** (board goalpost live immediately, not 0 until tee-off).
- Setup: "+ Add match" / per-card remove. Overview (mid-life): "+ Add match" (lands on setup to assign) / per-match remove with a **scored-match confirm**.
- **Live recompute**: create / save-setup / mid-life ±1 all refetch matches **and** invalidate `competitions.leaderboard` + `faceBootstrap` (CLAUDE.md #10), so "first to XX" + the match count update **on screen**.

### Backfill (out-of-band, [supabase/manual/](supabase/manual/20260617_backfill_default_match_row.sql))
Legacy match games created before the "≥1 row" invariant had 0 rows → would contribute 0. Backfilled each with one default match row (applied to prod; idempotent; not a migration — fresh DBs don't need it, new games get a default row at creation).

### Verification
- ✅ **Engine**: `rackNStack` + `matches` + `matches.doubles` + `d1followon` tests green. Live SQL: match games → sensible row-count totals (1v1 Match Test 6, Mp 6, Best ball 2, Teams 0→2); **rack-n-stack unchanged**; zero match-play games with 0 rows after backfill.
- ✅ **Reactive recompute (the explicit pass/fail)**: changing a game's match-row count moved the board's "first to XX" on screen (½ → 1½ when "Singles" went 0 → 1 row) — the same engine + invalidation path the in-app +/− buttons use.
- ✅ **Rack UI gate**: rack derivation is preserved (tests + scoping); client changes are confined to the match page (a different file/route from rack), so they can't leak into rack's display.
- ✅ `tsc` + `next lint` clean.

### Follow-on (noted, not in scope)
Mid-life *add* routes to setup for assignment; for 2v2 that re-save is the pre-existing bulk path — true incremental 2v2 assignment is a follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
