### PR TITLE
feat(games): Phase 2B.1 — scoring-enabled state + Enable/Disable (decoupled from Live)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -155,6 +155,8 @@ export default function NewMatchGamePage() {
   const setDoublesPairings = trpc.matches.setDoublesPairings.useMutation();
   const setDoublesHandicap = trpc.matches.setDoublesHandicap.useMutation();
   const activate = trpc.matches.activate.useMutation();
+  // Phase 2B.1: Disable scoring — close to the crew, back to setup, scores kept.
+  const disableScoring = trpc.games.disableScoring.useMutation();
   // Dynamic match count (+1 / −1). Each changes the game's configured match
   // count → the clinch goalpost (value × count) on the competition board, so
   // both refresh the board after (see refreshAfterMatchCountChange).
@@ -218,6 +220,10 @@ export default function NewMatchGamePage() {
   }, [assignQ.data, playersPerSide]);
 
   const status = gameQ.data?.status as string | undefined;
+  // Phase 2B.1: scoring enabled is the real "open for scoring" flag (publish no
+  // longer goes Live — first score does, #396). The owner lands on the overview
+  // once enabled (or active/complete); members see it once enabled (= published).
+  const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
   // Lifecycle #7: Final = locked. `locked` (posted, no correction) → read-only;
   // `correcting` (owner re-opened) → editable again until re-locked.
   const correctionsOpen = !!(gameQ.data as { corrections_open?: boolean } | undefined)?.corrections_open;
@@ -369,7 +375,7 @@ export default function NewMatchGamePage() {
   // Active/complete → the flat overview; pending → setup (owner) or wait (member).
   const derived: Screen = !gameId
     ? "new"
-    : status === "complete" || status === "active"
+    : status === "complete" || status === "active" || scoringEnabled
       ? "overview"
       : !canEdit
         ? "member-wait"
@@ -578,6 +584,25 @@ export default function NewMatchGamePage() {
     }
   }
 
