### PR TITLE
feat(e2e): fix the harness + land one critical-path Playwright gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,41 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
       - run: npx tsc --noEmit
       - run: npx vitest run
-      # Playwright E2E tests deferred — requires auth redirect fix + global-setup (Issue #29)
+
+  # Critical-path E2E gate (Issue #29 resolved). Runs the ONE merge-blocking
+  # smoke test (auth-setup → stroke game → scores → scorecard) against the same
+  # remote project the vitest job uses. Needs `test` first so migrations are
+  # pushed and unit tests gate before we spend time on the browser run.
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [test]
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - name: Cache Playwright browser
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright chromium (+ OS deps)
+        run: npx playwright install --with-deps chromium
+      - name: Build app (served by Playwright's webServer)
+        run: npm run build
+      - name: Run critical-path E2E
+        run: npx playwright test
+      - name: Upload report on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ next-env.d.ts
 .test-auth-pool.json
 .test-auth.json
 .claude/scheduled_tasks.lock
+
+# Playwright auth state (session — never commit)
+e2e/.auth/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,21 @@ seam, never on a calendar.
 ## Testing Rules
 
 - Every new tRPC router gets a Vitest unit test before the task is considered done
-- Every new database query gets tested against local Supabase (`supabase start`)
-- Every new UI screen gets at least one Playwright E2E test covering the happy path
+- Every new database query gets tested against the test DB the suite uses
+- **Critical-path E2E must stay green in CI (merge-blocking).** The one
+  Playwright smoke test (`e2e/critical-path.spec.ts`: auth → stroke game →
+  scores → scorecard) guards that the assembled spine is reachable — the class
+  of break unit tests miss. New screens get E2E coverage **when they touch the
+  critical path**; broader per-screen coverage is added as specific regressions
+  warrant — not up front. (The old "every screen gets an E2E test" rule was
+  aspirational and unmet; this is what's actually enforced.) E2E auth is a
+  `storageState` login as `test-owner` (`e2e/auth.setup.ts`); tests seed a unique
+  trip and tear it down. The 12 older `e2e/*.spec.ts` are a deferred, mock-based
+  set that no project runs yet.
 - Tests live next to what they test (`trips.test.ts` alongside `trips.ts`)
 - No task is considered complete until its tests pass
-- CI runs Vitest and Playwright on every push via GitHub Actions
+- CI runs Vitest (full) + the critical-path Playwright E2E on every push via
+  GitHub Actions; both are merge-blocking
 
 ## Seed Data Rules
 

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,53 @@
+import { test as setup } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+import { resolve } from "path";
+
+/**
+ * Auth setup — runs once before the critical-path test. Logs in as the seeded
+ * `test-owner` through the REAL login UI so @supabase/ssr writes the session
+ * cookie the middleware's server-side getUser() accepts, then saves the session
+ * to storageState. The critical-path project depends on this and reuses it, so
+ * it starts already-authenticated (route-mocking can't satisfy the server-side
+ * auth check — that's what kept the old e2e specs from ever reaching /trips/*).
+ */
+
+const OWNER_EMAIL = "test-owner@buddytrip.app";
+const OWNER_NAME = "Test Owner";
+const PASSWORD = "BuddyTripTest2026!"; // same shared test password as vitest global-setup
+const STORAGE = resolve(__dirname, ".auth/owner.json");
+
+setup("authenticate as test-owner", async ({ page }) => {
+  // 1. Ensure test-owner exists on the project (idempotent) — the same user
+  //    vitest's global-setup creates. Self-contained so the E2E CI job doesn't
+  //    depend on the vitest job having run first.
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    throw new Error("E2E auth setup needs NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env");
+  }
+  const admin = createClient(url, serviceKey);
+  const { data: list, error: listErr } = await admin.auth.admin.listUsers();
+  if (listErr) throw new Error(`Failed to list users: ${listErr.message}`);
+  if (!list?.users?.some((u) => u.email === OWNER_EMAIL)) {
+    const { error } = await admin.auth.admin.createUser({
+      email: OWNER_EMAIL,
+      password: PASSWORD,
+      email_confirm: true,
+      user_metadata: { name: OWNER_NAME },
+    });
+    if (error) throw new Error(`Failed to create test-owner: ${error.message}`);
+  }
+
+  // 2. Log in through the UI (the real signInWithPassword path).
+  await page.goto("/login");
+  await page.locator("#email").fill(OWNER_EMAIL);
+  await page.locator("#password").fill(PASSWORD);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+  // 3. The middleware bounces an authenticated user off /login → wait until we
+  //    leave it (proves the cookie is set and accepted).
+  await page.waitForURL((u) => !u.pathname.startsWith("/login"), { timeout: 30_000 });
+
+  // 4. Persist the session for the dependent project.
+  await page.context().storageState({ path: STORAGE });
+});

--- a/e2e/critical-path.spec.ts
+++ b/e2e/critical-path.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Critical-path E2E (the merge-blocking gate) — the GAME-SCORING SPINE, driven
+ * through the real UI as the logged-in owner (storageState from auth.setup.ts).
+ *
+ * Honestly scoped: the trip + crew are SEEDED via the admin client (fast, stable
+ * scaffolding — not the thing under test); the spine that's actually walked is
+ * **create a stroke-play game → enter scores → the scorecard reflects them**.
+ * That's the class of break unit tests miss and that's bitten this project:
+ * an unreachable setup state, a dead scorecard button, a score that doesn't
+ * surface. The fuller competition-run-to-leaderboard walk on real data is the
+ * BBMI-replay follow-on (a heavier acceptance test, not this per-push smoke).
+ *
+ * Runs against the remote project (same model as the vitest suite): a UNIQUE
+ * trip per run + full teardown, so reruns never collide and nothing is left.
+ */
+
+const OWNER_EMAIL = "test-owner@buddytrip.app";
+const MEMBER_EMAIL = "test-member@buddytrip.app";
+const PASSWORD = "BuddyTripTest2026!";
+
+let admin: SupabaseClient;
+let tripId: string;
+let ownerId: string;
+let memberId: string;
+
+async function ensureUser(email: string, name: string): Promise<string> {
+  const { data: list, error } = await admin.auth.admin.listUsers();
+  if (error) throw new Error(`listUsers failed: ${error.message}`);
+  const found = list?.users?.find((u) => u.email === email);
+  if (found) return found.id;
+  const { data, error: createErr } = await admin.auth.admin.createUser({
+    email,
+    password: PASSWORD,
+    email_confirm: true,
+    user_metadata: { name },
+  });
+  if (createErr || !data.user) throw new Error(`createUser ${email} failed: ${createErr?.message}`);
+  return data.user.id;
+}
+
+test.beforeAll(async () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("E2E needs NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY");
+  admin = createClient(url, key);
+
+  ownerId = await ensureUser(OWNER_EMAIL, "Test Owner");
+  memberId = await ensureUser(MEMBER_EMAIL, "Test Member");
+
+  // Unique trip per run (vitest isolation pattern). Owner + one member so the
+  // stroke game's 2–4-player picker has two crew to pick.
+  tripId = `e2e-trip-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const { error: tErr } = await admin.from("trips").insert({ id: tripId, title: "E2E Critical Path" });
+  if (tErr) throw new Error(`seed trip failed: ${tErr.message}`);
+  // Trip-scoped nicknames make the player picker deterministic regardless of the
+  // shared users' account names (which drift as other tests rename them) — and
+  // they mutate nothing outside this throwaway trip.
+  const { error: mErr } = await admin.from("trip_members").insert([
+    { trip_id: tripId, user_id: ownerId, role: "Owner", status: "in", nickname: "E2E Owner" },
+    { trip_id: tripId, user_id: memberId, role: "Member", status: "in", nickname: "E2E Member" },
+  ]);
+  if (mErr) throw new Error(`seed members failed: ${mErr.message}`);
+});
+
+test.afterAll(async () => {
+  if (!admin || !tripId) return;
+  // Tear down everything this run created — games (+ score_entries,
+  // game_participants) then the trip + memberships. Bulletproof: explicit, and
+  // ordered child-first so no FK blocks the delete.
+  const { data: games } = await admin.from("games").select("id").eq("trip_id", tripId);
+  for (const g of games ?? []) {
+    await admin.from("score_entries").delete().eq("game_id", g.id);
+    await admin.from("game_participants").delete().eq("game_id", g.id);
+    await admin.from("games").delete().eq("id", g.id);
+  }
+  await admin.from("trip_members").delete().eq("trip_id", tripId);
+  await admin.from("trips").delete().eq("id", tripId);
+});
+
+test("scoring spine — stroke game: create → enter scores → scorecard reflects them", async ({ page }) => {
+  // 1. New stroke-play game for this trip (owner is authenticated via storageState).
+  await page.goto(`/trips/${tripId}/games/new`);
+
+  // 2. Pick the two crew, start the game.
+  await page.getByRole("button", { name: "E2E Owner", exact: true }).click();
+  await page.getByRole("button", { name: "E2E Member", exact: true }).click();
+  await page.getByRole("button", { name: "Start game" }).click();
+
+  // 3. Enable scoring → reach the score-entry view.
+  await page.getByRole("button", { name: "Enable scoring" }).click();
+
+  // 4. Enter hole 1 for both players (confirm auto-advances to the next player).
+  //    Distinct values so the assertion can't pass on par/coincidence.
+  await page.getByRole("button", { name: "Score 7", exact: true }).click();
+  await page.getByRole("button", { name: "Confirm score" }).click();
+  await page.getByRole("button", { name: "Score 3", exact: true }).click();
+  await page.getByRole("button", { name: "Confirm score" }).click();
+
+  // 5. Open the review scorecard and assert BOTH entered scores surface in the
+  //    EXACT right cells (keyed by participant id = user id, hole "1") — "a score
+  //    shows up where it should". Test-id selectors, not brittle text.
+  await page.getByRole("button", { name: "Scorecard grid" }).click();
+
+  await expect(page.getByTestId(`score-cell-${ownerId}-1`)).toHaveText("7");
+  await expect(page.getByTestId(`score-cell-${memberId}-1`)).toHaveText("3");
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
+import { config as loadEnv } from "dotenv";
+
+// Load .env.local for local runs (NEXT_PUBLIC_SUPABASE_URL, service key, etc.).
+// In CI these come from job env (GitHub secrets); a missing .env.local is a
+// silent no-op, so this is safe in both places.
+loadEnv({ path: ".env.local" });
+
+const STORAGE_STATE = "e2e/.auth/owner.json";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -6,19 +14,31 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "html",
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
   },
   projects: [
+    // Logs in as test-owner once and saves the session; the critical-path
+    // project depends on it so it starts already-authenticated (the middleware
+    // does a server-side getUser() that route-mocks can't satisfy).
+    { name: "setup", testMatch: /auth\.setup\.ts/ },
     {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      // Scoped to the ONE critical-path spec — the merge-blocking CI gate. The
+      // other e2e/*.spec.ts files are the deferred mocked set (Issue #29) and
+      // match no project, so they don't run.
+      name: "critical-path",
+      testMatch: /critical-path\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"], storageState: STORAGE_STATE },
+      dependencies: ["setup"],
     },
   ],
   webServer: {
-    command: "npm run dev",
+    // CI runs the prebuilt app (the workflow does `npm run build` first) so
+    // there's no flaky on-demand route compilation mid-test; locally, dev is
+    // fine and reuses an already-running server.
+    command: process.env.CI ? "npm run start" : "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -258,6 +258,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                   return (
                     <button
                       key={u.label}
+                      data-testid={`score-cell-${p.id}-${u.label}`}
                       onClick={() => onCellTap?.(u.label)}
                       className="relative flex items-center justify-center"
                       style={{


### PR DESCRIPTION
## What
Fixes the broken Playwright harness and lands **one green, merge-blocking critical-path E2E** in CI. Deliberately minimal (not full-app coverage) — the point is a real safety net that catches "logic is right but the assembled path is unreachable," the class unit tests miss.

## Harness (the auth fix)
The old specs route-mocked `/auth` + `/api/trpc`, which can't satisfy the middleware's **server-side** `getUser()` — so `/trips/*` always redirected to `/login`. Now:
- **`e2e/auth.setup.ts`** — a setup project logs in as the seeded `test-owner` through the real login UI; `@supabase/ssr` writes the session cookie the middleware accepts; saved to `storageState`.
- **`playwright.config.ts`** — `critical-path` project depends on `setup`, reuses the session. Scoped to the one spec; the 12 deferred mock specs match no project.

## The critical-path test (`e2e/critical-path.spec.ts`)
Against the remote (same model as vitest): seeds a **unique trip + crew** via admin (trip-scoped nicknames → deterministic, no shared state touched), drives **create stroke game → enter scores → scorecard** through the UI as owner, asserts both scores land in the exact cells (`data-testid` added to `StandardGrid`), and **tears the trip down**. Honestly named for the game-scoring spine; the competition-run-to-leaderboard on real data is the BBMI-replay follow-on.

**Proven to go red:** broke the scorecard's score read → test failed at the assertion → restored.

## CI (merge gate)
New `e2e` job: `needs: [test]` (migrations + units first), **caches chromium**, builds the app, runs the test on every push/PR — **red blocks merge**. webServer runs the prebuilt app in CI (no flaky on-demand compile), dev locally.

## Docs + follow-ons
- **CLAUDE.md** reconciled: the unmet "every screen gets an E2E test" → "critical-path stays green (merge-blocking); per-screen as regressions warrant."
- Filed: BBMI-replay acceptance test (#419), evaluate local-Supabase migration (#420). **Closes #29** (superseded).

## Verified
- 2 passed locally (setup + critical-path, ~12s); tsc + eslint clean; 0 leftover e2e trips after teardown; goes-red proven.
- ⏳ The real proof — the `e2e` job green in CI — lands on this PR's run.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
