### PR TITLE
fix(courses): land PR 2 on main (two-stage search + counter + tee + walk fixes)

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -92,6 +92,22 @@ The heart of the event.
   within-format standards; template `config_schema` declares tunable keys
 - Moving tee boxes — available to any stroke-input scorecard; pop-up +
   per-cell visual cue; `tee_box_change` `game_live_events` (no September format requires it)
+  - **Tee-subset selection** (sub-note, captured 2026-06-20 during the
+    golfcourseapi build): when moving tees is on, the owner/delegate picks WHICH
+    of the course's stored tee sets rotate. Cannot be worked independently of
+    moving tees — it's a configuration knob on this feature. All tee sets are
+    already persisted (`courses.tee_sets`, mig 059), so the data is ready.
+
+### Desktop side-by-side tee display (someday nomination — not actionable now)
+
+*Captured 2026-06-20 (golfcourseapi build). NOTE: CLAUDE.md references a
+`TRACKER.md` "someday pile" that does not exist in the repo — parking this here
+in DEFERRED.md until that doc is created or this is promoted.*
+
+- A round uses one configured tee (snapshotted per game). On **desktop**, the
+  same captured per-tee data (`courses.tee_sets`) could render multiple tees
+  **side-by-side** rather than the single configured tee — same data, wider
+  viewport. Deferred; navigation/desktop-experience adjacent, not launch-blocking.
 
 ### Competition-style chooser — style → format → points enforcement
 

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -20,7 +20,7 @@ import { GameConfigurationView } from "@/components/games/GameConfigurationView"
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
-import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf } from "@/lib/strokePlayConfig";
+import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
@@ -708,6 +708,7 @@ export default function NewMatchGamePage() {
             <div className="min-h-0 flex-1">
               <StandardGrid
                 units={scUnits}
+                tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
                 participants={entryParticipants}
                 values={values}
                 direction="low_wins"

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -15,7 +15,7 @@ import { HandicapRoster, type HandicapPlayer } from "@/components/games/Handicap
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { useTripRole } from "@/hooks/useTripRole";
 import type { StrokeStanding } from "@/lib/strokePlay";
-import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf } from "@/lib/strokePlayConfig";
+import { PLAYER_COLORS, initialsOf, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { strokeHoles } from "@/lib/matchPlay";
 import type { Participant, ScoreValues } from "@/components/games/types";
@@ -382,6 +382,7 @@ export default function NewGamePage() {
             <div className="min-h-0 flex-1">
               <StandardGrid
                 units={scUnits}
+                tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
                 participants={game.participants}
                 values={values}
                 direction="low_wins"

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -21,7 +21,7 @@ import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/F
 import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
 import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/rackNStack";
 import { strokeHoles } from "@/lib/matchPlay";
-import { unitsFromSchema, strokeIndexOf, initialsOf } from "@/lib/strokePlayConfig";
+import { unitsFromSchema, strokeIndexOf, initialsOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
@@ -414,6 +414,7 @@ export default function RackNStackPage() {
           <div className="min-h-0 flex-1">
             <StandardGrid
               units={scUnits}
+              tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
               participants={ps}
               values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
               direction="low_wins"

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -69,9 +69,9 @@ export function GameSetupRows({
       {coursePickerOpen && (
         <CoursePicker
           onClose={() => setCoursePickerOpen(false)}
-          onApply={({ id }) => {
+          onApply={({ id, teeName }) => {
             applyCourse.mutate(
-              { tripId, gameId: game.id, courseId: id },
+              { tripId, gameId: game.id, courseId: id, teeSetName: teeName },
               {
                 onSuccess: () => {
                   utils.courses.getById.invalidate({ courseId: id });

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -46,6 +46,12 @@ interface StandardGridProps {
    * `${participantId}:${unitLabel}`.
    */
   saveStatus?: SaveStatusMap;
+  /**
+   * The configured tee (name + ratings) for the header line. Present only when a
+   * course/tee is applied; informational (does not affect scoring). The per-hole
+   * yardage rides on `units[].yardage` instead.
+   */
+  tee?: { name: string; courseRating?: number | null; slopeRating?: number | null; bogeyRating?: number | null } | null;
 }
 
 const NAME_W = 124;
@@ -53,7 +59,7 @@ const HOLE_W = 30;
 const SUB_W = 44;
 const TOTAL_W = 50;
 
-export function StandardGrid({ units, participants, values, onCellTap, pips, saveStatus }: StandardGridProps) {
+export function StandardGrid({ units, participants, values, onCellTap, pips, saveStatus, tee }: StandardGridProps) {
   const front = units.filter((u) => u.section === "front");
   const back = units.filter((u) => u.section === "back");
   const hasSections = front.length > 0 && back.length > 0;
@@ -69,7 +75,11 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
   // picker). ±-vs-par is over the holes a player has actually scored.
   const hasPar = units.length > 0 && units.every((u) => u.par != null);
   const hasIndex = units.length > 0 && units.every((u) => u.strokeIndex != null);
+  // Yardage (the configured tee) is informational; show the row when ANY hole
+  // carries a yardage (a tee may miss a hole or two).
+  const hasYards = units.length > 0 && units.some((u) => u.yardage != null);
   const parSum = (list: ScoreUnit[]) => list.reduce((a, u) => a + (u.par ?? 0), 0);
+  const yardSum = (list: ScoreUnit[]) => list.reduce((a, u) => a + (u.yardage ?? 0), 0);
   const vsParOf = (pid: string, list: ScoreUnit[]): number => {
     const scored = list.filter((u) => valOf(pid, u.label) != null);
     return scored.reduce((a, u) => a + (valOf(pid, u.label)! - (u.par ?? 0)), 0);
@@ -116,8 +126,25 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
     background: "var(--color-bt-card)",
   };
 
+  // Compact tee header: "Blue tees · CR 72.3 / Slope 131" (ratings shown only
+  // when present — a manual course carries a tee name but usually no ratings).
+  const teeRatings = tee
+    ? [
+        tee.courseRating != null ? `CR ${tee.courseRating}` : null,
+        tee.slopeRating != null ? `Slope ${tee.slopeRating}` : null,
+      ].filter(Boolean).join(" / ")
+    : "";
+
   return (
     <div className="h-full" style={{ background: "var(--color-bt-base)" }}>
+      {tee && (
+        <div className="flex items-center gap-2" style={{ padding: "8px 12px", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text)" }}>{tee.name} tees</span>
+          {teeRatings && (
+            <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>· {teeRatings}</span>
+          )}
+        </div>
+      )}
       <div className="relative">
         <div className="no-scrollbar overflow-x-auto">
           <div style={{ minWidth: "max-content" }}>
@@ -148,6 +175,25 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
             {hasSections && <HeaderSub label="In" />}
             <HeaderSub label="Total" wide />
           </div>
+
+          {/* Yards row (configured tee) — informational; sits on base like Index. */}
+          {hasYards && (
+            <div className="flex" style={{ height: 26, background: "var(--color-bt-base)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+              <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-base)", padding: "0 10px" }}>
+                <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+                  Yards
+                </span>
+              </div>
+              {units.map((u) => (
+                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                  <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.yardage ?? "—"}</span>
+                </div>
+              ))}
+              {hasSections && <ParSub value={yardSum(front)} />}
+              {hasSections && <ParSub value={yardSum(back)} />}
+              <ParSub value={yardSum(units)} wide />
+            </div>
+          )}
 
           {/* Par row — same surface as the Hole header. */}
           {hasPar && (

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -75,13 +75,17 @@ export function CoursePicker({
   onApply,
   onClose,
 }: {
-  onApply: (course: { id: string; name: string }) => void;
+  onApply: (course: { id: string; name: string; teeName?: string }) => void;
   onClose: () => void;
 }) {
   const [screen, setScreen] = useState<Screen>("search");
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<CourseSummary[]>([]);
-  const [searching, setSearching] = useState(false);
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  // API (golfcourseapi) results — populated ONLY by the explicit "Search the
+  // full database" control, never by typing. Local typeahead is the default.
+  const [apiResults, setApiResults] = useState<CourseSummary[]>([]);
+  const [apiSearching, setApiSearching] = useState(false);
+  const [apiSearched, setApiSearched] = useState(false);
   const [draft, setDraft] = useState<Draft>(() => blankDraft(18));
   const [activeTee, setActiveTee] = useState(0);
   const [hole, setHole] = useState(1);
@@ -101,24 +105,50 @@ export function CoursePicker({
 
   const recent = trpc.courses.list.useQuery({ limit: 8 });
   const createCourse = trpc.courses.create.useMutation();
+  // Daily golfcourseapi cap (50/day, UTC). atCap disables the wider-search +
+  // import and steers to the manual floor; local typeahead is never affected.
+  const utils = trpc.useUtils();
+  const apiUsage = trpc.courses.apiUsage.useQuery(undefined, { staleTime: 0 });
+  const recordApiCall = trpc.courses.recordApiCall.useMutation();
+  const atCap = apiUsage.data?.atCap ?? false;
 
+  // Debounce the typed query for the LOCAL search (free, never hits the API).
   useEffect(() => {
-    const q = query.trim();
-    if (q.length < 2) return;
-    let cancelled = false;
-    const t = setTimeout(async () => {
-      setSearching(true);
-      const r = await searchCourses(q);
-      if (!cancelled) {
-        setResults(r);
-        setSearching(false);
-      }
-    }, 350);
-    return () => {
-      cancelled = true;
-      clearTimeout(t);
-    };
+    const t = setTimeout(() => setDebouncedQuery(query.trim()), 250);
+    return () => clearTimeout(t);
   }, [query]);
+
+  // A new query invalidates any prior API results (they're for the old term).
+  useEffect(() => {
+    setApiResults([]);
+    setApiSearched(false);
+  }, [debouncedQuery]);
+
+  // LOCAL typeahead against our own courses table — the common path, zero API
+  // calls, unaffected by the daily cap.
+  const localSearch = trpc.courses.search.useQuery(
+    { q: debouncedQuery, limit: 10 },
+    { enabled: debouncedQuery.length >= 2 }
+  );
+
+  // The ONLY path that hits golfcourseapi — one call per explicit click, never
+  // per keystroke. Gated by the daily counter: record-then-fire, and bail
+  // (without firing) if the atomic check says we're at the cap.
+  async function searchFullDatabase() {
+    const q = query.trim();
+    if (q.length < 2 || apiSearching || atCap) return;
+    setApiSearching(true);
+    const gate = await recordApiCall.mutateAsync();
+    await utils.courses.apiUsage.invalidate();
+    if (!gate.permitted) {
+      setApiSearching(false); // hit the cap between render and click — button now disables
+      return;
+    }
+    const r = await searchCourses(q);
+    setApiResults(r);
+    setApiSearched(true);
+    setApiSearching(false);
+  }
 
   const validation = useMemo(
     () => validateStrokeIndex(draft.index, draft.holeCount),
@@ -160,6 +190,18 @@ export function CoursePicker({
     setIndexOptedIn(false);
     setConfirmMode("use");
     setPulling(true);
+    // Importing is a second API call — gate it too. At cap, fall back to manual
+    // entry with the name/location prefilled (same path as a failed detail).
+    const gate = await recordApiCall.mutateAsync();
+    await utils.courses.apiUsage.invalidate();
+    if (!gate.permitted) {
+      setPulling(false);
+      setDraft({ ...blankDraft(18), name: summary.name, location: summary.location });
+      setActiveTee(0);
+      setHole(1);
+      setScreen("new");
+      return;
+    }
     const detail = await getCourseDetail(summary.id);
     setPulling(false);
     if (!detail || detail.holes.length === 0) {
@@ -233,16 +275,18 @@ export function CoursePicker({
     return course;
   }
 
-  // mode 'use' — pick a course to drop into the game.
+  // mode 'use' — pick a course to drop into the game. The active tee chip is the
+  // configured tee — pass it so applyCourse snapshots THAT tee's yardage.
   async function useCourse() {
     if (!indexUsable || !draft.name.trim()) return;
+    const teeName = draft.teeSets[activeTee]?.name?.trim() || undefined;
     // Reviewing an existing library course, unedited → apply it directly.
     if (draft.existingId && !edited) {
-      onApply({ id: draft.existingId, name: draft.name.trim() });
+      onApply({ id: draft.existingId, name: draft.name.trim(), teeName });
       return;
     }
     const course = await persistDraft();
-    onApply({ id: course.id as string, name: course.name as string });
+    onApply({ id: course.id as string, name: course.name as string, teeName });
   }
 
   // mode 'summary' — manual add lands on My courses (NOT auto-used in a game).
@@ -319,12 +363,17 @@ export function CoursePicker({
         <SearchScreen
           query={query}
           setQuery={setQuery}
-          searching={searching}
-          results={results}
+          localResults={(localSearch.data as RecentCourse[]) ?? []}
+          localSearching={localSearch.isFetching && debouncedQuery.length >= 2}
+          apiResults={apiResults}
+          apiSearching={apiSearching}
+          apiSearched={apiSearched}
+          onSearchFull={searchFullDatabase}
+          atCap={atCap}
           recent={(recent.data as RecentCourse[]) ?? []}
           pulling={pulling}
           onPick={pull}
-          onPickRecent={reviewRecent}
+          onPickCourse={reviewRecent}
           onManual={() => {
             setEdited(false);
             setIndexOptedIn(false);
@@ -394,29 +443,46 @@ interface RecentCourse {
   tee_sets: TeeSet[];
 }
 
-// ── Search ──────────────────────────────────────────────────────────────────
+// ── Search (two-stage: local typeahead → explicit full-database) ──────────────
+// Typing searches OUR library only (free, instant, cap-proof). The full
+// golfcourseapi database is reached ONLY via the explicit control below the
+// local results — one API call per click, never per keystroke.
 function SearchScreen({
   query,
   setQuery,
-  searching,
-  results,
+  localResults,
+  localSearching,
+  apiResults,
+  apiSearching,
+  apiSearched,
+  onSearchFull,
+  atCap,
   recent,
   pulling,
   onPick,
-  onPickRecent,
+  onPickCourse,
   onManual,
 }: {
   query: string;
   setQuery: (q: string) => void;
-  searching: boolean;
-  results: CourseSummary[];
+  localResults: RecentCourse[];
+  localSearching: boolean;
+  apiResults: CourseSummary[];
+  apiSearching: boolean;
+  apiSearched: boolean;
+  onSearchFull: () => void;
+  atCap: boolean;
   recent: RecentCourse[];
   pulling: boolean;
   onPick: (c: CourseSummary) => void;
-  onPickRecent: (c: RecentCourse) => void;
+  onPickCourse: (c: RecentCourse) => void;
   onManual: () => void;
 }) {
   const showResults = query.trim().length >= 2;
+  const courseSub = (c: RecentCourse) => {
+    const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
+    return [c.location, par ? `Par ${par}` : "", `${c.hole_count} holes`].filter(Boolean).join(" · ");
+  };
   return (
     <div className="flex-1 overflow-y-auto" style={{ padding: 16 }}>
       <div className="flex items-center gap-2 rounded-xl border px-3" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
@@ -425,7 +491,7 @@ function SearchScreen({
           autoFocus
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search courses"
+          placeholder="Search your courses"
           className="w-full bg-transparent py-2.5 text-sm outline-none"
           style={{ color: "var(--color-bt-text)" }}
         />
@@ -434,29 +500,70 @@ function SearchScreen({
       {pulling && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 14 }}>Pulling scorecard…</p>}
 
       {showResults ? (
-        <div className="mt-4 flex flex-col gap-2">
-          {searching && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>Searching…</p>}
-          {!searching && results.length === 0 && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches.</p>}
-          {results.map((c) => (
-            <CourseRow key={c.id} name={c.name} sub={c.location} onClick={() => onPick(c)} />
-          ))}
-        </div>
+        <>
+          {/* Stage 1 — local library (free). */}
+          <div className="mt-4 flex flex-col gap-2">
+            {localSearching && localResults.length === 0 && (
+              <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>Searching your courses…</p>
+            )}
+            {!localSearching && localResults.length === 0 && (
+              <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No saved courses match.</p>
+            )}
+            {localResults.map((c) => (
+              <CourseRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => onPickCourse(c)} />
+            ))}
+          </div>
+
+          {/* Stage 2 — explicit, deliberate API search (the only golfcourseapi call).
+              At the daily cap the control is disabled and points at the manual floor;
+              local typeahead above keeps working (it never hits the API). */}
+          {atCap ? (
+            <div
+              className="mt-4 flex items-start gap-2 rounded-xl border px-3 py-2.5"
+              style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}
+            >
+              <AlertTriangle size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0, marginTop: 1 }} />
+              <span style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)" }}>
+                Course search is temporarily unavailable — you can add the course manually below.
+              </span>
+            </div>
+          ) : (
+            <button
+              onClick={onSearchFull}
+              disabled={apiSearching}
+              className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3 disabled:opacity-50"
+              style={{ borderColor: "var(--color-bt-border)", background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
+            >
+              <Search size={15} style={{ color: "var(--color-bt-text-dim)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600 }}>
+                {apiSearching ? "Searching the full database…" : "Don't see it? Search the full course database →"}
+              </span>
+            </button>
+          )}
+
+          {apiSearched && (
+            <div className="mt-4">
+              <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                From the course database
+              </p>
+              <div className="flex flex-col gap-2">
+                {apiResults.length === 0 ? (
+                  <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches in the database.</p>
+                ) : (
+                  apiResults.map((c) => <CourseRow key={c.id} name={c.name} sub={c.location} onClick={() => onPick(c)} />)
+                )}
+              </div>
+            </div>
+          )}
+        </>
       ) : (
         recent.length > 0 && (
           <div className="mt-5">
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Recent courses</p>
             <div className="flex flex-col gap-2">
-              {recent.map((c) => {
-                const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
-                return (
-                  <CourseRow
-                    key={c.id}
-                    name={c.name}
-                    sub={[c.location, par ? `Par ${par}` : "", `${c.hole_count} holes`].filter(Boolean).join(" · ")}
-                    onClick={() => onPickRecent(c)}
-                  />
-                );
-              })}
+              {recent.map((c) => (
+                <CourseRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => onPickCourse(c)} />
+              ))}
             </div>
           </div>
         )

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -118,11 +118,14 @@ export function CoursePicker({
     return () => clearTimeout(t);
   }, [query]);
 
-  // A new query invalidates any prior API results (they're for the old term).
-  useEffect(() => {
+  // Editing the query invalidates any prior API results (they're for the old
+  // term). Done here in the event handler — NOT a setState-in-effect — so the
+  // stale "FROM THE COURSE DATABASE" list clears the instant the user types.
+  const onQueryChange = (v: string) => {
+    setQuery(v);
     setApiResults([]);
     setApiSearched(false);
-  }, [debouncedQuery]);
+  };
 
   // LOCAL typeahead against our own courses table — the common path, zero API
   // calls, unaffected by the daily cap.
@@ -362,7 +365,7 @@ export function CoursePicker({
       ) : screen === "search" ? (
         <SearchScreen
           query={query}
-          setQuery={setQuery}
+          setQuery={onQueryChange}
           localResults={(localSearch.data as RecentCourse[]) ?? []}
           localSearching={localSearch.isFetching && debouncedQuery.length >= 2}
           apiResults={apiResults}

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -16,6 +16,9 @@ export interface ScoreUnit {
   /** Stroke (handicap) index, 1 = hardest. From `metadata.handicap_index[]`;
    *  shown in the GolfCard INDEX row and (with a course) allocates strokes. */
   strokeIndex?: number;
+  /** Yardage for the configured tee on this hole — from `metadata.tee.yards[]`.
+   *  Informational only (display); does not affect scoring. */
+  yardage?: number | null;
 }
 
 export interface Participant {

--- a/src/lib/courseIndex.ts
+++ b/src/lib/courseIndex.ts
@@ -80,12 +80,27 @@ export function applyStrokeIndexSwap(
 // units.metadata.{par,handicap_index} + labels/count/sections to the course's
 // hole layout; everything else on the template is preserved verbatim.
 
+/** The configured tee for a game — snapshotted alongside par/index so display
+ *  and any future per-tee math read the SAME tee the round was set up with. */
+export interface SnapshotTee {
+  name: string;
+  yards: (number | null)[];
+  courseRating?: number | null;
+  slopeRating?: number | null;
+  bogeyRating?: number | null;
+}
+
 export interface ScorecardUnits {
   type?: string;
   count?: number;
   ordered?: boolean;
   labels?: string[];
-  metadata?: { par?: number[]; handicap_index?: number[]; [k: string]: unknown };
+  metadata?: {
+    par?: number[];
+    handicap_index?: number[];
+    tee?: SnapshotTee;
+    [k: string]: unknown;
+  };
 }
 export interface ScorecardScoring {
   strategy?: string;
@@ -111,7 +126,8 @@ export function buildScorecardSchema(
   template: ScorecardSchema,
   par: number[],
   handicapIndex: number[] | null | undefined,
-  holeCount: number
+  holeCount: number,
+  tee?: SnapshotTee | null
 ): ScorecardSchema {
   const next = JSON.parse(JSON.stringify(template)) as ScorecardSchema;
   const labels = range(1, holeCount);
@@ -122,6 +138,10 @@ export function buildScorecardSchema(
   const metadata: ScorecardUnits["metadata"] = { ...(next.units.metadata ?? {}), par };
   if (handicapIndex?.length) metadata.handicap_index = handicapIndex;
   else delete metadata.handicap_index;
+  // The configured tee (its per-hole yardage clipped to the round) — informational
+  // display + provenance. Omitted when no course/tee is applied.
+  if (tee) metadata.tee = { ...tee, yards: tee.yards.slice(0, holeCount) };
+  else delete metadata.tee;
 
   next.units = { ...next.units, count: holeCount, labels, metadata };
 

--- a/src/lib/strokePlayConfig.ts
+++ b/src/lib/strokePlayConfig.ts
@@ -31,7 +31,14 @@ export const STROKE_PLAY_UNITS: ScoreUnit[] = Array.from({ length: 18 }, (_, i) 
  * grid/entry/pips read the SAME par + index the server scores on.
  */
 interface SchemaLike {
-  units?: { labels?: string[]; metadata?: { par?: number[]; handicap_index?: number[] } };
+  units?: {
+    labels?: string[];
+    metadata?: {
+      par?: number[];
+      handicap_index?: number[];
+      tee?: { name: string; yards?: (number | null)[] };
+    };
+  };
 }
 export function unitsFromSchema(schema?: SchemaLike | null): ScoreUnit[] {
   const meta = schema?.units?.metadata;
@@ -41,12 +48,24 @@ export function unitsFromSchema(schema?: SchemaLike | null): ScoreUnit[] {
   // handicap_index, so strokeIndex stays undefined here → the GolfCard INDEX row
   // omits itself and strokeHoles falls back to sequential.
   const hasIndex = meta.handicap_index?.length === labels.length;
+  // Configured tee yardage (informational) — present only when a course/tee is
+  // applied; per-hole, may be null on a hole the tee never had a yardage for.
+  const teeYards = meta.tee?.yards;
   return labels.map((label, i) => ({
     label,
     section: i < 9 ? "front" : "back",
     par: meta.par![i],
     strokeIndex: hasIndex ? meta.handicap_index![i] : undefined,
+    yardage: teeYards?.[i] ?? undefined,
   }));
+}
+
+/** The configured tee's display meta (name + ratings) from a schema snapshot,
+ *  for the scorecard header. Null when no course/tee is applied. */
+export function teeFromSchema(schema?: {
+  units?: { metadata?: { tee?: { name: string; courseRating?: number | null; slopeRating?: number | null; bogeyRating?: number | null } } };
+} | null): { name: string; courseRating?: number | null; slopeRating?: number | null; bogeyRating?: number | null } | null {
+  return schema?.units?.metadata?.tee ?? null;
 }
 
 /**

--- a/src/server/routers/courses.test.ts
+++ b/src/server/routers/courses.test.ts
@@ -105,6 +105,20 @@ describe("courses router — global library", () => {
     const one = await ctx.caller().courses.getById({ courseId: courseIds[0] });
     expect(one.name).toBe("Pebble Creek");
   });
+
+  it("search — local name ILIKE finds a saved course (the free typeahead path)", async () => {
+    // A uniquely-named course so the ILIKE match is unambiguous across the suite.
+    const unique = `Zzz Local Search ${Date.now()}`;
+    const c = await ctx.caller().courses.create({ name: unique, holeCount: 18, par: PAR, handicapIndex: IDX });
+    courseIds.push(c.id as string);
+
+    const hits = await ctx.caller().courses.search({ q: unique.slice(0, 12) });
+    expect(hits.some((h: { id: string }) => h.id === c.id)).toBe(true);
+
+    // A non-matching term returns nothing for this course.
+    const miss = await ctx.caller().courses.search({ q: "qqq-no-such-course-xyz" });
+    expect(miss.some((h: { id: string }) => h.id === c.id)).toBe(false);
+  });
 });
 
 describe("games.applyCourse — the contract snapshot", () => {
@@ -132,6 +146,50 @@ describe("games.applyCourse — the contract snapshot", () => {
     expect(updated!.course_id).toBe(course.id);
   });
 
+  it("snapshots the SELECTED tee (not the first) — display can't disagree with config", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Tee Select" });
+    const course = await ctx.caller().courses.create({
+      name: "Two Tee GC",
+      holeCount: 18,
+      par: PAR,
+      handicapIndex: IDX,
+      teeSets: [
+        { name: "Blue", courseRating: 72.3, slopeRating: 131, yards: Array(18).fill(410) },
+        { name: "White", courseRating: 70.1, slopeRating: 124, yards: Array(18).fill(380) },
+      ],
+    });
+    courseIds.push(course.id as string);
+
+    // Apply the SECOND tee explicitly — the snapshot must carry White, not Blue.
+    const updated = await ctx.caller().games.applyCourse({
+      tripId,
+      gameId: game.id as string,
+      courseId: course.id as string,
+      teeSetName: "White",
+    });
+    const tee = (updated!.scorecard_schema as { units: { metadata: { tee: { name: string; yards: number[]; courseRating: number } } } })
+      .units.metadata.tee;
+    expect(tee.name).toBe("White");
+    expect(tee.courseRating).toBe(70.1);
+    expect(tee.yards.every((y) => y === 380)).toBe(true);
+  });
+
+  it("defaults to the first tee when none is named", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Default Tee" });
+    const course = await ctx.caller().courses.create({
+      name: "Default Tee GC",
+      holeCount: 18,
+      par: PAR,
+      handicapIndex: IDX,
+      teeSets: [{ name: "Black", yards: Array(18).fill(450) }, { name: "Red", yards: Array(18).fill(300) }],
+    });
+    courseIds.push(course.id as string);
+
+    const updated = await ctx.caller().games.applyCourse({ tripId, gameId: game.id as string, courseId: course.id as string });
+    const tee = (updated!.scorecard_schema as { units: { metadata: { tee: { name: string } } } }).units.metadata.tee;
+    expect(tee.name).toBe("Black");
+  });
+
   it("is frozen once a score exists (re-apply blocked)", async () => {
     const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Frozen" });
     const course = await ctx.caller().courses.create({
@@ -157,5 +215,37 @@ describe("games.applyCourse — the contract snapshot", () => {
     await expect(
       ctx.caller().games.applyCourse({ tripId, gameId: game.id as string, courseId: course.id as string })
     ).rejects.toThrow(/already entered|can't be changed/i);
+  });
+});
+
+describe("courses router — golfcourseapi daily counter (Phase 4)", () => {
+  it("record_api_call increments under the limit then caps at it (atomic gate)", async () => {
+    // Throwaway provider + tiny limit so the cap is reachable without 50 calls
+    // and the real golfcourseapi counter is untouched.
+    const P = `__test_cap_${Date.now()}__`;
+    const c1 = await ctx.admin.rpc("record_api_call", { p_provider: P, p_limit: 2 });
+    const c2 = await ctx.admin.rpc("record_api_call", { p_provider: P, p_limit: 2 });
+    const c3 = await ctx.admin.rpc("record_api_call", { p_provider: P, p_limit: 2 });
+    expect(c1.data).toBe(1);
+    expect(c2.data).toBe(2);
+    expect(c3.data).toBe(-1); // at cap → no increment, signals "do not fire"
+    await ctx.admin.from("api_usage_daily").delete().eq("provider", P);
+  });
+
+  it("recordApiCall increments and apiUsage reflects it (tRPC wiring)", async () => {
+    const before = await ctx.caller().courses.apiUsage();
+    const rec = await ctx.caller().courses.recordApiCall();
+    expect(rec.permitted).toBe(true);
+    expect(rec.count).toBe(before.count + 1);
+
+    const after = await ctx.caller().courses.apiUsage();
+    expect(after.count).toBe(before.count + 1);
+    expect(after.limit).toBe(50);
+    expect(after.atCap).toBe(false);
+
+    // Clean up today's golfcourseapi row — no real API calls happen in test, so
+    // the counter should return to empty for the next run.
+    const today = new Date().toISOString().slice(0, 10);
+    await ctx.admin.from("api_usage_daily").delete().eq("provider", "golfcourseapi").eq("usage_date", today);
   });
 });

--- a/src/server/routers/courses.test.ts
+++ b/src/server/routers/courses.test.ts
@@ -80,7 +80,10 @@ describe("courses router — global library", () => {
       source: "golfcourseapi",
       providerId: "gca-7788",
       teeSets: [
-        { name: "Blue", courseRating: 72.3, slopeRating: 131, bogeyRating: 95.1, yards: Array(18).fill(410) },
+        // Bogey rating 101.7 is a REAL value (Pebble Beach Blue) that exceeds a
+        // bogey golfer's "100" intuition — guards the max(99) bound bug that
+        // verify-by-eye caught (the import silently failed on real data).
+        { name: "Blue", courseRating: 72.3, slopeRating: 131, bogeyRating: 101.7, yards: Array(18).fill(410) },
         { name: "White", courseRating: 70.1, slopeRating: 124, bogeyRating: 92, yards: Array(18).fill(380) },
       ],
     });
@@ -95,7 +98,7 @@ describe("courses router — global library", () => {
       yards: (number | null)[];
     }>;
     expect(tees).toHaveLength(2);
-    expect(tees[0]).toMatchObject({ name: "Blue", courseRating: 72.3, slopeRating: 131, bogeyRating: 95.1 });
+    expect(tees[0]).toMatchObject({ name: "Blue", courseRating: 72.3, slopeRating: 131, bogeyRating: 101.7 });
     expect(tees[1]).toMatchObject({ name: "White", slopeRating: 124 });
   });
 

--- a/src/server/routers/courses.ts
+++ b/src/server/routers/courses.ts
@@ -18,6 +18,11 @@ import { validateStrokeIndex } from "@/lib/courseIndex";
 // The full per-tee record (mig 059). Ratings are optional + nullable —
 // golfcourseapi supplies them; manual entry leaves them out (par + stroke index
 // alone still score). Stored verbatim in courses.tee_sets (jsonb).
+// golfcourseapi.com free tier: 50 requests/day, keyed to 0000 UTC. The counter
+// is provider-scoped so a future second provider gets its own row + cap.
+const GOLF_API_PROVIDER = "golfcourseapi";
+const GOLF_API_DAILY_LIMIT = 50;
+
 const teeSetSchema = z.object({
   name: z.string().trim().min(1).max(60),
   courseRating: z.number().positive().max(99).nullable().optional(),
@@ -96,6 +101,74 @@ export const coursesRouter = router({
       }
       return data;
     }),
+
+  // search — LOCAL typeahead against the global library (name ILIKE). This is
+  // the free, always-on first stage of the two-stage picker: keystroke search
+  // hits THIS, never golfcourseapi, so it's unaffected by the daily API cap.
+  // The explicit "Search the full database" control is the only API path.
+  search: authedProcedure
+    .input(
+      z.object({
+        q: z.string().trim().min(2).max(100),
+        limit: z.number().int().min(1).max(20).optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      // Escape LIKE wildcards in user input so a literal % / _ doesn't widen the
+      // match (defense — course names with these are rare but possible).
+      const term = input.q.replace(/[\\%_]/g, "\\$&");
+      const { data, error } = await ctx.supabase
+        .from("courses")
+        .select("*")
+        .ilike("name", `%${term}%`)
+        .order("created_at", { ascending: false })
+        .limit(input.limit ?? 10);
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to search courses: ${error.message}`,
+        });
+      }
+      return data ?? [];
+    }),
+
+  // apiUsage — today's golfcourseapi call count (UTC), for the picker to gate the
+  // "Search the full database" control. Read-only; never increments.
+  apiUsage: authedProcedure.query(async ({ ctx }) => {
+    const today = new Date().toISOString().slice(0, 10); // UTC day (matches the DB key)
+    const { data } = await ctx.supabase
+      .from("api_usage_daily")
+      .select("count")
+      .eq("provider", GOLF_API_PROVIDER)
+      .eq("usage_date", today)
+      .maybeSingle();
+    const count = (data?.count as number | undefined) ?? 0;
+    return { count, limit: GOLF_API_DAILY_LIMIT, atCap: count >= GOLF_API_DAILY_LIMIT };
+  }),
+
+  // recordApiCall — atomic check-and-increment before an actual golfcourseapi
+  // call (search or import). Returns permitted=false (without incrementing) when
+  // already at the daily cap, so the caller must NOT fire the API. The atomicity
+  // (a single DB function) is what makes "check before calling" race-safe.
+  recordApiCall: authedProcedure.mutation(async ({ ctx }) => {
+    const { data, error } = await ctx.supabase.rpc("record_api_call", {
+      p_provider: GOLF_API_PROVIDER,
+      p_limit: GOLF_API_DAILY_LIMIT,
+    });
+    if (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `Failed to record API usage: ${error.message}`,
+      });
+    }
+    const newCount = data as number; // new count, or -1 when already at cap
+    const permitted = newCount >= 0;
+    return {
+      permitted,
+      count: permitted ? newCount : GOLF_API_DAILY_LIMIT,
+      atCap: !permitted,
+    };
+  }),
 
   // list — recent courses for the empty-search "Recent courses" list (§2/§5).
   // Global most-recent, not per-circle.

--- a/src/server/routers/courses.ts
+++ b/src/server/routers/courses.ts
@@ -23,11 +23,17 @@ import { validateStrokeIndex } from "@/lib/courseIndex";
 const GOLF_API_PROVIDER = "golfcourseapi";
 const GOLF_API_DAILY_LIMIT = 50;
 
+// Rating bounds reflect REAL golf ranges (caught in verify-by-eye: Pebble's
+// Blue bogey rating is 101.7, which a max(99) wrongly rejected). Course rating
+// tops out ~80; slope is the USGA 55–155 range; BOGEY rating runs ~CR+25, so it
+// routinely exceeds 99 (≈120 from championship tees). Generous ceilings — these
+// are informational/display, not security-sensitive; the bound only catches
+// obvious garbage.
 const teeSetSchema = z.object({
   name: z.string().trim().min(1).max(60),
   courseRating: z.number().positive().max(99).nullable().optional(),
   slopeRating: z.number().int().min(55).max(155).nullable().optional(),
-  bogeyRating: z.number().positive().max(99).nullable().optional(),
+  bogeyRating: z.number().positive().max(150).nullable().optional(),
   yards: z.array(z.number().int().positive().nullable()).optional(),
 });
 

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -9,7 +9,7 @@ import { computeRackNStackResults } from "../lib/rackNStack";
 import type { MatchOutcome } from "../lib/matchPlay";
 import type { RackTeamOutcome } from "../lib/rackNStack";
 import type { StrokeStanding } from "@/lib/strokePlay";
-import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema } from "@/lib/courseIndex";
+import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema, type SnapshotTee } from "@/lib/courseIndex";
 import { validatePlacement } from "@/lib/gameConfig";
 
 /**
@@ -246,7 +246,16 @@ export const gamesRouter = router({
   // this game. course_id is kept as provenance. Re-snapshot is allowed before
   // any score exists; FROZEN once scores are entered (freeze boundary).
   applyCourse: authedProcedure
-    .input(z.object({ tripId: z.string(), gameId: z.string(), courseId: z.string().min(1) }))
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        courseId: z.string().min(1),
+        // The configured tee set (by name). Optional — defaults to the course's
+        // first tee. Snapshotted into the schema so display reads the SAME tee.
+        teeSetName: z.string().optional(),
+      })
+    )
     .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
@@ -272,7 +281,7 @@ export const gamesRouter = router({
 
       const { data: course } = await ctx.supabase
         .from("courses")
-        .select("hole_count, par, handicap_index, has_stroke_index")
+        .select("hole_count, par, handicap_index, has_stroke_index, tee_sets")
         .eq("id", input.courseId)
         .maybeSingle();
       if (!course) throw new TRPCError({ code: "NOT_FOUND", message: "Course not found" });
@@ -280,6 +289,15 @@ export const gamesRouter = router({
       const holeCount = course.hole_count as number;
       const par = course.par as number[];
       const hasIndex = (course.has_stroke_index as boolean | null) ?? true;
+
+      // Resolve the configured tee: the requested name, else the first tee.
+      // Snapshotting the SELECTED tee (not a hardcoded default) is what keeps the
+      // displayed yardage honest to what the round was set up with.
+      const teeSets = (course.tee_sets as SnapshotTee[] | null) ?? [];
+      const selectedTee =
+        (input.teeSetName ? teeSets.find((t) => t.name === input.teeSetName) : undefined) ??
+        teeSets[0] ??
+        null;
       // Index-off course → snapshot par only (buildScorecardSchema fills a
       // sequential index; net falls back to hole order). Index-on → validate it
       // as defense in depth before snapshotting.
@@ -304,7 +322,7 @@ export const gamesRouter = router({
         });
       }
 
-      const snapshot = buildScorecardSchema(baseSchema, par, handicapIndex, holeCount);
+      const snapshot = buildScorecardSchema(baseSchema, par, handicapIndex, holeCount, selectedTee);
       const { error } = await ctx.supabase
         .from("games")
         .update({ scorecard_schema: snapshot, course_id: input.courseId })

--- a/supabase/migrations/20260620150000_060_api_usage_daily.sql
+++ b/supabase/migrations/20260620150000_060_api_usage_daily.sql
@@ -1,0 +1,54 @@
+-- 060 — api_usage_daily: the golfcourseapi.com daily request counter (UTC).
+--
+-- golfcourseapi's free tier is 50 requests/day. This table is BOTH the rate
+-- limiter (check-before-call) AND the usage metric the future admin panel will
+-- read — one row per provider per UTC day. Keyed to 0000 UTC (the reset
+-- boundary we assume; validate against the live API once a key is in hand).
+-- Local-table searches never touch this; only an actual golfcourseapi call does.
+-- Idempotent.
+
+CREATE TABLE IF NOT EXISTS public.api_usage_daily (
+  provider   text not null,
+  usage_date date not null,                    -- UTC day
+  count      int  not null default 0,
+  PRIMARY KEY (provider, usage_date)
+);
+COMMENT ON TABLE public.api_usage_daily IS
+  'Daily external-API call counter (golfcourseapi.com), keyed to UTC day. Rate '
+  'limiter + usage metric. Incremented only on an actual API call (search/import).';
+
+ALTER TABLE public.api_usage_daily ENABLE ROW LEVEL SECURITY;
+
+-- Any authenticated user may READ today's count (the picker shows cap state).
+-- Writes go ONLY through record_api_call (SECURITY DEFINER) — no direct
+-- INSERT/UPDATE policy, so the count can't be tampered with from the client.
+DROP POLICY IF EXISTS api_usage_daily_select ON public.api_usage_daily;
+CREATE POLICY api_usage_daily_select ON public.api_usage_daily
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Atomic check-and-increment: increments today's counter for `p_provider` IFF
+-- it is below `p_limit`, returning the new count; returns -1 when already at the
+-- cap (no increment). One round-trip, race-safe — two concurrent callers can't
+-- both push past the limit. SECURITY DEFINER so it can write past RLS.
+CREATE OR REPLACE FUNCTION public.record_api_call(p_provider text, p_limit int)
+RETURNS int
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_count int;
+BEGIN
+  INSERT INTO public.api_usage_daily (provider, usage_date, count)
+  VALUES (p_provider, (now() AT TIME ZONE 'utc')::date, 1)
+  ON CONFLICT (provider, usage_date)
+  DO UPDATE SET count = public.api_usage_daily.count + 1
+    WHERE public.api_usage_daily.count < p_limit
+  RETURNING count INTO new_count;
+  -- A conflict whose WHERE failed (already at cap) returns no row → null.
+  RETURN COALESCE(new_count, -1);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.record_api_call(text, int) TO authenticated;


### PR DESCRIPTION
## Recovery PR — lands PR 2 on `main`

**What happened:** #417 (PR 2) was merged into its base branch `feat/golfcourseapi-provider-swap` instead of `main`, so when #415 (PR 1) squash-merged to main, PR 2's content never arrived. `main` currently has the provider swap **without** the two-stage search, the daily counter, the config-time tee, or the verify-by-eye fixes.

**Why this matters (current main/prod is a worse state than intended):**
- The course picker still fires golfcourseapi **on every keystroke** (PR 2 is what replaced that with local-first + an explicit search) — and golfcourseapi's free tier is **50/day**, so typing burns the cap fast.
- There is **no daily counter** guarding the cap (PR 2 adds it).
- `teeSetSchema` still caps `bogeyRating` at 99, so real-course imports silently fail (the verify-by-eye bug; fixed here).

**This PR** is exactly PR 2's three commits rebased onto current main (PR 1's commits dropped — already on main):
1. Two-stage local-first search + config-time tee + daily API cap (migration 060)
2. Bogey-rating bound fix (max 99 → 150) — caught in the authenticated walk
3. Lint fix — clear stale API results in the handler, not a setState-in-effect (the build error)

**Verified:** full authenticated walk passed end-to-end (local typeahead → wider search → import Pebble Beach → select White tee → snapshot got White → scorecard showed White's yardage + "White tees · CR 71.8 / Slope 134" + pips on holes 6/8/10/14 → counter = exactly 2). tsc + eslint clean. Migration 060 already applied to the linked DB (idempotent; CI re-applies as a no-op).

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
