### PR TITLE
feat(games): Phase 2B.3 — Configuration page + Disable-in-Configuration (match reference)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -16,6 +16,7 @@ import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
@@ -48,7 +49,7 @@ interface DraftMatch {
   b: string[]; // member user ids on side B
   handicap: number; // signed: <0 → a gets |n|, >0 → b gets n, 0 → even
 }
-type Screen = "new" | "member-wait" | "setup" | "overview" | "score";
+type Screen = "new" | "member-wait" | "setup" | "overview" | "score" | "config";
 
 /**
  * Singles match-play game flow (Slice B). TEMPORARY route — the real Games tab
@@ -586,9 +587,10 @@ export default function NewMatchGamePage() {
     }
   }
 
-  // Phase 2B.1: Disable scoring — close to the crew, revert to setup (scores
-  // kept). Invalidate the board (incl. faceBootstrap, CLAUDE.md #10) so the row
-  // drops back to muted-icon Ready, then continue configuring on setup.
+  // Phase 2B.3: Disable scoring — close to the crew, KEEP scores, and STAY in
+  // Configuration (continue configuring right here; NOT a hub reverse-transform).
+  // Invalidate the board (incl. faceBootstrap, CLAUDE.md #10) so the row drops
+  // back to the muted-icon Ready state.
   async function handleDisable() {
     if (!tripId || !gameId) return;
     try {
@@ -599,7 +601,25 @@ export default function NewMatchGamePage() {
         utils.games.listByTrip.invalidate({ tripId });
         utils.competitions.faceBootstrap.invalidate({ tripId });
       }
-      go("setup");
+      // Stay on the Configuration screen (manualScreen === "config" holds).
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+
+  // Phase 2B.3: re-Enable from Configuration → back to the score-entry hub. The
+  // pairings are already persisted, so this just flips the flag + publishes.
+  async function handleEnableFromConfig() {
+    if (!tripId || !gameId) return;
+    try {
+      await activate.mutateAsync({ tripId, gameId });
+      await Promise.all([gameQ.refetch(), matchesQ.refetch()]);
+      if (competitionId) {
+        utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+        utils.games.listByTrip.invalidate({ tripId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+      }
+      go("overview");
     } catch {
       // surfaced via the global error toast
     }
@@ -725,6 +745,35 @@ export default function NewMatchGamePage() {
     );
   }
 
+  // ── Configuration page (§B 2B.3) — the post-Enable editing home. Full-screen
+  // (own header), reached from the hub's top-right. ──
+  if (screen === "config" && gameQ.data) {
+    return (
+      <GameConfigurationView
+        subtitle={sided ? "Doubles · 2v2 Match Play" : "Singles · 1v1 Match Play"}
+        onBack={goBack}
+        tripId={tripId}
+        competitionId={gameCompId}
+        game={gameQ.data as unknown as GameRow}
+        canEdit={canEdit}
+        onChanged={() => {
+          void gameQ.refetch();
+          if (competitionId) {
+            utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+            utils.competitions.faceBootstrap.invalidate({ tripId });
+            utils.games.listByTrip.invalidate({ tripId });
+          }
+        }}
+        whosPlayingLabel={`${groups.length} ${groups.length === 1 ? "matchup" : "matchups"} · pairings & strokes`}
+        onEditWhosPlaying={startSetup}
+        scoringEnabled={scoringEnabled}
+        onEnable={handleEnableFromConfig}
+        onDisable={handleDisable}
+        busy={disableScoring.isPending || activate.isPending}
+      />
+    );
+  }
+
   // ── Shell for the setup screens ──
   const headerTitle = screen === "new" ? "New game" : screen === "setup" ? "Set Pairings" : "Matches";
   return (
@@ -735,16 +784,12 @@ export default function NewMatchGamePage() {
         onBack={goBack}
         right={
           screen === "overview" && canEdit && status !== "complete" ? (
-            <div className="flex items-center gap-3">
-              {scoringEnabled && (
-                <button onClick={handleDisable} disabled={disableScoring.isPending} style={{ color: "var(--color-bt-text-dim)", fontSize: 13, fontWeight: 600 }}>
-                  {disableScoring.isPending ? "Disabling…" : "Disable"}
-                </button>
-              )}
-              <button onClick={startSetup} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>
-                Edit
-              </button>
-            </div>
+            // §B (2B.3): the score-entry hub's top-right opens Configuration (the
+            // post-Enable editing home — Enable/Disable + the field editors live
+            // there now, not inline on the hub).
+            <button onClick={() => go("config")} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>
+              Configuration
+            </button>
           ) : null
         }
       />

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { GameSetupRows } from "@/components/games/GameSetupRows";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+
+/**
+ * §B Configuration page (Phase 2B.3) — the post-Enable home for editing. The
+ * ONE genuinely new §B surface. Reached from the score-entry hub (top-right), it
+ * holds the SAME field editors as the setup hull (reuses `GameSetupRows` +
+ * per-format drill-downs) PLUS the **Enabled / Disabled** pressed-state control.
+ *
+ * Disable here = `scoring_enabled=false`, **scores kept**, and you keep
+ * configuring RIGHT HERE — it is NOT a hub reverse-transform (the score-entry
+ * hub never morphs backward; editing happens in Configuration). Re-Enable returns
+ * to score entry. Vocabulary locked: Enabled / Disabled — never arm/open.
+ */
+export function GameConfigurationView({
+  subtitle,
+  onBack,
+  tripId,
+  competitionId,
+  game,
+  canEdit,
+  onChanged,
+  whosPlayingLabel,
+  onEditWhosPlaying,
+  scoringEnabled,
+  onEnable,
+  onDisable,
+  busy,
+}: {
+  subtitle: string;
+  onBack: () => void;
+  tripId: string;
+  competitionId: string | null;
+  game: GameRow;
+  canEdit: boolean;
+  onChanged: () => void;
+  /** Summary + drill-down into the format's existing who's-playing/handicaps
+   *  editor (the setup body — pairings / picker / groups). */
+  whosPlayingLabel: string;
+  onEditWhosPlaying: () => void;
+  scoringEnabled: boolean;
+  onEnable: () => void;
+  onDisable: () => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <header
+        className="flex shrink-0 items-center"
+        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
+          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Configuration</div>
+          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+        {/* Same editors as the setup hull — reused, never rebuilt. */}
+        <GameSetupRows
+          tripId={tripId}
+          competitionId={competitionId}
+          game={game}
+          canEdit={canEdit}
+          onChanged={onChanged}
+        />
+        <button
+          type="button"
+          onClick={onEditWhosPlaying}
+          disabled={!canEdit}
+          className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
+          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <div className="flex min-w-0 flex-col">
+            <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+              Who&rsquo;s playing · Handicaps
+            </span>
+            <span className="truncate text-sm" style={{ color: "var(--color-bt-text)", marginTop: 2 }}>{whosPlayingLabel}</span>
+          </div>
+          <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+        </button>
+
+        {/* Enabled / Disabled — the pressed-state control. */}
+        <div className="mt-6">
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Scoring</span>
+          <div
+            className="mt-2 flex gap-1 rounded-xl p-1"
+            style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+          >
+            <SegBtn label="Enabled" active={scoringEnabled} disabled={!canEdit || busy} onClick={scoringEnabled ? undefined : onEnable} />
+            <SegBtn label="Disabled" active={!scoringEnabled} disabled={!canEdit || busy} onClick={scoringEnabled ? onDisable : undefined} />
+          </div>
+          <p className="mt-2 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+            {scoringEnabled
+              ? "Enabled — open to the crew for scoring. Disabling closes it and returns to setup; scores are kept."
+              : "Disabled — closed to the crew. Keep configuring here; enable when you’re ready. Any scores already entered are kept."}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SegBtn({ label, active, disabled, onClick }: { label: string; active: boolean; disabled?: boolean; onClick?: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || !onClick}
+      className="flex-1 rounded-lg py-2 text-sm font-semibold disabled:opacity-60"
+      style={
+        active
+          ? { background: "var(--color-bt-accent)", color: "#0d1f1a" }
+          : { background: "transparent", color: "var(--color-bt-text-dim)" }
+      }
+    >
+      {label}
+    </button>
+  );
+}


