### PR TITLE
fix(competition): GameRows as standalone panels (W-GAMEROW-01)

### DIFF
--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -567,29 +567,17 @@ function SessionBreakdown({
   onOpenGame?: (gameId: string) => void;
 }) {
   return (
-    <div
-      className="overflow-hidden rounded-xl"
-      style={{
-        background: "var(--color-bt-card)",
-        border: "1px solid var(--color-bt-border)",
-      }}
-    >
-      <div
-        className="px-4 py-2.5"
-        style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+    <div>
+      <p
+        className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
       >
-        <p
-          className="text-[11px] font-semibold uppercase tracking-wider"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          Sessions{" "}
-          <span style={{ color: "var(--color-bt-text)" }}>
-            · {sessionsDone} of {games.length} done
-          </span>
-        </p>
-      </div>
-
-      <div className="divide-y" style={{ "--tw-divide-color": "var(--color-bt-border)" } as React.CSSProperties}>
+        Sessions{" "}
+        <span style={{ color: "var(--color-bt-text)" }}>
+          · {sessionsDone} of {games.length} done
+        </span>
+      </p>
+      <div className="flex flex-col gap-2">
         {games.map((game) => (
           <GameRow
             key={game.id}
@@ -678,25 +666,14 @@ function EarlyState({
 
       {/* Schedule */}
       {liveGames.length > 0 && (
-        <div
-          className="overflow-hidden rounded-xl"
-          style={{
-            background: "var(--color-bt-card)",
-            border: "1px solid var(--color-bt-border)",
-          }}
-        >
-          <div
-            className="px-4 py-2.5"
-            style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+        <div>
+          <p
+            className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
+            style={{ color: "var(--color-bt-text-dim)" }}
           >
-            <p
-              className="text-[11px] font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              The Schedule
-            </p>
-          </div>
-          <div className="divide-y" style={{ "--tw-divide-color": "var(--color-bt-border)" } as React.CSSProperties}>
+            The Schedule
+          </p>
+          <div className="flex flex-col gap-2">
             {liveGames.map((game) => (
               <GameRow
                 key={game.id}

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -159,16 +159,17 @@ export function GameRow({
   // The format icon shows FULL color only while scoring is enabled AND the game
   // isn't yet a finished record; Final quiets it back down (sheds the arm tell).
   const armedIcon = iconArmed(game) && !isFinal;
+  // Panel surface — each game is its own standalone card (not a row inside a
+  // shared panel). Setting-up gets a dashed left edge as its "not built yet"
+  // tell; it lives on the panel border so the inner content never shifts.
+  const panelStyle: React.CSSProperties = {
+    background: "var(--color-bt-card)",
+    border: "1px solid var(--color-bt-border)",
+    ...(lifecycle === "setting-up" ? { borderLeft: "2px dashed var(--color-bt-border)" } : {}),
+  };
   const rowStyle: React.CSSProperties = {
     // The one reserved background is Live (§A2) — the only "act now" fill.
     background: lifecycle === "live" ? "var(--color-bt-accent-faint)" : undefined,
-    // Setting-up gets the only special outline: a dashed left edge that reads
-    // "not built yet." Every other state reserves the same 2px transparent so
-    // the name never shifts as the outline appears/disappears.
-    borderLeft:
-      lifecycle === "setting-up"
-        ? "2px dashed var(--color-bt-border)"
-        : "2px solid transparent",
     // Final is a quiet record — recess the whole tile (§A3 "recessed").
     opacity: isFinal ? 0.72 : 1,
   };
@@ -253,7 +254,8 @@ export function GameRow({
     return (
       <Link
         href={href}
-        className="block hover:opacity-80 transition-opacity"
+        className="block rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
+        style={panelStyle}
         onPointerEnter={() => onPrefetch(game.id)}
         onPointerDown={() => onPrefetch(game.id)}
       >
@@ -269,14 +271,15 @@ export function GameRow({
       <button
         type="button"
         onClick={() => onOpenGame(game.id)}
-        className="block w-full text-left hover:opacity-80 transition-opacity"
+        className="block w-full text-left rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
+        style={panelStyle}
         data-testid={`game-open-${game.id}`}
       >
         {inner}
       </button>
     );
   }
-  return <div>{inner}</div>;
+  return <div className="rounded-xl overflow-hidden" style={panelStyle}>{inner}</div>;
 }
 
 /** §A5 outer column: `—` when nothing's in play, `N PTS` while unresolved, the


### PR DESCRIPTION
## Summary

- **The fix is the container, not the row.** `SessionBreakdown` and `EarlyState` both wrapped all GameRows in one shared `bt-card` panel with `divide-y` row dividers — the wrong surface relationship (rows sitting *on* a panel instead of each being a panel).
- Removed the shared panel wrapper from both sites; section headers ("SESSIONS · N of M done", "The Schedule") become plain labels above the gap list.
- `GameRow` now carries its own Level-1 surface (`bt-card` + border + `rounded-xl overflow-hidden`) on all three outer return variants (Link / button / inert div).
- `divide-y` dividers replaced with `flex flex-col gap-2` between independent panels.
- The setting-up dashed-left signal moves from `inner` to the panel border (`borderLeft` override on `panelStyle`) — cleaner, no inner/outer border conflict.
- No GameRow internal changes (content, layout, lifecycle logic unchanged).

## Test plan

- [x] Dark mode: discrete dark panels, gap-separated, no shared background — verified by eye
- [x] Light mode: discrete white panels on grey page background — verified by eye
- [x] Live games render with accent-faint fill inside their own panel
- [x] Golf + non-golf (Poker, euchre) both render as standalone panels
- [x] No console errors, `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)