### PR TITLE
fix(games): stroke/rack go Live on the first score

### DIFF
--- a/src/server/routers/scores.test.ts
+++ b/src/server/routers/scores.test.ts
@@ -86,4 +86,25 @@ describe("scores router (Slice A — per-hole entry)", () => {
     const entries = await ctx.callerAs("member").scores.listByGame({ tripId, gameId });
     expect(entries.some((e) => e.participant_id === memberId && e.unit_label === "3" && e.value === 5)).toBe(true);
   });
+
+  it("entering a score flips a pending game to active (Live) — stroke/rack have no explicit activate step", async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Goes Live" });
+    await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
+    const before = await ctx.admin.from("games").select("status").eq("id", g.id).single();
+    expect(before.data?.status).toBe("pending"); // a configured-but-unscored round is Ready, not Live
+
+    await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 });
+    const after = await ctx.admin.from("games").select("status").eq("id", g.id).single();
+    expect(after.data?.status).toBe("active"); // first score → Live
+  });
+
+  it("a posted game opened for correction is NOT reverted to active when a score is edited", async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Corrected" });
+    await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
+    // A posted round re-opened for correction (complete + corrections_open).
+    await ctx.admin.from("games").update({ status: "complete", corrections_open: true }).eq("id", g.id);
+    await ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 5 });
+    const after = await ctx.admin.from("games").select("status").eq("id", g.id).single();
+    expect(after.data?.status).toBe("complete"); // the flip only touches pending — a correction stays Final/correcting
+  });
 });

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember } from "../middleware";
+import { createAdminClient } from "@/lib/supabase-admin";
 
 /**
  * scores — per-unit score entry for a game (Slice A: per-hole strokes).
@@ -71,6 +72,27 @@ export const scoresRouter = router({
           code: "INTERNAL_SERVER_ERROR",
           message: `Failed to save score: ${error.message}`,
         });
+      }
+
+      // Scoring has begun → the game is Live (§A2: "scores are being entered
+      // right now"). Stroke and rack have no explicit activate step — only
+      // match play publishes pairings → active — so they would otherwise sit at
+      // `pending` (rendered "Ready") through the whole round and jump straight to
+      // Final on finish, never showing Live. This is the SINGLE score-write path
+      // for every golf format, so flipping `pending` → `active` here lights up
+      // all of them on the first score; an already-active (match-play) or
+      // complete/correcting game is left untouched.
+      //
+      // ANY member may score (requireTripMember), but the games UPDATE RLS only
+      // admits owner/organizer — so a member's own client can't flip the status.
+      // Use the service-role client (same pattern as server-authored system
+      // messages) for this automatic, non-privileged side effect.
+      if (game.status === "pending") {
+        await createAdminClient()
+          .from("games")
+          .update({ status: "active" })
+          .eq("id", input.gameId)
+          .eq("status", "pending");
       }
 
       const { data } = await ctx.supabase


### PR DESCRIPTION
## The bug
A rack-n-stack game with all groups teed off and scores submitted still showed **Ready**, never **Live**.

## Why
The board's Live state comes from `lifecycleOf` → `live` only when `game.status === "active"`. That status is set in exactly one place — **`matches.activate`** (the match-play "publish pairings" step). **Stroke and rack have no equivalent transition**; their pages only call `games.finish` (pending → complete). So a stroke/rack game sits at `pending` (rendered "Ready") through the entire round and jumps straight to **Final** on finish — never Live. `scores.upsertEntry` wrote the score but never touched status.

Systemic, not specific to one game: every `gtt_rack_n_stack` / `gtt_stroke_play` game with scores was stuck `pending`; zero properly-activated match games were.

## The fix
Flip `pending` → `active` in **`scores.upsertEntry`** — the single score-write path for every golf format (`useScoreSaver` for stroke/match + the rack page all route through it). This matches the §A2 lifecycle spec: *"Live = scores are being entered right now."* An already-active (match-play) or complete/correcting game is left untouched (guarded on `status='pending'`).

Any member may score (`requireTripMember`), but the `games` UPDATE RLS admits only owner/organizer — so the flip uses the **service-role client** (the same pattern as server-authored system messages); a member's own client can't update `games`.

## Tests
- A fresh stroke game flips `pending → active` on the first score.
- A posted game re-opened for correction is **not** reverted to active when a score is edited.
- `scores.test.ts` 7/7; `tsc` + `eslint` clean.

## Note
Existing stuck games in the live BBMI cup (rns course + the two other rack workflows) were backfilled to `active` out-of-band so they read Live immediately — verified on the board (all three now show **Live · Underway · scoring**). This is a one-time data correction, not part of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)