### PR TITLE
feat(competition): scoring_model + match-play win/lose/tie non-golf scoring (Closes #431)

### DIFF
--- a/src/__tests__/helpers/test-setup.ts
+++ b/src/__tests__/helpers/test-setup.ts
@@ -193,13 +193,24 @@ export class TestContext {
   }
 
   /** Create a competition for a trip. */
-  async createCompetition(tripId: string, name = "Test Competition"): Promise<string> {
+  async createCompetition(
+    tripId: string,
+    name = "Test Competition",
+    opts: { scoringModel?: "match_play" | "points" } = {}
+  ): Promise<string> {
     const competitionId = `test-comp-${Date.now()}-${Math.random()
       .toString(36)
       .slice(2, 6)}`;
     const { error } = await this.admin
       .from("competitions")
-      .insert({ id: competitionId, trip_id: tripId, name });
+      .insert({
+        id: competitionId,
+        trip_id: tripId,
+        name,
+        // Default (omitted) → the DB default 'match_play'. Suites that test the
+        // points/placement award model pass scoringModel:'points' (W-NONGOLF-02).
+        ...(opts.scoringModel ? { scoring_model: opts.scoringModel } : {}),
+      });
     if (error) throw new Error(`Failed to create competition: ${error.message}`);
     this._competitionIds.push(competitionId);
     return competitionId;

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -16,6 +16,10 @@ interface Competition {
   /** Roster-setup progression (building → saved → dismissed) — drives the
    *  Team Rosters button + the "moved to Settings" signpost on the board. */
   roster_setup?: "building" | "saved" | "dismissed";
+  /** Scoring-model axis (W-NONGOLF-02), independent of team count. Branches the
+   *  non-golf result editor: match_play → win/lose/tie; points → #430 placement.
+   *  Defaults to match_play when absent (matches the DB default + backfill). */
+  scoring_model?: "match_play" | "points";
 }
 
 /**
@@ -294,6 +298,7 @@ export function CompetitionFace({
           teams={(lb?.teams ?? []) as LBTeamLite[]}
           initialOrder={runningOrder}
           isEngine={!!(gameTypes as GameType[]).find((t) => t.id === running.game_type_id)?.isEngine}
+          matchPlay={(competition.scoring_model ?? "match_play") === "match_play"}
           onClose={() => {
             setRunning(null);
             utils.competitions.faceBootstrap.invalidate({ tripId });

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1434,10 +1434,14 @@ function FormatSheet({
 interface SchemaUnits { units?: { count?: number } }
 
 export function RunSheet({
-  tripId, competitionId, game, teams, initialOrder, isEngine, onClose, onEditConfig,
+  tripId, competitionId, game, teams, initialOrder, isEngine, matchPlay, onClose, onEditConfig,
 }: {
   tripId: string; competitionId: string; game: GameRow; teams: LBTeamLite[];
-  initialOrder: string[]; isEngine: boolean; onClose: () => void;
+  initialOrder: string[]; isEngine: boolean;
+  /** Match-play competition (W-NONGOLF-02): a non-golf game scores win/lose/tie
+   *  instead of a finishing order. Ignored for engine games + non-2-team comps. */
+  matchPlay?: boolean;
+  onClose: () => void;
   /** When present, a pencil in the header reopens the game's config (GameSheet).
    *  The non-golf board path uses it so config is reachable from the run sheet
    *  (the board row itself has no route — the config-vs-live split is WS4). */
@@ -1448,7 +1452,15 @@ export function RunSheet({
   const correcting = state === "posted" || state === "correcting";
   const dist = game.points_distribution?.type === "placement" ? game.points_distribution.values : [];
 
+  // Win/lose/tie scoring: a manual (non-engine) game in a match-play competition
+  // with exactly two sides. The winner takes the game's points; a tie splits them
+  // (the leaderboard derives [total,0] and averages a tie → P/2). Anything else
+  // (engine games, points comps, >2 teams) keeps #430's finishing-order editor.
+  const winLoseTie = !isEngine && !!matchPlay && teams.length === 2;
   const [order, setOrder] = useState<string[]>(initialOrder.length ? initialOrder : teams.map((t) => t.id));
+  // Selected outcome for the win/lose/tie editor: a team id (that side won) or
+  // "tie". Defaults to the leading side from the seeded order — adjust or pick Tie.
+  const [result, setResult] = useState<string>(() => initialOrder[0] ?? teams[0]?.id ?? "");
   const [confirmIncomplete, setConfirmIncomplete] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -1481,6 +1493,14 @@ export function RunSheet({
     try {
       if (isEngine) {
         await post.mutateAsync({ tripId, gameId: game.id });
+      } else if (winLoseTie) {
+        // Winner → position 1, loser → position 2; a tie puts BOTH at position 1
+        // (placementPoints averages → P/2 each). The leaderboard awards [total,0].
+        const placements =
+          result === "tie"
+            ? teams.map((t) => ({ entityId: t.id, position: 1 }))
+            : teams.map((t) => ({ entityId: t.id, position: t.id === result ? 1 : 2 }));
+        await post.mutateAsync({ tripId, gameId: game.id, placements });
       } else {
         await post.mutateAsync({ tripId, gameId: game.id, placements: order.map((id, i) => ({ entityId: id, position: i + 1 })) });
       }
@@ -1553,6 +1573,8 @@ export function RunSheet({
                 unlocking={openCorrection.isPending}
                 scoresOpen={game.corrections_open}
               />
+            ) : winLoseTie ? (
+              <WinLoseTieEditor teams={teams} result={result} onPick={setResult} />
             ) : (
               <ManualPlacementEditor order={order} teams={teams} dist={dist} teamById={teamById} move={move} />
             )}
@@ -1632,6 +1654,54 @@ function ManualPlacementEditor({
       </div>
       <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
         Order the teams by finish — points come from the game&rsquo;s configured distribution, so you set the order, not the points.
+      </p>
+    </div>
+  );
+}
+
+/** Win/lose/tie result for a match-play (head-to-head) non-golf game. The winner
+ *  takes the game's points; a tie splits them. Posts winner→pos 1, loser→pos 2,
+ *  tie→both pos 1 — the leaderboard awards [total,0] (averaged for a tie). */
+function WinLoseTieEditor({
+  teams, result, onPick,
+}: {
+  teams: LBTeamLite[]; result: string; onPick: (r: string) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2">
+        <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Result</span>
+      </div>
+      <div className="space-y-1.5">
+        {teams.map((t) => {
+          const sel = result === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => onPick(t.id)}
+              data-testid={`wlt-win-${t.id}`}
+              className="flex w-full items-center gap-2 rounded-lg px-2.5 py-3 text-left"
+              style={{ background: sel ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)", border: `1px solid ${sel ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}` }}
+            >
+              <span className="h-3 w-3 flex-shrink-0 rounded-full" style={{ background: t.color }} />
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>{t.name}</span>
+              <span className="text-[12px] font-semibold uppercase tracking-wider" style={{ color: sel ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>{sel ? "Winner" : "Wins"}</span>
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={() => onPick("tie")}
+          data-testid="wlt-tie"
+          className="flex w-full items-center justify-center rounded-lg px-2.5 py-3"
+          style={{ background: result === "tie" ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)", border: `1px solid ${result === "tie" ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}` }}
+        >
+          <span className="text-sm font-semibold" style={{ color: result === "tie" ? "var(--color-bt-accent)" : "var(--color-bt-text)" }}>Tie — split the points</span>
+        </button>
+      </div>
+      <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        Head-to-head: the winner takes the game&rsquo;s points; a tie splits them evenly.
       </p>
     </div>
   );

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1659,46 +1659,61 @@ function ManualPlacementEditor({
   );
 }
 
-/** Win/lose/tie result for a match-play (head-to-head) non-golf game. The winner
- *  takes the game's points; a tie splits them. Posts winner→pos 1, loser→pos 2,
- *  tie→both pos 1 — the leaderboard awards [total,0] (averaged for a tie). */
+/** Win/lose/tie result for a match-play (head-to-head) non-golf game: ONE
+ *  question, three mutually-exclusive PEERS (each side + Tie). Selection-state
+ *  alone carries the meaning — no per-row "wins" label, no two rows both saying
+ *  win. Posts winner→pos 1, loser→pos 2, tie→both pos 1; the leaderboard awards
+ *  [total,0] (averaged for a tie). */
 function WinLoseTieEditor({
   teams, result, onPick,
 }: {
   teams: LBTeamLite[]; result: string; onPick: (r: string) => void;
 }) {
+  // Three peers in one uniform row shape so none reads as primary: each side
+  // (its color disc) and Tie (a split disc of BOTH colors — "shared").
+  const options: { id: string; mark: React.ReactNode; label: string; testid: string }[] = [
+    ...teams.map((t) => ({
+      id: t.id,
+      mark: <span className="h-3 w-3 flex-shrink-0 rounded-full" style={{ background: t.color }} />,
+      label: t.name,
+      testid: `wlt-win-${t.id}`,
+    })),
+    {
+      id: "tie",
+      mark: (
+        <span className="flex h-3 w-3 flex-shrink-0 overflow-hidden rounded-full">
+          <span className="h-full w-1/2" style={{ background: teams[0]?.color ?? "var(--color-bt-text-dim)" }} />
+          <span className="h-full w-1/2" style={{ background: teams[1]?.color ?? "var(--color-bt-text-dim)" }} />
+        </span>
+      ),
+      label: "Tie",
+      testid: "wlt-tie",
+    },
+  ];
   return (
     <div>
       <div className="mb-2">
-        <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Result</span>
+        <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Who won?</span>
       </div>
-      <div className="space-y-1.5">
-        {teams.map((t) => {
-          const sel = result === t.id;
+      <div role="radiogroup" aria-label="Who won?" className="space-y-1.5">
+        {options.map((o) => {
+          const sel = result === o.id;
           return (
             <button
-              key={t.id}
+              key={o.id}
               type="button"
-              onClick={() => onPick(t.id)}
-              data-testid={`wlt-win-${t.id}`}
-              className="flex w-full items-center gap-2 rounded-lg px-2.5 py-3 text-left"
+              role="radio"
+              aria-checked={sel}
+              onClick={() => onPick(o.id)}
+              data-testid={o.testid}
+              className="flex w-full items-center gap-2.5 rounded-lg px-3 py-3 text-left"
               style={{ background: sel ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)", border: `1px solid ${sel ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}` }}
             >
-              <span className="h-3 w-3 flex-shrink-0 rounded-full" style={{ background: t.color }} />
-              <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>{t.name}</span>
-              <span className="text-[12px] font-semibold uppercase tracking-wider" style={{ color: sel ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>{sel ? "Winner" : "Wins"}</span>
+              {o.mark}
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: sel ? "var(--color-bt-accent)" : "var(--color-bt-text)" }}>{o.label}</span>
             </button>
           );
         })}
-        <button
-          type="button"
-          onClick={() => onPick("tie")}
-          data-testid="wlt-tie"
-          className="flex w-full items-center justify-center rounded-lg px-2.5 py-3"
-          style={{ background: result === "tie" ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)", border: `1px solid ${result === "tie" ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}` }}
-        >
-          <span className="text-sm font-semibold" style={{ color: result === "tie" ? "var(--color-bt-accent)" : "var(--color-bt-text)" }}>Tie — split the points</span>
-        </button>
       </div>
       <p className="mt-2 text-[11px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
         Head-to-head: the winner takes the game&rsquo;s points; a tie splits them evenly.

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -60,14 +60,14 @@ export async function computeCompetitionLeaderboard(
   // These reads are independent — run them in parallel (one round-trip's worth
   // of latency instead of stacked). `game_results` + the match counts alone
   // depend on the game ids, so they wait below.
-  const [teamsRes, compRes, gameRowsRes, assignmentsRes] = await Promise.all([
+  const [teamsRes, compRes, gameRowsRes, assignmentsRes, templatesRes] = await Promise.all([
     supabase
       .from("teams")
       .select("id, name, short_name, color")
       .eq("competition_id", competitionId),
     supabase
       .from("competitions")
-      .select("defending_team_id")
+      .select("defending_team_id, scoring_model")
       .eq("id", competitionId)
       .maybeSingle(),
     // Games of this competition. We fetch ALL (incl. dropped) so the grid can
@@ -83,10 +83,22 @@ export async function computeCompetitionLeaderboard(
       .from("team_assignments")
       .select("team_id")
       .eq("competition_id", competitionId),
+    // Template → result_strategy map, so we can tell a NON-GOLF MANUAL game
+    // (result_strategy NULL) from a golf game. Only manual games get the
+    // match-play winner-take-all award; golf scoring is never touched.
+    supabase.from("game_type_templates").select("id, result_strategy"),
   ]);
   const teams = teamsRes.data;
   const teamIds = (teams ?? []).map((t) => t.id as string);
   const comp = compRes.data;
+  // Scoring-model axis (independent of team count; default match_play). Branches
+  // ONLY the non-golf result award below — the hero stays on teams.length.
+  const scoringModel = (comp?.scoring_model as string | null) ?? "match_play";
+  const strategyByType = new Map<string, string | null>(
+    (templatesRes.data ?? []).map((t) => [t.id as string, (t.result_strategy as string | null) ?? null])
+  );
+  const isManualType = (typeId: string | null) =>
+    typeId != null && strategyByType.has(typeId) && strategyByType.get(typeId) == null;
   const allGames = gameRowsRes.data ?? [];
   const live = allGames.filter((g) => g.status !== "dropped");
   const sizeByTeam = new Map<string, number>();
@@ -147,6 +159,24 @@ export async function computeCompetitionLeaderboard(
   const liveGames: LiveGame[] = live.map((g) => {
     const rawDist = g.points_distribution as PointsDistribution | null;
     const standings = standingsByGame.get(g.id as string) ?? [];
+
+    // Match-play, non-golf MANUAL game → winner-take-all. The owner-set total all
+    // goes to the winner (position 1); a tie (both at position 1) splits it —
+    // placementPoints averages [P,0] → P/2 each, the same averaged convention a
+    // golf match-play halve uses. Derived from points_total, NOT a configured
+    // split, so the result is win/lose/tie regardless of any distribution values
+    // on the record. Manual games only (result_strategy NULL) — golf untouched.
+    if (scoringModel === "match_play" && isManualType(g.game_type_id as string | null)) {
+      const total = (g.points_total as number | null) ?? 0;
+      return {
+        id: g.id as string,
+        distribution: total > 0 ? [total, 0] : null,
+        numTeams: teamIds.length,
+        standings,
+        direction: "low_wins" as const,
+        pointsTotal: (g.points_total as number | null) ?? undefined,
+      };
+    }
 
     if (isPerMatch(rawDist)) {
       const typeId = g.game_type_id as string | null;

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -48,7 +48,9 @@ async function enterResults(
 beforeAll(async () => {
   ctx = await TestContext.create();
   tripId = await ctx.createTrip("D2 Leaderboard Trip");
-  competitionId = await ctx.createCompetition(tripId, "D2 Cup");
+  // D2 verifies the points/placement award model — declare it explicitly now
+  // that the DB default is match_play (W-NONGOLF-02).
+  competitionId = await ctx.createCompetition(tripId, "D2 Cup", { scoringModel: "points" });
 });
 
 afterAll(async () => {
@@ -110,7 +112,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
 
   it("clinched: pointsToClinch <= 0 when a team reaches winNumber", async () => {
     // Create a fresh competition for a clean slate
-    const cleanComp = await ctx.createCompetition(tripId, "D2 Clinch Comp");
+    const cleanComp = await ctx.createCompetition(tripId, "D2 Clinch Comp", { scoringModel: "points" });
     const ta = await ctx.createTeam(cleanComp, "Blue2", { shortName: "B2" });
     const tb = await ctx.createTeam(cleanComp, "Red2", { shortName: "R2" });
 
@@ -143,7 +145,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
   });
 
   it("retain case: defending team clinches at half (not > half)", async () => {
-    const cleanComp = await ctx.createCompetition(tripId, "D2 Retain Comp");
+    const cleanComp = await ctx.createCompetition(tripId, "D2 Retain Comp", { scoringModel: "points" });
     const defender = await ctx.createTeam(cleanComp, "Defender", { shortName: "DEF" });
     const challenger = await ctx.createTeam(cleanComp, "Challenger", { shortName: "CHL" });
 
@@ -184,7 +186,7 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
 
 describe("D2 §6 — N-team (3+ teams) ranked list data", () => {
   it("3-team competition: winNumber and pointsToClinch work for all three teams", async () => {
-    const comp = await ctx.createCompetition(tripId, "D2 3-Team Comp");
+    const comp = await ctx.createCompetition(tripId, "D2 3-Team Comp", { scoringModel: "points" });
     const t1 = await ctx.createTeam(comp, "Alpha", { shortName: "ALP" });
     const t2 = await ctx.createTeam(comp, "Beta", { shortName: "BET" });
     const t3 = await ctx.createTeam(comp, "Gamma", { shortName: "GAM" });
@@ -224,7 +226,7 @@ describe("D2 §6 — N-team (3+ teams) ranked list data", () => {
 
 describe("D2 §6 — dropped game excluded from totals and winNumber", () => {
   it("dropping a game moves the winNumber and removes it from cells", async () => {
-    const comp = await ctx.createCompetition(tripId, "D2 Drop Comp");
+    const comp = await ctx.createCompetition(tripId, "D2 Drop Comp", { scoringModel: "points" });
     const ta = await ctx.createTeam(comp, "Blue", { shortName: "BLU" });
     const tb = await ctx.createTeam(comp, "Red", { shortName: "RED" });
 
@@ -264,7 +266,7 @@ describe("D2 §6 — dropped game excluded from totals and winNumber", () => {
 
 describe("D2 §6 — non-engine game with no entry shows at 0, not hidden", () => {
   it("manual game with no results contributes to pointsAvailable but has no cells", async () => {
-    const comp = await ctx.createCompetition(tripId, "D2 NoEntry Comp");
+    const comp = await ctx.createCompetition(tripId, "D2 NoEntry Comp", { scoringModel: "points" });
     await ctx.createTeam(comp, "X", { shortName: "X" });
     await ctx.createTeam(comp, "Y", { shortName: "Y" });
 
@@ -376,7 +378,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
   it("pointsTotal (§A5 outer column) reads the distribution sum when no owner total is set", async () => {
     // The board row's `N PTS` must match what rollUp counts as available, even
     // for a distribution-only placement game (no explicit points_total). 9+6=15.
-    const comp = await ctx.createCompetition(tripId, "D2 Pts Comp");
+    const comp = await ctx.createCompetition(tripId, "D2 Pts Comp", { scoringModel: "points" });
     const t1 = await ctx.createTeam(comp, "A", { shortName: "A" });
     const t2 = await ctx.createTeam(comp, "B", { shortName: "B" });
     expect([t1, t2].length).toBe(2);
@@ -394,7 +396,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
   it("reads competitionPlacement.ts — rollUp matches the endpoint's teamTotals", async () => {
     // This test proves the endpoint delegates to the lib (CLAUDE.md #8 — single
     // source of truth). We run the same inputs through rollUp directly and compare.
-    const comp = await ctx.createCompetition(tripId, "D2 Delegation Comp");
+    const comp = await ctx.createCompetition(tripId, "D2 Delegation Comp", { scoringModel: "points" });
     const t1 = await ctx.createTeam(comp, "P", { shortName: "P" });
     const t2 = await ctx.createTeam(comp, "Q", { shortName: "Q" });
 

--- a/src/server/routers/competitions.matchplay.test.ts
+++ b/src/server/routers/competitions.matchplay.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * W-NONGOLF-02 — match-play (win/lose/tie) non-golf scoring.
+ *
+ * A `match_play` competition (the DB default) awards a non-golf MANUAL game
+ * winner-take-all: the winner takes the game's `points_total`, a tie splits it
+ * (placementPoints averages [P,0] → P/2 — the same averaged convention a golf
+ * match-play halve uses). A `points` competition keeps #430's placement model
+ * (the configured distribution). The branch is on `competitions.scoring_model`,
+ * NOT team count. Verified through the leaderboard endpoint (same isolation
+ * pattern as competitions.d1followon.test.ts).
+ */
+
+const MANUAL = "gtt_manual";
+
+let ctx: TestContext;
+let tripId: string;
+const gameIds: string[] = [];
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("MatchPlay NonGolf Trip");
+});
+
+afterAll(async () => {
+  if (gameIds.length) {
+    await ctx.admin.from("game_results").delete().in("game_id", gameIds);
+    await ctx.admin.from("games").delete().in("id", gameIds);
+  }
+  await ctx.cleanup();
+}, 30000);
+
+describe("match_play (default) — non-golf game scores winner-take-all", () => {
+  it("winner takes the game's points; loser gets 0", async () => {
+    const comp = await ctx.createCompetition(tripId, "MP Win Comp");
+    const ta = await ctx.createTeam(comp, "A", { shortName: "A" });
+    const tb = await ctx.createTeam(comp, "B", { shortName: "B" });
+    // pointsTotal only, NO distribution — winner-take-all is derived from total.
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Poker", competitionId: comp, pointsTotal: 5,
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    // Win/lose/tie posts winner → position 1, loser → position 2.
+    await ctx.caller().games.post({
+      tripId, gameId: g.id,
+      placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 2 }],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.teamTotals[ta]).toBe(5); // winner takes all
+    expect(lb.teamTotals[tb]).toBe(0);
+    expect(lb.pointsAvailable).toBe(5); // winner-take-all [5,0] → 5 in play
+  });
+
+  it("a tie splits the points evenly (P/2 each)", async () => {
+    const comp = await ctx.createCompetition(tripId, "MP Tie Comp");
+    const ta = await ctx.createTeam(comp, "A", { shortName: "A" });
+    const tb = await ctx.createTeam(comp, "B", { shortName: "B" });
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Cornhole", competitionId: comp, pointsTotal: 5,
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    // Tie → BOTH at position 1 (placementPoints averages [5,0] → 2.5 each).
+    await ctx.caller().games.post({
+      tripId, gameId: g.id,
+      placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 1 }],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.teamTotals[ta]).toBe(2.5);
+    expect(lb.teamTotals[tb]).toBe(2.5);
+  });
+});
+
+describe("points comp — keeps #430's placement model (regression)", () => {
+  it("the configured distribution awards per position, NOT winner-take-all", async () => {
+    const comp = await ctx.createCompetition(tripId, "Points Comp");
+    const ta = await ctx.createTeam(comp, "A", { shortName: "A" });
+    const tb = await ctx.createTeam(comp, "B", { shortName: "B" });
+    // Flip this comp to the points scoring model (independent of its 2 teams).
+    await ctx.admin.from("competitions").update({ scoring_model: "points" }).eq("id", comp);
+
+    const g = (await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Ranked", competitionId: comp,
+      pointsTotal: 8, pointsDistribution: { type: "placement", values: [5, 3] },
+    })) as { id: string };
+    gameIds.push(g.id);
+
+    await ctx.caller().games.post({
+      tripId, gameId: g.id,
+      placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 2 }],
+    });
+
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.teamTotals[ta]).toBe(5); // the configured split — not winner-take-all 8
+    expect(lb.teamTotals[tb]).toBe(3);
+  });
+});

--- a/src/server/routers/faceBootstrap.test.ts
+++ b/src/server/routers/faceBootstrap.test.ts
@@ -26,7 +26,7 @@ beforeAll(async () => {
   await ctx.addTripMember(tripId, "planner", "Organizer"); // → co_admin
   await ctx.addTripMember(tripId, "member", "Member");
   memberId = ctx.getUser("member").id;
-  competitionId = await ctx.createCompetition(tripId, "Bootstrap Cup");
+  competitionId = await ctx.createCompetition(tripId, "Bootstrap Cup", { scoringModel: "points" });
   await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
   await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
   const g = (await ctx.caller().games.create({

--- a/src/server/routers/games.d1.test.ts
+++ b/src/server/routers/games.d1.test.ts
@@ -38,7 +38,9 @@ beforeAll(async () => {
   tripId = await ctx.createTrip("D1 Trip");
   await ctx.addTripMember(tripId, "member", "Member"); // a plain trip Member (delegate target)
   memberId = ctx.getUser("member").id;
-  competitionId = await ctx.createCompetition(tripId, "D1 Comp");
+  // Placement/manual-adapter roll-up suite — points model (DB default is now
+  // match_play, which would award these manual games winner-take-all).
+  competitionId = await ctx.createCompetition(tripId, "D1 Comp", { scoringModel: "points" });
   teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
   teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
 });
@@ -92,7 +94,7 @@ describe("manual adapter → universal roll-up (§5)", () => {
 
   it("averaged ties flow through the stack (two teams tie 1st on [9,6] → 7.5 each)", async () => {
     // Fresh competition so totals are isolated.
-    const comp2 = await ctx.createCompetition(tripId, "Tie Comp");
+    const comp2 = await ctx.createCompetition(tripId, "Tie Comp", { scoringModel: "points" });
     const tA = await ctx.createTeam(comp2, "A");
     const tB = await ctx.createTeam(comp2, "B");
     const g = (await ctx.caller().games.create({
@@ -113,7 +115,7 @@ describe("manual adapter → universal roll-up (§5)", () => {
 
 describe("dropping recomputes the win number (§4/§6)", () => {
   it("dropping a game lowers points-available + win number; restoring raises them", async () => {
-    const comp3 = await ctx.createCompetition(tripId, "Drop Comp");
+    const comp3 = await ctx.createCompetition(tripId, "Drop Comp", { scoringModel: "points" });
     await ctx.createTeam(comp3, "A");
     await ctx.createTeam(comp3, "B");
     const g1 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G1", competitionId: comp3, pointsDistribution: DIST_96 })) as { id: string };

--- a/src/server/routers/games.runpost.test.ts
+++ b/src/server/routers/games.runpost.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
   await ctx.addTripMember(tripId, "planner", "Organizer"); // a trip planner (NOT a run-action)
   await ctx.addTripMember(tripId, "member", "Member"); // delegate candidate
   memberId = ctx.getUser("member").id;
-  competitionId = await ctx.createCompetition(tripId, "Run Cup");
+  competitionId = await ctx.createCompetition(tripId, "Run Cup", { scoringModel: "points" });
   teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
   teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
 });

--- a/supabase/migrations/20260621160000_062_competitions_scoring_model.sql
+++ b/supabase/migrations/20260621160000_062_competitions_scoring_model.sql
@@ -1,0 +1,41 @@
+-- 062 — competitions.scoring_model: the scoring-model axis (match_play vs points)
+--
+-- W-NONGOLF-02. Competition "type" was previously INFERRED from teams.length===2
+-- ("RYDER_CUP"). But team count and scoring model are INDEPENDENT axes: a 2-team
+-- competition can be points-based (two big teams, N scoring positions per game).
+-- So teams.length===2 is only ACCIDENTALLY a match-play signal — true so far
+-- because every comp built to date is match-play. This adds the scoring-model
+-- axis as a real, stored field: the only source for a distinction team count
+-- cannot supply.
+--
+--   match_play — head-to-head win/lose/tie; the winner takes the game's points,
+--                a tie splits them (the existing averaged-tie convention).
+--   points     — points-per-position distribution (the #430 placement model).
+--
+-- Branches the NON-GOLF result model ONLY. The leaderboard hero stays on
+-- teams.length (team count) — do NOT repoint it here. Golf scoring is untouched.
+--
+-- NOT NULL DEFAULT 'match_play' backfills every existing competition to
+-- match_play. Safe-backfill verified (2026-06-21, live DB): no existing comp has
+-- a placement game distributing across >2 positions, i.e. none was built as a
+-- points config — all extant comps are de-facto match-play. BBMI Cup (2 teams,
+-- 15 games) thus resolves to match_play with no new UI. The creation-time
+-- chooser (points vs match_play — needed for the 2-team-points case) rides the
+-- WS4 creation redesign (W-TYPE-01); it is intentionally not built here.
+-- Idempotent.
+ALTER TABLE public.competitions
+  ADD COLUMN IF NOT EXISTS scoring_model text NOT NULL DEFAULT 'match_play';
+
+DO $$ BEGIN
+  ALTER TABLE public.competitions
+    ADD CONSTRAINT competitions_scoring_model_check
+    CHECK (scoring_model IN ('match_play', 'points'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+COMMENT ON COLUMN public.competitions.scoring_model IS
+  'Scoring-model axis, INDEPENDENT of team count: match_play (win/lose/tie — '
+  'winner takes the game points, a tie splits them) | points (points-per-position '
+  'distribution, the #430 placement model). Branches the non-golf result model '
+  'ONLY; the leaderboard hero stays on teams.length. Default match_play (every '
+  'pre-existing comp was de-facto match-play). Creation-time chooser deferred to '
+  'W-TYPE-01.';


### PR DESCRIPTION
**BBMI-blocking** ([#431](https://github.com/zgrether/buddytrip/issues/431)). #430 re-wired non-golf scoring but only delivered the **placement** model (order → distribution) — correct for points comps, **wrong for match-play.** BBMI is a Ryder Cup; its non-golf games (Poker, euchre) must score **winner/loser/tie**. Together with #430 this genuinely closes #429.

## Phase 0 reframed the task
Competition "type" was inferred from `teams.length === 2` ("RYDER_CUP") and that inference is load-bearing (leaderboard hero). But **team count and scoring model are independent axes** — a 2-team comp can be points-based (two teams of 8, N scoring positions). So `teams.length === 2` is only *accidentally* a match-play signal. This adds the scoring-model axis as a real field rather than enshrining the conflation.

The win/lose/tie **math already exists**: a head-to-head result is a 2-team placement `[P,0]`; a tie = both at position 1 → `placementPoints` averages → `P/2` each (a golf match-play halve). `games.post` + the rollup needed no change.

## 1a — `competitions.scoring_model` (mig 062)
`match_play` | `points`, **independent of team count**, `NOT NULL DEFAULT 'match_play'`. Safe-backfill verified against the live DB: **no competition has a placement game distributing across >2 positions** → none was a points config, so defaulting all to `match_play` is safe. **BBMI resolves to `match_play` with no new UI.** The leaderboard hero stays on `teams.length`; the creation chooser (and the 2-team-points case) is deferred to W-TYPE-01.

## 1b — branch the non-golf result model on `scoring_model`
- **Leaderboard:** a non-golf **manual** game (`result_strategy` NULL) in a `match_play` comp awards winner-take-all `[points_total, 0]` — winner takes the total, a tie averages to `P/2`. **Golf is never touched** (the manual signal excludes it).
- **RunSheet:** `match_play` + non-engine + 2 teams → a **win/lose/tie** editor (posts winner→pos 1, loser→pos 2, tie→both pos 1). `points` / N-team → #430's order editor, unchanged. Reuses `games.post` + the rollup entirely.

## Tests
`competitions.matchplay.test` — winner-take-all, tie-splits-`P/2`, and a **points-comp regression** (configured split, not winner-take-all). Branches on `scoring_model`, never team count. `tsc` + `eslint` clean (3 pre-existing panel warnings, untouched). The migration applies in CI's `db push` before vitest.

## Verify-by-eye
Follows once CI's `db push` lands the column — a match-play non-golf game scores win/lose/tie on BBMI with correct direction + amount; a points comp keeps the placement editor; live standings reverted after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)