### PR TITLE
fix(competition): GameRow states match the legend — dashed outline, ready split, delegate avatar

### DIFF
--- a/TRACKER.md
+++ b/TRACKER.md
@@ -39,6 +39,15 @@ Tier 1 outranks Tier 2. Within each, **structural before mechanical** (fix the r
   -> `enableScoring` (code-identifier); `game_organizers` -> `game_delegates` (table + its 2 policies + the
   `is_game_delegate` helper + 5 dependent RLS policies, atomic mig 061). Phase-0 re-verify found `round`
   already clean and `planner`->`organizer` already shipped (mig 029) — **2 of the 4 renames were no-ops.**
+- **Non-golf game scoring** (#430 + #432) — un-orphaned RunSheet; non-golf board rows tappable; explicit
+  `competitions.scoring_model` field (`match_play` / `points`, mig 062 — team count and scoring model are
+  independent axes); match-play manual games award winner-take-all via `WinLoseTieEditor` (three-way peer
+  framing, selection-state carries meaning); placement games use configured distribution. BBMI's euchre
+  standing corrected on deploy.
+- **Course search + name fix** (#434) — Enter fires deep search when local has no hits (reuses existing
+  throttled/counted path, no per-keystroke calls); `transformCourse` now combines `club_name + course_name`
+  matching `normalizeSearch` logic (fixed "South" stored instead of "Torrey Pines Municipal Golf Course —
+  South"); `startsWith` guard prevents redundant prefix when course name already contains club name.
 
 ### NEXT — the polish period ("make BBMI FLAWLESS"; this IS the structural-first cleanup)
 - **R2 (docs) — nearly done:** `PROJECT_STATUS.md` deleted; this tracker is the SoR; CLAUDE.md authority

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -45,6 +45,12 @@ export interface LBCell {
   points: number;
 }
 
+/** The viewer's identity, threaded to GameRow for the delegate marker (§10). */
+export interface LBViewer {
+  name: string | null;
+  avatarIcon: string | null;
+}
+
 interface LeaderboardData {
   teams: LBTeam[];
   games: LBGame[];
@@ -95,6 +101,18 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
   const mineSet = useMemo(
     () => new Set(myDelegateIds as string[]),
     [myDelegateIds]
+  );
+
+  // The viewer's identity for the delegate marker (the avatar's filled treatment
+  // carries "yours", §10). Cheap, cached `getMe`; only the rows the viewer
+  // delegates render it. Falls back to a generic "You" avatar if not yet loaded.
+  const { data: me } = trpc.users.getMe.useQuery();
+  const viewer = useMemo(
+    () => ({
+      name: (me?.name as string | null) ?? null,
+      avatarIcon: (me?.avatar_icon as string | null) ?? null,
+    }),
+    [me]
   );
 
   const liveGames = useMemo(
@@ -165,6 +183,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
         winNumber={winNumber}
         tripId={tripId}
         mineSet={mineSet}
+        viewer={viewer}
         onPrefetch={prefetchGame}
         canEdit={canEdit}
         onAddGame={onAddGame}
@@ -245,6 +264,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
         sessionsDone={sessionsDone}
         tripId={tripId}
         mineSet={mineSet}
+        viewer={viewer}
         onPrefetch={prefetchGame}
         canEdit={canEdit}
         onAddGame={onAddGame}
@@ -259,7 +279,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
 // entry). Empty → the bones prompt + "Add a game"; populated → the session
 // breakdown + "Add a game". Editor-gated; the crew sees the list only.
 function GamesSection({
-  games, teams, cellsByGame, sessionsDone, tripId, mineSet, onPrefetch, canEdit, onAddGame, onOpenGame,
+  games, teams, cellsByGame, sessionsDone, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame, onOpenGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
@@ -267,6 +287,7 @@ function GamesSection({
   sessionsDone: number;
   tripId: string;
   mineSet: Set<string>;
+  viewer: LBViewer;
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
   onAddGame?: () => void;
@@ -314,6 +335,7 @@ function GamesSection({
         sessionsDone={sessionsDone}
         tripId={tripId}
         mineSet={mineSet}
+        viewer={viewer}
         onPrefetch={onPrefetch}
         onOpenGame={onOpenGame}
       />
@@ -554,6 +576,7 @@ function SessionBreakdown({
   sessionsDone,
   tripId,
   mineSet,
+  viewer,
   onPrefetch,
   onOpenGame,
 }: {
@@ -563,6 +586,7 @@ function SessionBreakdown({
   sessionsDone: number;
   tripId: string;
   mineSet: Set<string>;
+  viewer: LBViewer;
   onPrefetch: (gameId: string) => void;
   onOpenGame?: (gameId: string) => void;
 }) {
@@ -586,6 +610,8 @@ function SessionBreakdown({
             cells={cellsByGame.get(game.id)}
             tripId={tripId}
             mine={mineSet.has(game.id)}
+            viewerName={viewer.name}
+            viewerAvatarIcon={viewer.avatarIcon}
             onPrefetch={onPrefetch}
             onOpenGame={onOpenGame}
           />
@@ -603,6 +629,7 @@ function EarlyState({
   winNumber,
   tripId,
   mineSet,
+  viewer,
   onPrefetch,
   canEdit,
   onAddGame,
@@ -613,6 +640,7 @@ function EarlyState({
   winNumber: number;
   tripId: string;
   mineSet: Set<string>;
+  viewer: LBViewer;
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
   onAddGame?: () => void;
@@ -682,6 +710,8 @@ function EarlyState({
                 cells={undefined}
                 tripId={tripId}
                 mine={mineSet.has(game.id)}
+                viewerName={viewer.name}
+                viewerAvatarIcon={viewer.avatarIcon}
                 onPrefetch={onPrefetch}
                 onOpenGame={onOpenGame}
               />

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -45,10 +45,12 @@ export interface LBCell {
   points: number;
 }
 
-/** The viewer's identity, threaded to GameRow for the delegate marker (§10). */
+/** The viewer's identity, threaded to GameRow for the delegate marker (§10).
+ *  `teamColor` paints the marker in the viewer's competition-team color. */
 export interface LBViewer {
   name: string | null;
   avatarIcon: string | null;
+  teamColor: string | null;
 }
 
 interface LeaderboardData {
@@ -103,17 +105,26 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
     [myDelegateIds]
   );
 
-  // The viewer's identity for the delegate marker (the avatar's filled treatment
-  // carries "yours", §10). Cheap, cached `getMe`; only the rows the viewer
-  // delegates render it. Falls back to a generic "You" avatar if not yet loaded.
+  // The viewer's identity for the delegate marker (§10). The marker is the
+  // viewer's avatar in THEIR TEAM color (competition identity); only the rows the
+  // viewer delegates render it. `getMe` + the team assignment list are both cheap
+  // + cached. teamColor is null when the viewer isn't on a team → Avatar falls
+  // back to its accent ("you") treatment.
   const { data: me } = trpc.users.getMe.useQuery();
-  const viewer = useMemo(
-    () => ({
+  const { data: assignments = [] } = trpc.teamAssignments.list.useQuery(
+    { tripId, competitionId },
+    { enabled: !!competitionId }
+  );
+  const viewer = useMemo<LBViewer>(() => {
+    const myTeamId =
+      (assignments as { user_id: string; team_id: string }[]).find((a) => a.user_id === me?.id)?.team_id ?? null;
+    const teamColor = myTeamId ? (data?.teams.find((t) => t.id === myTeamId)?.color ?? null) : null;
+    return {
       name: (me?.name as string | null) ?? null,
       avatarIcon: (me?.avatar_icon as string | null) ?? null,
-    }),
-    [me]
-  );
+      teamColor,
+    };
+  }, [me, assignments, data?.teams]);
 
   const liveGames = useMemo(
     () => (data?.games ?? []).filter((g) => !g.dropped),
@@ -612,6 +623,7 @@ function SessionBreakdown({
             mine={mineSet.has(game.id)}
             viewerName={viewer.name}
             viewerAvatarIcon={viewer.avatarIcon}
+            viewerTeamColor={viewer.teamColor}
             onPrefetch={onPrefetch}
             onOpenGame={onOpenGame}
           />
@@ -712,6 +724,7 @@ function EarlyState({
                 mine={mineSet.has(game.id)}
                 viewerName={viewer.name}
                 viewerAvatarIcon={viewer.avatarIcon}
+                viewerTeamColor={viewer.teamColor}
                 onPrefetch={onPrefetch}
                 onOpenGame={onOpenGame}
               />

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -119,6 +119,7 @@ export function GameRow({
   mine,
   viewerName,
   viewerAvatarIcon,
+  viewerTeamColor,
   onPrefetch,
   onOpenGame,
 }: {
@@ -127,11 +128,12 @@ export function GameRow({
   cells: Map<string, LBCell> | undefined;
   tripId: string;
   mine: boolean;
-  /** The viewer's display name + chosen avatar icon — rendered as the delegate
-   *  marker when `mine` (the avatar's own filled treatment carries "yours", §10).
-   *  Only needed when the viewer delegates this game. */
+  /** The viewer's display name + chosen avatar icon + competition-team color —
+   *  rendered as the delegate marker when `mine` (the viewer's avatar in their
+   *  team color, §10). Only needed when the viewer delegates this game. */
   viewerName?: string | null;
   viewerAvatarIcon?: string | null;
+  viewerTeamColor?: string | null;
   onPrefetch: (gameId: string) => void;
   /** Non-golf games have no game-board route; when the viewer can act on them
    *  (editors only), the row opens the manual run sheet in place instead of
@@ -183,18 +185,24 @@ export function GameRow({
       : null;
 
   // Panel surface — each game is its own standalone card (not a row inside a
-  // shared panel). Setting-up is outlined with an ALL-SIDES dash as its "not
-  // built yet" tell; on the panel border so the inner content never shifts.
+  // shared panel). Only the ACTIVE states carry a fill: Ready (a solid card,
+  // "built + waiting") and Live (the one reserved accent-faint "act now" fill,
+  // §A2). Setting-up and Final get NO fill — setting-up is an outline-only dashed
+  // shell ("not built yet"), Final a recessed, dimmed record. The border lives on
+  // the panel so the inner content never shifts.
   const panelStyle: React.CSSProperties = {
-    background: "var(--color-bt-card)",
+    background:
+      lifecycle === "ready"
+        ? "var(--color-bt-card)"
+        : lifecycle === "live"
+        ? "var(--color-bt-accent-faint)"
+        : undefined, // setting-up + final: no fill
     border:
       lifecycle === "setting-up"
         ? "1.5px dashed var(--color-bt-border)"
         : "1px solid var(--color-bt-border)",
   };
   const rowStyle: React.CSSProperties = {
-    // The one reserved background is Live (§A2) — the only "act now" fill.
-    background: lifecycle === "live" ? "var(--color-bt-accent-faint)" : undefined,
     // Final is a quiet record — recess the whole tile (§A3 "recessed").
     opacity: isFinal ? 0.72 : 1,
   };
@@ -225,13 +233,14 @@ export function GameRow({
             {game.name}
           </span>
           {showDelegate && (
-            // The delegate marker IS the viewer's avatar in its filled (accent)
-            // treatment — the same "this is you" affordance as the top-nav
-            // account avatar (§10). The avatar's own treatment carries "yours";
-            // no separate word-chip. Reuses the one Avatar primitive (R3).
+            // The delegate marker IS the viewer's avatar in their COMPETITION-TEAM
+            // color (§10) — competition identity, not a separate "Yours" word-chip.
+            // Reuses the one Avatar primitive (R3). teamColor null (viewer not on a
+            // team) → Avatar's accent ("you") fallback.
             <Avatar
               name={viewerName || "You"}
               avatarIcon={viewerAvatarIcon ?? null}
+              teamColor={viewerTeamColor ?? null}
               accent
               sizePx={20}
               className="shrink-0"

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -4,6 +4,7 @@ import { createElement } from "react";
 import Link from "next/link";
 import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { Avatar } from "@/components/Avatar";
 import type { LBGame, LBTeam, LBCell } from "./CompetitionLeaderboard";
 
 // ── Row helpers (own the board-row primitives) ────────────────────────────────
@@ -116,6 +117,8 @@ export function GameRow({
   cells,
   tripId,
   mine,
+  viewerName,
+  viewerAvatarIcon,
   onPrefetch,
   onOpenGame,
 }: {
@@ -124,6 +127,11 @@ export function GameRow({
   cells: Map<string, LBCell> | undefined;
   tripId: string;
   mine: boolean;
+  /** The viewer's display name + chosen avatar icon — rendered as the delegate
+   *  marker when `mine` (the avatar's own filled treatment carries "yours", §10).
+   *  Only needed when the viewer delegates this game. */
+  viewerName?: string | null;
+  viewerAvatarIcon?: string | null;
   onPrefetch: (gameId: string) => void;
   /** Non-golf games have no game-board route; when the viewer can act on them
    *  (editors only), the row opens the manual run sheet in place instead of
@@ -144,28 +152,45 @@ export function GameRow({
   const showScorecard = isGolfFormat(game.gameTypeId) && !isFinal;
   const scorecardOpens = showScorecard && game.hasCourse === true && !!href;
   const showDelegate = mine && !isFinal;
+  // A row is tappable when it has a golf route OR a non-golf editor handler —
+  // gates the setting-up CTA subtitle (an inert crew row gets no "tap to…").
+  const tappable = !!href || !!onOpenGame;
 
-  // Subtitle / running state (§A3). Setting-up + Final carry none — the dashed
-  // outline and the outer result speak for them. Live's real running state
-  // ("Blue 2 up · thru 13") is deferred to a state-driven slot.
+  // §A3 arm tell: the format icon goes full-color once scoring is enabled
+  // (armed). The same signal splits the Ready subtitle (see below); Final quiets
+  // it back down (sheds the arm tell).
+  const armed = iconArmed(game);
+  const armedIcon = armed && !isFinal;
+
+  // Subtitle / running state (§A3), all keyed off the one derived lifecycle:
+  //  - live   → running state (the real "Blue 2 up · thru 13" is deferred).
+  //  - ready  → SPLIT by the arm tell: armed = good to go; not-armed = the
+  //             remaining pre-live step (so the muted icon has a matching nudge).
+  //  - setting-up → a tap-to-continue CTA, but only when the row is tappable;
+  //             an inert crew row leans on the dashed outline alone (§A3).
+  //  - final  → none; the recessed tile + outer result speak for it.
   const subtitle =
     lifecycle === "live"
       ? "Underway · scoring"
       : lifecycle === "ready"
-      ? "Ready to play"
+      ? armed
+        ? "Ready to play"
+        : "Assign players + handicaps"
+      : lifecycle === "setting-up"
+      ? tappable
+        ? "Tap to keep setting up"
+        : null
       : null;
 
-  // §A3 layer table — each visual layer wired to the one derived lifecycle.
-  // The format icon shows FULL color only while scoring is enabled AND the game
-  // isn't yet a finished record; Final quiets it back down (sheds the arm tell).
-  const armedIcon = iconArmed(game) && !isFinal;
   // Panel surface — each game is its own standalone card (not a row inside a
-  // shared panel). Setting-up gets a dashed left edge as its "not built yet"
-  // tell; it lives on the panel border so the inner content never shifts.
+  // shared panel). Setting-up is outlined with an ALL-SIDES dash as its "not
+  // built yet" tell; on the panel border so the inner content never shifts.
   const panelStyle: React.CSSProperties = {
     background: "var(--color-bt-card)",
-    border: "1px solid var(--color-bt-border)",
-    ...(lifecycle === "setting-up" ? { borderLeft: "2px dashed var(--color-bt-border)" } : {}),
+    border:
+      lifecycle === "setting-up"
+        ? "1.5px dashed var(--color-bt-border)"
+        : "1px solid var(--color-bt-border)",
   };
   const rowStyle: React.CSSProperties = {
     // The one reserved background is Live (§A2) — the only "act now" fill.
@@ -199,7 +224,19 @@ export function GameRow({
           >
             {game.name}
           </span>
-          {showDelegate && <YoursBadge />}
+          {showDelegate && (
+            // The delegate marker IS the viewer's avatar in its filled (accent)
+            // treatment — the same "this is you" affordance as the top-nav
+            // account avatar (§10). The avatar's own treatment carries "yours";
+            // no separate word-chip. Reuses the one Avatar primitive (R3).
+            <Avatar
+              name={viewerName || "You"}
+              avatarIcon={viewerAvatarIcon ?? null}
+              accent
+              sizePx={20}
+              className="shrink-0"
+            />
+          )}
           {lifecycle === "live" && <LiveBadge />}
         </div>
         {subtitle && (
@@ -351,21 +388,3 @@ export function LiveBadge() {
   );
 }
 
-/** "Yours"— marks a game the viewer is the delegate of (§10). Display-only;
- *  the controls live on the game page, not the board row (§5). Dropped at Final
- *  alongside the scorecard (round-3.1 §A2 — Final sheds operational chrome). */
-export function YoursBadge() {
-  return (
-    <span
-      className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold"
-      style={{
-        background: "var(--color-bt-accent-faint)",
-        color: "var(--color-bt-accent)",
-        border: "1px solid var(--color-bt-accent-border)",
-      }}
-      data-testid="game-yours-badge"
-    >
-      Yours
-    </span>
-  );
-}


### PR DESCRIPTION
Brings the board-row states into line with the states legend. Items 1–3 are the legend-conformance fixes; item 4 is a consistency fix routing the delegate marker through the R3 `Avatar` primitive. Item 5 (the Live running-state subtitle, "Blue 2 up · thru 13") stays **deferred** — the leaderboard doesn't fetch `game_matches` yet.

## Changes
| # | State | Was | Now |
|---|-------|-----|-----|
| 1 | Setting-up outline | left-edge dash on a solid border (3 sides solid) | **all-sides dashed** — one "not built yet" border |
| 2 | Setting-up subtitle | none | **"Tap to keep setting up"** — only when the row is tappable (golf route / non-golf editor handler); inert crew rows lean on the dash alone |
| 3 | Ready subtitle | always "Ready to play" | **split by the arm tell** (`scoring_enabled`): not-armed → "Assign players + handicaps", armed → "Ready to play" — matching the muted→full icon it already drove |
| 4 | Delegate marker | bespoke "Yours" text chip | the viewer's **`Avatar` in filled (accent) treatment** — the same "this is you" affordance as the top-nav account avatar |

### Item 4 detail
The `YoursBadge` chip is removed; the marker reuses the single R3 `Avatar` primitive with `accent` (solid-teal circle, dark foreground). The avatar's own treatment carries "yours" — no separate word. The viewer's name + chosen icon thread from `users.getMe` through the leaderboard (one `viewer` prop → `EarlyState`/`GamesSection`/`SessionBreakdown`) to `GameRow`, rendered only on rows the viewer delegates.

## Verification (by-eye on the live board)
- **Setting-up** ("test empty"): all-sides dashed outline + "Tap to keep setting up". ✅
- **Ready split**: "SP Course"/"test" → "Assign players + handicaps" (not armed); "Singles on Sunday"/"test match 2v2" → "Ready to play" (armed). ✅
- **Delegate avatar**: temporarily delegated a game to the viewer → the row rendered the teal account-style avatar (the viewer's `swords` icon) in place of the pill; reverted the temp row after. ✅
- `tsc --noEmit` + lint clean; the delegate-marking data test (`faceBootstrap`) green.

No DB or behavior changes — presentational + one read of the existing `getMe`.