### PR TITLE
R4 Rename 3: game_organizers → game_delegates (table + RLS + helper)

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -157,8 +157,8 @@ export function requireCompetitionRole(minRole: CompetitionRole) {
 //
 // The per-game edit gate: passes if the user is a competition owner/co-admin
 // (granted by the container) OR a delegated organizer of THIS game
-// (game_organizers row). Game-isolated — a pick'em delegate cannot touch the
-// scramble. Mirror of the DB rule in migration 045 (is_game_organizer).
+// (game_delegates row). Game-isolated — a pick'em delegate cannot touch the
+// scramble. Mirror of the DB rule (is_game_delegate, migration 045 → renamed 061).
 //
 // Authority is the COMPETITION role, not the trip role — the trip→co-admin
 // mapping lives in resolveCompetitionRole (the container), so this gate stays
@@ -187,7 +187,7 @@ export function requireGameEdit() {
     if (!allowed) {
       // …otherwise a delegated organizer of THIS game (game-isolated).
       const { data } = await (
-        ctx.supabase.from("game_organizers") as unknown as {
+        ctx.supabase.from("game_delegates") as unknown as {
           select: (s: string) => {
             eq: (c: string, v: string) => {
               eq: (c: string, v: string) => {
@@ -240,7 +240,7 @@ export function requireGameRunAction() {
 
     if (!allowed) {
       const { data } = await (
-        ctx.supabase.from("game_organizers") as unknown as {
+        ctx.supabase.from("game_delegates") as unknown as {
           select: (s: string) => {
             eq: (c: string, v: string) => {
               eq: (c: string, v: string) => {

--- a/src/server/routers/coAdminRole.test.ts
+++ b/src/server/routers/coAdminRole.test.ts
@@ -48,7 +48,7 @@ beforeAll(async () => {
 afterAll(async () => {
   for (const id of gameIds) {
     await ctx.admin.from("game_results").delete().eq("game_id", id);
-    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("game_delegates").delete().eq("game_id", id);
     await ctx.admin.from("games").delete().eq("id", id);
   }
   // Restore the organizer role in case a live-derivation test left it demoted.

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -133,7 +133,7 @@ export const competitionsRouter = router({
             .order("created_at", { ascending: false })
             .then((r) => r.data ?? []),
           ctx.supabase
-            .from("game_organizers")
+            .from("game_delegates")
             .select("game_id")
             .eq("user_id", ctx.user!.id)
             .then((r) => (r.data ?? []).map((x) => x.game_id as string)),

--- a/src/server/routers/delegateSetupGate.test.ts
+++ b/src/server/routers/delegateSetupGate.test.ts
@@ -4,7 +4,7 @@ import { TestContext } from "../../__tests__/helpers/test-setup";
 /**
  * Per-game delegate gate, extended to the SETUP routers (§10).
  *
- * Migration 045 landed the delegate path (game_organizers / requireGameEdit) on
+ * Migration 045 landed the delegate path (game_delegates / requireGameEdit) on
  * games + game_results, but the setup mutations — matches (pairings / handicap /
  * activate) and playGroups (foursomes / strokes) — were still gated
  * requireTripRole("Organizer"). Stage 4 extends requireGameEdit() to them so a
@@ -44,7 +44,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   for (const id of gameIds) {
-    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("game_delegates").delete().eq("game_id", id);
     await ctx.admin.from("game_participants").delete().eq("game_id", id);
     await ctx.admin.from("game_matches").delete().eq("game_id", id);
     await ctx.admin.from("play_groups").delete().eq("game_id", id);

--- a/src/server/routers/faceBootstrap.test.ts
+++ b/src/server/routers/faceBootstrap.test.ts
@@ -40,7 +40,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await ctx.admin.from("game_organizers").delete().eq("game_id", gameId);
+  await ctx.admin.from("game_delegates").delete().eq("game_id", gameId);
   await ctx.admin.from("game_results").delete().eq("game_id", gameId);
   await ctx.admin.from("games").delete().eq("id", gameId);
   await ctx.cleanup();

--- a/src/server/routers/games.d1.test.ts
+++ b/src/server/routers/games.d1.test.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
 afterAll(async () => {
   for (const id of gameIds) {
     await ctx.admin.from("game_results").delete().eq("game_id", id);
-    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("game_delegates").delete().eq("game_id", id);
     await ctx.admin.from("games").delete().eq("id", id);
   }
   await ctx.cleanup();

--- a/src/server/routers/games.d_addgame.test.ts
+++ b/src/server/routers/games.d_addgame.test.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   for (const id of gameIds) {
-    await ctx.admin.from("game_organizers").delete().eq("game_id", id);
+    await ctx.admin.from("game_delegates").delete().eq("game_id", id);
     await ctx.admin.from("games").delete().eq("id", id);
   }
   await ctx.cleanup();

--- a/src/server/routers/games.runpost.test.ts
+++ b/src/server/routers/games.runpost.test.ts
@@ -48,7 +48,7 @@ afterAll(async () => {
   if (gameIds.length) {
     await ctx.admin.from("score_entries").delete().in("game_id", gameIds);
     await ctx.admin.from("game_results").delete().in("game_id", gameIds);
-    await ctx.admin.from("game_organizers").delete().in("game_id", gameIds);
+    await ctx.admin.from("game_delegates").delete().in("game_id", gameIds);
     await ctx.admin.from("games").delete().in("id", gameIds);
   }
   await ctx.cleanup();

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -558,7 +558,7 @@ export const gamesRouter = router({
   // setPointsTotal — Owner/Organizer ONLY (the delegation boundary, Stage 3).
   // A game's TOTAL is owner-set; a game-delegate distributes WITHIN it but can't
   // change it. requireTripRole("Organizer") blocks a Member-level delegate
-  // outright (a delegate has only a game_organizers grant, not Organizer role).
+  // outright (a delegate has only a game_delegates grant, not Organizer role).
   // NULL clears the total (match games, whose total is derived).
   setPointsTotal: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string(), total: z.number().min(0).nullable() }))
@@ -781,7 +781,7 @@ export const gamesRouter = router({
         .maybeSingle();
       if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
       const { error } = await ctx.supabase
-        .from("game_organizers")
+        .from("game_delegates")
         .upsert(
           { game_id: input.gameId, user_id: input.userId, granted_by: ctx.user!.id },
           { onConflict: "game_id,user_id", ignoreDuplicates: true }
@@ -796,7 +796,7 @@ export const gamesRouter = router({
     .use(requireTripRole("Organizer"))
     .mutation(async ({ ctx, input }) => {
       const { error } = await ctx.supabase
-        .from("game_organizers")
+        .from("game_delegates")
         .delete()
         .eq("game_id", input.gameId)
         .eq("user_id", input.userId);
@@ -810,7 +810,7 @@ export const gamesRouter = router({
     .use(requireTripMember)
     .query(async ({ ctx, input }) => {
       const { data } = await ctx.supabase
-        .from("game_organizers")
+        .from("game_delegates")
         .select("user_id, granted_by, created_at")
         .eq("game_id", input.gameId);
       return data ?? [];
@@ -826,7 +826,7 @@ export const gamesRouter = router({
     .use(requireTripMember)
     .query(async ({ ctx }) => {
       const { data } = await ctx.supabase
-        .from("game_organizers")
+        .from("game_delegates")
         .select("game_id")
         .eq("user_id", ctx.user!.id);
       return (data ?? []).map((r) => r.game_id as string);

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -9,7 +9,7 @@ import { computeMatchPlayResults } from "../lib/matchPlay";
  *
  * Setup writes (pairings, handicap, reorder, activate) are gated by
  * `requireGameEdit()` — trip Owner/Organizer OR a delegated organizer of THIS
- * game (game_organizers / migration 045). This extends the per-game delegate
+ * game (game_delegates / migration 045 → 061). This extends the per-game delegate
  * path (originally landed for games / game_results) to the match-setup router so
  * a game's delegate can actually run it (§10), game-isolated: a delegate of one
  * game can't touch another. Score entry reuses Slice A's `scores.upsertEntry`

--- a/supabase/migrations/20260621120000_061_rename_game_organizers_to_delegates.sql
+++ b/supabase/migrations/20260621120000_061_rename_game_organizers_to_delegates.sql
@@ -1,0 +1,97 @@
+-- 061 · R4 Rename 3 — game_organizers → game_delegates (table + helper + policies)
+--
+-- The per-game delegation table was named `game_organizers`, which collides with
+-- the TRIP role "Organizer": a row here grants a GAME-scope delegate, NOT a
+-- trip-wide Organizer. R4 ratifies one game-scope term — `delegate` — so this
+-- renames the table, its two own-table RLS policies, and the
+-- is_game_organizer() helper → is_game_delegate(), keeping every dependent
+-- policy in lockstep (the helper is called by 5 PERMISSIVE delegate policies
+-- across games / game_results [045] and game_participants / play_groups /
+-- game_matches [053]).
+--
+-- DB-VALUE layer: tsc cannot catch a missed RLS reference, so every dependent
+-- policy is rebuilt explicitly here rather than relying on OID-deparse. The
+-- data and the access rules are byte-for-byte identical — behavior-preserving.
+-- Idempotent.
+
+-- 1. Rename the table. PK + the two outbound FKs (games, users) + ON DELETE
+--    CASCADE follow by OID; no data moves.
+ALTER TABLE IF EXISTS public.game_organizers RENAME TO game_delegates;
+
+-- 2. Its two own-table policies — drop under either name, recreate under the new
+--    one (the bodies are unchanged except the table-qualified column name).
+DROP POLICY IF EXISTS game_organizers_select ON public.game_delegates;
+DROP POLICY IF EXISTS game_delegates_select ON public.game_delegates;
+CREATE POLICY game_delegates_select ON public.game_delegates
+  FOR SELECT USING (EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = game_delegates.game_id AND is_trip_member(g.trip_id)
+  ));
+
+DROP POLICY IF EXISTS game_organizers_write ON public.game_delegates;
+DROP POLICY IF EXISTS game_delegates_write ON public.game_delegates;
+CREATE POLICY game_delegates_write ON public.game_delegates
+  FOR ALL USING (EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = game_delegates.game_id
+      AND has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+  )) WITH CHECK (EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = game_delegates.game_id
+      AND has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+  ));
+
+-- 3. New helper reading the renamed table. SECURITY DEFINER + pinned search_path
+--    so RLS can call it without recursing into game_delegates' own policies
+--    (identical contract to the old is_game_organizer). The old helper is
+--    dropped in step 5 once no policy depends on it.
+CREATE OR REPLACE FUNCTION public.is_game_delegate(p_game_id text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.game_delegates gd
+    WHERE gd.game_id = p_game_id
+      AND gd.user_id = (auth.uid())::text
+  );
+$$;
+
+-- 4. Repoint the five dependent delegate policies to the new helper. These are
+--    the SILENT-BREAK sites — each is recreated verbatim except the helper name.
+DROP POLICY IF EXISTS games_update_delegate ON public.games;
+CREATE POLICY games_update_delegate ON public.games
+  FOR UPDATE
+  USING (public.is_game_delegate(id))
+  WITH CHECK (public.is_game_delegate(id));
+
+DROP POLICY IF EXISTS game_results_delegate ON public.game_results;
+CREATE POLICY game_results_delegate ON public.game_results
+  FOR ALL
+  USING (public.is_game_delegate(game_id))
+  WITH CHECK (public.is_game_delegate(game_id));
+
+DROP POLICY IF EXISTS game_participants_delegate ON public.game_participants;
+CREATE POLICY game_participants_delegate ON public.game_participants
+  FOR ALL
+  USING (public.is_game_delegate(game_id))
+  WITH CHECK (public.is_game_delegate(game_id));
+
+DROP POLICY IF EXISTS play_groups_delegate ON public.play_groups;
+CREATE POLICY play_groups_delegate ON public.play_groups
+  FOR ALL
+  USING (public.is_game_delegate(game_id))
+  WITH CHECK (public.is_game_delegate(game_id));
+
+DROP POLICY IF EXISTS game_matches_delegate ON public.game_matches;
+CREATE POLICY game_matches_delegate ON public.game_matches
+  FOR ALL
+  USING (public.is_game_delegate(game_id))
+  WITH CHECK (public.is_game_delegate(game_id));
+
+-- 5. Drop the old helper now that all five policies point at the new one. If any
+--    reference were missed this DROP fails loudly (dependency error) rather than
+--    leaving two names live — the intended safety net.
+DROP FUNCTION IF EXISTS public.is_game_organizer(text);


### PR DESCRIPTION
The final R4 rename — the only piece the Phase 0 re-verify found still carrying the old name. Renames 2 (`round`) and 4 (`planner`) needed no work (already clean / done by migration 029); this unifies the last layer.

## Why
The per-game delegation table was named `game_organizers`, which **collides with the trip role "Organizer"** — but a row here grants a GAME-scope **delegate**, not a trip Organizer. R4 ratifies one game-scope term (`delegate`); this removes the collision at the DB layer.

## DB-VALUE layer (the risky one)
`tsc` cannot catch a missed RLS reference, so the atomic migration (`061`) rebuilds every dependent policy explicitly rather than relying on OID-deparse:
- renames the table (PK + outbound FKs + `ON DELETE CASCADE` follow by OID — no data moves);
- recreates its two own-table policies under the new name;
- adds `is_game_delegate()` reading the renamed table (identical `SECURITY DEFINER` contract);
- repoints all **five** dependent delegate policies — `games_update_delegate` / `game_results_delegate` (mig 045) + `game_participants_delegate` / `play_groups_delegate` / `game_matches_delegate` (mig 053) — each rebuilt verbatim except the helper name;
- drops the old `is_game_organizer()` last (fails loudly if any reference was missed — the safety net).

## Code
All 13 `.from("game_organizers")` reads → `game_delegates` (the `requireGameEdit` middleware gate, the competitions + games routers, 6 test teardowns) + the comments. Untyped Supabase client → no type regen. `tsc` + `eslint` clean; grep shows zero code stragglers.

## Verification (auth-specific, per the DB-value playbook)
Runs in CI: `supabase db push` applies `061`, then the delegate-path suites — **delegateSetupGate** (a game delegate clears the setup mutations its RLS now gates), **coAdminRole**, **games.d1 / d_addgame / runpost**, **faceBootstrap** — exercise `game_delegates` + the recreated policies. That's the "delegate can do delegate-things" check the silent-break class demands. Behavior-preserving: data + access rules byte-identical.

Closes the R4 rename sequence. Glossary already ratified into CLAUDE.md (#426).

🤖 Generated with [Claude Code](https://claude.com/claude-code)