### PR TITLE
feat(games): instant loading state on game-route navigation

### DIFF
--- a/src/app/trips/[tripId]/games/loading.tsx
+++ b/src/app/trips/[tripId]/games/loading.tsx
@@ -1,0 +1,29 @@
+/**
+ * Route-level loading UI for the game pages (stroke / match / rack).
+ *
+ * The game pages are client-rendered and cold-fetch their data on mount, so
+ * tapping a game from the leaderboard used to leave the PREVIOUS screen frozen
+ * during the JS + data load — which reads as "nothing happened," prompting
+ * repeated taps. This Suspense fallback paints an instant full-screen spinner
+ * the moment navigation starts, so the tap always registers visibly.
+ *
+ * This is the perceived-responsiveness half of the fix; server-rendering the
+ * game page's initial data (so it arrives populated, not after a 2–3s cold
+ * fetch) is the deeper follow-on (DEFERRED.md).
+ */
+export default function GamesLoading() {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: "var(--color-bt-base)" }}
+    >
+      <div
+        className="h-8 w-8 animate-spin rounded-full border-2"
+        style={{
+          borderColor: "var(--color-bt-accent)",
+          borderTopColor: "transparent",
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Instant loading state on game-route navigation (partial fix for "3–4 taps")

The game pages (stroke / match / rack) are client-rendered and cold-fetch their data on mount, and the `games` routes had **no route-level loading UI**. So tapping a game from the leaderboard left the previous screen frozen during the JS + data load — which reads as "nothing happened" and prompts repeated taps (the reported mobile "takes 3–4 taps" symptom).

Adds `trips/[tripId]/games/loading.tsx`: an instant full-screen spinner (Suspense fallback for the whole `games` segment) so a tap registers **visibly** the moment navigation starts.

### Scope — this is the perceived-responsiveness half
The deeper fix — **server-rendering the game page's initial data** so it arrives populated instead of after a 2–3s cold fetch — remains the larger follow-on (DEFERRED.md). That one is a Stage-B-style refactor of three client pages (one 1400+ lines) and is best done as its own focused effort, ideally after confirming the exact tap mechanism under mobile + network throttling.

Low-risk: one new static RSC file, no change to the pages themselves. `tsc` + `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
