### PR TITLE
feat(games): Phase 2B.3 — Configuration page wired into stroke + rack hubs

### DIFF
--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -9,6 +9,7 @@ import { StandardGrid } from "@/components/games/StandardGrid";
 import { FinalStandings } from "@/components/games/FinalStandings";
 import { EnableScoringGate } from "@/components/games/EnableScoringGate";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { useTripRole } from "@/hooks/useTripRole";
 import type { StrokeStanding } from "@/lib/strokePlay";
@@ -62,11 +63,13 @@ export default function NewGamePage() {
   const [view, setView] = useState<"entry" | "grid" | "final">("entry");
   const [currentHole, setCurrentHole] = useState(1);
   const [standings, setStandings] = useState<StrokeStanding[]>([]);
+  const [showConfig, setShowConfig] = useState(false); // §B 2B.3 Configuration page
 
   const createGame = trpc.games.create.useMutation();
   const addParticipants = trpc.games.addParticipants.useMutation();
   // Phase 2B.1: scoring must be enabled before entries land (universal gate).
   const enableScoring = trpc.games.enableScoring.useMutation();
+  const disableScoring = trpc.games.disableScoring.useMutation();
 
   const memberById = useMemo(() => {
     const m = new Map<string, { id: string; name: string }>();
@@ -105,16 +108,30 @@ export default function NewGamePage() {
   // Phase 2B.1: a configured game must be Enabled before its score screen opens.
   const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
   const gameCompetitionId = (gameQ.data as { competition_id?: string | null } | undefined)?.competition_id ?? null;
+  async function refreshGame() {
+    await gameQ.refetch();
+    if (gameCompetitionId) {
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId: gameCompetitionId });
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+      utils.games.listByTrip.invalidate({ tripId });
+    }
+  }
   async function handleEnable() {
     if (!tripId || !activeGameId) return;
     try {
       await enableScoring.mutateAsync({ tripId, gameId: activeGameId });
-      await gameQ.refetch();
-      if (gameCompetitionId) {
-        utils.competitions.leaderboard.invalidate({ tripId, competitionId: gameCompetitionId });
-        utils.competitions.faceBootstrap.invalidate({ tripId });
-        utils.games.listByTrip.invalidate({ tripId });
-      }
+      await refreshGame();
+      setShowConfig(false); // re-Enable from Configuration → back to score entry
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+  // §B 2B.3: Disable from Configuration — keep scores, STAY in Configuration.
+  async function handleDisable() {
+    if (!tripId || !activeGameId) return;
+    try {
+      await disableScoring.mutateAsync({ tripId, gameId: activeGameId });
+      await refreshGame();
     } catch {
       // surfaced via the global error toast
     }
@@ -218,7 +235,7 @@ export default function NewGamePage() {
   // ── Enable gate (Phase 2B.1) → §B setup hull (2B.2). A configured game must be
   // enabled before its score screen opens; the gate also hosts the standardized
   // course + Name·Format·Points drill-down rows. ──
-  if (game && !scoringEnabled) {
+  if (game && !scoringEnabled && !showConfig) {
     return (
       <EnableScoringGate
         title="Stroke Play"
@@ -245,6 +262,28 @@ export default function NewGamePage() {
           ) : null
         }
       />
+    );
+  }
+
+  // ── Configuration page (§B 2B.3) — the post-Enable editing home, reached from
+  // the score-entry hub's top-right gear. ──
+  if (game && showConfig && gameQ.data && canEdit) {
+    return (
+      <div className="fixed inset-0 z-50">
+        <GameConfigurationView
+          subtitle="Stroke Play"
+          onBack={() => setShowConfig(false)}
+          tripId={tripId}
+          competitionId={gameCompetitionId}
+          game={gameQ.data as unknown as GameRow}
+          canEdit={canEdit}
+          onChanged={() => void refreshGame()}
+          scoringEnabled={scoringEnabled}
+          onEnable={handleEnable}
+          onDisable={handleDisable}
+          busy={enableScoring.isPending || disableScoring.isPending}
+        />
+      </div>
     );
   }
 
@@ -296,6 +335,7 @@ export default function NewGamePage() {
             onRetryCell={retryCell}
             onBack={() => router.back()}
             onOpenGrid={() => setView("grid")}
+            onConfig={canEdit ? () => setShowConfig(true) : undefined}
             onFinish={handleFinish}
           />
         )}

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -14,6 +14,7 @@ import { StandardGrid } from "@/components/games/StandardGrid";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
 import { EnableScoringGate } from "@/components/games/EnableScoringGate";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
@@ -81,6 +82,7 @@ export default function RackNStackPage() {
   const [firstTee, setFirstTee] = useState(""); // "HH:MM" 24h; groups stagger +10
   const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
   const [showHandicaps, setShowHandicaps] = useState(false);
+  const [showConfig, setShowConfig] = useState(false); // §B 2B.3 Configuration page
   const [currentHole, setCurrentHole] = useState(1);
   const [values, setValues] = useState<ScoreValues>({});
 
@@ -107,6 +109,7 @@ export default function RackNStackPage() {
   const setFoursomes = trpc.playGroups.setFoursomes.useMutation();
   // Phase 2B.1: scoring must be enabled before entries land (universal gate).
   const enableScoring = trpc.games.enableScoring.useMutation();
+  const disableScoring = trpc.games.disableScoring.useMutation();
   const setStrokes = trpc.playGroups.setParticipantStrokes.useMutation();
   const upsertEntry = trpc.scores.upsertEntry.useMutation();
   const deleteEntry = trpc.scores.deleteEntry.useMutation();
@@ -328,16 +331,31 @@ export default function RackNStackPage() {
   // Phase 2B.1: a rack with its groups set must be Enabled before the play screen
   // opens (the score saver server-rejects entries until then).
   const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+  async function refreshGame() {
+    if (!tripId || !gid) return;
+    await utils.games.getById.invalidate({ tripId, gameId: gid });
+    if (competitionId) {
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+      utils.games.listByTrip.invalidate({ tripId });
+    }
+  }
   async function handleEnable() {
     if (!tripId || !gid) return;
     try {
       await enableScoring.mutateAsync({ tripId, gameId: gid });
-      await utils.games.getById.invalidate({ tripId, gameId: gid });
-      if (competitionId) {
-        utils.competitions.leaderboard.invalidate({ tripId, competitionId });
-        utils.competitions.faceBootstrap.invalidate({ tripId });
-        utils.games.listByTrip.invalidate({ tripId });
-      }
+      await refreshGame();
+      setShowConfig(false); // re-Enable from Configuration → back to score entry
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+  // §B 2B.3: Disable from Configuration — keep scores, STAY in Configuration.
+  async function handleDisable() {
+    if (!tripId || !gid) return;
+    try {
+      await disableScoring.mutateAsync({ tripId, gameId: gid });
+      await refreshGame();
     } catch {
       // surfaced via the global error toast
     }
@@ -422,6 +440,29 @@ export default function RackNStackPage() {
           pips={groupPips}
         />
       </div>
+    );
+  }
+
+  // §B 2B.3 Configuration page — the post-Enable editing home, reached from the
+  // play hub's top-right. Reused editors + the Enabled/Disabled control; Disable
+  // keeps scores and stays here (not a hub reverse-transform).
+  if (showConfig && gid && gameQ.data && canEdit) {
+    return (
+      <GameConfigurationView
+        subtitle="Net stroke play · team rack"
+        onBack={() => setShowConfig(false)}
+        tripId={tripId!}
+        competitionId={competitionId ?? null}
+        game={gameQ.data as unknown as GameRow}
+        canEdit={canEdit}
+        onChanged={() => void refreshGame()}
+        whosPlayingLabel={`${groupsQ.data?.groups?.length ?? 0} group${(groupsQ.data?.groups?.length ?? 0) === 1 ? "" : "s"} · auto-grouped · strokes`}
+        onEditWhosPlaying={() => { setShowConfig(false); setShowHandicaps(true); }}
+        scoringEnabled={scoringEnabled}
+        onEnable={handleEnable}
+        onDisable={handleDisable}
+        busy={enableScoring.isPending || disableScoring.isPending}
+      />
     );
   }
 
@@ -525,7 +566,18 @@ export default function RackNStackPage() {
   const final = gameQ.data?.status === "complete";
   const allThru18 = rack.slots.length > 0 && rack.slots.every((s) => s.a.thru >= scUnits.length && s.b.thru >= scUnits.length);
   return (
-    <Shell onBack={() => router.back()} title="Rack-n-Stack" subtitle={correcting ? "Net stroke play · correcting" : final ? "Net stroke play · final" : "Net stroke play · standings"}>
+    <Shell
+      onBack={() => router.back()}
+      title="Rack-n-Stack"
+      subtitle={correcting ? "Net stroke play · correcting" : final ? "Net stroke play · final" : "Net stroke play · standings"}
+      right={
+        canEdit && !final ? (
+          <button onClick={() => setShowConfig(true)} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>
+            Configuration
+          </button>
+        ) : undefined
+      }
+    >
       <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
       {canEdit && !final && (
@@ -571,7 +623,7 @@ export default function RackNStackPage() {
   );
 }
 
-function Shell({ title, subtitle, onBack, children }: { title: string; subtitle?: string; onBack: () => void; children: React.ReactNode }) {
+function Shell({ title, subtitle, onBack, right, children }: { title: string; subtitle?: string; onBack: () => void; right?: React.ReactNode; children: React.ReactNode }) {
   return (
     <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: "100vh" }}>
       <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
@@ -582,7 +634,7 @@ function Shell({ title, subtitle, onBack, children }: { title: string; subtitle?
           <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
           {subtitle && <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>}
         </div>
-        <div className="h-9 w-9" />
+        <div className="flex h-9 min-w-9 items-center justify-end pr-1">{right}</div>
       </header>
       <div className="flex-1">{children}</div>
     </div>

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -38,9 +38,10 @@ export function GameConfigurationView({
   canEdit: boolean;
   onChanged: () => void;
   /** Summary + drill-down into the format's existing who's-playing/handicaps
-   *  editor (the setup body — pairings / picker / groups). */
-  whosPlayingLabel: string;
-  onEditWhosPlaying: () => void;
+   *  editor (the setup body — pairings / groups). Omit when the format has no
+   *  post-create roster editor (stroke today — its handicaps step lands in §3). */
+  whosPlayingLabel?: string;
+  onEditWhosPlaying?: () => void;
   scoringEnabled: boolean;
   onEnable: () => void;
   onDisable: () => void;
@@ -70,21 +71,23 @@ export function GameConfigurationView({
           canEdit={canEdit}
           onChanged={onChanged}
         />
-        <button
-          type="button"
-          onClick={onEditWhosPlaying}
-          disabled={!canEdit}
-          className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
-          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-        >
-          <div className="flex min-w-0 flex-col">
-            <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-              Who&rsquo;s playing · Handicaps
-            </span>
-            <span className="truncate text-sm" style={{ color: "var(--color-bt-text)", marginTop: 2 }}>{whosPlayingLabel}</span>
-          </div>
-          <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
-        </button>
+        {onEditWhosPlaying && (
+          <button
+            type="button"
+            onClick={onEditWhosPlaying}
+            disabled={!canEdit}
+            className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
+            style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+          >
+            <div className="flex min-w-0 flex-col">
+              <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                Who&rsquo;s playing · Handicaps
+              </span>
+              <span className="truncate text-sm" style={{ color: "var(--color-bt-text)", marginTop: 2 }}>{whosPlayingLabel}</span>
+            </div>
+            <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+          </button>
+        )}
 
         {/* Enabled / Disabled — the pressed-state control. */}
         <div className="mt-6">

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronLeft, Grid3x3 } from "lucide-react";
+import { ChevronLeft, Grid3x3, Settings } from "lucide-react";
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import { StrokeKeypad } from "./StrokeKeypad";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
@@ -44,6 +44,9 @@ interface ScoreEntryViewProps {
   onFinish?: () => void;
   onBack?: () => void;
   onOpenGrid?: () => void;
+  /** §B 2B.3: open the Configuration page from the score-entry hub (top-right).
+   *  Omit where there's nothing to configure (Quick Game). */
+  onConfig?: () => void;
   /** Per-cell save state (Connectivity Layer 1) — drives the cell badges + the
    *  unsaved-scores banner. Keyed by `${participantId}:${unitLabel}`. */
   saveStatus?: SaveStatusMap;
@@ -68,6 +71,7 @@ export function ScoreEntryView({
   onFinish,
   onBack,
   onOpenGrid,
+  onConfig,
   saveStatus = {},
   onRetryCell,
   pips,
@@ -187,9 +191,16 @@ export function ScoreEntryView({
             Hole {hole} of {units.length}
           </div>
         </div>
-        <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
-          <Grid3x3 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
-        </button>
+        <div className="flex items-center">
+          {onConfig && (
+            <button onClick={onConfig} aria-label="Configuration" className="flex h-9 w-9 items-center justify-center">
+              <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+            </button>
+          )}
+          <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
+            <Grid3x3 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+          </button>
+        </div>
       </header>
 
       {/* ── Unsaved-scores safety net (Connectivity Layer 1) ── */}


### PR DESCRIPTION
Completes §1+§2 across all three formats (match shipped in #400). The score-entry hub for **stroke** and **rack** now opens the shared `GameConfigurationView` from its top-right, with the same **Disable-in-Configuration** semantics (scores kept, stays in Configuration, not a hub reverse-transform).

## What
- **Rack** — `Shell` gained a `right` slot; the play hub shows a **"Configuration"** action → the config page (reused `GameSetupRows` + a groups·strokes drill-down into the handicap roster + the **Enabled/Disabled** control). Added `disableScoring`.
- **Stroke** — `ScoreEntryView` gained an optional **`onConfig`** (a gear next to the grid button — additive; omitted for Quick Game). The config page has **no who's-playing row** (stroke has no post-create roster editor; its handicaps step is §3). `GameConfigurationView`'s who's-playing row is now optional.
- Fixed the stroke enable-gate precedence so **Disable stays in Configuration** (a `!showConfig` guard) rather than falling through to the enable gate; rack already rendered config before its gate.

## Verified on BBMI
- **Stroke** (SP Course, briefly enabled via DB then restored exactly to pending/not-enabled): gear → **Configuration** (Course → Pebble Beach, Name·Format·Points → "SP Course · 8 pts", **no who's-playing row**, Enabled/Disabled); tapping **Disabled** stayed in Configuration (hint flipped to "closed to the crew").
- **Rack** (Rack-n-Stack Workflow): play hub **Configuration** → the config page with the groups drill-down + the Enabled/Disabled control.
- `tsc` + `eslint` clean; no console errors.

## §B status
- 2B.1 #397 · 2B.2 #398/#399 · 2B.3 §1+§2 match #400 · **this = §1+§2 stroke+rack**.
- **Remaining to close §B: 2B.3 §3** — the can't-skip stroke per-player handicaps step (server `game_participants` strokes + `HandicapRoster` UI + `netStrokeEntries` display, closing the Phase-1 loop). Its own PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)