### PR TITLE
fix(games): typed result_strategy dispatch -- unknown strategy throws, no silent stroke-play

### DIFF
--- a/src/server/routers/games.test.ts
+++ b/src/server/routers/games.test.ts
@@ -104,3 +104,56 @@ describe("games router (Slice A — stroke play)", () => {
     await expect(ctx.callerAs("member").games.finish({ tripId, gameId })).rejects.toThrow();
   });
 });
+
+describe("games router — result_strategy dispatch guard", () => {
+  let ctx: TestContext;
+  let tripId: string;
+
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    tripId = await ctx.createTrip("Dispatch Guard Trip");
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it("finish — manual game (strategy=null) throws BAD_REQUEST, no stroke-play results written", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: "gtt_manual", name: "Cornhole" });
+    await expect(ctx.caller().games.finish({ tripId, gameId: game.id })).rejects.toMatchObject({
+      message: expect.stringContaining("Manual games cannot be finalized via finish"),
+    });
+    // Guard must fire before any compute — confirm no game_results rows exist.
+    const { data: results } = await ctx.admin.from("game_results").select("id").eq("game_id", game.id);
+    expect(results).toHaveLength(0);
+  });
+
+  it("finish — unknown result_strategy throws rather than silently scoring as stroke play", async () => {
+    // Temporarily insert a template with an unregistered strategy, use it to
+    // create a game, exercise the guard, then clean up.
+    const FAKE_ID = "gtt_b2_test_unknown";
+    await ctx.admin.from("game_type_templates").insert({
+      id: FAKE_ID,
+      key: "b2_test_unknown",
+      name: "B2 Test Unknown",
+      description: "Temporary template for B2 guard test",
+      result_strategy: "unknown_strategy",
+      entry_schema: "user_holes",
+      supports_free_for_all: true,
+      supports_sides: false,
+      requires_sides: false,
+      sort_order: 999,
+    });
+    try {
+      const game = await ctx.caller().games.create({ tripId, gameTypeId: FAKE_ID, name: "Unknown" });
+      await expect(ctx.caller().games.finish({ tripId, gameId: game.id })).rejects.toMatchObject({
+        message: expect.stringContaining("Unknown result_strategy 'unknown_strategy'"),
+      });
+      // Guard fires before any compute — no results written.
+      const { data: results } = await ctx.admin.from("game_results").select("id").eq("game_id", game.id);
+      expect(results).toHaveLength(0);
+    } finally {
+      await ctx.admin.from("game_type_templates").delete().eq("id", FAKE_ID);
+    }
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -6,6 +6,9 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
+import type { MatchOutcome } from "../lib/matchPlay";
+import type { RackTeamOutcome } from "../lib/rackNStack";
+import type { StrokeStanding } from "@/lib/strokePlay";
 import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema } from "@/lib/courseIndex";
 import { validatePlacement } from "@/lib/gameConfig";
 
@@ -389,16 +392,32 @@ export const gamesRouter = router({
         .select("result_strategy")
         .eq("id", game.game_type_id as string)
         .maybeSingle();
-      const strategy = (template?.result_strategy as string | null) ?? "stroke_total";
+      const strategy = template?.result_strategy as string | null;
 
       // Data-driven branch on the template's result_strategy (CLAUDE.md #8) —
       // new strategies slot in here without touching the rest of finish.
-      const matches = strategy === "match_play" ? await computeMatchPlayResults(ctx.supabase, input.gameId) : [];
-      const teams = strategy === "rack_n_stack" ? await computeRackNStackResults(ctx.supabase, input.gameId) : [];
-      const standings =
-        strategy === "match_play" || strategy === "rack_n_stack"
-          ? []
-          : await computeStrokePlayResults(ctx.supabase, input.gameId);
+      // null (manual): finish has no placements input — caller must use post.
+      // Unregistered string: loud throw; silent stroke-play fallback is gone.
+      let matches: MatchOutcome[] = [];
+      let teams: RackTeamOutcome[] = [];
+      let standings: StrokeStanding[] = [];
+      if (strategy === null) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Manual games cannot be finalized via finish — use post with a placements array.",
+        });
+      } else if (strategy === "match_play") {
+        matches = await computeMatchPlayResults(ctx.supabase, input.gameId);
+      } else if (strategy === "rack_n_stack") {
+        teams = await computeRackNStackResults(ctx.supabase, input.gameId);
+      } else if (strategy === "stroke_total") {
+        standings = await computeStrokePlayResults(ctx.supabase, input.gameId);
+      } else {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Unknown result_strategy '${strategy}' — refusing to compute to avoid silent stroke-play scoring`,
+        });
+      }
 
       // status='complete' + corrections_open=false IS the locked state. Clearing
       // corrections_open here is what makes finalize the proper LOCK and lets a
@@ -682,8 +701,13 @@ export const gamesRouter = router({
         await computeMatchPlayResults(ctx.supabase, input.gameId);
       } else if (strategy === "rack_n_stack") {
         await computeRackNStackResults(ctx.supabase, input.gameId);
-      } else {
+      } else if (strategy === "stroke_total") {
         await computeStrokePlayResults(ctx.supabase, input.gameId);
+      } else {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Unknown result_strategy '${strategy}' — refusing to compute to avoid silent stroke-play scoring`,
+        });
       }
 
       const { error } = await ctx.supabase


### PR DESCRIPTION
## Summary

- Both `finish` and `post` previously fell through an open `else` to `computeStrokePlayResults` for any unregistered `result_strategy`, silently producing plausible-but-wrong scores on the leaderboard
- Replaces the open `else` (and the `?? "stroke_total"` coercion on `finish`) with a fully typed dispatch: every known strategy is an explicit named branch; anything else throws loudly

**`finish`:**
- Removes `?? "stroke_total"` — manual games (result_strategy=null) no longer coerced to stroke play
- `null` (manual): explicit `BAD_REQUEST` — `finish` has no `placements` input; caller must use `post`
- `"stroke_total"` / `"match_play"` / `"rack_n_stack"`: explicit named branches, behavior unchanged
- Anything else: `INTERNAL_SERVER_ERROR` naming the offending strategy value

**`post`:**
- Replaces open `else` with `else if (strategy === "stroke_total")` + final `else { throw }`
- Existing `null` -> manual branch and all three engine paths unchanged

## Test plan
- [ ] 2 new guard tests in `games.test.ts`: manual-via-finish (BAD_REQUEST, 0 results written) + unknown-strategy (INTERNAL_SERVER_ERROR, 0 results written)
- [ ] Existing suites: stroke (games.test.ts), match 1v1 (matches.test.ts), match 2v2 (matches.doubles.test.ts), rack (rackNStack.test.ts) -- all 38 tests pass unchanged
- [ ] `tsc --noEmit` clean
- [ ] Add-time footgun (raw stroke game in competition won't aggregate to team points) filed separately as #411 / #412 -- not fixed here

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
