### PR TITLE
fix(games): 2v2 team colors persist on re-entry (stale groups memo)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -587,8 +587,15 @@ export default function NewMatchGamePage() {
             rightColor: twoTeams ? teamOfSide(b.id)?.color : undefined,
           };
         }),
+    // Team colors come from teamOfSide / sideParticipant, which are plain
+    // per-render closures — so we depend on the DATA they read, including the
+    // team inputs (twoTeams, teamOfUser, teamById, membersOfSide). Without these,
+    // a `groups` computed BEFORE the teams/assignments queries resolved kept
+    // stale neutral colors and never recovered when team data landed — the 2v2
+    // "teams disappeared on re-entry" bug. Listing them recolors the moment team
+    // data arrives. (eslint-disable: we list the data, not the closures.)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [serverMatches, handicapOf, colorOf, nameOf]
+    [serverMatches, handicapOf, colorOf, nameOf, twoTeams, teamOfUser, teamById, membersOfSide, avatarIconOf, sided]
   );
   // One match at a time: the strip tapped on the overview (falls back to the
   // first). Single-match entry — no shared keypad across matches.


### PR DESCRIPTION
## 2v2 team colors disappear on re-entry (stale memo)

**Symptom:** a 2v2 match strip sometimes rendered in the neutral "leader green" instead of the two team colors, and stayed that way on re-entry — the team assignments looked like they'd vanished.

**Data was intact** — every 2v2 match still maps to play-groups with 2 members, all assigned to teams. This is a client-side stale-memo bug.

### Root cause
`groups` (which carries each match's `leftColor`/`rightColor`) is a `useMemo` whose colors come from `teamOfSide()` + `sideParticipant()` — but its dependency list was:

```js
// eslint-disable-next-line react-hooks/exhaustive-deps
[serverMatches, handicapOf, colorOf, nameOf]
```

`teamOfSide` reads the **teams** and **team-assignments** queries, neither of which was in the deps (the `eslint-disable` hid it). When `serverMatches` resolved **before** those queries — a race that a score-edit → back-out → re-enter sequence reshuffles — `groups` computed with no team data → `undefined` colors → neutral fallback. And since the memo didn't depend on the team data, it **never recomputed** when teams/assignments arrived, so neutral **persisted**. That's the intermittent "this time the teams were gone."

### Fix
Depend on the underlying team data (`twoTeams, teamOfUser, teamById, membersOfSide, avatarIconOf, sided`) so `groups` recolors the moment team data lands. The change only **adds** recompute triggers (no loop; can't break the happy-path coloring that already worked). The closures (`teamOfSide`/`sideParticipant`) stay un-listed by design — we depend on the data they read — so a corrected `eslint-disable` is retained.

### Scope / verification
- Pre-existing in the 2v2 work (#385/#387), **not** the dynamic-match-count change.
- `tsc` + `next lint` clean.
- The fix is a dependency correction addressing the confirmed root cause; the triggering race is timing-dependent and not deterministically reproducible on fast localhost, but the added deps make `groups` recompute when team data loads by construction.

### Separate, not in this PR
"Best ball" / "Teams" point to a **deleted** competition id (orphaned `games.competition_id`) — competition delete didn't null/cascade it. Latent data-hygiene gap; worth a follow-up (null `games.competition_id` on competition delete, or cascade/block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