### PR DESCRIPTION
§B's one genuinely new surface — the post-Enable **Configuration page** (§1 + §2). Reference format (match) first; stroke + rack follow in the next PR.

## What
- **`GameConfigurationView`** (new, shared): reached from the score-entry hub's top-right (**"Configuration"**). Holds the **same field editors** as the setup hull — reuses `GameSetupRows` (course + Name·Format·Points) + a **Who's playing · Handicaps** drill-down into the existing pairing editor — **plus** an **Enabled / Disabled** pressed-state segmented control. Nothing rebuilt.
- **§1.2** — the match overview hub gains the **Configuration** top-right (replacing the inline Edit/Disable from 2B.1). **§1.1** (Enable flips the hub to score-entry in place) was already the behavior.
- **§2.2** — **Disable happens IN Configuration and stays there**: `scoring_enabled=false`, **all scores kept**, and you keep configuring right here. It is **not** a hub reverse-transform (the score-entry hub never morphs backward). **Re-Enable** returns to score entry.

## Verified — the full loop on BBMI (1v1 Match Play Workflow, 2 scores)
overview → **Configuration** (reused editors + Enabled/Disabled control, Enabled active) → **Disable** → DB: `scoring_enabled=false`, `status` active→pending, `published=false`, **`scores=2` survived**, and the screen **stayed in Configuration** (hint flipped to "closed to the crew") → **re-Enable** → back to the score-entry hub. Restored to active+enabled exactly. `tsc` + `eslint` clean; no console errors.

## Next
- Wire the Configuration page into **stroke** + **rack** hubs (run the same loop in all three — spec's verify-by-eye).
- **2B.3 §3** — the stroke per-player handicaps step (server `game_participants` strokes + the `HandicapRoster` UI + `netStrokeEntries` display), closing the Phase-1 loop. Separate PR (net-new scoring math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)