+  // Phase 2B.1: Disable scoring — close to the crew, revert to setup (scores
+  // kept). Invalidate the board (incl. faceBootstrap, CLAUDE.md #10) so the row
+  // drops back to muted-icon Ready, then continue configuring on setup.
+  async function handleDisable() {
+    if (!tripId || !gameId) return;
+    try {
+      await disableScoring.mutateAsync({ tripId, gameId });
+      await Promise.all([gameQ.refetch(), matchesQ.refetch()]);
+      if (competitionId) {
+        utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+        utils.games.listByTrip.invalidate({ tripId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+      }
+      go("setup");
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+
   // #7: reopen a posted game for correction, then land on the overview so the
   // editor can tap the match to fix (entry is editable again while correcting).
   async function handleCorrect() {
@@ -708,9 +733,16 @@ export default function NewMatchGamePage() {
         onBack={goBack}
         right={
           screen === "overview" && canEdit && status !== "complete" ? (
-            <button onClick={startSetup} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>
-              Edit
-            </button>
+            <div className="flex items-center gap-3">
+              {scoringEnabled && (
+                <button onClick={handleDisable} disabled={disableScoring.isPending} style={{ color: "var(--color-bt-text-dim)", fontSize: 13, fontWeight: 600 }}>
+                  {disableScoring.isPending ? "Disabling…" : "Disable"}
+                </button>
+              )}
+              <button onClick={startSetup} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>
+                Edit
+              </button>
+            </div>
           ) : null
         }
       />
@@ -882,7 +914,7 @@ function CollapseConfirm({
           {unfilled} {unfilled === 1 ? "match isn’t" : "matches aren’t"} set
         </div>
         <p style={{ fontSize: 14, lineHeight: 1.5, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
-          Tee off now and this game collapses to{" "}
+          Enable scoring now and this game collapses to{" "}
           <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
             {filled} {filled === 1 ? "match" : "matches"}
             {pts != null ? ` · ${pts} pts` : ""}
@@ -897,7 +929,7 @@ function CollapseConfirm({
             className="w-full disabled:opacity-40"
             style={{ height: 48, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 15, fontWeight: 600 }}
           >
-            {pending ? "Setting up…" : `Tee off with ${filled}`}
+            {pending ? "Enabling…" : `Enable with ${filled}`}
           </button>
           <button
             onClick={onCancel}
@@ -1321,7 +1353,7 @@ function MatchSetup({
           while slots are unfilled, outlined until every slot is assigned, filled
           once complete. Disabled only with nothing to tee off (no full match). */}
       <PrimaryButton
-        label={saving ? "Setting up…" : "Ready to tee off"}
+        label={saving ? "Enabling…" : "Enable scoring"}
         onClick={onReady}
         disabled={saving || filledCount === 0}
         outlined={!allFilled}

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -7,6 +7,7 @@ import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { FinalStandings } from "@/components/games/FinalStandings";
+import { EnableScoringGate } from "@/components/games/EnableScoringGate";
 import type { StrokeStanding } from "@/lib/strokePlay";
 import { STROKE_PLAY_UNITS, PLAYER_COLORS, initialsOf } from "@/lib/strokePlayConfig";
 import type { Participant, ScoreValues } from "@/components/games/types";
@@ -60,6 +61,8 @@ export default function NewGamePage() {
 
   const createGame = trpc.games.create.useMutation();
   const addParticipants = trpc.games.addParticipants.useMutation();
+  // Phase 2B.1: scoring must be enabled before entries land (universal gate).
+  const enableScoring = trpc.games.enableScoring.useMutation();
 
   const memberById = useMemo(() => {
     const m = new Map<string, { id: string; name: string }>();
@@ -95,6 +98,23 @@ export default function NewGamePage() {
 
   // The id the saver writes to: the resumed game, else the one created here.
   const activeGameId = urlGameId ?? createdGame?.id;
+  // Phase 2B.1: a configured game must be Enabled before its score screen opens.
+  const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+  const gameCompetitionId = (gameQ.data as { competition_id?: string | null } | undefined)?.competition_id ?? null;
+  async function handleEnable() {
+    if (!tripId || !activeGameId) return;
+    try {
+      await enableScoring.mutateAsync({ tripId, gameId: activeGameId });
+      await gameQ.refetch();
+      if (gameCompetitionId) {
+        utils.competitions.leaderboard.invalidate({ tripId, competitionId: gameCompetitionId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+        utils.games.listByTrip.invalidate({ tripId });
+      }
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
   // Score writes go through the connectivity-resilient saver: optimistic value,
   // retry-with-backoff, per-cell save status, kept-and-flagged (never rolled
   // back) on failure. Owns `values` + `saveStatus` for this game.
@@ -189,6 +209,20 @@ export default function NewGamePage() {
     seededRef.current = false;
     // Drop ?game so "Play again" starts a fresh game instead of resuming this one.
     if (urlGameId) router.replace(`/trips/${param}/games/new`);
+  }
+
+  // ── Enable gate (Phase 2B.1) — a configured game must be enabled before its
+  // score screen opens. The score saver server-rejects entries until then. ──
+  if (game && !scoringEnabled) {
+    return (
+      <EnableScoringGate
+        title="Stroke Play"
+        subtitle={`${game.participants.length} player${game.participants.length === 1 ? "" : "s"}`}
+        onEnable={handleEnable}
+        onBack={() => router.back()}
+        pending={enableScoring.isPending}
+      />
+    );
   }
 
   // ── Play ──

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -12,6 +12,7 @@ import { parseTime, toTime24 } from "@/lib/time";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
+import { EnableScoringGate } from "@/components/games/EnableScoringGate";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
 import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
@@ -102,6 +103,8 @@ export default function RackNStackPage() {
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
   const setFoursomes = trpc.playGroups.setFoursomes.useMutation();
+  // Phase 2B.1: scoring must be enabled before entries land (universal gate).
+  const enableScoring = trpc.games.enableScoring.useMutation();
   const setStrokes = trpc.playGroups.setParticipantStrokes.useMutation();
   const upsertEntry = trpc.scores.upsertEntry.useMutation();
   const deleteEntry = trpc.scores.deleteEntry.useMutation();
@@ -320,6 +323,23 @@ export default function RackNStackPage() {
   // (created as a bare games row by add-game). Route it to the setup step instead
   // of the empty play screen — startRack seeds onto the existing game.
   const needsSetup = !!gid && groupsQ.isSuccess && (groupsQ.data?.groups?.length ?? 0) === 0;
+  // Phase 2B.1: a rack with its groups set must be Enabled before the play screen
+  // opens (the score saver server-rejects entries until then).
+  const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+  async function handleEnable() {
+    if (!tripId || !gid) return;
+    try {
+      await enableScoring.mutateAsync({ tripId, gameId: gid });
+      await utils.games.getById.invalidate({ tripId, gameId: gid });
+      if (competitionId) {
+        utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+        utils.games.listByTrip.invalidate({ tripId });
+      }
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
 
   // ── Render ───────────────────────────────────────────────────────────
   if (!tripId || roleLoading || crew.isLoading || competition.isLoading) {
@@ -455,6 +475,29 @@ export default function RackNStackPage() {
           <CoursePicker onClose={() => setCoursePickerOpen(false)} onApply={(c) => { setPendingCourse(c); setCoursePickerOpen(false); }} />
         )}
       </Shell>
+    );
+  }
+
+  // Phase 2B.1 Enable gate: the groups are set but scoring isn't enabled yet.
+  // The owner enables here (the score saver server-rejects entries until then);
+  // a member sees the warm not-ready message. Complete/correcting games are
+  // already enabled (backfill), so they fall through to the play screen.
+  if (!scoringEnabled) {
+    if (!canEdit) {
+      return (
+        <Shell onBack={() => router.back()} title="Rack-n-Stack">
+          <MemberNotReady gameName={gameQ.data?.name as string | undefined} />
+        </Shell>
+      );
+    }
+    return (
+      <EnableScoringGate
+        title="Rack-n-Stack"
+        subtitle={`${groupsQ.data?.groups?.length ?? 0} group${(groupsQ.data?.groups?.length ?? 0) === 1 ? "" : "s"} · net stroke play`}
+        onEnable={handleEnable}
+        onBack={() => router.back()}
+        pending={enableScoring.isPending}
+      />
     );
   }
 

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -30,6 +30,9 @@ export interface LBGame {
   /** A course is applied to this game — drives the scorecard chip's button vs
    *  muted-status three-way (course is optional, never an error). */
   hasCourse?: boolean;
+  /** Scoring is enabled (Phase 2B.1) — the real arming signal the format-icon
+   *  color reads (§A4). False until the owner enables; first score → Live. */
+  scoringEnabled?: boolean;
   /** Points in play for this game — the §A5 outer-column `N PTS` value. Carries
    *  the match-play total too (whose `distribution` is null pre-decision). */
   pointsTotal?: number | null;

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -79,14 +79,14 @@ export function lifecycleOf(game: LBGame): LifecycleState {
 }
 
 /**
- * §A4 arm signal: the format-icon shows full color when scoring is enabled,
- * muted while the game is still being set up. There is no `scoring_enabled`
- * field yet (Phase 2's Enable/Disable adds it), so for now arm == "structure is
- * done": muted iff setting-up/configuring, full-color otherwise. Wired to the
- * DERIVED lifecycle, so swapping in the real field later is a one-line change.
+ * §A4 arm signal: the format-icon shows full color once scoring is ENABLED,
+ * muted before. Phase 2B.1 wired this to the real `scoring_enabled` field
+ * (replacing the Phase-3 derived stub `lifecycle !== "setting-up"`), so the two
+ * §A signals finally diverge on a real state: a Ready-but-not-enabled game reads
+ * full name (structure done) + muted icon (not enabled) until the owner enables.
  */
-export function iconArmed(lifecycle: LifecycleState): boolean {
-  return lifecycle !== "setting-up";
+export function iconArmed(game: LBGame): boolean {
+  return game.scoringEnabled === true;
 }
 
 // ── GameRow ────────────────────────────────────────────────────────────────────
@@ -153,7 +153,7 @@ export function GameRow({
   // §A3 layer table — each visual layer wired to the one derived lifecycle.
   // The format icon shows FULL color only while scoring is enabled AND the game
   // isn't yet a finished record; Final quiets it back down (sheds the arm tell).
-  const armedIcon = iconArmed(lifecycle) && !isFinal;
+  const armedIcon = iconArmed(game) && !isFinal;
   const rowStyle: React.CSSProperties = {
     // The one reserved background is Live (§A2) — the only "act now" fill.
     background: lifecycle === "live" ? "var(--color-bt-accent-faint)" : undefined,

--- a/src/components/games/EnableScoringGate.tsx
+++ b/src/components/games/EnableScoringGate.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ChevronLeft, PlayCircle } from "lucide-react";
+
+/**
+ * Minimal "Enable scoring" gate (Phase 2B.1). Stroke and rack have no explicit
+ * enable step today — they score immediately — but §B makes scoring-enabled a
+ * universal precondition for score entry (the server gate rejects entries until
+ * enabled). This is the stop-gap control that drives `games.enableScoring`; the
+ * full setup-shell phase (drill-down rows + this CTA at the bottom) is 2B.2.
+ *
+ * Vocabulary is locked: "Enable scoring" — never arm/open. Enabling opens the
+ * game to the crew; the first score flips it Live (#396). It does not gate on a
+ * course (course is optional, never an error).
+ */
+export function EnableScoringGate({
+  title,
+  subtitle,
+  onEnable,
+  onBack,
+  pending,
+}: {
+  title: string;
+  subtitle: string;
+  onEnable: () => void;
+  onBack: () => void;
+  pending: boolean;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <header
+        className="flex shrink-0 items-center"
+        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
+          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
+          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
+        </div>
+      </header>
+
+      <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
+        <PlayCircle size={44} style={{ color: "var(--color-bt-accent)" }} />
+        <p className="mt-4" style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>
+          Ready to score
+        </p>
+        <p className="mt-2 max-w-xs" style={{ fontSize: 13, lineHeight: 1.5, color: "var(--color-bt-text-dim)" }}>
+          Enable scoring to open this game to the crew. Scores can be entered once
+          it&rsquo;s enabled; the round goes live on the first score.
+        </p>
+        <button
+          onClick={onEnable}
+          disabled={pending}
+          className="mt-6 w-full max-w-xs disabled:opacity-40"
+          style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
+        >
+          {pending ? "Enabling…" : "Enable scoring"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -74,7 +74,7 @@ export async function computeCompetitionLeaderboard(
     // show an "Abandoned" column, but only LIVE ones feed the roll-up.
     supabase
       .from("games")
-      .select("id, name, points_distribution, points_total, status, game_type_id, course_id")
+      .select("id, name, points_distribution, points_total, status, game_type_id, course_id, scoring_enabled")
       .eq("competition_id", competitionId)
       .order("created_at", { ascending: true }),
     // Team sizes drive the team-size-derived per_match formats (rack-n-stack):
@@ -259,6 +259,9 @@ export async function computeCompetitionLeaderboard(
         // scorecard chip can be a real button (course set) vs a muted status
         // icon (no course). Course is optional and never an error.
         hasCourse: g.course_id != null,
+        // Scoring enabled (Phase 2B.1) — the real arming signal the format-icon
+        // color reads (§A4), replacing the Phase-3 derived stub.
+        scoringEnabled: g.scoring_enabled === true,
         // Points in play (§A5 outer column). Match-play games carry it here even
         // though `distribution` is null pre-decision; dropped games (not in the
         // roll-up) get null and the row never renders them anyway.

--- a/src/server/routers/games.test.ts
+++ b/src/server/routers/games.test.ts
@@ -83,6 +83,7 @@ describe("games router (Slice A — stroke play)", () => {
   it("finish — computes results, ranks by total, marks complete", async () => {
     const caller = ctx.caller();
     const memberId = ctx.getUser("member").id;
+    await caller.games.enableScoring({ tripId, gameId }); // Phase 2B.1 universal gate
     // owner 4+4 = 8, member 5+6 = 11
     await caller.scores.upsertEntry({ tripId, gameId, participantId: ctx.user.id, unitLabel: "1", value: 4 });
     await caller.scores.upsertEntry({ tripId, gameId, participantId: ctx.user.id, unitLabel: "2", value: 4 });

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -403,9 +403,11 @@ export const gamesRouter = router({
       // status='complete' + corrections_open=false IS the locked state. Clearing
       // corrections_open here is what makes finalize the proper LOCK and lets a
       // re-lock exit score-correction mode (openCorrection → edit → finish).
+      // scoring_enabled=true keeps the "a run/posted game is enabled" invariant
+      // (Phase 2B.1) so a correction edit passes the score-entry gate.
       const { error } = await ctx.supabase
         .from("games")
-        .update({ status: "complete", corrections_open: false })
+        .update({ status: "complete", corrections_open: false, scoring_enabled: true })
         .eq("id", input.gameId);
       if (error) {
         throw new TRPCError({
@@ -472,6 +474,47 @@ export const gamesRouter = router({
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set status: ${error.message}` });
+      return { success: true };
+    }),
+
+  // enableScoring — Phase 2B.1. Open this game for scoring (the single
+  // authoritative flag, every format) AND publish it to the crew. It does NOT
+  // set status='active' — the FIRST score owns the flip to Live (#396), so a
+  // game can sit "enabled but not yet Live" (the §A full-name + full-color-icon
+  // state). Distinct from competition reveal (competitions.status). Config-class
+  // → requireGameEdit (owner / organizer / that game's delegate), same as
+  // setStatus.
+  enableScoring: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ scoring_enabled: true, pairings_published_at: new Date().toISOString() })
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to enable scoring: ${error.message}` });
+      return { success: true };
+    }),
+
+  // disableScoring — Phase 2B.1. Close the game to the crew and return it to
+  // setup, KEEPING all scores (never deletes entries). If it was Live (active),
+  // revert to pending so it reads not-Live; you continue configuring from here.
+  // Re-enabling re-opens it; the next score flips it Live again.
+  disableScoring: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games").select("status").eq("id", input.gameId).eq("trip_id", ctx.tripId).maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      const next = game.status === "active" ? "pending" : (game.status as string);
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ scoring_enabled: false, pairings_published_at: null, status: next })
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to disable scoring: ${error.message}` });
       return { success: true };
     }),
 
@@ -645,7 +688,9 @@ export const gamesRouter = router({
 
       const { error } = await ctx.supabase
         .from("games")
-        .update({ status: "complete", corrections_open: false })
+        // scoring_enabled=true keeps the "a run/posted game is enabled" invariant
+        // (Phase 2B.1) so a correction edit passes the score-entry gate.
+        .update({ status: "complete", corrections_open: false, scoring_enabled: true })
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to post game: ${error.message}` });

--- a/src/server/routers/matches.doubles.test.ts
+++ b/src/server/routers/matches.doubles.test.ts
@@ -51,6 +51,7 @@ async function enterSides(
   scoreB: Record<number, number>
 ) {
   const caller = ctx.caller();
+  await caller.games.enableScoring({ tripId, gameId }); // Phase 2B.1 universal gate
   for (const [h, v] of Object.entries(scoreA)) {
     await caller.scores.upsertEntry({ tripId, gameId, participantId: pgA, unitLabel: h, value: v, participantType: "play_group" });
   }
@@ -252,6 +253,7 @@ describe("doubles team integrity — same-team pairs + correct attribution", () 
       bHalf[h] = 4;
     }
     const caller = ctx.caller();
+    await caller.games.enableScoring({ tripId, gameId }); // Phase 2B.1 universal gate
     for (const [h, v] of Object.entries({ 1: 4, 2: 4, 3: 4, ...aHalf })) {
       await caller.scores.upsertEntry({ tripId, gameId, participantId: pgA, unitLabel: h, value: v, participantType: "play_group" });
     }

--- a/src/server/routers/matches.test.ts
+++ b/src/server/routers/matches.test.ts
@@ -100,8 +100,11 @@ describe("matches router (Slice B — setup + visibility)", () => {
     const res = await ctx.callerAs("member").matches.listByGame({ tripId, gameId });
     expect(res.published).toBe(true);
     expect(res.matches).toHaveLength(2);
-    const { data: game } = await ctx.admin.from("games").select("status").eq("id", gameId).single();
-    expect((game as { status: string }).status).toBe("active");
+    // Phase 2B.1: activate is match play's Enable — it publishes + enables, but
+    // no longer goes Live (status stays pending until the first score, #396).
+    const { data: game } = await ctx.admin.from("games").select("status, scoring_enabled").eq("id", gameId).single();
+    expect((game as { status: string; scoring_enabled: boolean }).scoring_enabled).toBe(true);
+    expect((game as { status: string }).status).toBe("pending");
   });
 
   it("assignPlayer — moving a player clears the vacated match's handicap", async () => {
@@ -160,6 +163,8 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     scoreB: Record<number, number>
   ) {
     const caller = ctx.caller();
+    // Phase 2B.1 universal gate: scoring must be enabled before entries land.
+    await caller.games.enableScoring({ tripId, gameId });
     for (const [h, v] of Object.entries(scoreA)) {
       await caller.scores.upsertEntry({ tripId, gameId, participantId: a, unitLabel: h, value: v });
     }

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -599,8 +599,12 @@ export const matchesRouter = router({
       return { ok: true };
     }),
 
-  // activate — Owner/Organizer. Publish pairings to members; round goes active.
-  // Does NOT post to Notes (Slice F).
+  // activate — Owner/Organizer. This is match play's "Enable scoring": publish
+  // pairings to the crew + open the game for scoring (scoring_enabled). Phase
+  // 2B.1 SPLIT it from going Live — it no longer sets status='active'; the FIRST
+  // score owns the flip to Live (#396, uniform across formats). So enabled-ness
+  // lives in scoring_enabled for every format (not pairings_published_at for
+  // match while the boolean covers stroke/rack). Does NOT post to Notes (Slice F).
   activate: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
     .use(requireGameEdit())
@@ -608,12 +612,12 @@ export const matchesRouter = router({
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
       const { error } = await ctx.supabase
         .from("games")
-        .update({ pairings_published_at: new Date().toISOString(), status: "active" })
+        .update({ pairings_published_at: new Date().toISOString(), scoring_enabled: true })
         .eq("id", input.gameId);
       if (error) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
-          message: `Failed to activate: ${error.message}`,
+          message: `Failed to enable scoring: ${error.message}`,
         });
       }
       await ctx.supabase

--- a/src/server/routers/rackNStack.test.ts
+++ b/src/server/routers/rackNStack.test.ts
@@ -38,6 +38,7 @@ afterAll(async () => {
 });
 
 async function enter(gameId: string, userId: string, gross: number[]) {
+  await ctx.callerAs("planner").games.enableScoring({ tripId, gameId }); // Phase 2B.1 universal gate
   for (let i = 0; i < gross.length; i++) {
     await ctx.callerAs("planner").scores.upsertEntry({
       tripId,

--- a/src/server/routers/scores.test.ts
+++ b/src/server/routers/scores.test.ts
@@ -21,6 +21,8 @@ describe("scores router (Slice A — per-hole entry)", () => {
       .games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Round" });
     gameId = game.id;
     await ctx.caller().games.addParticipants({ tripId, gameId, userIds: [ownerId, memberId] });
+    // Phase 2B.1: scoring must be enabled before entries land (universal gate).
+    await ctx.caller().games.enableScoring({ tripId, gameId });
   });
 
   afterAll(async () => {
@@ -87,22 +89,61 @@ describe("scores router (Slice A — per-hole entry)", () => {
     expect(entries.some((e) => e.participant_id === memberId && e.unit_label === "3" && e.value === 5)).toBe(true);
   });
 
-  it("entering a score flips a pending game to active (Live) — stroke/rack have no explicit activate step", async () => {
+  it("scores are REJECTED until scoring is enabled (Phase 2B.1 universal gate)", async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Gated" });
+    await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
+    // Configured but not enabled → entries are refused, for every format.
+    await expect(
+      ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 })
+    ).rejects.toThrow(/enable scoring/i);
+    // Enable → entry is accepted.
+    await ctx.caller().games.enableScoring({ tripId, gameId: g.id });
+    const entry = await ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 });
+    expect(entry.value).toBe(4);
+  });
+
+  it("Enable keeps the game pre-Live; the first score flips it to active", async () => {
     const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Goes Live" });
     await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
-    const before = await ctx.admin.from("games").select("status").eq("id", g.id).single();
-    expect(before.data?.status).toBe("pending"); // a configured-but-unscored round is Ready, not Live
+    await ctx.caller().games.enableScoring({ tripId, gameId: g.id });
+    const before = await ctx.admin.from("games").select("status, scoring_enabled").eq("id", g.id).single();
+    expect(before.data?.scoring_enabled).toBe(true);
+    expect(before.data?.status).toBe("pending"); // enabled but NOT yet Live — the §A "enabled" state
 
     await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 });
     const after = await ctx.admin.from("games").select("status").eq("id", g.id).single();
-    expect(after.data?.status).toBe("active"); // first score → Live
+    expect(after.data?.status).toBe("active"); // first score → Live (#396)
+  });
+
+  it("Disable reverts active→pending and KEEPS scores; re-enable allows scoring again", async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Toggled" });
+    await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
+    await ctx.caller().games.enableScoring({ tripId, gameId: g.id });
+    await ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 });
+
+    await ctx.caller().games.disableScoring({ tripId, gameId: g.id });
+    const off = await ctx.admin.from("games").select("status, scoring_enabled, pairings_published_at").eq("id", g.id).single();
+    expect(off.data?.scoring_enabled).toBe(false);
+    expect(off.data?.status).toBe("pending"); // Live → back to setup, not Final
+    expect(off.data?.pairings_published_at).toBeNull(); // closed to the crew
+    const kept = await ctx.admin.from("score_entries").select("value").eq("game_id", g.id).eq("participant_id", ownerId).eq("unit_label", "1").single();
+    expect(kept.data?.value).toBe(4); // scores are NEVER deleted on Disable
+
+    // While disabled, entries are refused again; re-enabling re-opens it.
+    await expect(
+      ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "2", value: 5 })
+    ).rejects.toThrow(/enable scoring/i);
+    await ctx.caller().games.enableScoring({ tripId, gameId: g.id });
+    const re = await ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "2", value: 5 });
+    expect(re.value).toBe(5);
   });
 
   it("a posted game opened for correction is NOT reverted to active when a score is edited", async () => {
     const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Corrected" });
     await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
-    // A posted round re-opened for correction (complete + corrections_open).
-    await ctx.admin.from("games").update({ status: "complete", corrections_open: true }).eq("id", g.id);
+    // A posted round re-opened for correction (complete + corrections_open) is
+    // already enabled, so the gate lets the correction through.
+    await ctx.admin.from("games").update({ status: "complete", corrections_open: true, scoring_enabled: true }).eq("id", g.id);
     await ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 5 });
     const after = await ctx.admin.from("games").select("status").eq("id", g.id).single();
     expect(after.data?.status).toBe("complete"); // the flip only touches pending — a correction stays Final/correcting

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -37,7 +37,7 @@ export const scoresRouter = router({
       // visible; only entry is closed.
       const { data: game } = await ctx.supabase
         .from("games")
-        .select("id, status, corrections_open")
+        .select("id, status, corrections_open, scoring_enabled")
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId)
         .maybeSingle();
@@ -48,6 +48,16 @@ export const scoresRouter = router({
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "This round is posted — open score correction to edit it.",
+        });
+      }
+      // Phase 2B.1 universal gate: scoring must be ENABLED before entries land,
+      // for every format (match play already gated via publish; stroke/rack gain
+      // the gate they lacked). A posted game re-opened for correction is already
+      // enabled, so corrections still pass. Enable the game first to score it.
+      if (!game.scoring_enabled) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Enable scoring before entering scores.",
         });
       }
 

--- a/supabase/migrations/20260619210000_057_games_scoring_enabled.sql
+++ b/supabase/migrations/20260619210000_057_games_scoring_enabled.sql
@@ -1,0 +1,32 @@
+-- Phase 2B.1: per-game "scoring enabled" — the single authoritative flag for
+-- whether a game is open for scoring, for EVERY format. It replaces Phase 3's
+-- derived `iconArmed` stub (`lifecycle !== "setting-up"`) with a real state.
+--
+-- Distinct concepts (do NOT conflate):
+--   * competition reveal  = competitions.status (member visibility of the cup)
+--   * scoring enabled      = THIS flag (per-game, all formats)
+--   * Live                 = games.status='active', set on the FIRST score (#396)
+--
+-- Match play previously coupled "publish pairings" with status='active' in
+-- matches.activate, so "enabled but not yet Live" couldn't exist. 2B.1 splits
+-- that: Enable sets THIS flag (+ keeps publishing pairings) but NOT status; the
+-- first score still owns the flip to Live. So enabled-ness lives in this one
+-- boolean for every format — never in pairings_published_at for match while the
+-- boolean covers stroke/rack (the overloaded-field trap, cf. per_match).
+
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS scoring_enabled boolean NOT NULL DEFAULT false;
+
+-- Backfill so existing live games don't regress to Setting-up / `—`: a game that
+-- has been run (active or complete), has any score, or (match play) published its
+-- pairings is already enabled. Idempotent — only ever sets true, derived from
+-- immutable columns, guarded on the current value, so CI re-applying this file is
+-- a no-op.
+UPDATE public.games g
+SET scoring_enabled = true
+WHERE g.scoring_enabled = false
+  AND (
+    g.status IN ('active', 'complete')
+    OR g.pairings_published_at IS NOT NULL
+    OR EXISTS (SELECT 1 FROM public.score_entries s WHERE s.game_id = g.id)
+  );


### PR DESCRIPTION
The §B foundation, and the completion of Phase 3's stub. Introduces a real per-game **scoring-enabled** state; `iconArmed` reads it, so the two §A signals finally diverge on a real state.

## The marquee outcome
A **Ready-but-not-enabled** game now reads **full name + MUTED icon** until Enabled, then **full-color icon** on Enable — the two §A signals (name strength = structure done; icon color = scoring enabled) diverging for the first time. Unreachable under the Phase-3 stub (`lifecycle !== "setting-up"`).

## Schema — migration 057 (additive, idempotent backfill; backup taken)
`games.scoring_enabled boolean default false` — the **single authoritative flag** for every format. Backfill: `active`/`complete`/scored/published games → enabled, so no live game regresses to Setting-up/`—`. Idempotent (CI re-applies as a no-op).

## Server
- **`games.enableScoring` / `disableScoring`** (`requireGameEdit`). Enable opens scoring + publishes to the crew; Disable closes it, reverts `active→pending`, and **keeps all scores**.
- **Split `matches.activate`** — it now sets `scoring_enabled` (+ keeps publishing pairings) but **no longer `status='active'`**. The **first score owns the flip to Live** (#396, now uniform across formats). Enabled-ness lives in the one boolean — never `pairings_published_at` for match while the boolean covers stroke/rack (avoids the `per_match`-style overloaded-field trap).
- **Universal gate** — `scores.upsertEntry` rejects entries until the game is enabled (stroke/rack gain the gate match play already had via publish). `finish`/`post` set `scoring_enabled=true` (a run game is enabled) so corrections pass the gate.
- `iconArmed(game) = game.scoringEnabled`; surfaced additively on the leaderboard payload.

## UI (minimal — the full setup shell is 2B.2/2B.3)
- Vocabulary locked to **Enable/Disable scoring** (match's "Ready to tee off" → "Enable scoring"); match screen-derivation + a minimal Disable key off the flag.
- `EnableScoringGate` — stroke/rack must be enabled before their score screen opens (the behavior change for those two formats; flagged).

## Regression checks (the `activate` split changes the reference format)
1. **Match still goes Live on first score** — unit test (`Enable keeps pre-Live; first score → active`); the #396 path is unchanged.
2. **Pairings still publish at Enable** — verified (`published=true` after enable); `pairings_published_at` retained.
3. **Existing active games not stranded** — backfill enabled them; board shows them full-color/Live.

## Verified on live BBMI
Backfill: every active/complete/scored game reads enabled; `SP Course`/`test` read Ready + **muted** icon. Enabling `SP Course` flipped its icon to full color while it stayed `status=pending` (enabled, not yet Live), then reverted. No `—` regression.

## Tests
`scores.test.ts` rewritten for the gate (reject-until-enabled, Enable-keeps-pending, Disable-keeps-scores + re-enable, correction-not-reverted); `matches`/`matches.doubles`/`rackNStack`/`games`/`games.runpost` updated to enable before scoring; leaderboard suites confirm the additive payload. 103+ server tests green; `tsc` + `eslint` clean.

## Note
Migration applied to the remote DB out-of-band via SQL (no `supabase` CLI available); the committed migration file is idempotent so CI re-applies it cleanly. Next: 2B.2 (setup-phase shell) and 2B.3 (Configuration page + Disable-in-Configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)