### PR TITLE
feat(competition): reset primitives — resetScoring + resetToSkeleton (Phase 1)

### DIFF
--- a/src/server/routers/competitions.reset.test.ts
+++ b/src/server/routers/competitions.reset.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext, genId } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Reset primitives (WS4) — competitions.resetScoring / resetToSkeleton.
+ *
+ * Exercises the two transactional plpgsql primitives (migration 063) through
+ * their tRPC procedures. Fixtures are built directly via the admin client so each
+ * game's pre-state (config + scoring buckets) is exact and the test subject is the
+ * RESET logic itself, not the scoring pipeline (covered elsewhere).
+ *
+ * The buckets under test (Phase-0 audit):
+ *  - resetScoring clears RESULTS, keeps CONFIG + IDENTITY, keeps scoring_enabled.
+ *  - resetToSkeleton = resetScoring + clears CONFIG, keeps IDENTITY, un-arms.
+ */
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let ownerId: string;
+let memberId: string;
+const gameIds: string[] = [];
+
+function gid(prefix: string) {
+  return genId(prefix);
+}
+
+/** A scored STROKE game: course + roster (2) + handicaps (config); scores +
+ *  results (scoring); placement points (identity total + config split). */
+async function makeStrokeGame(): Promise<string> {
+  const id = gid("reset-stroke");
+  gameIds.push(id);
+  await ctx.admin.from("games").insert({
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_stroke_play",
+    name: "Stroke", status: "complete", corrections_open: true, scoring_enabled: true,
+    course_id: null, // course optional; left null to avoid a course fixture
+    scorecard_schema: { units: { metadata: { par: [4, 4] } } },
+    points_distribution: { type: "placement", values: [5, 3] }, points_total: 8,
+    modifiers: { glorious_holes: {} }, rules_for_today: "be nice", competition_format: "head_to_head",
+    pairings_published_at: new Date(0).toISOString(),
+  });
+  await ctx.admin.from("game_participants").insert([
+    { id: gid("p"), game_id: id, user_id: ownerId, handicap_strokes: 4 },
+    { id: gid("p"), game_id: id, user_id: memberId, handicap_strokes: 9 },
+  ]);
+  await ctx.admin.from("score_entries").insert([
+    { id: gid("se"), game_id: id, participant_id: ownerId, participant_type: "user", unit_label: "1", value: 4 },
+    { id: gid("se"), game_id: id, participant_id: memberId, participant_type: "user", unit_label: "1", value: 5 },
+  ]);
+  await ctx.admin.from("game_results").insert([
+    { id: gid("gr"), game_id: id, entity_id: ownerId, entity_type: "user", position: 1, raw_score: 4 },
+    { id: gid("gr"), game_id: id, entity_id: memberId, entity_type: "user", position: 2, raw_score: 5 },
+  ]);
+  return id;
+}
+
+/** A scored 1v1 MATCH game: a pairing (config: side_a/side_b) carrying a result
+ *  (scoring: result/margin/status) — the dual-bucket game_matches row. Per-match
+ *  points (the value is IDENTITY, kept by skeleton). */
+async function makeMatchGame(): Promise<string> {
+  const id = gid("reset-match");
+  gameIds.push(id);
+  await ctx.admin.from("games").insert({
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play_singles",
+    name: "Match", status: "complete", corrections_open: false, scoring_enabled: true,
+    points_distribution: { type: "per_match", value: 2 }, points_total: null,
+  });
+  await ctx.admin.from("game_participants").insert([
+    { id: gid("p"), game_id: id, user_id: ownerId, handicap_strokes: 0 },
+    { id: gid("p"), game_id: id, user_id: memberId, handicap_strokes: 0 },
+  ]);
+  const { error: gmErr } = await ctx.admin.from("game_matches").insert({
+    id: gid("gm"), game_id: id, match_number: 1, display_order: 0,
+    side_a: { type: "user", id: ownerId }, side_b: { type: "user", id: memberId },
+    result: "a_win", margin: "2up", status: "complete", // result ∈ {a_win,b_win,halve}
+  });
+  if (gmErr) throw new Error(`game_matches insert failed: ${gmErr.message}`);
+  await ctx.admin.from("game_results").insert({
+    id: gid("gr"), game_id: id, entity_id: ownerId, entity_type: "user", position: 1, raw_score: 1,
+  });
+  return id;
+}
+
+/** A scored 2v2 game with play_groups (config: the pairs + side handicaps). */
+async function makeDoublesGame(): Promise<string> {
+  const id = gid("reset-doubles");
+  gameIds.push(id);
+  await ctx.admin.from("games").insert({
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play_doubles",
+    name: "Doubles", status: "active", scoring_enabled: true,
+    points_distribution: { type: "per_match", value: 1 },
+  });
+  const pgId = gid("pg");
+  await ctx.admin.from("play_groups").insert({ id: pgId, game_id: id, display_name: null, handicap_strokes: 3 });
+  await ctx.admin.from("game_participants").insert({ id: gid("p"), game_id: id, user_id: ownerId, play_group_id: pgId });
+  return id;
+}
+
+/** A non-golf MANUAL game: placements only (no course/roster/pairings). Config =
+ *  the placement split + format + rules; identity = its point total. */
+async function makeManualGame(): Promise<string> {
+  const id = gid("reset-manual");
+  gameIds.push(id);
+  await ctx.admin.from("games").insert({
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_manual",
+    name: "Cornhole", status: "complete", scoring_enabled: true,
+    points_distribution: { type: "placement", values: [5, 3] }, points_total: 8,
+    competition_format: "head_to_head", rules_for_today: "best of 3",
+  });
+  await ctx.admin.from("game_results").insert([
+    { id: gid("gr"), game_id: id, entity_id: teamA, entity_type: "team", position: 1, raw_score: 1 },
+    { id: gid("gr"), game_id: id, entity_id: teamB, entity_type: "team", position: 2, raw_score: 2 },
+  ]);
+  return id;
+}
+
+async function gameRow(id: string) {
+  const { data } = await ctx.admin.from("games").select("*").eq("id", id).single();
+  return data as Record<string, unknown>;
+}
+async function count(table: string, gameId: string): Promise<number> {
+  const { count: c } = await ctx.admin.from(table).select("id", { count: "exact", head: true }).eq("game_id", gameId);
+  return c ?? 0;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  ownerId = ctx.user.id;
+  tripId = await ctx.createTrip("Reset Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // co_admin — NOT owner
+  await ctx.addTripMember(tripId, "member", "Member");
+  memberId = ctx.getUser("member").id;
+  competitionId = await ctx.createCompetition(tripId, "Reset Cup", { scoringModel: "points" });
+  teamA = await ctx.createTeam(competitionId, "Blue", { shortName: "BLU" });
+  teamB = await ctx.createTeam(competitionId, "Red", { shortName: "RED" });
+});
+
+afterAll(async () => {
+  if (gameIds.length) await ctx.admin.from("games").delete().in("id", gameIds); // cascade clears children
+  await ctx.cleanup();
+}, 30000);
+
+describe("resetScoring — clears results, keeps config + identity, stays armed", () => {
+  it("clears scoring buckets across game types but leaves config intact", async () => {
+    const stroke = await makeStrokeGame();
+    const match = await makeMatchGame();
+    const manual = await makeManualGame();
+
+    await ctx.caller().competitions.resetScoring({ tripId, competitionId });
+
+    // SCORING cleared everywhere.
+    expect(await count("game_results", stroke)).toBe(0);
+    expect(await count("score_entries", stroke)).toBe(0);
+    expect(await count("game_results", match)).toBe(0);
+    expect(await count("game_results", manual)).toBe(0);
+
+    // CONFIG intact (stroke): roster + handicaps + course schema + points all survive.
+    expect(await count("game_participants", stroke)).toBe(2);
+    const sg = await gameRow(stroke);
+    expect(sg.scorecard_schema).not.toBeNull();
+    expect(sg.points_total).toBe(8);
+    expect(sg.points_distribution).toMatchObject({ type: "placement" });
+    expect(sg.modifiers).toMatchObject({ glorious_holes: {} });
+    expect(sg.competition_format).toBe("head_to_head");
+    // Unscored lifecycle, but STILL ARMED (scoring_enabled kept).
+    expect(sg.status).toBe("pending");
+    expect(sg.corrections_open).toBe(false);
+    expect(sg.scoring_enabled).toBe(true);
+
+    // Match: the dual-bucket game_matches row SURVIVES with its pairing, but its
+    // RESULT columns are nulled and status reset.
+    expect(await count("game_matches", match)).toBe(1);
+    const { data: gm } = await ctx.admin.from("game_matches").select("*").eq("game_id", match).single();
+    const m = gm as Record<string, unknown>;
+    expect(m.side_a).toMatchObject({ type: "user", id: ownerId }); // pairing kept
+    expect(m.result).toBeNull();
+    expect(m.margin).toBeNull();
+    expect(m.status).toBe("pending");
+  });
+
+  it("a non-owner (co_admin) cannot reset scoring", async () => {
+    await expect(
+      ctx.callerAs("planner").competitions.resetScoring({ tripId, competitionId })
+    ).rejects.toThrow();
+  });
+});
+
+describe("resetToSkeleton — also clears config, keeps identity, un-arms", () => {
+  it("clears config across game types but leaves identity (shell + teams + point value)", async () => {
+    const stroke = await makeStrokeGame();
+    const match = await makeMatchGame();
+    const doubles = await makeDoublesGame();
+    const manual = await makeManualGame();
+
+    await ctx.caller().competitions.resetToSkeleton({ tripId, competitionId });
+
+    // CONFIG cleared: roster, pairings, foursomes.
+    expect(await count("game_participants", stroke)).toBe(0);
+    expect(await count("game_matches", match)).toBe(0);
+    expect(await count("game_participants", match)).toBe(0);
+    expect(await count("play_groups", doubles)).toBe(0);
+    expect(await count("game_participants", doubles)).toBe(0);
+
+    // Stroke shell: config columns cleared, identity kept, un-armed.
+    const sg = await gameRow(stroke);
+    expect(sg.course_id).toBeNull();
+    expect(sg.scorecard_schema).toBeNull();
+    expect(sg.modifiers).toMatchObject({}); // reset to '{}'
+    expect(sg.rules_for_today).toBeNull();
+    expect(sg.competition_format).toBeNull();
+    expect(sg.pairings_published_at).toBeNull();
+    expect(sg.scoring_enabled).toBe(false);
+    // IDENTITY survives: placement point VALUE kept; only the SPLIT cleared.
+    expect(sg.points_total).toBe(8);
+    expect(sg.points_distribution).toBeNull();
+    expect(sg.name).toBe("Stroke"); // shell identity
+    expect(sg.game_type_id).toBe("gtt_stroke_play");
+
+    // Per-match distribution is the point VALUE (identity) — KEPT, not nulled.
+    const mg = await gameRow(match);
+    expect(mg.points_distribution).toMatchObject({ type: "per_match", value: 2 });
+
+    // Manual: format/rules/split cleared, total kept.
+    const ng = await gameRow(manual);
+    expect(ng.competition_format).toBeNull();
+    expect(ng.rules_for_today).toBeNull();
+    expect(ng.points_distribution).toBeNull();
+    expect(ng.points_total).toBe(8);
+
+    // IDENTITY at competition level: teams survive both resets.
+    const { count: teamCount } = await ctx.admin
+      .from("teams").select("id", { count: "exact", head: true }).eq("competition_id", competitionId);
+    expect(teamCount).toBe(2);
+  });
+
+  it("a plain member cannot reset to skeleton", async () => {
+    await expect(
+      ctx.callerAs("member").competitions.resetToSkeleton({ tripId, competitionId })
+    ).rejects.toThrow();
+  });
+});

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -315,4 +315,48 @@ export const competitionsRouter = router({
 
       return { success: true };
     }),
