### PR TITLE
feat(games): Phase 2B.2 — setup-phase shell (reference format: match play)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -15,6 +15,8 @@ import { RelHandicapControl } from "@/components/games/RelHandicapControl";
 import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { GameSetupRows } from "@/components/games/GameSetupRows";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf } from "@/lib/strokePlayConfig";
@@ -779,20 +781,44 @@ export default function NewMatchGamePage() {
       {screen === "member-wait" && <MemberNotReady gameName={gameQ.data?.name as string | undefined} />}
 
       {screen === "setup" && (
-        <MatchSetup
-          tripId={tripId}
-          draft={draft}
-          setDraft={setDraft}
-          playersPerSide={playersPerSide}
-          teamA={teamForSlot("a")}
-          teamB={teamForSlot("b")}
-          nameOf={nameOf}
-          colorOf={colorOf}
-          avatarIconOf={avatarIconOf}
-          openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
-          onReady={attemptReady}
-          saving={setPairings.isPending || setHandicap.isPending || setDoublesPairings.isPending || setDoublesHandicap.isPending || activate.isPending}
-        />
+        <>
+          {/* §B setup shell (Phase 2B.2): the standardized course + Name·Format·
+              Points drill-down rows above the format's own who's-playing body
+              (the pairing cards). Handicaps stay inline per pairing; "Enable
+              scoring" is MatchSetup's bottom CTA. */}
+          {gameQ.data && (
+            <div style={{ marginBottom: 14 }}>
+              <GameSetupRows
+                tripId={tripId}
+                competitionId={gameCompId}
+                game={gameQ.data as unknown as GameRow}
+                canEdit={canEdit}
+                onChanged={() => {
+                  void gameQ.refetch();
+                  if (competitionId) {
+                    utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+                    utils.competitions.faceBootstrap.invalidate({ tripId });
+                    utils.games.listByTrip.invalidate({ tripId });
+                  }
+                }}
+              />
+            </div>
+          )}
+          <MatchSetup
+            tripId={tripId}
+            draft={draft}
+            setDraft={setDraft}
+            playersPerSide={playersPerSide}
+            teamA={teamForSlot("a")}
+            teamB={teamForSlot("b")}
+            nameOf={nameOf}
+            colorOf={colorOf}
+            avatarIconOf={avatarIconOf}
+            openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
+            onReady={attemptReady}
+            saving={setPairings.isPending || setHandicap.isPending || setDoublesPairings.isPending || setDoublesHandicap.isPending || activate.isPending}
+          />
+        </>
       )}
 
       {screen === "overview" && (

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -73,7 +73,7 @@ export interface GameRow {
   corrections_open: boolean;
 }
 
-interface GameType {
+export interface GameType {
   id: string;
   key: string;
   name: string;
@@ -376,7 +376,7 @@ function RunButton({ state, onClick }: { state: RunState; onClick: () => void })
 
 type Tab = "game" | "config";
 
-function GameSheet({
+export function GameSheet({
   tripId, competitionId, game, types, canEdit, onClose,
 }: {
   tripId: string;

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { GameSheet, type GameType, type GameRow } from "@/components/competition/CompetitionGamesPanel";
+
+/**
+ * §B setup-shell drill-down rows (Phase 2B.2). The standardized top of every
+ * format's setup phase: the **course pre-step** then **Name · Format · Points**,
+ * each opening its ALREADY-BUILT editor (CoursePicker / the GameSheet add-edit
+ * modal — reuse, never rebuild). The format's own who's-playing + handicaps body
+ * renders BELOW this, and "Enable scoring" is the bottom CTA — this component is
+ * just the shared hull header. Course is optional and never gates readiness.
+ *
+ * No checklist, no top-level Save: edits are live (CoursePicker applies on pick;
+ * GameSheet persists on its own Save), and `onChanged` refetches the game so the
+ * row summaries and the body update in place.
+ */
+export function GameSetupRows({
+  tripId,
+  competitionId,
+  game,
+  canEdit,
+  onChanged,
+}: {
+  tripId: string;
+  /** Null for a standalone game — the Name·Format·Points editor is competition-
+   *  scoped, so that row is hidden there (name/format are fixed at creation). */
+  competitionId: string | null;
+  game: GameRow;
+  canEdit: boolean;
+  onChanged: () => void;
+}) {
+  const [coursePickerOpen, setCoursePickerOpen] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
+
+  // Types only needed once the config editor opens.
+  const { data: types = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: configOpen });
+  const applyCourse = trpc.games.applyCourse.useMutation();
+  const utils = trpc.useUtils();
+
+  const courseQ = trpc.courses.getById.useQuery(
+    { courseId: game.course_id ?? "" },
+    { enabled: !!game.course_id }
+  );
+  const courseName = (courseQ.data?.name as string | undefined) ?? null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <DrillRow
+        label="Course / tee"
+        optional
+        value={courseName ?? "Add a course"}
+        muted={!courseName}
+        disabled={!canEdit}
+        onClick={() => setCoursePickerOpen(true)}
+      />
+      {competitionId && (
+        <DrillRow
+          label="Name · Format · Points"
+          value={`${game.name ?? "Untitled"}${pointsSummary(game) ? ` · ${pointsSummary(game)}` : ""}`}
+          disabled={!canEdit}
+          onClick={() => setConfigOpen(true)}
+        />
+      )}
+
+      {coursePickerOpen && (
+        <CoursePicker
+          onClose={() => setCoursePickerOpen(false)}
+          onApply={({ id }) => {
+            applyCourse.mutate(
+              { tripId, gameId: game.id, courseId: id },
+              {
+                onSuccess: () => {
+                  utils.courses.getById.invalidate({ courseId: id });
+                  onChanged();
+                },
+              }
+            );
+            setCoursePickerOpen(false);
+          }}
+        />
+      )}
+
+      {configOpen && competitionId && (
+        <GameSheet
+          tripId={tripId}
+          competitionId={competitionId}
+          game={game}
+          types={types as GameType[]}
+          canEdit={canEdit}
+          onClose={() => {
+            setConfigOpen(false);
+            onChanged();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** A compact points summary for the config row: "2/match" · "8 pts". */
+function pointsSummary(game: GameRow): string | null {
+  const d = game.points_distribution;
+  if (d?.type === "per_match") return `${d.value}/match`;
+  if (d?.type === "placement") {
+    const total = game.points_total ?? d.values.reduce((a, b) => a + b, 0);
+    return `${total} pts`;
+  }
+  if (game.points_total != null) return `${game.points_total} pts`;
+  return null;
+}
+
+/** One drill-down setup row: label (+ optional tag), summary value, chevron. The
+ *  emptiness of an unfilled value is a neutral "more to add" cue, not an error. */
+function DrillRow({
+  label,
+  value,
+  optional,
+  muted,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  value: string;
+  optional?: boolean;
+  muted?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
+      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+    >
+      <div className="flex min-w-0 flex-col">
+        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          {label}
+          {optional && <span style={{ fontWeight: 500, textTransform: "none", letterSpacing: 0 }}>· optional</span>}
+        </span>
+        <span className="truncate text-sm" style={{ color: muted ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", marginTop: 2 }}>
+          {value}
+        </span>
+      </div>
+      <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+    </button>
+  );
+}


### PR DESCRIPTION
The §B shared setup-phase hull, wired into the **match** body first (round-3.1's reference body — the mock illustrates the wrapper with 2v2). Stroke + rack follow in a fast-follow PR (scoped this way to keep each format verified).

## What
The game-page setup now opens with the standardized **drill-down rows in order** — **course pre-step → Name·Format·Points → who's-playing → handicaps → "Enable scoring"** — each row opening its **already-built editor** (reuse, never rebuild).

- **`GameSetupRows`** (new shared shell header): the **course pre-step** (reuses `CoursePicker` → `applyCourse`) and the **Name·Format·Points** row (reuses the existing **`GameSheet`** add/edit modal — now exported). Edits are live; **no checklist, no top-level Save**. Course is optional and never gates readiness.
- **Match** setup renders the rows above its existing **pairing cards** (who's-playing + inline handicaps stay as the format body); **"Enable scoring"** remains the only bottom CTA. `onChanged` refetches the game + invalidates the board so the row summaries + leaderboard update in place.
- Exported `GameSheet` + `GameType` from `CompetitionGamesPanel` for the reuse.

This deliberately keeps the format *body* intact (shared shell, not a generic hub) — no flattening, no rebuilt editors, no §C eligible-set funnel.

## Verified on BBMI
Opened Singles on Sunday → Disable (→ setup) → the setup shows the ordered rows: **Course / tee · optional** → **Name · Format · Points — "Singles on Sunday · 2/match"** → the pairing cards (with inline "who gets strokes?") → **Enable scoring**. Tapping the Name·Format·Points row opens the reused **Edit Game** modal (Title/Course/Points/Matches/Configuration). Re-enabled to restore state. `tsc` + `eslint` clean; no console errors.

## Follow-up (next PR)
Wire the same shell into **stroke** (add its course + Name·Format·Points rows + a handicaps step) and **rack** (add the Name·Format·Points row; it already has course + groups + `HandicapRoster`). Then 2B.3 (scoring-enabled phase flip + Configuration page + Disable-in-Configuration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)