### PR TITLE
feat(games): Phase 2B.2 — setup-shell rows for stroke + rack

### DIFF
--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -8,6 +8,9 @@ import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { FinalStandings } from "@/components/games/FinalStandings";
 import { EnableScoringGate } from "@/components/games/EnableScoringGate";
+import { GameSetupRows } from "@/components/games/GameSetupRows";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { useTripRole } from "@/hooks/useTripRole";
 import type { StrokeStanding } from "@/lib/strokePlay";
 import { STROKE_PLAY_UNITS, PLAYER_COLORS, initialsOf } from "@/lib/strokePlayConfig";
 import type { Participant, ScoreValues } from "@/components/games/types";
@@ -37,6 +40,7 @@ export default function NewGamePage() {
   );
   const tripId = isId ? param : resolved.data?.id;
   const utils = trpc.useUtils();
+  const { canEdit } = useTripRole(tripId);
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { enabled: !!tripId });
 
@@ -211,8 +215,9 @@ export default function NewGamePage() {
     if (urlGameId) router.replace(`/trips/${param}/games/new`);
   }
 
-  // ── Enable gate (Phase 2B.1) — a configured game must be enabled before its
-  // score screen opens. The score saver server-rejects entries until then. ──
+  // ── Enable gate (Phase 2B.1) → §B setup hull (2B.2). A configured game must be
+  // enabled before its score screen opens; the gate also hosts the standardized
+  // course + Name·Format·Points drill-down rows. ──
   if (game && !scoringEnabled) {
     return (
       <EnableScoringGate
@@ -221,6 +226,24 @@ export default function NewGamePage() {
         onEnable={handleEnable}
         onBack={() => router.back()}
         pending={enableScoring.isPending}
+        setupRows={
+          gameQ.data ? (
+            <GameSetupRows
+              tripId={tripId}
+              competitionId={gameCompetitionId}
+              game={gameQ.data as unknown as GameRow}
+              canEdit={canEdit}
+              onChanged={() => {
+                void gameQ.refetch();
+                if (gameCompetitionId) {
+                  utils.competitions.leaderboard.invalidate({ tripId, competitionId: gameCompetitionId });
+                  utils.competitions.faceBootstrap.invalidate({ tripId });
+                  utils.games.listByTrip.invalidate({ tripId });
+                }
+              }}
+            />
+          ) : null
+        }
       />
     );
   }

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -13,6 +13,8 @@ import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
 import { EnableScoringGate } from "@/components/games/EnableScoringGate";
+import { GameSetupRows } from "@/components/games/GameSetupRows";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
 import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
@@ -497,6 +499,24 @@ export default function RackNStackPage() {
         onEnable={handleEnable}
         onBack={() => router.back()}
         pending={enableScoring.isPending}
+        setupRows={
+          gameQ.data ? (
+            <GameSetupRows
+              tripId={tripId!}
+              competitionId={competitionId ?? null}
+              game={gameQ.data as unknown as GameRow}
+              canEdit={canEdit}
+              onChanged={() => {
+                void utils.games.getById.invalidate({ tripId: tripId!, gameId: gid! });
+                if (competitionId) {
+                  utils.competitions.leaderboard.invalidate({ tripId: tripId!, competitionId });
+                  utils.competitions.faceBootstrap.invalidate({ tripId: tripId! });
+                  utils.games.listByTrip.invalidate({ tripId: tripId! });
+                }
+              }}
+            />
+          ) : null
+        }
       />
     );
   }