+
+  // resetScoring — owner-only. Clears every game's RESULTS back to unscored;
+  // keeps full config (pairings, course, points, handicaps) + identity. Games are
+  // immediately re-scoreable. Delegates to the transactional plpgsql primitive
+  // (migration 063) — all-or-nothing per competition. The danger-zone ladder's
+  // first rung (below it: resetToSkeleton; below that: delete).
+  resetScoring: authedProcedure
+    .input(z.object({ tripId: z.string(), competitionId: z.string() }))
+    .use(requireCompetitionRole("owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase.rpc("reset_competition_scoring", {
+        p_trip_id: input.tripId,
+        p_competition_id: input.competitionId,
+      });
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to reset scoring: ${error.message}`,
+        });
+      }
+      return { success: true };
+    }),
+
+  // resetToSkeleton — owner-only. SUPERSET of resetScoring: the SQL primitive
+  // CALLS reset_competition_scoring first, then additionally clears config back
+  // to unconfigured shells (keeps teams + game shells + point values). Used for
+  // "set up wrong, redo" and cleaning a competition's test games. Also the op the
+  // future scoring_model-change path will call (pre-score model switch).
+  resetToSkeleton: authedProcedure
+    .input(z.object({ tripId: z.string(), competitionId: z.string() }))
+    .use(requireCompetitionRole("owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase.rpc("reset_competition_to_skeleton", {
+        p_trip_id: input.tripId,
+        p_competition_id: input.competitionId,
+      });
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to reset to skeleton: ${error.message}`,
+        });
+      }
+      return { success: true };
+    }),
 });

