### PR TITLE
feat(competition): manual scoring for non-golf games (Closes #429)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronLeft, Users, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CompetitionHeader } from "./CompetitionHeader";
 import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
-import { GameSheet, type GameType } from "./CompetitionGamesPanel";
+import { GameSheet, RunSheet, type GameType, type GameRow, type LBTeamLite } from "./CompetitionGamesPanel";
 
 interface Competition {
   id: string;
@@ -74,6 +74,39 @@ export function CompetitionFace({
   // GameSheet (add-game modal) needs the type catalog — fetched once here so the
   // modal opens without its own waterfall. Only editors ever open it.
   const { data: gameTypes = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: canEdit });
+
+  // ── Non-golf (manual) game scoring + config-reopen, routed from the board ───
+  // Golf games open via their per-format route (the GameRow links). Non-golf
+  // games have no route, so an editor taps the row → the manual run sheet (the
+  // orphaned RunSheet, re-attached here), and its pencil reopens config in the
+  // GameSheet. This restores the entry points the retired CompetitionGamesPanel
+  // wired; the board only re-attaches them. Both queries are seeded by
+  // faceBootstrap (cache hit — no extra waterfall) and editor-only.
+  const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { enabled: canEdit });
+  const { data: lb } = trpc.competitions.leaderboard.useQuery(
+    { tripId, competitionId: competition.id },
+    { enabled: canEdit }
+  );
+  const compGames = useMemo(
+    () => (allGames as GameRow[]).filter((g) => g.competition_id === competition.id),
+    [allGames, competition.id]
+  );
+  const [running, setRunning] = useState<GameRow | null>(null); // manual game being posted
+  const [editing, setEditing] = useState<GameRow | null>(null); // game whose config is reopened
+  // Seed the run sheet's finishing order from the posted leaderboard cells (when
+  // correcting), else the roster order — mirrors the retired panel.
+  const runningOrder = useMemo(() => {
+    if (!running) return [];
+    const teams = (lb?.teams ?? []) as LBTeamLite[];
+    const cells = ((lb?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
+      .filter((c) => c.gameId === running.id)
+      .sort((a, b) => a.place - b.place);
+    return cells.length ? cells.map((c) => c.teamId) : teams.map((t) => t.id);
+  }, [running, lb]);
+  const openManualGame = (gameId: string) => {
+    const g = compGames.find((x) => x.id === gameId);
+    if (g) setRunning(g);
+  };
 
   // ── Go live / back to setup (visibility switch, NOT a data lock) ───────────
   // Centralized here (not in the header) so going live can also flip the
@@ -226,23 +259,46 @@ export function CompetitionFace({
         canEdit={canEdit}
         onAddGame={() => setAddingGame(true)}
         onEditTeam={canEdit ? () => setView("settings") : undefined}
+        onOpenGame={canEdit ? openManualGame : undefined}
       />
 
       {/* Add a game opens the GameSheet modal directly over the board (the
           aggregate games panel was retired). It persists on its own Save and
           invalidates the board's leaderboard; we also re-resolve faceBootstrap
           so the board's GAMES list refreshes without a hard reload (#10). */}
-      {addingGame && canEdit && (
+      {(addingGame || editing) && canEdit && (
         <GameSheet
           tripId={tripId}
           competitionId={competition.id}
-          game={null}
+          game={editing}
           types={gameTypes as GameType[]}
           canEdit={canEdit}
           onClose={() => {
             setAddingGame(false);
+            setEditing(null);
             utils.competitions.faceBootstrap.invalidate({ tripId });
           }}
+        />
+      )}
+
+      {/* Manual (non-golf) scoring — the orphaned RunSheet re-attached to the
+          board. Tapping a non-golf row opens it (winner/loser/tie via the
+          finishing order → games.post → leaderboard); its pencil reopens config.
+          faceBootstrap is invalidated on close so the board reflects the posted
+          result without a hard reload (pattern #10 — the board seeds from it). */}
+      {running && canEdit && (
+        <RunSheet
+          tripId={tripId}
+          competitionId={competition.id}
+          game={running}
+          teams={(lb?.teams ?? []) as LBTeamLite[]}
+          initialOrder={runningOrder}
+          isEngine={!!(gameTypes as GameType[]).find((t) => t.id === running.game_type_id)?.isEngine}
+          onClose={() => {
+            setRunning(null);
+            utils.competitions.faceBootstrap.invalidate({ tripId });
+          }}
+          onEditConfig={() => { setEditing(running); setRunning(null); }}
         />
       )}
     </div>

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -51,7 +51,7 @@ function runState(g: GameRow): RunState {
   return "upcoming";
 }
 
-interface LBTeamLite { id: string; name: string; short_name: string; color: string }
+export interface LBTeamLite { id: string; name: string; short_name: string; color: string }
 
 /** Drag payload key for a game id — read by the agenda drop targets. */
 export const DND_GAME_KEY = "application/x-buddytrip-game-id";
@@ -1433,11 +1433,15 @@ function FormatSheet({
 
 interface SchemaUnits { units?: { count?: number } }
 
-function RunSheet({
-  tripId, competitionId, game, teams, initialOrder, isEngine, onClose,
+export function RunSheet({
+  tripId, competitionId, game, teams, initialOrder, isEngine, onClose, onEditConfig,
 }: {
   tripId: string; competitionId: string; game: GameRow; teams: LBTeamLite[];
   initialOrder: string[]; isEngine: boolean; onClose: () => void;
+  /** When present, a pencil in the header reopens the game's config (GameSheet).
+   *  The non-golf board path uses it so config is reachable from the run sheet
+   *  (the board row itself has no route — the config-vs-live split is WS4). */
+  onEditConfig?: () => void;
 }) {
   const utils = trpc.useUtils();
   const state = runState(game);
@@ -1518,9 +1522,16 @@ function RunSheet({
               <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>{correcting ? "Score correction" : "Post results"}</h3>
               <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>{game.name || "Game"}</p>
             </div>
-            <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
-              <X size={16} />
-            </button>
+            <div className="flex items-center gap-1">
+              {onEditConfig && (
+                <button type="button" onClick={onEditConfig} aria-label="Edit game settings" data-testid="run-edit-config" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
+                  <Pencil size={15} />
+                </button>
+              )}
+              <button type="button" onClick={onClose} aria-label="Close" className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: "var(--color-bt-text-dim)" }}>
+                <X size={16} />
+              </button>
+            </div>
           </div>
 
           <div className="flex-1 space-y-3 overflow-y-auto p-4">

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -67,9 +67,12 @@ interface Props {
   onAddGame?: () => void;
   /** Tap a team name on the hero → its in-place editor (routed by the face). */
   onEditTeam?: () => void;
+  /** Tap a non-golf game row (no route) → open its manual run sheet (routed by
+   *  the face). Editors only; omitted for crew. */
+  onOpenGame?: (gameId: string) => void;
 }
 
-export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam }: Props) {
+export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam, onOpenGame }: Props) {
   const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
@@ -165,6 +168,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
         onPrefetch={prefetchGame}
         canEdit={canEdit}
         onAddGame={onAddGame}
+        onOpenGame={onOpenGame}
       />
     );
   }
@@ -244,6 +248,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
         onPrefetch={prefetchGame}
         canEdit={canEdit}
         onAddGame={onAddGame}
+        onOpenGame={onOpenGame}
       />
     </div>
   );
@@ -254,7 +259,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
 // entry). Empty → the bones prompt + "Add a game"; populated → the session
 // breakdown + "Add a game". Editor-gated; the crew sees the list only.
 function GamesSection({
-  games, teams, cellsByGame, sessionsDone, tripId, mineSet, onPrefetch, canEdit, onAddGame,
+  games, teams, cellsByGame, sessionsDone, tripId, mineSet, onPrefetch, canEdit, onAddGame, onOpenGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
@@ -265,6 +270,7 @@ function GamesSection({
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
   onAddGame?: () => void;
+  onOpenGame?: (gameId: string) => void;
 }) {
   const addBtn = canEdit && onAddGame && (
     <button
@@ -309,6 +315,7 @@ function GamesSection({
         tripId={tripId}
         mineSet={mineSet}
         onPrefetch={onPrefetch}
+        onOpenGame={onOpenGame}
       />
       {addBtn}
     </div>
@@ -548,6 +555,7 @@ function SessionBreakdown({
   tripId,
   mineSet,
   onPrefetch,
+  onOpenGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
@@ -556,6 +564,7 @@ function SessionBreakdown({
   tripId: string;
   mineSet: Set<string>;
   onPrefetch: (gameId: string) => void;
+  onOpenGame?: (gameId: string) => void;
 }) {
   return (
     <div
@@ -590,6 +599,7 @@ function SessionBreakdown({
             tripId={tripId}
             mine={mineSet.has(game.id)}
             onPrefetch={onPrefetch}
+            onOpenGame={onOpenGame}
           />
         ))}
       </div>
@@ -608,6 +618,7 @@ function EarlyState({
   onPrefetch,
   canEdit,
   onAddGame,
+  onOpenGame,
 }: {
   teams: LBTeam[];
   liveGames: LBGame[];
@@ -617,6 +628,7 @@ function EarlyState({
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
   onAddGame?: () => void;
+  onOpenGame?: (gameId: string) => void;
 }) {
   return (
     <div className="space-y-3" data-testid="competition-leaderboard">
@@ -694,6 +706,7 @@ function EarlyState({
                 tripId={tripId}
                 mine={mineSet.has(game.id)}
                 onPrefetch={onPrefetch}
+                onOpenGame={onOpenGame}
               />
             ))}
           </div>

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -117,6 +117,7 @@ export function GameRow({
   tripId,
   mine,
   onPrefetch,
+  onOpenGame,
 }: {
   game: LBGame;
   teams: LBTeam[];
@@ -124,6 +125,10 @@ export function GameRow({
   tripId: string;
   mine: boolean;
   onPrefetch: (gameId: string) => void;
+  /** Non-golf games have no game-board route; when the viewer can act on them
+   *  (editors only), the row opens the manual run sheet in place instead of
+   *  navigating. Omitted → the row stays inert (crew, or no manual path). */
+  onOpenGame?: (gameId: string) => void;
 }) {
   const href = gameHref(tripId, game.gameTypeId, game.id);
   const hasScores = cells && cells.size > 0;
@@ -254,6 +259,21 @@ export function GameRow({
       >
         {inner}
       </Link>
+    );
+  }
+  // Non-golf game (no route): an editor taps to open the manual run sheet in
+  // place — the same tap feel as a golf row, no navigation. Without onOpenGame
+  // (crew) the row stays a plain, inert tile.
+  if (onOpenGame) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenGame(game.id)}
+        className="block w-full text-left hover:opacity-80 transition-opacity"
+        data-testid={`game-open-${game.id}`}
+      >
+        {inner}
+      </button>
     );
   }
   return <div>{inner}</div>;


### PR DESCRIPTION
**BBMI-blocking** (Issue #429, BBMI 2026 milestone). BBMI runs 5–7 non-golf scored games every year (poker, cornhole, euchre…); they appeared on the board with point values but **couldn't be scored** — the rows were click-disabled and config wouldn't reopen.

## Phase 0 finding — disabled/unwired, NOT absent
The full manual stack already exists; the **bones-board redesign retired `CompetitionGamesPanel`**, the surface that wired non-golf config (`onEdit`→GameSheet) and result entry (`onRun`→RunSheet). The replacement board re-wired only the golf path (route links), so non-golf `GameRow`s became inert `<div>`s with no entry point and `RunSheet` was orphaned.

## The re-wire (reuse, not rebuild — not R1)
Re-attaches the entry points to the live board, reusing the whole existing manual stack (`games.post` + `writeManualResults` + `placementPoints` + the leaderboard rollup — no new scoring logic, no format-specific code):
- **`GameRow`** — a non-golf row (no route) renders as a tappable button when the viewer can act (`onOpenGame`, editors only); same tap feel as a golf row, no nav.
- **`CompetitionLeaderboard`** — threads `onOpenGame` down to both `GameRow` sites.
- **`CompetitionFace`** — re-attaches the orphaned `RunSheet`: tap a non-golf row → manual placement entry (winner/loser/tie via finishing order) → `games.post` → leaderboard. A pencil in the RunSheet reopens config via the already-edit-capable `GameSheet`. `faceBootstrap` invalidated on close so the posted result lands without a hard reload (pattern #10).
- **`RunSheet`/`LBTeamLite`** exported; `RunSheet` gains an optional `onEditConfig` pencil.

Ties reuse the existing convention (tied positions split via `placementPoints`). The board's config-vs-live presentation is intentionally left as-is — a WS4 question.

## Verify-by-eye (against the live BBMI Cup, fully reverted after)
1. Non-golf games (Poker, euchre) now render as **tappable buttons**; golf games stay route links. ✅
2. Tap → **RunSheet** opens (finishing-order editor, both teams). ✅
3. Pencil → **GameSheet** reopens with the game's config loaded. ✅
4. Created a throwaway non-golf game (8 pts, split 8│0), posted Rhinos as winner → **RHI 1 → 9, pts-in-play 161 → 169**, game shows its 8/0 final result. **The manual result counts toward the cup.** ✅
5. Deleted the throwaway → leaderboard reverted to RHI 1 / 161 pts. ✅

`tsc` + `eslint` clean (the 3 panel warnings are pre-existing, untouched regions). No new server code, so existing `games.post` unit tests cover the write path; non-golf scoring isn't on the critical path, so no new E2E is required (per the testing rule) — the critical-path smoke stays green.

Scope note: this is the permanent manual floor R1 later generalizes (like manual course entry under the course API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)