### PR TITLE
fix(games): competition delete detaches games instead of orphaning them (FK SET NULL)

### DIFF
--- a/src/server/routers/competitions.test.ts
+++ b/src/server/routers/competitions.test.ts
@@ -90,4 +90,31 @@ describe("competitions router", () => {
     });
     expect(ok).toEqual({ success: true });
   });
+
+  it("delete — DETACHES its games (competition_id → null), never orphans them", async () => {
+    const caller = ctx.caller();
+    const comp = await caller.competitions.create({ tripId, name: "Detach Cup" });
+    ctx.trackCompetition(comp.id);
+    const game = (await caller.games.create({
+      tripId,
+      gameTypeId: "gtt_manual",
+      name: "Detach Game",
+      competitionId: comp.id,
+      pointsDistribution: { type: "placement", values: [3, 1] },
+    })) as { id: string };
+
+    await caller.competitions.delete({ tripId, competitionId: comp.id });
+
+    // The game SURVIVES (non-destructive) but no longer claims a dead
+    // competition — the FK's ON DELETE SET NULL detaches it to standalone.
+    const { data: row } = await ctx.admin
+      .from("games")
+      .select("id, competition_id")
+      .eq("id", game.id)
+      .maybeSingle();
+    expect(row).not.toBeNull();
+    expect(row!.competition_id).toBeNull();
+
+    await ctx.admin.from("games").delete().eq("id", game.id);
+  });
 });

--- a/supabase/migrations/20260619120000_056_games_competition_id_fk_set_null.sql
+++ b/supabase/migrations/20260619120000_056_games_competition_id_fk_set_null.sql
@@ -1,0 +1,25 @@
+-- games.competition_id: add the missing FK with ON DELETE SET NULL.
+--
+-- Migration 033 added games.competition_id as a plain text column with the FK
+-- deferred ("FK added in the competition slice") — and it was never added. So
+-- teams / team_assignments CASCADE when a competition is deleted, but its GAMES
+-- were left with a dangling competition_id pointing at a row that no longer
+-- exists (the orphaned-competition bug: a 2v2 game whose competition was deleted
+-- still claimed that dead id).
+--
+-- Desired behavior: deleting a competition DETACHES its games (they become
+-- standalone trip games) rather than vanishing (CASCADE would discard a played
+-- round + its scores) or dangling. competition_id is already nullable, so
+-- ON DELETE SET NULL is the right action.
+
+-- 1) Clean existing orphans so the constraint can validate.
+UPDATE games g
+  SET competition_id = NULL
+  WHERE competition_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM competitions c WHERE c.id = g.competition_id);
+
+-- 2) Add the FK (idempotent: drop any prior version first).
+ALTER TABLE games DROP CONSTRAINT IF EXISTS games_competition_id_fkey;
+ALTER TABLE games
+  ADD CONSTRAINT games_competition_id_fkey
+  FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Competition delete leaves orphaned games (missing FK)

**Bug:** deleting a competition left its games with a **dangling `competition_id`** pointing at a row that no longer exists (surfaced while diagnosing the 2v2 team-color issue — "Best ball"/"Teams" still claimed a deleted competition id).

**Root cause:** `teams` and `team_assignments` both `REFERENCES competitions(id) ON DELETE CASCADE`, but `games.competition_id` was added in migration 033 as a **plain text column with the FK deferred** ("FK added in the competition slice") — and never added. So competition delete cascaded teams/assignments but left games dangling.

### Fix (migration 056)
1. Null existing orphans (`competition_id` not in `competitions`) so the constraint validates.
2. Add `games_competition_id_fkey REFERENCES competitions(id) ON DELETE SET NULL`.

`ON DELETE SET NULL` (not CASCADE) is intentional: deleting a competition **detaches** its games to standalone trip games — **non-destructive**, a played round + its scores survive — rather than vanishing or dangling. `competition_id` is already nullable. No `competitions.delete` change needed; the DB enforces it on every delete path.

### Test
`competitions.test.ts`: deleting a competition leaves its game alive with `competition_id = null`.

`tsc` clean. (The new test exercises the FK, so it validates once CI applies migration 056 to the test DB.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
