### PR TITLE
perf(games): format definitions → code, dialog never blocks on a fetch (W-PERF-01)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -6,7 +6,8 @@ import { trpc } from "@/lib/trpc-client";
 import { CompetitionHeader } from "./CompetitionHeader";
 import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
-import { GameSheet, RunSheet, type GameType, type GameRow, type LBTeamLite } from "./CompetitionGamesPanel";
+import { GameSheet, RunSheet, type GameRow, type LBTeamLite } from "./CompetitionGamesPanel";
+import { GAME_TYPES } from "@/lib/gameTypes";
 
 interface Competition {
   id: string;
@@ -75,9 +76,10 @@ export function CompetitionFace({
   const [view, setView] = useState<FaceView>("board");
   const [addingGame, setAddingGame] = useState(false);
 
-  // GameSheet (add-game modal) needs the type catalog — fetched once here so the
-  // modal opens without its own waterfall. Only editors ever open it.
-  const { data: gameTypes = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: canEdit });
+  // GameSheet (add-game modal) needs the type catalog. Format definitions live in
+  // CODE (W-PERF-01) — read synchronously, no fetch — so the modal's top half is
+  // present the instant it opens, even on the bad signal organizers hit on-site.
+  const gameTypes = GAME_TYPES;
 
   // ── Non-golf (manual) game scoring + config-reopen, routed from the board ───
   // Golf games open via their per-format route (the GameRow links). Non-golf
@@ -275,7 +277,7 @@ export function CompetitionFace({
           tripId={tripId}
           competitionId={competition.id}
           game={editing}
-          types={gameTypes as GameType[]}
+          types={gameTypes}
           canEdit={canEdit}
           onClose={() => {
             setAddingGame(false);
@@ -297,7 +299,7 @@ export function CompetitionFace({
           game={running}
           teams={(lb?.teams ?? []) as LBTeamLite[]}
           initialOrder={runningOrder}
-          isEngine={!!(gameTypes as GameType[]).find((t) => t.id === running.game_type_id)?.isEngine}
+          isEngine={!!gameTypes.find((t) => t.id === running.game_type_id)?.isEngine}
           matchPlay={(competition.scoring_model ?? "match_play") === "match_play"}
           onClose={() => {
             setRunning(null);

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -12,6 +12,13 @@ import type { PointsDistribution } from "@/lib/pointsDistribution";
 import {
   validatePlacement, matchReadout, placementFit, matchFit, deriveMatchCount, type MatchFormat,
 } from "@/lib/gameConfig";
+// Format definitions live in code (W-PERF-01) — the catalog + its type come from
+// here, read synchronously, never fetched. Re-exported below so existing
+// consumers (CompetitionFace, GameSetupRows) keep their `from "./CompetitionGamesPanel"`
+// import path.
+import { GAME_TYPES, type GameType } from "@/lib/gameTypes";
+
+export type { GameType };
 
 // Mirrors the builder cap (matches router / match-new page). The page-one match
 // count seeds the builder's initial slot count up to here.
@@ -73,18 +80,6 @@ export interface GameRow {
   corrections_open: boolean;
 }
 
-export interface GameType {
-  id: string;
-  key: string;
-  name: string;
-  description: string | null;
-  isEngine: boolean;
-  isGolf: boolean;
-  resultStrategy: string | null;
-  category: string;
-  compatibleModifiers: string[];
-}
-
 interface Member { memberId: string; displayName: string }
 
 // ── Static option tables ──────────────────────────────────────────────────────
@@ -131,7 +126,7 @@ export function CompetitionGamesPanel({ competitionId, tripId, canEdit, isOwner 
   const [running, setRunning] = useState<GameRow | null>(null); // game being posted/corrected
 
   const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { enabled: !!tripId });
-  const { data: types = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: !!tripId });
+  const types = GAME_TYPES; // format definitions in code (W-PERF-01) — no fetch
   const { data: lb } = trpc.competitions.leaderboard.useQuery({ tripId, competitionId }, { enabled: !!competitionId });
 
   const games = useMemo(

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
-import { GameSheet, type GameType, type GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { GameSheet, type GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { GAME_TYPES } from "@/lib/gameTypes";
 
 /**
  * §B setup-shell drill-down rows (Phase 2B.2). The standardized top of every
@@ -36,8 +37,8 @@ export function GameSetupRows({
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
 
-  // Types only needed once the config editor opens.
-  const { data: types = [] } = trpc.games.listTypes.useQuery(undefined, { enabled: configOpen });
+  // Format definitions live in code (W-PERF-01) — no fetch, always available.
+  const types = GAME_TYPES;
   const applyCourse = trpc.games.applyCourse.useMutation();
   const utils = trpc.useUtils();
 
@@ -89,7 +90,7 @@ export function GameSetupRows({
           tripId={tripId}
           competitionId={competitionId}
           game={game}
-          types={types as GameType[]}
+          types={types}
           canEdit={canEdit}
           onClose={() => {
             setConfigOpen(false);

--- a/src/lib/gameTypes.ts
+++ b/src/lib/gameTypes.ts
@@ -1,0 +1,325 @@
+/**
+ * gameTypes — the format DEFINITIONS, in code (W-PERF-01).
+ *
+ * A game format's definition is "what that format IS" — its name, the engine that
+ * scores it (`resultStrategy`), the scorecard shape it carries, the categories and
+ * modifiers it offers. None of this varies per game or per trip; it is fixed by
+ * the code that implements each format. So it lives HERE, read synchronously and
+ * locally — NOT fetched from the DB at dialog-open (which blanked the add-game
+ * dialog's top half for 20–30s on bad signal at the course).
+ *
+ * The rule (CLAUDE.md, the data-vs-code seam): data that CHANGES (per-user,
+ * per-trip, over time) → database; data FIXED BY THE CODE → code. The DB keeps
+ * only the per-game REFERENCE (`games.game_type_id`) + genuine per-instance config
+ * (points, course snapshot, modifiers-enabled); the code stores what that
+ * reference MEANS.
+ *
+ * CLIENT-SAFE: this module imports only a pure type from `@/lib/courseIndex` and
+ * defines const data — no Supabase, no tRPC server, no node deps. The add-game
+ * dialog imports `GAME_TYPES` directly, so the format chips are present before the
+ * component even mounts: no fetch, no loading state, offline-safe.
+ *
+ * This is the concrete precursor to R1's template registry — the clean code-home
+ * now; R1 generalizes routing/grouping/handicap/readiness over it later. It is NOT
+ * the full registry: it relocates the existing definitions, nothing more.
+ *
+ * SOURCE OF TRUTH: the values below are copied VERBATIM from the live
+ * `game_type_templates` rows (incl. each `scorecard_schema`, which had drifted
+ * from its seed migration — e.g. stroke play's live `handicap_index`). The
+ * `game_type_templates` table is intentionally LEFT IN PLACE until every reader is
+ * proven migrated (audit-before-delete); a later migration archives it.
+ */
+
+import type { ScorecardSchema } from "@/lib/courseIndex";
+
+/** The scoring engines a format can dispatch to. `null` = manual / non-engine
+ *  (finishing order entered by hand — cornhole, trivia, generic games). */
+export type ResultStrategy = "stroke_total" | "match_play" | "rack_n_stack";
+
+/** Creation Type tier the dialog groups formats under. */
+export type GameCategory = "golf" | "card" | "yard" | "bar" | "other";
+
+/**
+ * The full definition of one game format — the code home of record. Every field
+ * is a property of the FORMAT, not of any particular game. Only a subset is read
+ * today (resultStrategy, scorecardSchema, category, compatibleModifiers, the
+ * display strings); the structural axes (`supportsSides` etc.) are carried for
+ * faithfulness + future readers. The two reserved-empty jsonb columns
+ * (`config`/`config_schema`, always `{}`/unused) are intentionally omitted.
+ */
+export interface GameTypeDefinition {
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  sortOrder: number;
+  category: GameCategory;
+  /** How scores are entered. null for manual (no scorecard entry). */
+  entrySchema: string | null;
+  /** The scoring engine; null = manual. Branches games.finish / games.post. */
+  resultStrategy: ResultStrategy | null;
+  /** The base scorecard the format carries; null = non-golf (no scorecard).
+   *  applyCourse patches a COPY of this with the course's par/index. */
+  scorecardSchema: ScorecardSchema | null;
+  /** Special-rule keys this format offers (golf modifier toggles). */
+  compatibleModifiers: string[];
+  // ── Structural axes (definition, not read by any current reader) ──
+  supportsFreeForAll: boolean | null;
+  supportsSides: boolean | null;
+  requiresSides: boolean | null;
+  maxPlayersPerSide: number | null;
+  compatibleCompetitionFormats: string[] | null;
+}
+
+// ── Shared golf scorecard schemas ────────────────────────────────────────────
+// Copied verbatim from the live `game_type_templates.scorecard_schema`. The
+// par-72 layout is the template DEFAULT; applyCourse overwrites par + index with
+// the chosen course's real values (on a deep clone — buildScorecardSchema never
+// mutates the input, so sharing these consts is safe).
+
+const HOLE_LABELS = ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18"];
+const PAR_72 = [4,5,3,4,4,3,5,4,4,4,3,5,4,4,3,4,5,4];
+const SECTIONS_18 = [
+  { name: "Front 9", units: ["1","2","3","4","5","6","7","8","9"] },
+  { name: "Back 9", units: ["10","11","12","13","14","15","16","17","18"] },
+];
+
+const STROKE_INDEX_DEFAULT = [7,3,15,1,11,5,17,9,13,8,4,16,2,12,6,18,10,14];
+
+// Asserted `as ScorecardSchema`: these mirror the DB's untyped `jsonb` and carry
+// fields beyond courseIndex's intentionally-minimal "shape we read/patch" type
+// (entry/interaction/participants, scoring.aggregation/tiebreaker). The assertion
+// preserves them verbatim without widening the shared contract.
+const strokeSchema = {
+  units: { type: "holes", count: 18, ordered: true, labels: HOLE_LABELS, metadata: { par: PAR_72, handicap_index: STROKE_INDEX_DEFAULT } },
+  entry: { value_type: "integer", value_label: "Strokes", min: 1, max: null },
+  scoring: { strategy: "stroke_total", direction: "low_wins", aggregation: "sum", sections: SECTIONS_18, tiebreaker: "shared" },
+  interaction: { model: "simultaneous", entry_timing: "per_unit" },
+  participants: { min: 2, max: 4, participant_type: "individual", assigned_pairings: false },
+} as ScorecardSchema;
+
+const singlesSchema = {
+  units: { type: "holes", count: 18, ordered: true, labels: HOLE_LABELS, metadata: { par: PAR_72, handicap_index: STROKE_INDEX_DEFAULT } },
+  entry: { value_type: "integer", value_label: "Strokes", min: 1, max: null },
+  scoring: { strategy: "match_play", direction: "low_wins", aggregation: "match", sections: SECTIONS_18, tiebreaker: "shared" },
+  interaction: { model: "simultaneous", entry_timing: "per_unit" },
+  participants: { min: 2, max: 4, participant_type: "individual", assigned_pairings: true },
+} as ScorecardSchema;
+
+const doublesSchema = {
+  // NB: doubles carries par only (no handicap_index) — matches the live row.
+  units: { type: "holes", count: 18, ordered: true, labels: HOLE_LABELS, metadata: { par: PAR_72 } },
+  entry: { value_type: "integer", value_label: "Strokes", min: 1, max: null },
+  scoring: { strategy: "match_play", direction: "low_wins", aggregation: "match", sections: SECTIONS_18, tiebreaker: "shared" },
+  interaction: { model: "simultaneous", entry_timing: "per_unit" },
+  participants: { min: 4, max: 8, participant_type: "side", players_per_side: 2, assigned_pairings: true },
+} as ScorecardSchema;
+
+const rackSchema = {
+  units: { type: "holes", count: 18, ordered: true, labels: HOLE_LABELS, metadata: { par: PAR_72, handicap_index: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18] } },
+  entry: { value_type: "integer", value_label: "Strokes", min: 1, max: null },
+  scoring: { strategy: "rack_n_stack", direction: "low_wins", aggregation: "net_to_par", sections: SECTIONS_18, tiebreaker: "shared" },
+  interaction: { model: "simultaneous", entry_timing: "per_unit" },
+  participants: { min: 2, max: null, participant_type: "individual", assigned_pairings: false },
+} as ScorecardSchema;
+
+// ── The format catalog ───────────────────────────────────────────────────────
+
+/** Every game format, keyed by id (= `games.game_type_id`). The home of record. */
+export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
+  gtt_stroke_play: {
+    id: "gtt_stroke_play",
+    key: "stroke_play",
+    name: "Stroke Play",
+    description: "Individual gross stroke play — lowest total wins.",
+    sortOrder: 0,
+    category: "golf",
+    entrySchema: "user_holes",
+    resultStrategy: "stroke_total",
+    scorecardSchema: strokeSchema,
+    compatibleModifiers: ["glorious_holes"],
+    supportsFreeForAll: true,
+    supportsSides: false,
+    requiresSides: false,
+    maxPlayersPerSide: null,
+    compatibleCompetitionFormats: ["free_for_all"],
+  },
+  gtt_match_play_singles: {
+    id: "gtt_match_play_singles",
+    key: "match_play_singles",
+    name: "Singles Match Play",
+    description: "1v1 match play — low net wins each hole; the match resolves W/H/L hole-by-hole.",
+    sortOrder: 1,
+    category: "golf",
+    entrySchema: "user_holes",
+    resultStrategy: "match_play",
+    scorecardSchema: singlesSchema,
+    compatibleModifiers: ["moving_tees", "glorious_holes"],
+    supportsFreeForAll: false,
+    supportsSides: true,
+    requiresSides: true,
+    maxPlayersPerSide: 1,
+    compatibleCompetitionFormats: ["ryder_cup"],
+  },
+  gtt_match_play_doubles: {
+    id: "gtt_match_play_doubles",
+    key: "match_play_doubles",
+    name: "2v2 Match Play",
+    description: "2v2 match play — one score per side per hole, low net wins each hole; the match resolves W/H/L hole-by-hole between two pairs. Scramble / Alt-Shot / Best-Ball are presets over this one engine.",
+    sortOrder: 2,
+    category: "golf",
+    entrySchema: "group_holes",
+    resultStrategy: "match_play",
+    scorecardSchema: doublesSchema,
+    compatibleModifiers: ["moving_tees", "glorious_holes"],
+    supportsFreeForAll: false,
+    supportsSides: true,
+    requiresSides: true,
+    maxPlayersPerSide: 2,
+    compatibleCompetitionFormats: ["ryder_cup"],
+  },
+  gtt_rack_n_stack: {
+    id: "gtt_rack_n_stack",
+    key: "rack_n_stack",
+    name: "Rack-n-Stack",
+    description: "Net stroke play scored as a rank-paired team board: each team is sorted by net-to-par and paired by rank; the lower net wins each slot (a tie halves).",
+    sortOrder: 2,
+    category: "golf",
+    entrySchema: "user_holes",
+    resultStrategy: "rack_n_stack",
+    scorecardSchema: rackSchema,
+    compatibleModifiers: ["moving_tees", "glorious_holes"],
+    supportsFreeForAll: false,
+    supportsSides: true,
+    requiresSides: true,
+    maxPlayersPerSide: null,
+    compatibleCompetitionFormats: ["ryder_cup"],
+  },
+  gtt_generic_card: {
+    id: "gtt_generic_card",
+    key: "generic_card",
+    name: "Generic Card Game",
+    description: "No built-in scoring engine — name it and enter the result by hand.",
+    sortOrder: 90,
+    category: "card",
+    entrySchema: null,
+    resultStrategy: null,
+    scorecardSchema: null,
+    compatibleModifiers: [],
+    supportsFreeForAll: null,
+    supportsSides: null,
+    requiresSides: null,
+    maxPlayersPerSide: null,
+    compatibleCompetitionFormats: null,
+  },
+  gtt_generic_yard: {
+    id: "gtt_generic_yard",
+    key: "generic_yard",
+    name: "Generic Yard Game",
+    description: "No built-in scoring engine — name it and enter the result by hand.",
+    sortOrder: 91,
+    category: "yard",
+    entrySchema: null,
+    resultStrategy: null,
+    scorecardSchema: null,
+    compatibleModifiers: [],
+    supportsFreeForAll: null,
+    supportsSides: null,
+    requiresSides: null,
+    maxPlayersPerSide: null,
+    compatibleCompetitionFormats: null,
+  },
+  gtt_generic_bar: {
+    id: "gtt_generic_bar",
+    key: "generic_bar",
+    name: "Generic Bar Game",
+    description: "No built-in scoring engine — name it and enter the result by hand.",
+    sortOrder: 92,
+    category: "bar",
+    entrySchema: null,
+    resultStrategy: null,
+    scorecardSchema: null,
+    compatibleModifiers: [],
+    supportsFreeForAll: null,
+    supportsSides: null,
+    requiresSides: null,
+    maxPlayersPerSide: null,
+    compatibleCompetitionFormats: null,
+  },
+  gtt_manual: {
+    id: "gtt_manual",
+    key: "manual",
+    name: "Generic Game",
+    description: "A non-engine contest (cornhole, trivia, pick'em, H-O-R-S-E…) — finishing order entered by hand.",
+    sortOrder: 99,
+    category: "other",
+    entrySchema: null,
+    resultStrategy: null,
+    scorecardSchema: null,
+    compatibleModifiers: [],
+    supportsFreeForAll: true,
+    supportsSides: true,
+    requiresSides: false,
+    maxPlayersPerSide: null,
+    compatibleCompetitionFormats: null,
+  },
+};
+
+/** All definitions, sorted by sortOrder then id (stable) — the catalog order. */
+export const GAME_TYPE_LIST: GameTypeDefinition[] = Object.values(GAME_TYPE_DEFINITIONS).sort(
+  (a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id)
+);
+
+// ── Client-facing shape ──────────────────────────────────────────────────────
+
+/**
+ * The shape the creation UI consumes — the format catalog as the add-game dialog
+ * needs it. `isEngine`/`isGolf` are DERIVED (an engine computes results; a golf
+ * type carries a scorecard), so the two booleans can't drift from the strategy /
+ * schema they're derived from.
+ */
+export interface GameType {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  isEngine: boolean;
+  isGolf: boolean;
+  resultStrategy: string | null;
+  category: string;
+  compatibleModifiers: string[];
+}
+
+/** Project a definition to the client `GameType` shape. */
+export function toGameType(d: GameTypeDefinition): GameType {
+  return {
+    id: d.id,
+    key: d.key,
+    name: d.name,
+    description: d.description,
+    isEngine: d.resultStrategy != null,
+    isGolf: d.scorecardSchema != null,
+    resultStrategy: d.resultStrategy,
+    category: d.category,
+    compatibleModifiers: d.compatibleModifiers,
+  };
+}
+
+/** The client format catalog — import this directly; never fetch it. */
+export const GAME_TYPES: GameType[] = GAME_TYPE_LIST.map(toGameType);
+
+// ── Lookups (the server readers' synchronous replacement for the DB query) ────
+
+/** The definition for a game type id, or undefined if the id is unregistered. */
+export function getGameTypeDefinition(id: string | null | undefined): GameTypeDefinition | undefined {
+  return id ? GAME_TYPE_DEFINITIONS[id] : undefined;
+}
+
+/** A type is "manual" (non-engine, finishing order entered by hand) when it is a
+ *  KNOWN format whose resultStrategy is null. An unregistered id is NOT manual —
+ *  it's unknown (the caller decides how to fail). Mirrors the old leaderboard
+ *  `isManualType` (known AND null), now sourced from code. */
+export function isManualGameType(id: string | null | undefined): boolean {
+  const def = getGameTypeDefinition(id);
+  return def != null && def.resultStrategy == null;
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { rollUp, placementDetail, awardedForGame, type LiveGame } from "@/lib/competitionPlacement";
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
 import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
+import { isManualGameType } from "@/lib/gameTypes";
 
 const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
 // Roster-gated golf formats: a stroke field / rack auto-grouping is "configured"
@@ -60,7 +61,7 @@ export async function computeCompetitionLeaderboard(
   // These reads are independent — run them in parallel (one round-trip's worth
   // of latency instead of stacked). `game_results` + the match counts alone
   // depend on the game ids, so they wait below.
-  const [teamsRes, compRes, gameRowsRes, assignmentsRes, templatesRes] = await Promise.all([
+  const [teamsRes, compRes, gameRowsRes, assignmentsRes] = await Promise.all([
     supabase
       .from("teams")
       .select("id, name, short_name, color")
@@ -83,10 +84,6 @@ export async function computeCompetitionLeaderboard(
       .from("team_assignments")
       .select("team_id")
       .eq("competition_id", competitionId),
-    // Template → result_strategy map, so we can tell a NON-GOLF MANUAL game
-    // (result_strategy NULL) from a golf game. Only manual games get the
-    // match-play winner-take-all award; golf scoring is never touched.
-    supabase.from("game_type_templates").select("id, result_strategy"),
   ]);
   const teams = teamsRes.data;
   const teamIds = (teams ?? []).map((t) => t.id as string);
@@ -94,11 +91,10 @@ export async function computeCompetitionLeaderboard(
   // Scoring-model axis (independent of team count; default match_play). Branches
   // ONLY the non-golf result award below — the hero stays on teams.length.
   const scoringModel = (comp?.scoring_model as string | null) ?? "match_play";
-  const strategyByType = new Map<string, string | null>(
-    (templatesRes.data ?? []).map((t) => [t.id as string, (t.result_strategy as string | null) ?? null])
-  );
-  const isManualType = (typeId: string | null) =>
-    typeId != null && strategyByType.has(typeId) && strategyByType.get(typeId) == null;
+  // A NON-GOLF MANUAL game (result_strategy NULL) vs a golf game — sourced from
+  // the format definitions in code (W-PERF-01), no longer a DB template fetch.
+  // Only manual games get the match-play winner-take-all award; golf untouched.
+  const isManualType = (typeId: string | null) => isManualGameType(typeId);
   const allGames = gameRowsRes.data ?? [];
   const live = allGames.filter((g) => g.status !== "dropped");
   const sizeByTeam = new Map<string, number>();

--- a/src/server/lib/rackNStack.ts
+++ b/src/server/lib/rackNStack.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { playerStats, computeRack, type RackPlayer, type Team } from "@/lib/rackNStack";
 import { effectiveStrokes } from "@/lib/handicap";
 import { isPerMatch } from "@/lib/pointsDistribution";
+import { getGameTypeDefinition } from "@/lib/gameTypes";
 
 /**
  * DB-persist side of rack-n-stack. Builds the SAME read-model the live client
@@ -49,15 +50,11 @@ export async function computeRackNStackResults(
   const perMatch = isPerMatch(game.points_distribution);
   const value = perMatch ? (game.points_distribution as { value: number }).value : 1;
 
-  // Effective par/index: the game's course snapshot, else its template default.
+  // Effective par/index: the game's course snapshot, else its format's default
+  // schema — from the code definitions now (W-PERF-01), not a DB template fetch.
   let schema = game.scorecard_schema as SchemaShape | null;
   if (!schema?.units?.metadata?.par && game.game_type_id) {
-    const { data: tmpl } = await supabase
-      .from("game_type_templates")
-      .select("scorecard_schema")
-      .eq("id", game.game_type_id as string)
-      .maybeSingle();
-    schema = (tmpl?.scorecard_schema as SchemaShape | null) ?? null;
+    schema = (getGameTypeDefinition(game.game_type_id as string)?.scorecardSchema as SchemaShape | null) ?? null;
   }
   const par = schema?.units?.metadata?.par;
   const strokeIndex = schema?.units?.metadata?.handicap_index;

--- a/src/server/routers/games.test.ts
+++ b/src/server/routers/games.test.ts
@@ -128,9 +128,13 @@ describe("games router — result_strategy dispatch guard", () => {
     expect(results).toHaveLength(0);
   });
 
-  it("finish — unknown result_strategy throws rather than silently scoring as stroke play", async () => {
-    // Temporarily insert a template with an unregistered strategy, use it to
-    // create a game, exercise the guard, then clean up.
+  it("finish — an unregistered game type throws rather than silently scoring as stroke play", async () => {
+    // The B2 guard, generalized by W-PERF-01: format definitions live in code,
+    // so "unrecognized" now means "game_type_id not in the code catalog" (it used
+    // to mean "unknown result_strategy string read from the DB"). The DB FK on
+    // games.game_type_id still requires the type row to EXIST, so we seed it — but
+    // because the id is absent from GAME_TYPE_DEFINITIONS, finish refuses to
+    // compute. Seed, exercise the guard, clean up.
     const FAKE_ID = "gtt_b2_test_unknown";
     await ctx.admin.from("game_type_templates").insert({
       id: FAKE_ID,
@@ -147,7 +151,7 @@ describe("games router — result_strategy dispatch guard", () => {
     try {
       const game = await ctx.caller().games.create({ tripId, gameTypeId: FAKE_ID, name: "Unknown" });
       await expect(ctx.caller().games.finish({ tripId, gameId: game.id })).rejects.toMatchObject({
-        message: expect.stringContaining("Unknown result_strategy 'unknown_strategy'"),
+        message: expect.stringContaining(`Unknown game type '${FAKE_ID}'`),
       });
       // Guard fires before any compute — no results written.
       const { data: results } = await ctx.admin.from("game_results").select("id").eq("game_id", game.id);

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -9,8 +9,9 @@ import { computeRackNStackResults } from "../lib/rackNStack";
 import type { MatchOutcome } from "../lib/matchPlay";
 import type { RackTeamOutcome } from "../lib/rackNStack";
 import type { StrokeStanding } from "@/lib/strokePlay";
-import { buildScorecardSchema, validateStrokeIndex, type ScorecardSchema, type SnapshotTee } from "@/lib/courseIndex";
+import { buildScorecardSchema, validateStrokeIndex, type SnapshotTee } from "@/lib/courseIndex";
 import { validatePlacement } from "@/lib/gameConfig";
+import { GAME_TYPES, getGameTypeDefinition } from "@/lib/gameTypes";
 
 /**
  * games — the competition-engine spine (Slice A: individual stroke play).
@@ -116,32 +117,12 @@ export const gamesRouter = router({
       return data;
     }),
 
-  // listTypes — the format catalog driving the creation chips (data-driven, NOT a
-  // hardcoded enum). `manual` (no result_strategy / no scorecard_schema) is the
-  // non-engine "Other" type; the rest are engine golf formats. (§2b/§7)
-  listTypes: authedProcedure.query(async ({ ctx }) => {
-    const { data, error } = await ctx.supabase
-      .from("game_type_templates")
-      .select("id, key, name, description, result_strategy, scorecard_schema, category, compatible_modifiers, sort_order")
-      .order("sort_order", { ascending: true });
-    if (error) {
-      throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to list game types: ${error.message}` });
-    }
-    return (data ?? []).map((t) => ({
-      id: t.id as string,
-      key: t.key as string,
-      name: t.name as string,
-      description: (t.description as string | null) ?? null,
-      // "engine" = computes results from a scorecard; otherwise manual (entered).
-      isEngine: t.result_strategy != null,
-      isGolf: t.scorecard_schema != null, // golf engine types carry a scorecard
-      resultStrategy: (t.result_strategy as string | null) ?? null,
-      // The creation Type tier (golf | card | yard | bar | other). Data-driven.
-      category: (t.category as string | null) ?? "other",
-      // Optional special rules this format supports (SPECIAL RULES toggles).
-      compatibleModifiers: (t.compatible_modifiers as string[] | null) ?? [],
-    }));
-  }),
+  // listTypes — the format catalog driving the creation chips. Format DEFINITIONS
+  // live in CODE now (W-PERF-01, `@/lib/gameTypes`), read synchronously — so this
+  // no longer hits the DB. The add-game dialog imports `GAME_TYPES` directly and
+  // never calls this; the procedure stays as a thin server-side accessor (tests /
+  // any future server caller) returning the SAME code array, contract unchanged.
+  listTypes: authedProcedure.query(() => GAME_TYPES),
 
   // listByTrip — any trip member.
   listByTrip: authedProcedure
@@ -309,12 +290,9 @@ export const gamesRouter = router({
         });
       }
 
-      const { data: template } = await ctx.supabase
-        .from("game_type_templates")
-        .select("scorecard_schema")
-        .eq("id", game.game_type_id as string)
-        .maybeSingle();
-      const baseSchema = template?.scorecard_schema as ScorecardSchema | null;
+      // Base scorecard comes from the format definition in code (W-PERF-01) —
+      // buildScorecardSchema deep-clones it, so sharing the const is safe.
+      const baseSchema = getGameTypeDefinition(game.game_type_id as string)?.scorecardSchema ?? null;
       if (!baseSchema?.units) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
@@ -366,15 +344,13 @@ export const gamesRouter = router({
         });
       }
 
-      const { data: template } = await ctx.supabase
-        .from("game_type_templates")
-        .select("scorecard_schema")
-        .eq("id", game.game_type_id as string)
-        .maybeSingle();
+      // Revert to the format's CODE-defined base schema (W-PERF-01) — the
+      // template default with no course par/index.
+      const baseSchema = getGameTypeDefinition(game.game_type_id as string)?.scorecardSchema ?? null;
 
       const { error } = await ctx.supabase
         .from("games")
-        .update({ scorecard_schema: template?.scorecard_schema ?? null, course_id: null })
+        .update({ scorecard_schema: baseSchema, course_id: null })
         .eq("id", input.gameId);
       if (error) {
         throw new TRPCError({
@@ -405,17 +381,24 @@ export const gamesRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
       }
 
-      const { data: template } = await ctx.supabase
-        .from("game_type_templates")
-        .select("result_strategy")
-        .eq("id", game.game_type_id as string)
-        .maybeSingle();
-      const strategy = template?.result_strategy as string | null;
+      // Result strategy comes from the format definition in CODE (W-PERF-01).
+      // An unregistered game_type_id (not in the code catalog) is the generalized
+      // form of the B2 guard — refuse to compute rather than silently scoring as
+      // stroke play. (Before W-PERF-01 the guard caught an unknown result_strategy
+      // STRING read from the DB; the code catalog is closed, so "unknown type" is
+      // the only way to be unrecognized now.)
+      const def = getGameTypeDefinition(game.game_type_id as string);
+      if (!def) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Unknown game type '${game.game_type_id}' — refusing to compute to avoid silent stroke-play scoring`,
+        });
+      }
+      const strategy = def.resultStrategy;
 
-      // Data-driven branch on the template's result_strategy (CLAUDE.md #8) —
-      // new strategies slot in here without touching the rest of finish.
+      // Data-driven branch on the format's result_strategy (CLAUDE.md #8) — new
+      // strategies slot in here without touching the rest of finish.
       // null (manual): finish has no placements input — caller must use post.
-      // Unregistered string: loud throw; silent stroke-play fallback is gone.
       let matches: MatchOutcome[] = [];
       let teams: RackTeamOutcome[] = [];
       let standings: StrokeStanding[] = [];
@@ -431,9 +414,11 @@ export const gamesRouter = router({
       } else if (strategy === "stroke_total") {
         standings = await computeStrokePlayResults(ctx.supabase, input.gameId);
       } else {
+        // Defense in depth: the union above is exhaustive, so this is unreachable
+        // via types — a new ResultStrategy that forgets a branch trips it loudly.
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
-          message: `Unknown result_strategy '${strategy}' — refusing to compute to avoid silent stroke-play scoring`,
+          message: `Unhandled result_strategy '${strategy as string}' — refusing to compute to avoid silent stroke-play scoring`,
         });
       }
 
@@ -702,12 +687,16 @@ export const gamesRouter = router({
         .maybeSingle();
       if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
 
-      const { data: template } = await ctx.supabase
-        .from("game_type_templates")
-        .select("result_strategy")
-        .eq("id", game.game_type_id as string)
-        .maybeSingle();
-      const strategy = (template?.result_strategy as string | null) ?? null;
+      // Result strategy from the format definition in CODE (W-PERF-01); an
+      // unregistered type loud-fails (the generalized B2 guard — see finish).
+      const def = getGameTypeDefinition(game.game_type_id as string);
+      if (!def) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Unknown game type '${game.game_type_id}' — refusing to compute to avoid silent stroke-play scoring`,
+        });
+      }
+      const strategy = def.resultStrategy;
 
       if (strategy === null) {
         // Manual: commit the entered finishing order (shared write path).
@@ -722,9 +711,10 @@ export const gamesRouter = router({
       } else if (strategy === "stroke_total") {
         await computeStrokePlayResults(ctx.supabase, input.gameId);
       } else {
+        // Defense in depth: union is exhaustive, unreachable via types.
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
-          message: `Unknown result_strategy '${strategy}' — refusing to compute to avoid silent stroke-play scoring`,
+          message: `Unhandled result_strategy '${strategy as string}' — refusing to compute to avoid silent stroke-play scoring`,
         });
       }
 

--- a/src/server/routers/playGroups.ts
+++ b/src/server/routers/playGroups.ts
@@ -5,6 +5,7 @@ import { requireTripMember, requireGameEdit } from "../middleware";
 import { clampStrokes } from "@/lib/handicap";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
+import { getGameTypeDefinition } from "@/lib/gameTypes";
 
 /**
  * playGroups — foursomes for a game (the scoring-side use of `play_groups`,
@@ -109,13 +110,10 @@ export const playGroupsRouter = router({
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set strokes: ${error.message}` });
 
       // Re-derive in-progress results; leave a complete (frozen) game untouched.
+      // Result strategy from the format definition in code (W-PERF-01); an
+      // unknown/unset type falls back to stroke_total (no recompute branch fires).
       if (game.status !== "complete") {
-        const { data: tmpl } = await ctx.supabase
-          .from("game_type_templates")
-          .select("result_strategy")
-          .eq("id", game.game_type_id as string)
-          .maybeSingle();
-        const strategy = (tmpl?.result_strategy as string | null) ?? "stroke_total";
+        const strategy = getGameTypeDefinition(game.game_type_id as string)?.resultStrategy ?? "stroke_total";
         if (strategy === "match_play") await computeMatchPlayResults(ctx.supabase, input.gameId, { skipComplete: true });
         else if (strategy === "rack_n_stack") await computeRackNStackResults(ctx.supabase, input.gameId);
       }


### PR DESCRIPTION
## The on-site failure
BBMI is at a golf course with bad signal, and organizers open **add-game on-site**. On poor connectivity the **top half of the add-game dialog blanked for 20-30s** — it blocked on a network fetch of the game-type templates.

## Root cause (the real fix, not a band-aid)
Format **definitions** were stored in the DB and fetched at dialog-open. But a format's definition — its `result_strategy`, scorecard schema, categories, modifiers — is *what that format IS*, fixed by the code that implements it. It doesn't vary per-game or per-trip. **Data that changes → DB; data fixed by the code → code.** Fetching definitions is a category error *and* the cause of the blank.

## What changed
**New `src/lib/gameTypes.ts`** — CLIENT-SAFE (only a `type` import from `courseIndex` + const data, no Supabase/tRPC/node). `GAME_TYPE_DEFINITIONS` keyed by `game_type_id`, values copied **verbatim from the live `game_type_templates` rows** (incl. each `scorecard_schema`, which had drifted from its seed migration). Exposes `GAME_TYPES` (client catalog) + `getGameTypeDefinition` / `isManualGameType`.

**All 8 readers migrated** DB query → synchronous local lookup:
| Reader | Was | Now |
|--------|-----|-----|
| `listTypes` | DB select | returns `GAME_TYPES` (no DB) |
| `applyCourse` / `clearCourse` | template `scorecard_schema` | `getGameTypeDefinition(...).scorecardSchema` |
| `finish` / `post` | template `result_strategy` | code lookup + generalized unknown-type guard |
| `setHandicap` (playGroups) | template `result_strategy` | code lookup |
| leaderboard `isManualType` | template map fetch | `isManualGameType` |
| rack scorecard fallback | template `scorecard_schema` | code lookup |

**3 client callers** (`CompetitionFace`, `CompetitionGamesPanel`, `GameSetupRows`) import `GAME_TYPES` directly — no `useQuery`, no loading state, offline-safe. `GameType` moved to `gameTypes.ts`, re-exported so existing import paths are unchanged.

**B2 guard generalized** — "unrecognized format" now means "`game_type_id` absent from the code catalog" (the catalog is closed, so an unknown `result_strategy` string can't occur). `finish`/`post` loud-fail rather than silently scoring as stroke play. B2 test updated to assert the new message.

**The `game_type_templates` table stays in place** until readers are proven (audit-before-delete). A later migration archives it.

This is the concrete precursor to R1's template registry — the clean code-home now; R1 generalizes over it later. It is NOT the full registry.

## Verification
- **By-eye, simulated dead signal** (every `fetch` hung forever): the dialog's top half renders **instantly** with all 5 type tiers + all 4 golf formats present and correctly labelled — sourced from code. Screenshot in the issue thread.
- Incidental: the `gtt_b2_test_unknown` DB fixture no longer leaks into the dialog's "Other" tier.
- `tsc --noEmit` clean; lint clean (only pre-existing warnings in the dead `CompetitionGamesPanel` component).
- **87 unit tests green** across every touched path: games (incl. migrated B2 guard), add-game, run/post, match-play, rack-n-stack, leaderboard, faceBootstrap, competitions d1/d2.

Closes #437