### PR TITLE
feat(competition): Phase 3 — GameRow §A lifecycle state machine

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -101,6 +101,9 @@ export default function NewMatchGamePage() {
   const [view, setView] = useState<"entry" | "grid">("entry");
   const [currentHole, setCurrentHole] = useState(1);
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
+  // Collapse-on-advance: when teeing off with some slots still unfilled, confirm
+  // the consequence (the game drops to the filled count; cup clinch shifts).
+  const [confirmCollapse, setConfirmCollapse] = useState(false);
   // Course (Slice C): picked on the new-game screen, applied to the game once
   // it's created. id null until chosen.
   const [courseId, setCourseId] = useState<string | null>(null);
@@ -123,6 +126,15 @@ export default function NewMatchGamePage() {
   const resumedTypeId = gameQ.data?.game_type_id as string | undefined;
   const sided = resumedTypeId ? resumedTypeId === MATCH_PLAY_DOUBLES : search.get("format") === "doubles";
   const playersPerSide = sided ? 2 : 1;
+
+  // The matches that are actually playable — both sides fully assigned. An
+  // unfilled slot is not a match (it never scores), so teeing off COLLAPSES the
+  // game to these: the unfilled slots are discarded and points-in-play / the cup
+  // clinch recompute from this count. "Defined" was builder-time intent only.
+  const filledDraft = useMemo(
+    () => draft.filter((d) => d.a.length === playersPerSide && d.b.length === playersPerSide),
+    [draft, playersPerSide]
+  );
 
   // Scoring — the connectivity-resilient saver owns `values` + `saveStatus`:
   // optimistic value, retry-with-backoff, per-cell status, kept-and-flagged
@@ -454,29 +466,41 @@ export default function NewMatchGamePage() {
     go("setup");
   }
 
-  // Ready to tee off — one action: persist the pairings + handicaps, publish
-  // (activate) so members can see them, and land on the overview. No separate
-  // Save-then-Activate, no confirmation screen.
-  async function readyToTeeOff() {
+  // Tee off — the advance affordance. It's a SIGNAL, not a gate: clickable while
+  // slots are unfilled. With every slot filled it commits straight through; with
+  // some unfilled it confirms the collapse first (the game drops to the filled
+  // count and the cup clinch shifts — a surfaced consequence, not a scold). With
+  // nothing filled there's no match to play, so it's a no-op.
+  function attemptReady() {
+    if (filledDraft.length === 0) return;
+    if (filledDraft.length < draft.length) {
+      setConfirmCollapse(true);
+      return;
+    }
+    void commitReady();
+  }
+
+  // Persist the pairings + handicaps, publish (activate), land on the overview.
+  // Operates on `filledDraft` ONLY — unfilled slots are discarded here (the
+  // collapse: setPairings clean-replaces, so the dropped rows are gone and the
+  // board recomputes points-in-play / clinch from the filled count). No separate
+  // Save-then-Activate; the two formats differ only in side shape + procedure.
+  async function commitReady() {
     if (!tripId || !gameId) return;
-    // Persist pairings + per-match handicaps (one side n, other 0), then publish
-    // — in parallel: each only depends on the just-saved pairings, touches
-    // different rows, and there are no scores yet (no recompute contention).
-    // The two formats differ only in how a side is shaped + which procedure
-    // persists it; the handicap recipient resolves from the saved match's side.
+    setConfirmCollapse(false);
+    const matches = filledDraft;
+    if (matches.length === 0) return;
     if (sided) {
       const saved = await setDoublesPairings.mutateAsync({
         tripId,
         gameId,
-        // Only fully-formed pairs persist (a half-filled side stays null until
-        // both partners are picked — enforced by the CTA gate below).
-        matches: draft.map((d, i) => ({
-          sideA: d.a.length === playersPerSide ? { members: d.a } : null,
-          sideB: d.b.length === playersPerSide ? { members: d.b } : null,
+        matches: matches.map((d, i) => ({
+          sideA: { members: d.a },
+          sideB: { members: d.b },
           matchNumber: i + 1,
         })),
       });
-      const handicapWrites = draft.flatMap((d, i) => {
+      const handicapWrites = matches.flatMap((d, i) => {
         const row = saved[i] as { id: string; side_a: SideRef; side_b: SideRef } | undefined;
         if (!row || d.handicap === 0) return [];
         const recipient = d.handicap < 0 ? row.side_a : row.side_b;
@@ -488,15 +512,15 @@ export default function NewMatchGamePage() {
       const saved = await setPairings.mutateAsync({
         tripId,
         gameId,
-        matches: draft.map((d, i) => ({
-          sideA: d.a[0] ? { type: "user" as const, id: d.a[0] } : null,
-          sideB: d.b[0] ? { type: "user" as const, id: d.b[0] } : null,
+        matches: matches.map((d, i) => ({
+          sideA: { type: "user" as const, id: d.a[0] },
+          sideB: { type: "user" as const, id: d.b[0] },
           matchNumber: i + 1,
         })),
       });
-      const handicapWrites = draft.flatMap((d, i) => {
+      const handicapWrites = matches.flatMap((d, i) => {
         const row = saved[i] as { id: string } | undefined;
-        if (!row || !d.a[0] || !d.b[0] || d.handicap === 0) return [];
+        if (!row || d.handicap === 0) return [];
         const recipientUserId = d.handicap < 0 ? d.a[0] : d.b[0];
         return [setHandicap.mutateAsync({ tripId, gameId, matchId: row.id, recipientUserId, strokes: Math.abs(d.handicap) })];
       });
@@ -734,7 +758,7 @@ export default function NewMatchGamePage() {
           colorOf={colorOf}
           avatarIconOf={avatarIconOf}
           openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
-          onReady={readyToTeeOff}
+          onReady={attemptReady}
           saving={setPairings.isPending || setHandicap.isPending || setDoublesPairings.isPending || setDoublesHandicap.isPending || activate.isPending}
         />
       )}
@@ -805,6 +829,85 @@ export default function NewMatchGamePage() {
           />
         );
       })()}
+
+      {/* Collapse-on-incomplete confirm — fires only when teeing off with some
+          slots unfilled. States the real drop (filled count · points) and that
+          the cup clinch recalculates; confirming discards the unfilled slots. */}
+      {confirmCollapse && (
+        <CollapseConfirm
+          filled={filledDraft.length}
+          total={draft.length}
+          perMatchValue={(gameQ.data?.points_distribution as { value?: number } | null)?.value ?? null}
+          inCompetition={!!gameCompId}
+          pending={setPairings.isPending || setDoublesPairings.isPending || activate.isPending}
+          onConfirm={() => void commitReady()}
+          onCancel={() => setConfirmCollapse(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Collapse confirm (advance with unfilled slots). A consequence notice, not a
+ * scold: the unfilled matches aren't being created, so the game drops to the
+ * filled count, its points-in-play drop with it, and — in a competition — the
+ * cup's first-to-win total recalculates (the surprising part, so say it).
+ * Recovery is adding matches later, not an undo.
+ */
+function CollapseConfirm({
+  filled,
+  total,
+  perMatchValue,
+  inCompetition,
+  pending,
+  onConfirm,
+  onCancel,
+}: {
+  filled: number;
+  total: number;
+  perMatchValue: number | null;
+  inCompetition: boolean;
+  pending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const unfilled = total - filled;
+  const pts = perMatchValue != null ? filled * perMatchValue : null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onCancel}>
+      <div onClick={(e) => e.stopPropagation()} className="w-full" style={{ maxWidth: 360, background: "var(--color-bt-card-float)", borderRadius: 18, padding: 20, border: "1px solid var(--color-bt-border)" }}>
+        <div style={{ fontSize: 17, fontWeight: 700, color: "var(--color-bt-text)" }}>
+          {unfilled} {unfilled === 1 ? "match isn’t" : "matches aren’t"} set
+        </div>
+        <p style={{ fontSize: 14, lineHeight: 1.5, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
+          Tee off now and this game collapses to{" "}
+          <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
+            {filled} {filled === 1 ? "match" : "matches"}
+            {pts != null ? ` · ${pts} pts` : ""}
+          </span>
+          . The unfilled {unfilled === 1 ? "slot is" : "slots are"} discarded.
+          {inCompetition && " The cup’s first-to-win total recalculates from the lower total."}
+        </p>
+        <div className="mt-5 flex flex-col gap-2">
+          <button
+            onClick={onConfirm}
+            disabled={pending}
+            className="w-full disabled:opacity-40"
+            style={{ height: 48, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 15, fontWeight: 600 }}
+          >
+            {pending ? "Setting up…" : `Tee off with ${filled}`}
+          </button>
+          <button
+            onClick={onCancel}
+            disabled={pending}
+            className="w-full disabled:opacity-40"
+            style={{ height: 46, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
+          >
+            Keep setting up
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -1085,6 +1188,11 @@ function MatchSetup({
     );
   };
 
+  // Filled = both sides fully assigned (a real match). Drives the advance
+  // affordance: outlined until every slot is filled, disabled with none filled.
+  const filledCount = draft.filter((d) => d.a.length === playersPerSide && d.b.length === playersPerSide).length;
+  const allFilled = draft.length > 0 && filledCount === draft.length;
+
   return (
     <div>
       <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginBottom: 14 }}>
@@ -1208,10 +1316,14 @@ function MatchSetup({
         </button>
       )}
 
+      {/* Advance is a SIGNAL, not a gate (collapse-on-incomplete): clickable
+          while slots are unfilled, outlined until every slot is assigned, filled
+          once complete. Disabled only with nothing to tee off (no full match). */}
       <PrimaryButton
         label={saving ? "Setting up…" : "Ready to tee off"}
         onClick={onReady}
-        disabled={saving || draft.length === 0 || !draft.every((d) => d.a.length === playersPerSide && d.b.length === playersPerSide)}
+        disabled={saving || filledCount === 0}
+        outlined={!allFilled}
       />
     </div>
   );
@@ -1520,9 +1632,14 @@ function SelectorRow({ name, avatarIcon, sub, dim, onClick }: { name: string; av
   );
 }
 
-function PrimaryButton({ label, onClick, disabled }: { label: string; onClick: () => void; disabled?: boolean }) {
+function PrimaryButton({ label, onClick, disabled, outlined }: { label: string; onClick: () => void; disabled?: boolean; outlined?: boolean }) {
+  // Outlined = the "more to fill" signal (neutral, not an error): same accent,
+  // hollow. Filled accent once every slot is assigned.
+  const style: React.CSSProperties = outlined
+    ? { height: 52, borderRadius: 12, background: "transparent", color: "var(--color-bt-accent)", border: "1.5px solid var(--color-bt-accent-border)", fontSize: 16, fontWeight: 600 }
+    : { height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 };
   return (
-    <button onClick={onClick} disabled={disabled} className="mt-6 w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
+    <button onClick={onClick} disabled={disabled} className="mt-6 w-full disabled:opacity-40" style={style}>
       {label}
     </button>
   );

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -788,8 +788,9 @@ export default function NewMatchGamePage() {
             setView(locked ? "grid" : "entry");
             go("score");
           }}
-          // +1 mid-life: persist an empty match (board recomputes immediately),
-          // then land on setup to pick its players (assignment is the same flow).
+          // +1 mid-life: persist an empty match, then land on setup to pick its
+          // players. The board's clinch goalpost moves once the match is PAIRED
+          // (a match = assigned), not the instant the empty slot is added.
           onAddMatch={async () => {
             await handleAddMatch();
             go("setup");
@@ -1438,7 +1439,7 @@ function Overview({
       </div>
 
       {/* +1: add another match mid-life (lands on setup to pick its players).
-          The board's "first to XX" jumps by one × value immediately. */}
+          The board's "first to XX" moves once the new match is PAIRED. */}
       {canEdit && !complete && groups.length < MAX_MATCHES && (
         <button
           type="button"

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -21,8 +21,15 @@ export interface LBGame {
   status: string;
   dropped: boolean;
   gameTypeId: string | null;
-  /** Points configured (scoring-ready). Drives the state-aware rows (§7). */
+  /** Points configured (scoring-ready). Kept for the games-panel/test consumers. */
   ready?: boolean;
+  /** The §A readiness gate: the format's required roster is assigned (match-play
+   *  pairings / stroke-rack participants / manual points). Drives BOTH the
+   *  Setting-up↔Ready lifecycle and the `N PTS`/`—` column — one signal. */
+  configured?: boolean;
+  /** A course is applied to this game — drives the scorecard chip's button vs
+   *  muted-status three-way (course is optional, never an error). */
+  hasCourse?: boolean;
   /** Points in play for this game — the §A5 outer-column `N PTS` value. Carries
    *  the match-play total too (whose `distribution` is null pre-decision). */
   pointsTotal?: number | null;

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -23,6 +23,9 @@ export interface LBGame {
   gameTypeId: string | null;
   /** Points configured (scoring-ready). Drives the state-aware rows (§7). */
   ready?: boolean;
+  /** Points in play for this game — the §A5 outer-column `N PTS` value. Carries
+   *  the match-play total too (whose `distribution` is null pre-decision). */
+  pointsTotal?: number | null;
 }
 
 export interface LBCell {

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -577,7 +577,6 @@ function EarlyState({
                 tripId={tripId}
                 mine={mineSet.has(game.id)}
                 onPrefetch={onPrefetch}
-                phase="early"
               />
             ))}
           </div>

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createElement } from "react";
 import Link from "next/link";
 import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -124,7 +125,6 @@ export function GameRow({
   const lifecycle = lifecycleOf(game);
   const isFinal = lifecycle === "final";
 
-  const Icon = formatIcon(game.gameTypeId);
   // Final sheds the operational layer (scorecard + delegate), keeps the result
   // (round-3.1 §A2). The scorecard column is golf-only and present everywhere
   // EXCEPT Final.
@@ -165,14 +165,15 @@ export function GameRow({
 
   const inner = (
     <div className="flex items-center gap-3 px-4 py-3" style={rowStyle}>
-      {/* Format icon — color carries the arming tell (§A4). */}
-      <Icon
-        size={18}
-        className="shrink-0"
-        style={{
+      {/* Format icon — color carries the arming tell (§A4). Rendered via
+          createElement so the icon component isn't re-created during render. */}
+      {createElement(formatIcon(game.gameTypeId), {
+        size: 18,
+        className: "shrink-0",
+        style: {
           color: armedIcon ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
-        }}
-      />
+        },
+      })}
 
       {/* Name + delegate, subtitle stacked beneath */}
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -57,18 +57,25 @@ export function isGolfFormat(gameTypeId: string | null): boolean {
 
 /**
  * The §A lifecycle state the row reads — replaces the old 4-value RowState.
- * DERIVED from the game's actual status + points-config; it is the row's single
+ * DERIVED from the game's actual status + readiness; it is the row's single
  * source of truth, not a layout flag (§A2). The two gravy sub-states are carried
  * as data ON TOP of these four, not as extra enum values: "configuring" is a
  * partial "setting-up", and "armed vs not-armed" lives inside "ready" (carried
  * by the format-icon color, §A4 — wired to this derived value, never a literal
  * board/layout string).
+ *
+ * Ready must be EARNED, not assumed: a game is Setting up until the format's
+ * required roster is assigned (`configured`, derived server-side from pairing /
+ * participant counts). "Exists and not live/final" is NOT Ready — that was the
+ * bug where an unconfigured match game rendered Ready while its points read `—`.
+ * Course/handicaps never gate this (locked, readiness model). Same `configured`
+ * signal feeds the outer `N PTS`/`—` column, so the two can't disagree.
  */
 export type LifecycleState = "setting-up" | "ready" | "live" | "final";
 export function lifecycleOf(game: LBGame): LifecycleState {
   if (game.status === "complete") return "final";
   if (game.status === "active") return "live";
-  return game.ready === false ? "setting-up" : "ready";
+  return game.configured ? "ready" : "setting-up";
 }
 
 /**
@@ -127,8 +134,10 @@ export function GameRow({
 
   // Final sheds the operational layer (scorecard + delegate), keeps the result
   // (round-3.1 §A2). The scorecard column is golf-only and present everywhere
-  // EXCEPT Final.
+  // EXCEPT Final; a course set makes it a real button (opens the scorecard via
+  // the row link), no course makes it a muted, inert status icon.
   const showScorecard = isGolfFormat(game.gameTypeId) && !isFinal;
+  const scorecardOpens = showScorecard && game.hasCourse === true && !!href;
   const showDelegate = mine && !isFinal;
 
   // Subtitle / running state (§A3). Setting-up + Final carry none — the dashed
@@ -194,22 +203,39 @@ export function GameRow({
         )}
       </div>
 
-      {/* Scorecard button (golf-only, dropped at Final) — inboard of the outer
-          column so the right edge holds when it vanishes. */}
-      {showScorecard && (
-        <span
-          className="flex shrink-0 items-center justify-center rounded-lg"
-          style={{
-            width: 30,
-            height: 30,
-            background: "var(--color-bt-card-raised)",
-            color: "var(--color-bt-text-dim)",
-          }}
-          aria-hidden
-        >
-          <ClipboardList size={15} />
-        </span>
-      )}
+      {/* Scorecard column (golf-only, dropped at Final) — inboard of the outer
+          column so the right edge holds when it vanishes. Course set → a real
+          button that opens the scorecard (via the row link to the score-entry
+          route); no course → a muted, inert status icon (no nav, not an error). */}
+      {showScorecard &&
+        (scorecardOpens ? (
+          <span
+            className="flex shrink-0 items-center justify-center rounded-lg"
+            style={{
+              width: 30,
+              height: 30,
+              background: "var(--color-bt-card-raised)",
+              border: "1px solid var(--color-bt-border)",
+              color: "var(--color-bt-text)",
+            }}
+          >
+            <ClipboardList size={15} />
+          </span>
+        ) : (
+          <span
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: 30, height: 30, color: "var(--color-bt-text-dim)", opacity: 0.5 }}
+            // No course yet — status only, never a tap target (the row stays
+            // navigable around it for games that are otherwise reachable).
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            title="No course set"
+          >
+            <ClipboardList size={15} />
+          </span>
+        ))}
 
       {/* Outer column — pts-or-result, pinned right, right-aligned (§A5). */}
       <div className="flex shrink-0 flex-col items-end" style={{ minWidth: 44 }}>
@@ -266,8 +292,11 @@ function OuterColumn({
     );
   }
 
+  // `N PTS` only once the game is configured (the SAME gate as Ready) — a
+  // setting-up game reads `—` even if it carries a stray points value, so the
+  // column and the state always agree.
   const pts = game.pointsTotal;
-  if (pts != null && pts > 0) {
+  if (game.configured && pts != null && pts > 0) {
     return (
       <span className="text-[13px] font-semibold tabular-nums" style={{ color: "var(--color-bt-text)" }}>
         {fmtPts(pts)} <span className="text-[10px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>PTS</span>

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -120,7 +120,7 @@ export function GameRow({
   const href = gameHref(tripId, game.gameTypeId, game.id);
   const hasScores = cells && cells.size > 0;
   // The row's single source of truth — the game's actual lifecycle, not a board
-  // context flag. Layout + (Commit 3) every layer key off this one value.
+  // context flag. Layout + every §A3 layer key off this one value.
   const lifecycle = lifecycleOf(game);
   const isFinal = lifecycle === "final";
 
@@ -132,8 +132,8 @@ export function GameRow({
   const showDelegate = mine && !isFinal;
 
   // Subtitle / running state (§A3). Setting-up + Final carry none — the dashed
-  // outline (Commit 3) and the outer result speak for them. Live's real running
-  // state ("Blue 2 up · thru 13") is deferred to a state-driven slot.
+  // outline and the outer result speak for them. Live's real running state
+  // ("Blue 2 up · thru 13") is deferred to a state-driven slot.
   const subtitle =
     lifecycle === "live"
       ? "Underway · scoring"
@@ -141,16 +141,36 @@ export function GameRow({
       ? "Ready to play"
       : null;
 
+  // §A3 layer table — each visual layer wired to the one derived lifecycle.
+  // The format icon shows FULL color only while scoring is enabled AND the game
+  // isn't yet a finished record; Final quiets it back down (sheds the arm tell).
+  const armedIcon = iconArmed(lifecycle) && !isFinal;
+  const rowStyle: React.CSSProperties = {
+    // The one reserved background is Live (§A2) — the only "act now" fill.
+    background: lifecycle === "live" ? "var(--color-bt-accent-faint)" : undefined,
+    // Setting-up gets the only special outline: a dashed left edge that reads
+    // "not built yet." Every other state reserves the same 2px transparent so
+    // the name never shifts as the outline appears/disappears.
+    borderLeft:
+      lifecycle === "setting-up"
+        ? "2px dashed var(--color-bt-border)"
+        : "2px solid transparent",
+    // Final is a quiet record — recess the whole tile (§A3 "recessed").
+    opacity: isFinal ? 0.72 : 1,
+  };
+  // Name-text strength = "is the structure done?" — dim while setting up, full
+  // the moment it's Ready (§A3). Final keeps the name full but the tile recedes.
+  const nameColor =
+    lifecycle === "setting-up" ? "var(--color-bt-text-dim)" : "var(--color-bt-text)";
+
   const inner = (
-    <div className="flex items-center gap-3 px-4 py-3">
-      {/* Format icon */}
+    <div className="flex items-center gap-3 px-4 py-3" style={rowStyle}>
+      {/* Format icon — color carries the arming tell (§A4). */}
       <Icon
         size={18}
         className="shrink-0"
         style={{
-          color: iconArmed(lifecycle)
-            ? "var(--color-bt-text)"
-            : "var(--color-bt-text-dim)",
+          color: armedIcon ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)",
         }}
       />
 
@@ -159,7 +179,7 @@ export function GameRow({
         <div className="flex min-w-0 items-center gap-2">
           <span
             className="truncate text-sm font-semibold"
-            style={{ color: "var(--color-bt-text)" }}
+            style={{ color: nameColor }}
           >
             {game.name}
           </span>

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronRight, Check, Radio } from "lucide-react";
+import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { LBGame, LBTeam, LBCell } from "./CompetitionLeaderboard";
 
 // ── Row helpers (own the board-row primitives) ────────────────────────────────
@@ -30,6 +31,27 @@ export function gameHref(
   if (!gameTypeId) return null;
   const seg = GAME_ROUTES[gameTypeId];
   return seg ? `/trips/${tripId}/games/${seg}?game=${gameId}` : null;
+}
+
+/** §A1 format icon — the leading glyph that names the game's format, glanceable
+ *  down the board. Its COLOR carries the arming tell (§A4, applied in Commit 3);
+ *  the glyph itself just identifies the format. Unknown types fall back to a
+ *  generic game glyph rather than going blank. */
+const FORMAT_ICONS: Record<string, LucideIcon> = {
+  gtt_stroke_play: Flag,
+  gtt_match_play_singles: Swords,
+  gtt_match_play_doubles: Swords,
+  gtt_rack_n_stack: Layers,
+};
+export function formatIcon(gameTypeId: string | null): LucideIcon {
+  return (gameTypeId && FORMAT_ICONS[gameTypeId]) || Gamepad2;
+}
+
+/** Golf games carry a scorecard (§A3 scorecard column is golf-only). Today every
+ *  built format is golf — proxy "golf" by "has a known game-board route"; a
+ *  manual win/lose/halve side event (no route) is correctly excluded. */
+export function isGolfFormat(gameTypeId: string | null): boolean {
+  return !!gameTypeId && gameTypeId in GAME_ROUTES;
 }
 
 /**
@@ -62,11 +84,23 @@ export function iconArmed(lifecycle: LifecycleState): boolean {
 // ── GameRow ────────────────────────────────────────────────────────────────────
 
 /**
- * The canonical per-game board row. Today it renders the active-board layout
- * (two lines: name + a per-team score line or status text). The pre-game
- * "Schedule" variant still lives inline in EarlyState; it folds into this same
- * component behind a lifecycle-state prop next, and Phase 3 layers the §A state
- * machine on top. Extracted byte-identical from the former `SessionRow`.
+ * The canonical per-game board row (§A1). One column skeleton for every
+ * lifecycle state:
+ *
+ *   [format icon] [ name + delegate / subtitle ] [scorecard btn] [ pts-or-result ]
+ *
+ * - `pts-or-result` is the outermost column, pinned to the right edge and
+ *   right-aligned (§A4): `N PTS` (potential) while unresolved, the stacked team
+ *   result at Final. It is ALWAYS present, so the right edge never reflows.
+ * - `scorecard btn` sits just inboard of it — golf-only, and dropped at Final —
+ *   so the column that vanishes is the inner one and the outer edge holds steady.
+ * - the format icon's color is the arming tell (§A4); the name never gets
+ *   crowded out (§A6). The full §A3 layer table (outline / name strength / the
+ *   one Live background / LIVE badge) lands in Commit 3.
+ *
+ * Subtitle and name+delegate stack vertically inside the name column (mobile —
+ * keeps the name uncrowded); the delegate chip travels with the name (§A1) and
+ * drops at Final alongside the scorecard (round-3.1 §A2).
  */
 export function GameRow({
   game,
@@ -88,36 +122,40 @@ export function GameRow({
   // The row's single source of truth — the game's actual lifecycle, not a board
   // context flag. Layout + (Commit 3) every layer key off this one value.
   const lifecycle = lifecycleOf(game);
-  // Show the per-team result line only when there's a committed/in-progress
-  // result; otherwise a single status line — NEVER an empty "– / –" (0–0) row.
-  const showTeamLine = lifecycle === "final" || (lifecycle === "live" && hasScores);
+  const isFinal = lifecycle === "final";
 
-  // Compact pre-config layout for setting-up; the fuller row otherwise. These
-  // two branches converge into one §A column skeleton in Commit 2.
-  const inner = lifecycle === "setting-up" ? (
-    <div className="flex items-center justify-between gap-2 px-4 py-3">
-      <div className="flex min-w-0 items-center gap-2">
-        <span
-          className="truncate text-sm"
-          style={{ color: "var(--color-bt-text)" }}
-        >
-          {game.name}
-        </span>
-        {mine && <YoursBadge />}
-      </div>
-      <div className="flex items-center gap-1.5">
-        <RowBadge state={lifecycle} />
-        {href && (
-          <ChevronRight
-            size={14}
-            style={{ color: "var(--color-bt-text-dim)" }}
-          />
-        )}
-      </div>
-    </div>
-  ) : (
-    <div className="flex flex-col gap-0.5 px-4 py-3">
-      <div className="flex items-center justify-between gap-2">
+  const Icon = formatIcon(game.gameTypeId);
+  // Final sheds the operational layer (scorecard + delegate), keeps the result
+  // (round-3.1 §A2). The scorecard column is golf-only and present everywhere
+  // EXCEPT Final.
+  const showScorecard = isGolfFormat(game.gameTypeId) && !isFinal;
+  const showDelegate = mine && !isFinal;
+
+  // Subtitle / running state (§A3). Setting-up + Final carry none — the dashed
+  // outline (Commit 3) and the outer result speak for them. Live's real running
+  // state ("Blue 2 up · thru 13") is deferred to a state-driven slot.
+  const subtitle =
+    lifecycle === "live"
+      ? "Underway · scoring"
+      : lifecycle === "ready"
+      ? "Ready to play"
+      : null;
+
+  const inner = (
+    <div className="flex items-center gap-3 px-4 py-3">
+      {/* Format icon */}
+      <Icon
+        size={18}
+        className="shrink-0"
+        style={{
+          color: iconArmed(lifecycle)
+            ? "var(--color-bt-text)"
+            : "var(--color-bt-text-dim)",
+        }}
+      />
+
+      {/* Name + delegate, subtitle stacked beneath */}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex min-w-0 items-center gap-2">
           <span
             className="truncate text-sm font-semibold"
@@ -125,41 +163,37 @@ export function GameRow({
           >
             {game.name}
           </span>
-          {mine && <YoursBadge />}
+          {showDelegate && <YoursBadge />}
+          {lifecycle === "live" && <LiveBadge />}
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <RowBadge state={lifecycle} />
-          {href && (
-            <ChevronRight size={14} style={{ color: "var(--color-bt-text-dim)" }} />
-          )}
-        </div>
+        {subtitle && (
+          <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {subtitle}
+          </span>
+        )}
       </div>
 
-      {showTeamLine ? (
-        <div className="flex flex-wrap gap-x-3 gap-y-0.5">
-          {teams.map((team) => {
-            const cell = cells?.get(team.id);
-            return (
-              <span
-                key={team.id}
-                className="flex items-center gap-1 text-[12px]"
-                style={{ color: "var(--color-bt-text-dim)" }}
-              >
-                <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: team.color }} />
-                <span style={{ color: team.color }}>{team.short_name}</span>
-                <span style={{ color: "var(--color-bt-text)" }}>{cell ? fmtPts(cell.points) : "–"}</span>
-              </span>
-            );
-          })}
-        </div>
-      ) : (
+      {/* Scorecard button (golf-only, dropped at Final) — inboard of the outer
+          column so the right edge holds when it vanishes. */}
+      {showScorecard && (
         <span
-          className="text-[12px]"
-          style={{ color: "var(--color-bt-text-dim)" }}
+          className="flex shrink-0 items-center justify-center rounded-lg"
+          style={{
+            width: 30,
+            height: 30,
+            background: "var(--color-bt-card-raised)",
+            color: "var(--color-bt-text-dim)",
+          }}
+          aria-hidden
         >
-          {lifecycle === "live" ? "Underway · scoring" : "Not started yet"}
+          <ClipboardList size={15} />
         </span>
       )}
+
+      {/* Outer column — pts-or-result, pinned right, right-aligned (§A5). */}
+      <div className="flex shrink-0 flex-col items-end" style={{ minWidth: 44 }}>
+        <OuterColumn game={game} teams={teams} cells={cells} isFinal={isFinal} hasScores={!!hasScores} />
+      </div>
     </div>
   );
 
@@ -178,40 +212,75 @@ export function GameRow({
   return <div>{inner}</div>;
 }
 
-export function RowBadge({ state }: { state: LifecycleState }) {
-  if (state === "final") {
+/** §A5 outer column: `—` when nothing's in play, `N PTS` while unresolved, the
+ *  stacked team result at Final (team-color dots — the existing result widget,
+ *  not redesigned). Data-driven: Final → result; else points in play → `N PTS`;
+ *  else `—`. */
+function OuterColumn({
+  game,
+  teams,
+  cells,
+  isFinal,
+  hasScores,
+}: {
+  game: LBGame;
+  teams: LBTeam[];
+  cells: Map<string, LBCell> | undefined;
+  isFinal: boolean;
+  hasScores: boolean;
+}) {
+  if (isFinal && hasScores) {
     return (
-      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
-        <Check size={9} />
-        Final
+      <div className="flex flex-col items-end gap-0.5">
+        {teams.map((team) => {
+          const cell = cells?.get(team.id);
+          return (
+            <span key={team.id} className="flex items-center gap-1 text-[13px] font-semibold tabular-nums">
+              <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: team.color }} />
+              <span style={{ color: "var(--color-bt-text)" }}>{cell ? fmtPts(cell.points) : "–"}</span>
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+
+  const pts = game.pointsTotal;
+  if (pts != null && pts > 0) {
+    return (
+      <span className="text-[13px] font-semibold tabular-nums" style={{ color: "var(--color-bt-text)" }}>
+        {fmtPts(pts)} <span className="text-[10px] font-medium" style={{ color: "var(--color-bt-text-dim)" }}>PTS</span>
       </span>
     );
   }
-  if (state === "live") {
-    return (
-      <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)", border: "1px solid var(--color-bt-accent-border)" }}>
-        <Radio size={9} />
-        Live
-      </span>
-    );
-  }
-  if (state === "setting-up") {
-    return (
-      <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}>
-        Needs setup
-      </span>
-    );
-  }
-  // ready
   return (
-    <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
-      Upcoming
+    <span className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+      —
     </span>
   );
 }
 
-/** "Yours" — marks a game the viewer is the delegate of (§10). Display-only;
- *  the controls live on the game page, not the board row (§5). */
+/** §A2 — LIVE is the one surviving word-badge (the OPEN badge is removed; arming
+ *  is carried by the format-icon color, §A4). */
+export function LiveBadge() {
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
+      style={{
+        background: "var(--color-bt-accent-faint)",
+        color: "var(--color-bt-accent)",
+        border: "1px solid var(--color-bt-accent-border)",
+      }}
+    >
+      <Radio size={9} />
+      Live
+    </span>
+  );
+}
+
+/** "Yours"— marks a game the viewer is the delegate of (§10). Display-only;
+ *  the controls live on the game page, not the board row (§5). Dropped at Final
+ *  alongside the scorecard (round-3.1 §A2 — Final sheds operational chrome). */
 export function YoursBadge() {
   return (
     <span

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -32,12 +32,31 @@ export function gameHref(
   return seg ? `/trips/${tripId}/games/${seg}?game=${gameId}` : null;
 }
 
-/** The four leaderboard-row states (§7). */
-export type RowState = "final" | "live" | "upcoming" | "unready";
-export function rowStateOf(game: LBGame): RowState {
+/**
+ * The §A lifecycle state the row reads — replaces the old 4-value RowState.
+ * DERIVED from the game's actual status + points-config; it is the row's single
+ * source of truth, not a layout flag (§A2). The two gravy sub-states are carried
+ * as data ON TOP of these four, not as extra enum values: "configuring" is a
+ * partial "setting-up", and "armed vs not-armed" lives inside "ready" (carried
+ * by the format-icon color, §A4 — wired to this derived value, never a literal
+ * board/layout string).
+ */
+export type LifecycleState = "setting-up" | "ready" | "live" | "final";
+export function lifecycleOf(game: LBGame): LifecycleState {
   if (game.status === "complete") return "final";
   if (game.status === "active") return "live";
-  return game.ready === false ? "unready" : "upcoming";
+  return game.ready === false ? "setting-up" : "ready";
+}
+
+/**
+ * §A4 arm signal: the format-icon shows full color when scoring is enabled,
+ * muted while the game is still being set up. There is no `scoring_enabled`
+ * field yet (Phase 2's Enable/Disable adds it), so for now arm == "structure is
+ * done": muted iff setting-up/configuring, full-color otherwise. Wired to the
+ * DERIVED lifecycle, so swapping in the real field later is a one-line change.
+ */
+export function iconArmed(lifecycle: LifecycleState): boolean {
+  return lifecycle !== "setting-up";
 }
 
 // ── GameRow ────────────────────────────────────────────────────────────────────
@@ -56,7 +75,6 @@ export function GameRow({
   tripId,
   mine,
   onPrefetch,
-  phase = "live",
 }: {
   game: LBGame;
   teams: LBTeam[];
@@ -64,19 +82,19 @@ export function GameRow({
   tripId: string;
   mine: boolean;
   onPrefetch: (gameId: string) => void;
-  /** Competition lifecycle: "live" = full active-board row (name + per-team /
-   *  status line); "early" = compact pre-game schedule row (name + badge only).
-   *  Phase 3 replaces this two-way branch with the full §A state machine. */
-  phase?: "live" | "early";
 }) {
   const href = gameHref(tripId, game.gameTypeId, game.id);
   const hasScores = cells && cells.size > 0;
-  const state = rowStateOf(game);
+  // The row's single source of truth — the game's actual lifecycle, not a board
+  // context flag. Layout + (Commit 3) every layer key off this one value.
+  const lifecycle = lifecycleOf(game);
   // Show the per-team result line only when there's a committed/in-progress
   // result; otherwise a single status line — NEVER an empty "– / –" (0–0) row.
-  const showTeamLine = state === "final" || (state === "live" && hasScores);
+  const showTeamLine = lifecycle === "final" || (lifecycle === "live" && hasScores);
 
-  const inner = phase === "early" ? (
+  // Compact pre-config layout for setting-up; the fuller row otherwise. These
+  // two branches converge into one §A column skeleton in Commit 2.
+  const inner = lifecycle === "setting-up" ? (
     <div className="flex items-center justify-between gap-2 px-4 py-3">
       <div className="flex min-w-0 items-center gap-2">
         <span
@@ -88,7 +106,7 @@ export function GameRow({
         {mine && <YoursBadge />}
       </div>
       <div className="flex items-center gap-1.5">
-        <RowBadge state={state} />
+        <RowBadge state={lifecycle} />
         {href && (
           <ChevronRight
             size={14}
@@ -110,7 +128,7 @@ export function GameRow({
           {mine && <YoursBadge />}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          <RowBadge state={state} />
+          <RowBadge state={lifecycle} />
           {href && (
             <ChevronRight size={14} style={{ color: "var(--color-bt-text-dim)" }} />
           )}
@@ -137,13 +155,9 @@ export function GameRow({
       ) : (
         <span
           className="text-[12px]"
-          style={{ color: state === "unready" ? "var(--color-bt-warning)" : "var(--color-bt-text-dim)" }}
+          style={{ color: "var(--color-bt-text-dim)" }}
         >
-          {state === "live"
-            ? "Underway · scoring"
-            : state === "unready"
-              ? "Not scoring yet — still being set up"
-              : "Not started yet"}
+          {lifecycle === "live" ? "Underway · scoring" : "Not started yet"}
         </span>
       )}
     </div>
@@ -164,7 +178,7 @@ export function GameRow({
   return <div>{inner}</div>;
 }
 
-export function RowBadge({ state }: { state: RowState }) {
+export function RowBadge({ state }: { state: LifecycleState }) {
   if (state === "final") {
     return (
       <span className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
@@ -181,14 +195,14 @@ export function RowBadge({ state }: { state: RowState }) {
       </span>
     );
   }
-  if (state === "unready") {
+  if (state === "setting-up") {
     return (
       <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-warning-faint)", color: "var(--color-bt-warning)" }}>
         Needs setup
       </span>
     );
   }
-  // upcoming
+  // ready
   return (
     <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold" style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}>
       Upcoming

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { rollUp, placementDetail, type LiveGame } from "@/lib/competitionPlacement";
+import { rollUp, placementDetail, awardedForGame, type LiveGame } from "@/lib/competitionPlacement";
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
 import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
 
@@ -169,14 +169,15 @@ export async function computeCompetitionLeaderboard(
 
   const roll = rollUp(liveGames, teamIds, { defendingTeamId: comp?.defending_team_id ?? null });
 
-  // Per-game points in play, keyed by id — the SAME authoritative value the
-  // roll-up uses (owner-set total for placement; value × match count for
-  // per_match). The board row's outer column (§A5 `N PTS`) reads this so a
-  // match-play game — whose `distribution` is null until decided — still shows
-  // its potential. Built from the computed liveGames so the row can't diverge
-  // from the standings.
-  const ptsInPlayByGame = new Map<string, number | null>(
-    liveGames.map((g) => [g.id, g.pointsTotal ?? null])
+  // Per-game points in play, keyed by id — the SAME per-game expression rollUp
+  // sums into points-available (owner-set total, else the distribution sum). The
+  // board row's outer column (§A5 `N PTS`) reads this so a match-play game —
+  // whose `distribution` is null until decided — still shows its potential, AND
+  // a distribution-only placement game (no owner total) shows its sum instead of
+  // a bare `—`. Built from the computed liveGames so the row can't diverge from
+  // the standings.
+  const ptsInPlayByGame = new Map<string, number>(
+    liveGames.map((g) => [g.id, g.pointsTotal ?? awardedForGame(g.distribution, g.numTeams)])
   );
 
   // Per-game grid cells (place + points per team) — same averaging as the totals,

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -109,8 +109,8 @@ export async function computeCompetitionLeaderboard(
           .eq("entity_type", "team")
       : Promise.resolve({ data: [] as { game_id: string; entity_id: string; position: number | null; raw_score: number | null }[] }),
     gameIds.length
-      ? supabase.from("game_matches").select("game_id").in("game_id", gameIds)
-      : Promise.resolve({ data: [] as { game_id: string }[] }),
+      ? supabase.from("game_matches").select("game_id, side_a, side_b").in("game_id", gameIds)
+      : Promise.resolve({ data: [] as { game_id: string; side_a: unknown; side_b: unknown }[] }),
     gameIds.length
       ? supabase.from("game_participants").select("game_id").in("game_id", gameIds)
       : Promise.resolve({ data: [] as { game_id: string }[] }),
@@ -121,14 +121,17 @@ export async function computeCompetitionLeaderboard(
   for (const r of (participantRowsRes.data ?? []) as { game_id: string }[]) {
     participantCountByGame.set(r.game_id, (participantCountByGame.get(r.game_id) ?? 0) + 1);
   }
-  // A match game's available points = value × the number of matches it is
-  // CONFIGURED to have (its game_matches rows), counted regardless of whether
-  // they're paired yet — the configured count, ≥1 from creation. Adding/removing
-  // a match moves this (the live clinch target); pairing or playing does not.
-  // (Was value × deriveMatchCount(teamSizes) — the stable §8 estimate; the
-  // dynamic-match-count build moves the goalpost to the live configured count.)
+  // A match game's available points = value × the number of ASSIGNED matches
+  // (both sides paired). "A match = assigned, everywhere" (round-3.1 addendum):
+  // an unfilled slot is not a match — it never scores, so it contributes nothing
+  // to points-in-play and doesn't make the game Ready. Empty slots are builder
+  // scaffolding that the tee-off COLLAPSE discards; counting them here would show
+  // a created-but-unpaired game phantom points. (Supersedes the earlier Slice-D
+  // "configured rows incl. empty, ≥1 from creation" goalpost — pairing now moves
+  // the live clinch target, by design.)
   const matchCountByGame = new Map<string, number>();
-  for (const r of (matchRowsRes.data ?? []) as { game_id: string }[]) {
+  for (const r of (matchRowsRes.data ?? []) as { game_id: string; side_a: unknown; side_b: unknown }[]) {
+    if (r.side_a == null || r.side_b == null) continue;
     matchCountByGame.set(r.game_id, (matchCountByGame.get(r.game_id) ?? 0) + 1);
   }
 
@@ -147,9 +150,10 @@ export async function computeCompetitionLeaderboard(
 
     if (isPerMatch(rawDist)) {
       const typeId = g.game_type_id as string | null;
-      // Match play (singles/doubles): available = value × the game's CONFIGURED
-      // match count (its game_matches rows), regardless of pairing — the live
-      // clinch goalpost that add/remove moves (dynamic match count). Other
+      // Match play (singles/doubles): available = value × the game's ASSIGNED
+      // match count (game_matches rows with both sides paired) — an unfilled slot
+      // isn't a match, so it adds no points (round-3.1 "a match = assigned"). The
+      // live clinch goalpost moves as matches get paired / added / removed. Other
       // per_match formats (rack-n-stack) DON'T use game_matches; their count is
       // the team-size-derived head-to-head sizing (unchanged stable model) — so
       // counting rows there would zero them out.

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -169,6 +169,16 @@ export async function computeCompetitionLeaderboard(
 
   const roll = rollUp(liveGames, teamIds, { defendingTeamId: comp?.defending_team_id ?? null });
 
+  // Per-game points in play, keyed by id — the SAME authoritative value the
+  // roll-up uses (owner-set total for placement; value × match count for
+  // per_match). The board row's outer column (§A5 `N PTS`) reads this so a
+  // match-play game — whose `distribution` is null until decided — still shows
+  // its potential. Built from the computed liveGames so the row can't diverge
+  // from the standings.
+  const ptsInPlayByGame = new Map<string, number | null>(
+    liveGames.map((g) => [g.id, g.pointsTotal ?? null])
+  );
+
   // Per-game grid cells (place + points per team) — same averaging as the totals,
   // so the grid and the totals can't disagree. Only live games carry cells.
   const cells: { gameId: string; teamId: string; place: number; points: number }[] = [];
@@ -196,6 +206,10 @@ export async function computeCompetitionLeaderboard(
         // owner-set total). Drives the state-aware leaderboard rows: an unready
         // game reads "not scoring yet" instead of an empty/0–0 line (§7).
         ready: !!rawDist || g.points_total != null,
+        // Points in play (§A5 outer column). Match-play games carry it here even
+        // though `distribution` is null pre-decision; dropped games (not in the
+        // roll-up) get null and the row never renders them anyway.
+        pointsTotal: ptsInPlayByGame.get(g.id as string) ?? null,
       };
     }),
     cells,

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -4,6 +4,30 @@ import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDi
 import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
 
 const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
+// Roster-gated golf formats: a stroke field / rack auto-grouping is "configured"
+// once it has participants (match play instead needs pairing rows — see below).
+const ROSTER_TYPES = new Set(["gtt_stroke_play", "gtt_rack_n_stack"]);
+
+/**
+ * Is the game configured enough to be Ready (vs still Setting up)? "Ready must
+ * be earned, not assumed" — exists-and-not-live ≠ Ready. The format's REQUIRED
+ * roster is the gate; course + handicaps are optional and NEVER gate readiness:
+ *  - match play → pairings assigned (game_matches rows)
+ *  - stroke / rack → participants assigned (game_participants rows)
+ *  - manual / side events → points configured (no roster to assign)
+ * One signal: lifecycle AND the row's `N PTS`/`—` both read it, so they can't
+ * disagree (the Ready-but-`—` divergence class).
+ */
+function isConfigured(
+  typeId: string | null,
+  matchCount: number,
+  participantCount: number,
+  hasPoints: boolean
+): boolean {
+  if (typeId && MATCH_PLAY_TYPES.has(typeId)) return matchCount > 0;
+  if (typeId && ROSTER_TYPES.has(typeId)) return participantCount > 0;
+  return hasPoints;
+}
 
 /** Singles vs doubles head-to-head sizing for the team-size-derived formats
  *  (rack-n-stack). Match play itself counts its configured rows instead. */
@@ -50,7 +74,7 @@ export async function computeCompetitionLeaderboard(
     // show an "Abandoned" column, but only LIVE ones feed the roll-up.
     supabase
       .from("games")
-      .select("id, name, points_distribution, points_total, status, game_type_id")
+      .select("id, name, points_distribution, points_total, status, game_type_id, course_id")
       .eq("competition_id", competitionId)
       .order("created_at", { ascending: true }),
     // Team sizes drive the team-size-derived per_match formats (rack-n-stack):
@@ -73,9 +97,10 @@ export async function computeCompetitionLeaderboard(
   const teamSizes = teamIds.map((id) => sizeByTeam.get(id) ?? 0);
 
   const gameIds = live.map((g) => g.id as string);
-  // game_results (awarded) + the per-game match COUNT (available). Both depend on
-  // the live game ids; run them together.
-  const [resultsRes, matchRowsRes] = await Promise.all([
+  // game_results (awarded) + the per-game match COUNT (available) + the per-game
+  // participant COUNT (the stroke/rack readiness gate). All depend on the live
+  // game ids; run them together.
+  const [resultsRes, matchRowsRes, participantRowsRes] = await Promise.all([
     gameIds.length
       ? supabase
           .from("game_results")
@@ -86,8 +111,16 @@ export async function computeCompetitionLeaderboard(
     gameIds.length
       ? supabase.from("game_matches").select("game_id").in("game_id", gameIds)
       : Promise.resolve({ data: [] as { game_id: string }[] }),
+    gameIds.length
+      ? supabase.from("game_participants").select("game_id").in("game_id", gameIds)
+      : Promise.resolve({ data: [] as { game_id: string }[] }),
   ]);
   const results = resultsRes.data;
+  // Participant rows per game — "field picked" (stroke) / "auto-grouped" (rack).
+  const participantCountByGame = new Map<string, number>();
+  for (const r of (participantRowsRes.data ?? []) as { game_id: string }[]) {
+    participantCountByGame.set(r.game_id, (participantCountByGame.get(r.game_id) ?? 0) + 1);
+  }
   // A match game's available points = value × the number of matches it is
   // CONFIGURED to have (its game_matches rows), counted regardless of whether
   // they're paired yet — the configured count, ≥1 from creation. Adding/removing
@@ -196,21 +229,36 @@ export async function computeCompetitionLeaderboard(
     defendingTeamId: (comp?.defending_team_id as string | null) ?? null,
     games: allGames.map((g) => {
       const rawDist = g.points_distribution as PointsDistribution | null;
+      const typeId = (g.game_type_id as string | null) ?? null;
+      const hasPoints = !!rawDist || g.points_total != null;
+      const gid = g.id as string;
       return {
-        id: g.id as string,
+        id: gid,
         name: (g.name as string | null) ?? "Game",
         distribution: isPlacement(rawDist) ? rawDist.values : null,
         status: g.status as string,
         dropped: g.status === "dropped",
-        gameTypeId: (g.game_type_id as string | null) ?? null,
+        gameTypeId: typeId,
         // "ready to score" = points are configured (a distribution shape or an
-        // owner-set total). Drives the state-aware leaderboard rows: an unready
-        // game reads "not scoring yet" instead of an empty/0–0 line (§7).
-        ready: !!rawDist || g.points_total != null,
+        // owner-set total). Kept for the games-panel/test consumers.
+        ready: hasPoints,
+        // The §A readiness gate: is the format's REQUIRED roster assigned? Drives
+        // the Setting-up↔Ready transition AND the `N PTS`/`—` outer column from
+        // ONE signal so they can't disagree (course/handicaps never gate this).
+        configured: isConfigured(
+          typeId,
+          matchCountByGame.get(gid) ?? 0,
+          participantCountByGame.get(gid) ?? 0,
+          hasPoints
+        ),
+        // Course presence (§ scorecard three-way) — surfaced so the row's
+        // scorecard chip can be a real button (course set) vs a muted status
+        // icon (no course). Course is optional and never an error.
+        hasCourse: g.course_id != null,
         // Points in play (§A5 outer column). Match-play games carry it here even
         // though `distribution` is null pre-decision; dropped games (not in the
         // roll-up) get null and the row never renders them anyway.
-        pointsTotal: ptsInPlayByGame.get(g.id as string) ?? null,
+        pointsTotal: ptsInPlayByGame.get(gid) ?? null,
       };
     }),
     cells,

--- a/src/server/routers/competitions.d1followon.test.ts
+++ b/src/server/routers/competitions.d1followon.test.ts
@@ -124,11 +124,11 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     })) as { id: string };
     gameIds.push(g.id);
 
-    // Configured to have 2 matches (rows) → available = value × 2. (Dynamic
-    // match count derives available from the match rows, not team sizes.)
+    // 2 ASSIGNED matches (both sides paired) → available = value × 2. Empty
+    // slots wouldn't count (a match = assigned), so the fixture pairs them.
     await ctx.admin.from("game_matches").insert([
-      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: null, side_b: null, status: "active" },
-      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: null, side_b: null, status: "active" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: { type: "user", id: ctx.getUser("owner").id }, side_b: { type: "user", id: ctx.getUser("member").id }, status: "active" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: { type: "user", id: ctx.getUser("planner").id }, side_b: { type: "user", id: ctx.getUser("outsider").id }, status: "active" },
     ]);
 
     // Realized awarded points (adapter output): Blue won both of the 2 matches.
@@ -169,11 +169,10 @@ describe("§5 — roll-up parity: per_match game_results feed through competitio
     })) as { id: string };
     gameIds.push(g.id);
 
-    // Configured to have 2 matches (rows) → available = value × 2 = 2. (Dynamic
-    // match count: available derives from the match ROWS, not team sizes.)
+    // 2 ASSIGNED matches → available = value × 2 = 2 (a match = assigned).
     await ctx.admin.from("game_matches").insert([
-      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: null, side_b: null, status: "active" },
-      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: null, side_b: null, status: "active" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: { type: "user", id: ctx.getUser("owner").id }, side_b: { type: "user", id: ctx.getUser("member").id }, status: "active" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: { type: "user", id: ctx.getUser("planner").id }, side_b: { type: "user", id: ctx.getUser("outsider").id }, status: "active" },
     ]);
 
     // 2 matches played: 1 halve (each gets 0.5) + A wins 1 (A gets 1).
@@ -285,7 +284,7 @@ describe("Stage 4 — available counts owner-set totals; configuring doesn't mov
     expect(after.pointsAvailable).toBe(8); // unchanged — only awarded points move
   });
 
-  it("per_match available = value × configured match count (the rows), before any scoring", async () => {
+  it("per_match available = value × ASSIGNED match count; unpaired rows contribute 0", async () => {
     const comp = await ctx.createCompetition(tripId, "Stable Match Comp");
     const ta = await ctx.createTeam(comp, "A");
     await ctx.createTeam(comp, "B");
@@ -295,17 +294,18 @@ describe("Stage 4 — available counts owner-set totals; configuring doesn't mov
     })) as { id: string };
     gameIds.push(g.id);
 
-    // Dynamic match count: available derives from the matches the game is
-    // CONFIGURED to have (its rows, ≥1 from creation), NOT a team-size estimate.
-    // 3 configured matches → available = value × 3 = 3, even unpaired/unscored.
+    // "A match = assigned, everywhere" (round-3.1): available derives from the
+    // matches that are actually PAIRED, not the configured slot count. 3 rows but
+    // only 2 paired → available = value × 2 = 2; the empty slot adds nothing
+    // (it's builder scaffolding the tee-off collapse discards).
     await ctx.admin.from("game_matches").insert([
-      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: null, side_b: null, status: "pending" },
-      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: null, side_b: null, status: "pending" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0, side_a: { type: "user", id: ctx.getUser("owner").id }, side_b: { type: "user", id: ctx.getUser("member").id }, status: "pending" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1, side_a: { type: "user", id: ctx.getUser("planner").id }, side_b: { type: "user", id: ctx.getUser("outsider").id }, status: "pending" },
       { id: crypto.randomUUID(), game_id: g.id, match_number: 3, display_order: 2, side_a: null, side_b: null, status: "pending" },
     ]);
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
-    expect(lb.pointsAvailable).toBe(3);
+    expect(lb.pointsAvailable).toBe(2); // 2 paired × value 1 — the empty slot is ignored
     expect(lb.teamTotals[ta]).toBe(0); // nothing awarded yet
   });
 });

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -319,8 +319,28 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     const g = await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "Unready", competitionId: comp }) as { id: string };
     gameIds.push(g.id);
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
-    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { ready: boolean };
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { ready: boolean; pointsTotal: number | null };
     expect(game!.ready).toBe(false);
+    // An unready game has no points in play → the row's outer column reads `—`.
+    expect(game!.pointsTotal ?? 0).toBe(0);
+  });
+
+  it("pointsTotal (§A5 outer column) reads the distribution sum when no owner total is set", async () => {
+    // The board row's `N PTS` must match what rollUp counts as available, even
+    // for a distribution-only placement game (no explicit points_total). 9+6=15.
+    const comp = await ctx.createCompetition(tripId, "D2 Pts Comp");
+    const t1 = await ctx.createTeam(comp, "A", { shortName: "A" });
+    const t2 = await ctx.createTeam(comp, "B", { shortName: "B" });
+    expect([t1, t2].length).toBe(2);
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Pts", competitionId: comp,
+      pointsDistribution: { type: "placement", values: [9, 6] },
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { pointsTotal: number };
+    expect(game!.pointsTotal).toBe(15);
   });
 
   it("reads competitionPlacement.ts — rollUp matches the endpoint's teamTotals", async () => {

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext } from "../../__tests__/helpers/test-setup";
-import { rollUp, placementPoints, winThreshold, type LiveGame } from "../../lib/competitionPlacement";
+import { rollUp, type LiveGame } from "../../lib/competitionPlacement";
 import type { PointsDistribution } from "../../lib/pointsDistribution";
 
 /**
@@ -348,15 +348,29 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     expect(game.configured).toBe(false);
     expect(game.pointsTotal ?? 0).toBe(0); // outer column agrees → `—`
 
-    // Assign a pairing → it EARNS Ready in place, and points in play appear.
+    // A HALF-paired slot (one side still empty) is NOT a match — "a match =
+    // assigned, everywhere." It must STILL read Setting up and add no points.
     await ctx.caller().matches.setPairings({
       tripId, gameId: g.id,
       matches: [{ sideA: { type: "user", id: ctx.user.id }, sideB: null, matchNumber: 1 }],
     });
     lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
     game = lb.games.find((x: { id: string }) => x.id === g.id) as { ready: boolean; configured: boolean; pointsTotal: number | null };
+    expect(game.configured).toBe(false);
+    expect(game.pointsTotal ?? 0).toBe(0);
+
+    // Fully pair it → it EARNS Ready in place, and points in play appear.
+    await ctx.admin.from("game_matches").delete().eq("game_id", g.id);
+    await ctx.admin.from("game_matches").insert({
+      id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0,
+      side_a: { type: "user", id: ctx.getUser("owner").id },
+      side_b: { type: "user", id: ctx.getUser("member").id },
+      status: "pending",
+    });
+    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    game = lb.games.find((x: { id: string }) => x.id === g.id) as { ready: boolean; configured: boolean; pointsTotal: number | null };
     expect(game.configured).toBe(true);
-    expect(game.pointsTotal).toBe(2); // value 2 × 1 match
+    expect(game.pointsTotal).toBe(2); // value 2 × 1 assigned match
   });
 
   it("pointsTotal (§A5 outer column) reads the distribution sum when no owner total is set", async () => {

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -303,13 +303,17 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
 
     const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
 
-    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { gameTypeId: string; ready: boolean };
+    const game = lb.games.find((g2: { id: string }) => g2.id === g.id) as { gameTypeId: string; ready: boolean; configured: boolean; hasCourse: boolean };
     expect(game).toBeDefined();
     expect("gameTypeId" in game!).toBe(true);
     expect(game!.gameTypeId).toBe(MANUAL);
     expect("defendingTeamId" in lb).toBe(true);
     // State-aware rows (§7): a configured game is scoring-ready.
     expect(game!.ready).toBe(true);
+    // §A fields present: a manual game has no roster gate, so points = configured.
+    expect(game!.configured).toBe(true);
+    expect("hasCourse" in game!).toBe(true);
+    expect(game!.hasCourse).toBe(false);
   });
 
   it("a game with no points configured is NOT ready (drives the 'needs setup' row)", async () => {
@@ -323,6 +327,36 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     expect(game!.ready).toBe(false);
     // An unready game has no points in play → the row's outer column reads `—`.
     expect(game!.pointsTotal ?? 0).toBe(0);
+  });
+
+  it("a match-play game is Setting up until pairings are assigned, then earns Ready (§A readiness gate)", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 Roster Gate Comp");
+    await ctx.createTeam(comp, "A", { shortName: "A" });
+    await ctx.createTeam(comp, "B", { shortName: "B" });
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: "gtt_match_play_singles", name: "Roster Gate", competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 2 },
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    // Points ARE configured (per_match value) so the legacy `ready` is true — but
+    // with NO pairings the §A gate must still read NOT configured (→ Setting up).
+    // This is the exact divergence bug: Ready while the points column shows `—`.
+    let lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    let game = lb.games.find((x: { id: string }) => x.id === g.id) as { ready: boolean; configured: boolean; pointsTotal: number | null };
+    expect(game.ready).toBe(true);
+    expect(game.configured).toBe(false);
+    expect(game.pointsTotal ?? 0).toBe(0); // outer column agrees → `—`
+
+    // Assign a pairing → it EARNS Ready in place, and points in play appear.
+    await ctx.caller().matches.setPairings({
+      tripId, gameId: g.id,
+      matches: [{ sideA: { type: "user", id: ctx.user.id }, sideB: null, matchNumber: 1 }],
+    });
+    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    game = lb.games.find((x: { id: string }) => x.id === g.id) as { ready: boolean; configured: boolean; pointsTotal: number | null };
+    expect(game.configured).toBe(true);
+    expect(game.pointsTotal).toBe(2); // value 2 × 1 match
   });
 
   it("pointsTotal (§A5 outer column) reads the distribution sum when no owner total is set", async () => {


### PR DESCRIPTION
Layers the §A board-row state machine onto the unified `GameRow`, per the round-3 design docs (`CD_UPDATE_round3_rows_hub_roster.md` §A + `CD_UPDATE_round3_1_deltas_and_format_contract.md` §A). Scope is **§A only** — the board row; §B (the two-phase hub) and §C (roster provenance) are separate future work.

## What changed

**One column skeleton for every lifecycle state** (`setting-up | ready | live | final`):

```
[format icon] [ name + delegate / subtitle ] [scorecard btn] [ pts-or-result ]
```

- **`pts-or-result`** — outermost, pinned right, right-aligned (§A5): `—` / `N PTS` while unresolved → stacked team result (team-color dots) at Final.
- **`scorecard btn`** — golf-only, inboard of the outer column so the right edge never reflows; dropped at Final.
- **format icon** — color carries the arming tell (§A4); muted while setting-up, full accent while scoring-enabled, quieted at Final.
- **delegate chip** travels with the name, dropped at Final (round-3.1 §A2).
- **LIVE** is the one surviving word-badge (§A2); the old `RowBadge` zoo is removed.

**§A3 layer table** — each visual layer wired to the one derived lifecycle: dashed-left outline (setting-up only), name dim→full, the single reserved Live background, Final recessed + sheds the operational layer (scorecard, delegate, subtitle), leaving only the result.

**Data fix** — the leaderboard now surfaces per-game points in play (`pointsTotal ?? awardedForGame(distribution, numTeams)` — the same expression rollUp sums), so match-play games (null `distribution` pre-decision) and distribution-only placement games both render their `N PTS` instead of a bare `—`.

## Commits
- `14f66bcf` widen GameRow to the §A lifecycle enum
- `00a6f084` converge to the §A1 column skeleton + match-play `N PTS` data fix
- `aefc9039` layer the §A3 lifecycle table
- `f10b0db7` row `N PTS` falls back to the distribution sum (+2 d2 tests)
- `67be08a1` render the format icon via `createElement` (lint)

## Testing
- `npx tsc --noEmit` clean; `eslint` clean.
- `competitions.d2.test.ts` 11/11 (incl. 2 new `pointsTotal` assertions).
- Verified all four states by eye on the BBMI cup — ready + live from live data; setting-up + final (including the stacked team result) via a throwaway HMR override, no data touched.

## Notes / deferred
- No `scoring_enabled` field exists yet, so arming is approximated as `lifecycle !== "setting-up"` (ready treated as armed) — a one-line swap when Phase 2's Enable/Disable lands.
- Live subtitle stays `Underway · scoring`; the real running state (`Blue 2 up · thru 13`) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)