--- a/supabase/migrations/20260622120000_063_competition_reset_primitives.sql
+++ b/supabase/migrations/20260622120000_063_competition_reset_primitives.sql
@@ -1,0 +1,164 @@
+-- 063 — Competition reset primitives (WS4 "reset primitives" pattern).
+--
+-- Two reusable, TRANSACTIONAL operations over every game in a competition, by
+-- blast radius. A reset is all-or-nothing per competition (a plpgsql function is
+-- atomic by default), which the Supabase JS client cannot guarantee across the
+-- multiple deletes/updates involved — so the logic lives here, called by thin
+-- tRPC procedures (competitions.resetScoring / resetToSkeleton).
+--
+-- The buckets (Phase-0 audit, per game type):
+--   IDENTITY  (never cleared): the game shell — id, name, type, competition,
+--             point VALUE (points_total / per-match value), schedule; teams +
+--             team_assignments (competition-level).
+--   CONFIG    (skeleton clears): pairings (game_matches rows), roster
+--             (game_participants), foursomes/pairs (play_groups), course
+--             (course_id + scorecard_schema), modifiers, rules_for_today,
+--             competition_format, pairings_published_at, and the placement SPLIT
+--             (points_distribution for placement games — the per-match value is
+--             identity and is kept).
+--   SCORING   (both clear): game_results, score_entries, the RESULT columns on
+--             game_matches (result/margin/status — NOT the pairing columns),
+--             games.status/corrections_open.
+--
+-- The clears are TYPE-AGNOSTIC: each game type simply lacks the buckets it does
+-- not use, so an absent table/column is a no-op (e.g. a stroke game has no
+-- game_matches; a non-golf manual game has no participants/course/score_entries).
+-- The per-type table in the audit is the correctness proof, not a branch.
+--
+-- reset_to_skeleton CALLS reset_scoring (superset by blast radius — results can't
+-- outlive their config), it does NOT reimplement the result-clearing.
+--
+-- SECURITY DEFINER + an internal trip-Owner check: the op is owner-only (matching
+-- the tRPC requireCompetitionRole('owner') gate). DEFINER lets one atomic function
+-- clear across all the competition's games without per-table RLS friction; the
+-- internal auth.uid() check closes the direct-PostgREST escalation hole that
+-- DEFINER + EXECUTE-to-authenticated would otherwise open. Idempotent (CREATE OR
+-- REPLACE).
+
+-- ── Shared guard: caller must be the trip Owner, and the competition must belong
+--    to the named trip (defends against a competition id from another trip). ────
+CREATE OR REPLACE FUNCTION public.assert_competition_owner(p_trip_id text, p_competition_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.trip_members tm
+    WHERE tm.trip_id = p_trip_id
+      AND tm.user_id = (auth.uid())::text
+      AND tm.role = 'Owner'
+  ) THEN
+    RAISE EXCEPTION 'Only the trip owner can reset a competition' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.competitions c
+    WHERE c.id = p_competition_id AND c.trip_id = p_trip_id
+  ) THEN
+    RAISE EXCEPTION 'Competition % not found in trip %', p_competition_id, p_trip_id USING ERRCODE = 'P0002';
+  END IF;
+END;
+$$;
+
+-- ── reset_competition_scoring — clears the SCORING bucket for every game in the
+--    competition; keeps full config + identity. Games become re-scoreable
+--    (config-intact, unscored): status → pending, corrections closed,
+--    scoring_enabled KEPT (the game stays armed). ────────────────────────────
+CREATE OR REPLACE FUNCTION public.reset_competition_scoring(p_trip_id text, p_competition_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+DECLARE
+  v_game_ids text[];
+BEGIN
+  PERFORM public.assert_competition_owner(p_trip_id, p_competition_id);
+
+  SELECT array_agg(id) INTO v_game_ids
+  FROM public.games
+  WHERE competition_id = p_competition_id;
+
+  IF v_game_ids IS NULL THEN
+    RETURN; -- no games — nothing to clear
+  END IF;
+
+  -- Results + raw scores (all game types that score).
+  DELETE FROM public.game_results WHERE game_id = ANY(v_game_ids);
+  DELETE FROM public.score_entries WHERE game_id = ANY(v_game_ids);
+
+  -- Match-play RESULT columns only — keep the pairings (side_a/side_b). For
+  -- non-match types there are no game_matches rows, so this is a no-op.
+  UPDATE public.game_matches
+    SET result = NULL, margin = NULL, status = 'pending'
+    WHERE game_id = ANY(v_game_ids);
+
+  -- Unscored lifecycle: drop active/complete back to pending, close corrections.
+  -- scoring_enabled is intentionally KEPT (the game stays armed / re-scoreable).
+  -- Dropped (abandoned) games stay dropped — un-dropping is a separate action.
+  UPDATE public.games
+    SET status = 'pending', corrections_open = false
+    WHERE competition_id = p_competition_id AND status <> 'dropped';
+END;
+$$;
+
+-- ── reset_competition_to_skeleton — SUPERSET of reset_scoring: clears scoring
+--    (by CALLING it), then additionally clears the CONFIG bucket, leaving the
+--    identity shell (+ teams) only. Games return to the setting-up/bones state:
+--    scoring_enabled → false (un-armed). Golf types lose pairings/roster/course
+--    and so derive back to "setting-up"; a non-golf manual game has no such
+--    config, so it keeps its point value (identity) and reads "ready" — by
+--    design, a manual game has nothing to set up beyond its name + value. ─────
+CREATE OR REPLACE FUNCTION public.reset_competition_to_skeleton(p_trip_id text, p_competition_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+DECLARE
+  v_game_ids text[];
+BEGIN
+  -- Built ON reset_scoring (which also runs the owner guard) — NOT reimplemented.
+  PERFORM public.reset_competition_scoring(p_trip_id, p_competition_id);
+
+  SELECT array_agg(id) INTO v_game_ids
+  FROM public.games
+  WHERE competition_id = p_competition_id;
+
+  IF v_game_ids IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Config rows: pairings, roster, foursomes/pairs. (game_matches results were
+  -- already nulled by reset_scoring; here the rows go entirely.)
+  DELETE FROM public.game_matches WHERE game_id = ANY(v_game_ids);
+  DELETE FROM public.game_participants WHERE game_id = ANY(v_game_ids);
+  DELETE FROM public.play_groups WHERE game_id = ANY(v_game_ids);
+
+  -- Per-game config columns. The point VALUE survives (identity): for placement
+  -- games clear only the SPLIT (points_distribution → NULL, keep points_total);
+  -- a per-match distribution holds the value itself, so it is kept untouched.
+  UPDATE public.games
+    SET course_id = NULL,
+        scorecard_schema = NULL,
+        modifiers = '{}'::jsonb,
+        rules_for_today = NULL,
+        competition_format = NULL,
+        pairings_published_at = NULL,
+        scoring_enabled = false,
+        points_distribution = CASE
+          WHEN points_distribution->>'type' = 'placement' THEN NULL
+          ELSE points_distribution
+        END
+    WHERE competition_id = p_competition_id AND status <> 'dropped';
+END;
+$$;
+
+-- The functions self-guard (owner check inside), so EXECUTE-to-authenticated is
+-- safe — the tRPC layer also gates owner, but a direct PostgREST call is caught
+-- by assert_competition_owner.
+GRANT EXECUTE ON FUNCTION public.assert_competition_owner(text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_competition_scoring(text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_competition_to_skeleton(text, text) TO authenticated;


### PR DESCRIPTION
Two reusable, transactional reset operations over a competition's games, by blast radius (WS4 "reset primitives"). One known home; callers call, they don't reimplement. **Server-only (Phase 1)** — the danger-zone buttons + confirms are Phase 2.

Closes the Phase 0 audit (reported + confirmed) and builds the two primitives.

## Phase 0 — the per-type Identity / Config / Scoring definition (confirmed)
| Bucket | Cleared by | Tables / columns |
|--------|-----------|------------------|
| **Identity** | neither | `games`: id, name, game_type_id, competition_id, **points_total / per-match value**, schedule · `teams` · `team_assignments` |
| **Config** | skeleton only | `game_matches` pairing cols · `game_participants` · `play_groups` · `games`: course_id, scorecard_schema, modifiers, rules_for_today, competition_format, pairings_published_at, **placement split** (`points_distribution`, placement only) |
| **Scoring** | both | `game_results` · `score_entries` · `game_matches` result cols (result/margin/status) · `games`: status, corrections_open |

Key findings: the clears are **type-agnostic** (each type lacks the buckets it doesn't use → absent = no-op); `game_matches` is the one **dual-bucket** table (scoring nulls its result cols + keeps the pairing; skeleton deletes the row); the **point value is identity** (kept by skeleton) while only the **placement split** is config.

## Phase 1 — the two primitives
- **migration 063** — three plpgsql functions, transactional (all-or-nothing per competition; the JS client can't wrap multi-table work, plpgsql is atomic):
  - `assert_competition_owner` — trip-Owner check + competition-belongs-to-trip.
  - `reset_competition_scoring` — clears the scoring bucket; keeps config + identity; `scoring_enabled` **kept** (armed, re-scoreable).
  - `reset_competition_to_skeleton` — **`PERFORM`s `reset_competition_scoring`** (built on it, not reimplemented), then clears config; un-arms. Placement split → null (keep `points_total`); per-match value kept (it's the identity value).
  - `SECURITY DEFINER` for one atomic cross-game clear; the internal owner check closes the direct-PostgREST escalation hole that DEFINER + EXECUTE-to-authenticated would open.
- **`competitions.resetScoring` / `resetToSkeleton`** — thin owner-gated (`requireCompetitionRole("owner")`) tRPC procedures calling the functions via `rpc()`.

## Lifecycle targets
- resetScoring → `status='pending'`, corrections closed, **scoring_enabled kept** → "ready/armed", re-scoreable.
- resetToSkeleton → also **un-armed** + config gone → "setting-up" (golf). Non-golf keeps its point value (identity) → reads "ready" (a manual game has nothing to set up). Leaderboard is fully derived from `game_results`, so clearing zeroes standings on next read.

## Tests (4, green)
- resetScoring: results + scores cleared, **config intact** (roster/handicaps/schema/points/modifiers/format), `status=pending`, **scoring_enabled still true**; `game_matches` row survives with its pairing but result cols nulled — across stroke + match + manual.
- resetToSkeleton: config cleared (participants/pairings/play_groups/course/format/modifiers/rules + placement split), **identity kept** (points_total, **per-match value kept**, name, type, **teams survive**), un-armed — across stroke + match + doubles + manual.
- Owner-gating: co_admin and member both rejected.

tsc + lint clean. Existing competitions suite still green.

## Notes
- Migration applied to the DB via raw SQL (records no `schema_migrations` row), so CI's `db push` re-applies 063 idempotently (`CREATE OR REPLACE` + `GRANT`) and records it — no apply-timestamp mismatch.
- **Phase 2** (danger-zone buttons above Delete, with in-app cost-naming confirms — reusing the `DeleteCompetitionConfirmModal` pattern, **not** `window.confirm`) follows. Enables cleaning the BBMI test-game pile via reset-to-skeleton.

Refs #441.