--- a/src/components/games/EnableScoringGate.tsx
+++ b/src/components/games/EnableScoringGate.tsx
@@ -3,14 +3,16 @@
 import { ChevronLeft, PlayCircle } from "lucide-react";
 
 /**
- * Minimal "Enable scoring" gate (Phase 2B.1). Stroke and rack have no explicit
- * enable step today — they score immediately — but §B makes scoring-enabled a
- * universal precondition for score entry (the server gate rejects entries until
- * enabled). This is the stop-gap control that drives `games.enableScoring`; the
- * full setup-shell phase (drill-down rows + this CTA at the bottom) is 2B.2.
+ * The §B pre-Enable setup surface (Phase 2B.1 → 2B.2). Stroke and rack have no
+ * explicit enable step natively — they score immediately — but §B makes
+ * scoring-enabled a universal precondition (the server gate rejects entries until
+ * enabled). This screen is that gate, and in 2B.2 it became the shared **setup
+ * hull** for stroke/rack: the standardized drill-down rows (`setupRows` —
+ * course pre-step + Name·Format·Points, via GameSetupRows) above a "ready to
+ * score" hint and the bottom **Enable scoring** CTA.
  *
  * Vocabulary is locked: "Enable scoring" — never arm/open. Enabling opens the
- * game to the crew; the first score flips it Live (#396). It does not gate on a
+ * game to the crew; the first score flips it Live (#396). It never gates on a
  * course (course is optional, never an error).
  */
 export function EnableScoringGate({
@@ -19,12 +21,16 @@ export function EnableScoringGate({
   onEnable,
   onBack,
   pending,
+  setupRows,
 }: {
   title: string;
   subtitle: string;
   onEnable: () => void;
   onBack: () => void;
   pending: boolean;
+  /** The standardized setup drill-down rows (GameSetupRows). Omitted for a
+   *  standalone game with nothing competition-scoped to configure. */
+  setupRows?: React.ReactNode;
 }) {
   return (
     <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
@@ -41,19 +47,26 @@ export function EnableScoringGate({
         </div>
       </header>
 
-      <div className="flex flex-1 flex-col items-center justify-center px-6 text-center">
-        <PlayCircle size={44} style={{ color: "var(--color-bt-accent)" }} />
-        <p className="mt-4" style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>
-          Ready to score
-        </p>
-        <p className="mt-2 max-w-xs" style={{ fontSize: 13, lineHeight: 1.5, color: "var(--color-bt-text-dim)" }}>
-          Enable scoring to open this game to the crew. Scores can be entered once
-          it&rsquo;s enabled; the round goes live on the first score.
-        </p>
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+        {setupRows}
+
+        <div
+          className="mt-4 flex items-center gap-3 rounded-xl px-4 py-3.5"
+          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <PlayCircle size={24} style={{ color: "var(--color-bt-accent)", flexShrink: 0 }} />
+          <p style={{ fontSize: 13, lineHeight: 1.5, color: "var(--color-bt-text-dim)" }}>
+            <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>Ready to score.</span>{" "}
+            Enabling opens this game to the crew; the round goes live on the first score.
+          </p>
+        </div>
+      </div>
+
+      <div className="shrink-0 px-4 pb-6 pt-2">
         <button
           onClick={onEnable}
           disabled={pending}
-          className="mt-6 w-full max-w-xs disabled:opacity-40"
+          className="w-full disabled:opacity-40"
           style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}
         >
           {pending ? "Enabling…" : "Enable scoring"}


### PR DESCRIPTION
Extends the §B setup hull to the other two format bodies. The match reference shipped in #398; this wires **stroke** and **rack** so all three formats present the same standardized course + Name·Format·Points drill-down rows in their setup phase.

## What
- **`EnableScoringGate`** (the universal pre-Enable surface from 2B.1) became the shared **setup hull** for stroke/rack: a top-aligned screen that hosts an optional **`setupRows`** slot — the course pre-step + Name·Format·Points rows (via `GameSetupRows`) — above a "ready to score" hint and the bottom **"Enable scoring"** CTA. Same reused `CoursePicker` + `GameSheet` editors; nothing rebuilt.
- **Stroke** (`new` page): added `useTripRole` for `canEdit`; passes `GameSetupRows` into its gate.
- **Rack** (`rack/new` page): same wiring (it already had `canEdit`/`competitionId`).

## Verified on BBMI
- **Stroke** — `SP Course`: **Course / tee → Pebble Beach**, **Name·Format·Points → "SP Course · 8 pts"**, ready hint, **Enable scoring** CTA.
- **Rack** — `Rack-n-Stack No Course Workflow`: **Course / tee → "Add a course"**, **Name·Format·Points → "Rack-n-Stack No Course Workflow · 2/match"**, Enable CTA. (Toggled via DB to reach the gate, then restored to `active`+enabled exactly.)
- `tsc` + `eslint` clean; fresh preview compile, **no console errors**.

## Deferred (flagged for 2B.3)
- Stroke's **net-new per-player handicaps step** — needs server support (`game_participants` strokes), so it's a real feature, not a relabel.
- The deeper single-surface unification (who's-playing + handicaps inline on the same setup screen, as match has) — pairs naturally with 2B.3's scoring-enabled phase flip + Configuration page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)