### PR TITLE
chore: pin Supabase CLI in CI + remove test-only netForHole

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       - run: npm ci --ignore-scripts
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned (not `latest`): `latest` resolves the newest release from a
+          # gateway that intermittently times out and blocks the merge-gating job.
+          version: 2.78.1
       - name: Push migrations to Supabase
         run: supabase db push --db-url "$SUPABASE_DB_URL"
         env:

--- a/src/lib/matchPlay.test.ts
+++ b/src/lib/matchPlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { strokeHoles, netForHole, buildDecided, matchState, type HoleResult } from "./matchPlay";
+import { strokeHoles, buildDecided, matchState, type HoleResult } from "./matchPlay";
 
 describe("strokeHoles", () => {
   it("returns nothing for n <= 0", () => {
@@ -33,13 +33,6 @@ describe("strokeHoles", () => {
   it("no-index fallback respects a passed holeCount (won't strike beyond the round)", () => {
     // 12 strokes on a 9-hole round with no index → every hole, capped at 9.
     expect([...strokeHoles(12, undefined, 9)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  });
-});
-
-describe("netForHole", () => {
-  it("subtracts a stroke only on a hole the player receives one (fallback)", () => {
-    expect(netForHole(5, 1, 1)).toBe(4); // hole 1 gets the stroke
-    expect(netForHole(5, 2, 1)).toBe(5); // hole 2 does not
   });
 });
 

--- a/src/lib/matchPlay.ts
+++ b/src/lib/matchPlay.ts
@@ -47,11 +47,6 @@ export function strokeHoles(n: number, strokeIndex?: number[], holeCount?: numbe
   return new Set([...Array(Math.min(n, H))].map((_, i) => i + 1));
 }
 
-/** gross − strokes received on that hole. */
-export function netForHole(gross: number, hole: number, n: number, strokeIndex?: number[]): number {
-  return gross - (strokeHoles(n, strokeIndex).has(hole) ? 1 : 0);
-}
-
 /**
  * Build the decided `HoleResult[]` (A's perspective, hole order) from both
  * sides' gross-per-hole maps + each side's handicap strokes. A hole is decided


### PR DESCRIPTION
Two small, independent cleanups (the loose threads after R3).

## 1. Pin the Supabase CLI in CI
The merge-gating `test` job used `supabase/setup-cli` with **`version: latest`**, which resolves the newest release from a gateway that intermittently times out (the "Gateway Time-out" that just blocked #423). Pinned to **`2.78.1`** (matches the npm devDep) so the install is deterministic and a Supabase-gateway hiccup no longer blocks unrelated merges.

## 2. Remove test-only `netForHole` (Closes #408)
`netForHole` (`matchPlay.ts`) was imported **only by its own test** — zero production refs, re-confirmed at delete time. Removed the function + its describe block. `strokeHoles` (which it wrapped) stays — it's used by `buildDecided`.

## Verified
tsc + eslint clean; `matchPlay.test` green (19 tests).

Two commits, bisectable. Closes #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)