### PR TITLE
R4 Phase 0 + Rename 1: ratify glossary + matches.activate → enableScoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,30 @@
 
 - Next.js 15 (App Router) · React 18 · TypeScript · Tailwind v4 · tRPC v11 · TanStack Query v5 · Supabase (Postgres + Auth + Realtime) · Zod · Vitest · Playwright · Vercel
 
+## Glossary — ratified nomenclature (one word per concept, every layer)
+
+Consistency is load-bearing: the same concept under two names is how auth/spec
+seams drift. These are the canonical terms — use them in code identifiers, DB
+values, and UI copy alike. (Ratified in `TRACKER.md` §3; this is the home of
+record.) Any rename must declare which layer it touches —
+**display-string** (cosmetic), **code-identifier** (`tsc`+grep catch misses), or
+**DB-value** (an enum/string RLS branches on — `tsc` CANNOT catch a missed RLS
+string; highest risk, needs an atomic migration + auth verification).
+
+**Competition hierarchy (4 levels):** competition leaderboard (cup standings) →
+game scoreboard (one game's state) → game score entry (entering scores) → game
+scorecard (hole-by-hole). "hub" is retired. "face" stays a *navigation* term only
+(`CompetitionFace.tsx` — a competition is a face, not a tab).
+
+| Concept | Canonical | Note / landmine |
+|---------|-----------|-----------------|
+| Unit of play | **game** + **match** (a pairing inside match-play) | "round" means golf's 18 holes ONLY — never a game/match |
+| Scoring-on / visibility | **enableScoring** / **Live** (first score flips it) / reveal = Go-Live | one action, one name (`matches.activate` was the old alias — renamed) |
+| Combatants | **team** (roster) / **side** (slot, may be solo) | preserve the split — a side is a slot, a team is the roster |
+| Rights | **Owner / Organizer / Member** (trip) · **co_admin** (comp) · **delegate** (game) | trip role VALUE is `Organizer` (mig 029, not "Planner"); the one game-scope term is `delegate` |
+| A person | **member** (trip) / **participant** (game) / **guest** (placeholder) | ghost == guest — grep hazard |
+| Container | **competition** (code) / **cup** (UI) | not "Events" |
+
 ## Commit Rules
 
 - Commit after each individual task, not at the end of a phase

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -53,7 +53,7 @@ type Screen = "new" | "member-wait" | "setup" | "overview" | "score" | "config";
 
 /**
  * Singles match-play game flow (Slice B). TEMPORARY route — the real Games tab
- * is Slice E. Walks the full lifecycle (create → pairings → handicap → activate
+ * is Slice E. Walks the full lifecycle (create → pairings → handicap → enableScoring
  * → score → finish), role-gated, persisting each step via the `matches` router.
  * Resume an existing game with `?game=<id>`.
  */
@@ -157,7 +157,7 @@ export default function NewMatchGamePage() {
   const setHandicap = trpc.matches.setHandicap.useMutation();
   const setDoublesPairings = trpc.matches.setDoublesPairings.useMutation();
   const setDoublesHandicap = trpc.matches.setDoublesHandicap.useMutation();
-  const activate = trpc.matches.activate.useMutation();
+  const enableScoring = trpc.matches.enableScoring.useMutation();
   // Phase 2B.1: Disable scoring — close to the crew, back to setup, scores kept.
   const disableScoring = trpc.games.disableScoring.useMutation();
   // Dynamic match count (+1 / −1). Each changes the game's configured match
@@ -487,7 +487,7 @@ export default function NewMatchGamePage() {
     void commitReady();
   }
 
-  // Persist the pairings + handicaps, publish (activate), land on the overview.
+  // Persist the pairings + handicaps, publish (enableScoring), land on the overview.
   // Operates on `filledDraft` ONLY — unfilled slots are discarded here (the
   // collapse: setPairings clean-replaces, so the dropped rows are gone and the
   // board recomputes points-in-play / clinch from the filled count). No separate
@@ -514,7 +514,7 @@ export default function NewMatchGamePage() {
         if (!recipient?.id) return [];
         return [setDoublesHandicap.mutateAsync({ tripId, gameId, matchId: row.id, recipientPlayGroupId: recipient.id, strokes: Math.abs(d.handicap) })];
       });
-      await Promise.all([...handicapWrites, activate.mutateAsync({ tripId, gameId })]);
+      await Promise.all([...handicapWrites, enableScoring.mutateAsync({ tripId, gameId })]);
     } else {
       const saved = await setPairings.mutateAsync({
         tripId,
@@ -531,7 +531,7 @@ export default function NewMatchGamePage() {
         const recipientUserId = d.handicap < 0 ? d.a[0] : d.b[0];
         return [setHandicap.mutateAsync({ tripId, gameId, matchId: row.id, recipientUserId, strokes: Math.abs(d.handicap) })];
       });
-      await Promise.all([...handicapWrites, activate.mutateAsync({ tripId, gameId })]);
+      await Promise.all([...handicapWrites, enableScoring.mutateAsync({ tripId, gameId })]);
     }
     // Saving setup changes the configured match count → refresh the board so
     // "first to XX" reflects it on screen.
@@ -610,7 +610,7 @@ export default function NewMatchGamePage() {
   async function handleEnableFromConfig() {
     if (!tripId || !gameId) return;
     try {
-      await activate.mutateAsync({ tripId, gameId });
+      await enableScoring.mutateAsync({ tripId, gameId });
       await Promise.all([gameQ.refetch(), matchesQ.refetch()]);
       if (competitionId) {
         utils.competitions.leaderboard.invalidate({ tripId, competitionId });
@@ -768,7 +768,7 @@ export default function NewMatchGamePage() {
         scoringEnabled={scoringEnabled}
         onEnable={handleEnableFromConfig}
         onDisable={handleDisable}
-        busy={disableScoring.isPending || activate.isPending}
+        busy={disableScoring.isPending || enableScoring.isPending}
       />
     );
   }
@@ -860,7 +860,7 @@ export default function NewMatchGamePage() {
             avatarIconOf={avatarIconOf}
             openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
             onReady={attemptReady}
-            saving={setPairings.isPending || setHandicap.isPending || setDoublesPairings.isPending || setDoublesHandicap.isPending || activate.isPending}
+            saving={setPairings.isPending || setHandicap.isPending || setDoublesPairings.isPending || setDoublesHandicap.isPending || enableScoring.isPending}
           />
         </>
       )}
@@ -943,7 +943,7 @@ export default function NewMatchGamePage() {
           total={draft.length}
           perMatchValue={(gameQ.data?.points_distribution as { value?: number } | null)?.value ?? null}
           inCompetition={!!gameCompId}
-          pending={setPairings.isPending || setDoublesPairings.isPending || activate.isPending}
+          pending={setPairings.isPending || setDoublesPairings.isPending || enableScoring.isPending}
           onConfirm={() => void commitReady()}
           onCancel={() => setConfirmCollapse(false)}
         />

--- a/src/server/routers/delegateSetupGate.test.ts
+++ b/src/server/routers/delegateSetupGate.test.ts
@@ -66,9 +66,9 @@ describe("matches setup gate admits the game delegate (§10)", () => {
     await expect(
       member.matches.setPairings({ tripId, gameId: mine, matches: pairings })
     ).resolves.toBeTruthy();
-    // …activate too.
+    // …enableScoring too.
     await expect(
-      member.matches.activate({ tripId, gameId: mine })
+      member.matches.enableScoring({ tripId, gameId: mine })
     ).resolves.toBeTruthy();
 
     // …but NOT another game (game-isolated).

--- a/src/server/routers/matches.test.ts
+++ b/src/server/routers/matches.test.ts
@@ -95,8 +95,8 @@ describe("matches router (Slice B — setup + visibility)", () => {
     expect(res.matches).toHaveLength(2);
   });
 
-  it("activate — publishes pairings; the Member can now see them", async () => {
-    await ctx.callerAs("planner").matches.activate({ tripId, gameId });
+  it("enableScoring — publishes pairings; the Member can now see them", async () => {
+    await ctx.callerAs("planner").matches.enableScoring({ tripId, gameId });
     const res = await ctx.callerAs("member").matches.listByGame({ tripId, gameId });
     expect(res.published).toBe(true);
     expect(res.matches).toHaveLength(2);
@@ -149,7 +149,7 @@ describe("matches router (Slice B — setup + visibility)", () => {
         matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
       })
     ).rejects.toThrow();
-    await expect(ctx.callerAs("member").matches.activate({ tripId, gameId })).rejects.toThrow();
+    await expect(ctx.callerAs("member").matches.enableScoring({ tripId, gameId })).rejects.toThrow();
   });
 });
 

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -599,13 +599,14 @@ export const matchesRouter = router({
       return { ok: true };
     }),
 
-  // activate — Owner/Organizer. This is match play's "Enable scoring": publish
+  // enableScoring — Owner/Organizer. Match play's "Enable scoring": publish
   // pairings to the crew + open the game for scoring (scoring_enabled). Phase
   // 2B.1 SPLIT it from going Live — it no longer sets status='active'; the FIRST
   // score owns the flip to Live (#396, uniform across formats). So enabled-ness
   // lives in scoring_enabled for every format (not pairings_published_at for
   // match while the boolean covers stroke/rack). Does NOT post to Notes (Slice F).
-  activate: authedProcedure
+  // (Was `activate` — renamed in R4 to the single ratified term; see CLAUDE.md glossary.)
+  enableScoring: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
     .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
First slice of **R4 (glossary ratification + per-concept renames)**. Phase 0 (the structural keystone) + Rename 1 (the lowest-risk, code-identifier-only rename). Each later rename is its own PR.

## Phase 0 — glossary ratified into CLAUDE.md
Committed the agreed vocabulary (`TRACKER.md` §3) into CLAUDE.md as the home of record: the 4-level competition hierarchy (leaderboard → scoreboard → score entry → scorecard) + the concept table (game/match · enableScoring/Live · team/side · Owner/Organizer/Member + co_admin + delegate · member/participant/guest · competition/cup), plus the layer principle (display / code-identifier / DB-value risk tiers).

## Rename 1 — `matches.activate` → `enableScoring`
The same action under two names (the tRPC mutation `matches.activate` vs. the user-facing "Enable scoring"). Unified to the ratified term. **Code-identifier layer only — no DB value, no auth/RLS touched.** All 5 sites: the procedure, the client mutation + its local var, and 3 test call sites. `tsc` clean, zero `matches.activate` stragglers, matches + delegateSetupGate suites green (18 tests, incl. the renamed `enableScoring` test).

## Phase 0 re-verify findings (the rest of R4, against current code)
Diagnosing each rename before building surfaced significant staleness in the spec (same class as R3's stale PROJECT_STATUS):

- **Rename 2 (`round` → game/match): already clean — no-op.** Every `round` in the codebase is golf-literal ("Golf Round"), SVG `strokeLinecap="round"`, `Math.round`, or design-iteration comments. Zero uses of "round" meaning a competition game/match. Nothing to rename.
- **Rename 3 (game-scope role → `delegate`): real, with a DB component.** `game_organizers` (table, 17 refs) + `is_game_organizer` (fn) still carry the old name alongside the newer "delegate" vocab → escalates to DB-value treatment (atomic migration + RLS). **Its own follow-up PR.**
- **Rename 4 (`planner` → `organizer`): already done by migration 029.** The role value, CHECK constraint, `is_trip_planner()` body, and all 30 RLS policies were migrated `Planner → Organizer` on 2026-06-07. Only cosmetic residue remains (one stale comment + the `test-planner` persona key). The spec's "scariest auth rename" is moot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)