### PR TITLE
refactor(competition): unify board rows into GameRow (Phase 2 §A groundwork)

### DIFF
--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo } from "react";
-import Link from "next/link";
-import { ChevronRight, Trophy, CloudOff, RefreshCw } from "lucide-react";
+import { Trophy, CloudOff, RefreshCw } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { GameRow, RowBadge, YoursBadge, fmtPts, gameHref, rowStateOf } from "./GameRow";
+import { GameRow, fmtPts } from "./GameRow";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -569,44 +568,18 @@ function EarlyState({
             </p>
           </div>
           <div className="divide-y" style={{ "--tw-divide-color": "var(--color-bt-border)" } as React.CSSProperties}>
-            {liveGames.map((game) => {
-              const href = gameHref(tripId, game.gameTypeId, game.id);
-              const row = (
-                <div className="flex items-center justify-between gap-2 px-4 py-3">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span
-                      className="truncate text-sm"
-                      style={{ color: "var(--color-bt-text)" }}
-                    >
-                      {game.name}
-                    </span>
-                    {mineSet.has(game.id) && <YoursBadge />}
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <RowBadge state={rowStateOf(game)} />
-                    {href && (
-                      <ChevronRight
-                        size={14}
-                        style={{ color: "var(--color-bt-text-dim)" }}
-                      />
-                    )}
-                  </div>
-                </div>
-              );
-              return href ? (
-                <Link
-                  key={game.id}
-                  href={href}
-                  className="block hover:opacity-80 transition-opacity"
-                  onPointerEnter={() => onPrefetch(game.id)}
-                  onPointerDown={() => onPrefetch(game.id)}
-                >
-                  {row}
-                </Link>
-              ) : (
-                <div key={game.id}>{row}</div>
-              );
-            })}
+            {liveGames.map((game) => (
+              <GameRow
+                key={game.id}
+                game={game}
+                teams={teams}
+                cells={undefined}
+                tripId={tripId}
+                mine={mineSet.has(game.id)}
+                onPrefetch={onPrefetch}
+                phase="early"
+              />
+            ))}
           </div>
         </div>
       )}

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -2,19 +2,20 @@
 
 import { useCallback, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { ChevronRight, Check, Radio, Trophy, CloudOff, RefreshCw } from "lucide-react";
+import { ChevronRight, Trophy, CloudOff, RefreshCw } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { GameRow, RowBadge, YoursBadge, fmtPts, gameHref, rowStateOf } from "./GameRow";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-interface LBTeam {
+export interface LBTeam {
   id: string;
   name: string;
   short_name: string;
   color: string;
 }
 
-interface LBGame {
+export interface LBGame {
   id: string;
   name: string;
   distribution: number[] | null;
@@ -25,15 +26,7 @@ interface LBGame {
   ready?: boolean;
 }
 
-/** The four leaderboard-row states (§7). */
-type RowState = "final" | "live" | "upcoming" | "unready";
-function rowStateOf(game: LBGame): RowState {
-  if (game.status === "complete") return "final";
-  if (game.status === "active") return "live";
-  return game.ready === false ? "unready" : "upcoming";
-}
-
-interface LBCell {
+export interface LBCell {
   gameId: string;
   teamId: string;
   place: number;
@@ -49,34 +42,6 @@ interface LeaderboardData {
   winNumber: number;
   pointsToClinch: Record<string, number>;
   defendingTeamId: string | null;
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-/** "8.5" → "8½", "14" → "14", "0.5" → "½" */
-function fmtPts(n: number): string {
-  const whole = Math.floor(n);
-  const isHalf = Math.abs(n - whole - 0.5) < 0.001;
-  if (!isHalf) return String(whole);
-  return whole === 0 ? "½" : `${whole}½`;
-}
-
-/** Map known game type IDs to their game board route segment. */
-const GAME_ROUTES: Record<string, string> = {
-  gtt_stroke_play: "new",
-  gtt_match_play_singles: "match/new",
-  gtt_match_play_doubles: "match/new",
-  gtt_rack_n_stack: "rack/new",
-};
-
-function gameHref(
-  tripId: string,
-  gameTypeId: string | null,
-  gameId: string
-): string | null {
-  if (!gameTypeId) return null;
-  const seg = GAME_ROUTES[gameTypeId];
-  return seg ? `/trips/${tripId}/games/${seg}?game=${gameId}` : null;
 }
 
 // ── Root component ────────────────────────────────────────────────────────────
@@ -505,7 +470,7 @@ function SessionBreakdown({
 
       <div className="divide-y" style={{ "--tw-divide-color": "var(--color-bt-border)" } as React.CSSProperties}>
         {games.map((game) => (
-          <SessionRow
+          <GameRow
             key={game.id}
             game={game}
             teams={teams}
@@ -517,145 +482,6 @@ function SessionBreakdown({
         ))}
       </div>
     </div>
-  );
-}
-
-function SessionRow({
-  game,
-  teams,
-  cells,
-  tripId,
-  mine,
-  onPrefetch,
-}: {
-  game: LBGame;
-  teams: LBTeam[];
-  cells: Map<string, LBCell> | undefined;
-  tripId: string;
-  mine: boolean;
-  onPrefetch: (gameId: string) => void;
-}) {
-  const href = gameHref(tripId, game.gameTypeId, game.id);
-  const hasScores = cells && cells.size > 0;
-  const state = rowStateOf(game);
-  // Show the per-team result line only when there's a committed/in-progress
-  // result; otherwise a single status line — NEVER an empty "– / –" (0–0) row.
-  const showTeamLine = state === "final" || (state === "live" && hasScores);
-
-  const inner = (
-    <div className="flex flex-col gap-0.5 px-4 py-3">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <span
-            className="truncate text-sm font-semibold"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            {game.name}
-          </span>
-          {mine && <YoursBadge />}
-        </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <RowBadge state={state} />
-          {href && (
-            <ChevronRight size={14} style={{ color: "var(--color-bt-text-dim)" }} />
-          )}
-        </div>
-      </div>
-
-      {showTeamLine ? (
-        <div className="flex flex-wrap gap-x-3 gap-y-0.5">
-          {teams.map((team) => {
-            const cell = cells?.get(team.id);
-            return (
-              <span
-                key={team.id}
-                className="flex items-center gap-1 text-[12px]"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: team.color }} />
-                <span style={{ color: team.color }}>{team.short_name}</span>
-                <span style={{ color: "var(--color-bt-text)" }}>{cell ? fmtPts(cell.points) : "–"}</span>
-              </span>
-            );
-          })}
-        </div>
-      ) : (
-        <span
-          className="text-[12px]"
-          style={{ color: state === "unready" ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)" }}
-        >
-          {state === "live"
-            ? "Underway · scoring"
-            : state === "unready"
-              ? "Not scoring yet — still being set up"
-              : "Not started yet"}
-        </span>
-      )}
-    </div>
-  );
-
-  if (href) {
-    return (
-      <Link
-        href={href}
-        className="block hover:opacity-80 transition-opacity"
-        onPointerEnter={() => onPrefetch(game.id)}
-        onPointerDown={() => onPrefetch(game.id)}
-      >
-        {inner}
-      </Link>
-    );
-  }
-  return <div>{inner}</div>;
-}
-
-function RowBadge({ state }: { state: RowState }) {
-  if (state === "final") {
-    return (
-      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
-        <Check size={9} />
-        Final
-      </span>
-    );
-  }
-  if (state === "live") {
-    return (
-      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)", border: "1px solid var(--color-bt-accent-border)" }}>
-        <Radio size={9} />
-        Live
-      </span>
-    );
-  }
-  if (state === "unready") {
-    return (
-      <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}>
-        Needs setup
-      </span>
-    );
-  }
-  // upcoming
-  return (
-    <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
-      Upcoming
-    </span>
-  );
-}
-
-/** "Yours" — marks a game the viewer is the delegate of (§10). Display-only;
- *  the controls live on the game page, not the board row (§5). */
-function YoursBadge() {
-  return (
-    <span
-      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold"
-      style={{
-        background: "var(--color-bt-accent-faint)",
-        color: "var(--color-bt-accent)",
-        border: "1px solid var(--color-bt-accent-border)",
-      }}
-      data-testid="game-yours-badge"
-    >
-      Yours
-    </span>
   );
 }
 

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight, Check, Radio } from "lucide-react";
+import type { LBGame, LBTeam, LBCell } from "./CompetitionLeaderboard";
+
+// ── Row helpers (own the board-row primitives) ────────────────────────────────
+
+/** "8.5" → "8½", "14" → "14", "0.5" → "½" */
+export function fmtPts(n: number): string {
+  const whole = Math.floor(n);
+  const isHalf = Math.abs(n - whole - 0.5) < 0.001;
+  if (!isHalf) return String(whole);
+  return whole === 0 ? "½" : `${whole}½`;
+}
+
+/** Map known game type IDs to their game board route segment. */
+const GAME_ROUTES: Record<string, string> = {
+  gtt_stroke_play: "new",
+  gtt_match_play_singles: "match/new",
+  gtt_match_play_doubles: "match/new",
+  gtt_rack_n_stack: "rack/new",
+};
+
+export function gameHref(
+  tripId: string,
+  gameTypeId: string | null,
+  gameId: string
+): string | null {
+  if (!gameTypeId) return null;
+  const seg = GAME_ROUTES[gameTypeId];
+  return seg ? `/trips/${tripId}/games/${seg}?game=${gameId}` : null;
+}
+
+/** The four leaderboard-row states (§7). */
+export type RowState = "final" | "live" | "upcoming" | "unready";
+export function rowStateOf(game: LBGame): RowState {
+  if (game.status === "complete") return "final";
+  if (game.status === "active") return "live";
+  return game.ready === false ? "unready" : "upcoming";
+}
+
+// ── GameRow ────────────────────────────────────────────────────────────────────
+
+/**
+ * The canonical per-game board row. Today it renders the active-board layout
+ * (two lines: name + a per-team score line or status text). The pre-game
+ * "Schedule" variant still lives inline in EarlyState; it folds into this same
+ * component behind a lifecycle-state prop next, and Phase 3 layers the §A state
+ * machine on top. Extracted byte-identical from the former `SessionRow`.
+ */
+export function GameRow({
+  game,
+  teams,
+  cells,
+  tripId,
+  mine,
+  onPrefetch,
+}: {
+  game: LBGame;
+  teams: LBTeam[];
+  cells: Map<string, LBCell> | undefined;
+  tripId: string;
+  mine: boolean;
+  onPrefetch: (gameId: string) => void;
+}) {
+  const href = gameHref(tripId, game.gameTypeId, game.id);
+  const hasScores = cells && cells.size > 0;
+  const state = rowStateOf(game);
+  // Show the per-team result line only when there's a committed/in-progress
+  // result; otherwise a single status line — NEVER an empty "– / –" (0–0) row.
+  const showTeamLine = state === "final" || (state === "live" && hasScores);
+
+  const inner = (
+    <div className="flex flex-col gap-0.5 px-4 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className="truncate text-sm font-semibold"
+            style={{ color: "var(--color-bt-text)" }}
+          >
+            {game.name}
+          </span>
+          {mine && <YoursBadge />}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <RowBadge state={state} />
+          {href && (
+            <ChevronRight size={14} style={{ color: "var(--color-bt-text-dim)" }} />
+          )}
+        </div>
+      </div>
+
+      {showTeamLine ? (
+        <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+          {teams.map((team) => {
+            const cell = cells?.get(team.id);
+            return (
+              <span
+                key={team.id}
+                className="flex items-center gap-1 text-[12px]"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: team.color }} />
+                <span style={{ color: team.color }}>{team.short_name}</span>
+                <span style={{ color: "var(--color-bt-text)" }}>{cell ? fmtPts(cell.points) : "–"}</span>
+              </span>
+            );
+          })}
+        </div>
+      ) : (
+        <span
+          className="text-[12px]"
+          style={{ color: state === "unready" ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)" }}
+        >
+          {state === "live"
+            ? "Underway · scoring"
+            : state === "unready"
+              ? "Not scoring yet — still being set up"
+              : "Not started yet"}
+        </span>
+      )}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="block hover:opacity-80 transition-opacity"
+        onPointerEnter={() => onPrefetch(game.id)}
+        onPointerDown={() => onPrefetch(game.id)}
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return <div>{inner}</div>;
+}
+
+export function RowBadge({ state }: { state: RowState }) {
+  if (state === "final") {
+    return (
+      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
+        <Check size={9} />
+        Final
+      </span>
+    );
+  }
+  if (state === "live") {
+    return (
+      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)", border: "1px solid var(--color-bt-accent-border)" }}>
+        <Radio size={9} />
+        Live
+      </span>
+    );
+  }
+  if (state === "unready") {
+    return (
+      <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}>
+        Needs setup
+      </span>
+    );
+  }
+  // upcoming
+  return (
+    <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
+      Upcoming
+    </span>
+  );
+}
+
+/** "Yours" — marks a game the viewer is the delegate of (§10). Display-only;
+ *  the controls live on the game page, not the board row (§5). */
+export function YoursBadge() {
+  return (
+    <span
+      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold"
+      style={{
+        background: "var(--color-bt-accent-faint)",
+        color: "var(--color-bt-accent)",
+        border: "1px solid var(--color-bt-accent-border)",
+      }}
+      data-testid="game-yours-badge"
+    >
+      Yours
+    </span>
+  );
+}

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -56,6 +56,7 @@ export function GameRow({
   tripId,
   mine,
   onPrefetch,
+  phase = "live",
 }: {
   game: LBGame;
   teams: LBTeam[];
@@ -63,6 +64,10 @@ export function GameRow({
   tripId: string;
   mine: boolean;
   onPrefetch: (gameId: string) => void;
+  /** Competition lifecycle: "live" = full active-board row (name + per-team /
+   *  status line); "early" = compact pre-game schedule row (name + badge only).
+   *  Phase 3 replaces this two-way branch with the full §A state machine. */
+  phase?: "live" | "early";
 }) {
   const href = gameHref(tripId, game.gameTypeId, game.id);
   const hasScores = cells && cells.size > 0;
@@ -71,7 +76,28 @@ export function GameRow({
   // result; otherwise a single status line — NEVER an empty "– / –" (0–0) row.
   const showTeamLine = state === "final" || (state === "live" && hasScores);
 
-  const inner = (
+  const inner = phase === "early" ? (
+    <div className="flex items-center justify-between gap-2 px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className="truncate text-sm"
+          style={{ color: "var(--color-bt-text)" }}
+        >
+          {game.name}
+        </span>
+        {mine && <YoursBadge />}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <RowBadge state={state} />
+        {href && (
+          <ChevronRight
+            size={14}
+            style={{ color: "var(--color-bt-text-dim)" }}
+          />
+        )}
+      </div>
+    </div>
+  ) : (
     <div className="flex flex-col gap-0.5 px-4 py-3">
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">


### PR DESCRIPTION
## Phase 2 §A groundwork — unify the competition board rows into one `GameRow`

Pure refactor, **no behavior or visual change**, in two identical-render commits. Sets up the single row component that Phase 3 layers the §A lifecycle state machine onto.

### Commit 1 — extract the active row → `GameRow.tsx`
The per-game board row (formerly the in-file `SessionRow`) moves **verbatim** into its own exported `src/components/competition/GameRow.tsx`; `SessionBreakdown` points at it. Row-only helpers move with it (`gameHref`/`GAME_ROUTES`, `rowStateOf`/`RowState`, `RowBadge`, `YoursBadge`) plus `fmtPts` (re-exported) so the only runtime import edge is `CompetitionLeaderboard → GameRow` — no cycle. `LB*` types are exported and type-imported (erased).

### Commit 2 — fold `EarlyState`'s row into `GameRow` behind a `phase` prop
`EarlyState`'s inline pre-game "Schedule" row is removed; it now renders `<GameRow phase="early">`. The prop (`"live"` default | `"early"`) selects the two-line active layout vs the compact single-line schedule layout; the `Link`/`div` href wrapper is shared. Now-unused imports trimmed from `CompetitionLeaderboard`.

### Verification (identical-render)
- `tsc` + `next lint` clean.
- **Eyes-on, BBMI Cup:** active board (two-line rows, "Underway · scoring" / "Not started yet", Poker chevron-less) unchanged; the **early** board (temporarily forced, then reverted) renders the same compact schedule rows as before. Both layouts now come from the one `GameRow`.

### Next (not in this PR)
Phase 3 replaces the two-way `phase` branch with the full §A lifecycle state machine on this now-single row component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
