### PR TITLE
feat(competition): Rosters overlay — team management leaves Settings (W-TEAMSURFACE-01, PR a)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CompetitionHeader } from "./CompetitionHeader";
 import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
@@ -215,15 +215,31 @@ export function CompetitionFace({
     <div className="space-y-4">
       {header}
 
+      {/* Rosters entry point (W-TEAMSURFACE-01) — board-level so it shows in EVERY
+          standings state (empty / setup / live / final), which is precisely when
+          you need it. Member-visible: the board only renders to those who can see
+          the competition, and the overlay reads are member-accessible. A hero
+          team-name tap (onEditTeam) is the secondary entry. */}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => setRostersOpen(true)}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-semibold"
+          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "0.5px solid var(--color-bt-border)" }}
+          data-testid="open-rosters"
+        >
+          <Users size={14} style={{ color: "var(--color-bt-accent)" }} />
+          Rosters
+        </button>
+      </div>
+
       <CompetitionLeaderboard
         competitionId={competition.id}
         tripId={tripId}
         canEdit={canEdit}
         onAddGame={() => setAddingGame(true)}
-        // Team management now lives in the Rosters overlay (W-TEAMSURFACE-01), not
-        // Settings — the header "Rosters" button and a hero team-name tap both
-        // open it. Member-visible, so it's not canEdit-gated.
-        onOpenRosters={() => setRostersOpen(true)}
+        // A hero team-name tap also opens the Rosters overlay (the team-edit is
+        // there now, not Settings). Member-visible, so not canEdit-gated.
         onEditTeam={() => setRostersOpen(true)}
         onOpenGame={canEdit ? openManualGame : undefined}
       />

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronLeft, Users, X } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CompetitionHeader } from "./CompetitionHeader";
 import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
+import { RostersOverlay } from "./RostersOverlay";
 import { GameSheet, RunSheet, type GameRow, type LBTeamLite } from "./CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 
@@ -75,6 +76,7 @@ export function CompetitionFace({
   // board and returns to it. "Add a game" opens a modal over the board.
   const [view, setView] = useState<FaceView>("board");
   const [addingGame, setAddingGame] = useState(false);
+  const [rostersOpen, setRostersOpen] = useState(false);
 
   // GameSheet (add-game modal) needs the type catalog. Format definitions live in
   // CODE (W-PERF-01) — read synchronously, no fetch — so the modal's top half is
@@ -202,12 +204,6 @@ export function CompetitionFace({
           tripId={tripId}
           canEdit={canEdit}
           isOwner={isOwner}
-          isLive={isLive}
-          rosterBuilding={rosterSetup === "building"}
-          // "Save rosters" (setup phase only) commits the roster build one-way:
-          // the board's Team Rosters button gives way to the moved-to-Settings
-          // signpost. Returns to the board so the transition is visible.
-          onSaveRosters={() => { setRosterSetup("saved"); setView("board"); }}
           onDeleted={onCompetitionDeleted}
         />
       </div>
@@ -219,52 +215,16 @@ export function CompetitionFace({
     <div className="space-y-4">
       {header}
 
-      {/* Setup-phase roster affordance: the Team Rosters button (building) gives
-          way to a dismissable "moved to Settings" signpost (saved) → clean
-          (dismissed). Editors only — the crew never sees management chrome. */}
-      {canEdit && rosterSetup === "building" && (
-        <button
-          type="button"
-          onClick={() => setView("settings")}
-          className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-[13px] font-semibold"
-          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
-          data-testid="comp-team-rosters-btn"
-        >
-          <Users size={15} style={{ color: "var(--color-bt-accent)" }} /> Team Rosters
-        </button>
-      )}
-      {canEdit && rosterSetup === "saved" && (
-        <div
-          className="flex items-start gap-3 rounded-lg px-3 py-2.5"
-          style={{ background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}
-          data-testid="comp-rosters-moved-signpost"
-        >
-          <p className="min-w-0 flex-1 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-            Roster management has moved to Settings —{" "}
-            <button type="button" onClick={() => setView("settings")} className="font-semibold underline" style={{ color: "var(--color-bt-accent)" }}>
-              Open Settings
-            </button>
-            . Manage a team by tapping its name.
-          </p>
-          <button
-            type="button"
-            onClick={() => setRosterSetup("dismissed")}
-            aria-label="Dismiss"
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded"
-            style={{ color: "var(--color-bt-text-dim)" }}
-            data-testid="comp-rosters-signpost-dismiss"
-          >
-            <X size={14} />
-          </button>
-        </div>
-      )}
-
       <CompetitionLeaderboard
         competitionId={competition.id}
         tripId={tripId}
         canEdit={canEdit}
         onAddGame={() => setAddingGame(true)}
-        onEditTeam={canEdit ? () => setView("settings") : undefined}
+        // Team management now lives in the Rosters overlay (W-TEAMSURFACE-01), not
+        // Settings — the header "Rosters" button and a hero team-name tap both
+        // open it. Member-visible, so it's not canEdit-gated.
+        onOpenRosters={() => setRostersOpen(true)}
+        onEditTeam={() => setRostersOpen(true)}
         onOpenGame={canEdit ? openManualGame : undefined}
       />
 
@@ -306,6 +266,21 @@ export function CompetitionFace({
             utils.competitions.faceBootstrap.invalidate({ tripId });
           }}
           onEditConfig={() => { setEditing(running); setRunning(null); }}
+        />
+      )}
+
+      {/* Rosters overlay — the one home for team management (W-TEAMSURFACE-01),
+          member-visible, owner-editable. Opened from the leaderboard header (or a
+          hero team-name tap). Carries the relocated "Save rosters" commit. */}
+      {rostersOpen && (
+        <RostersOverlay
+          tripId={tripId}
+          competitionId={competition.id}
+          isOwner={isOwner}
+          structureLocked={isLive}
+          rosterBuilding={rosterSetup === "building"}
+          onSaveRosters={() => { setRosterSetup("saved"); setRostersOpen(false); }}
+          onClose={() => setRostersOpen(false)}
         />
       )}
     </div>

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo } from "react";
-import { Trophy, CloudOff, RefreshCw, Plus, Users } from "lucide-react";
+import { Trophy, CloudOff, RefreshCw, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { GameRow, fmtPts } from "./GameRow";
 
@@ -75,15 +75,12 @@ interface Props {
   onAddGame?: () => void;
   /** Tap a team name on the hero → opens the Rosters overlay (routed by the face). */
   onEditTeam?: () => void;
-  /** Open the Rosters overlay — the header "Rosters" button. Member-visible
-   *  (the overlay reads are member-accessible); routed by the face. */
-  onOpenRosters?: () => void;
   /** Tap a non-golf game row (no route) → open its manual run sheet (routed by
    *  the face). Editors only; omitted for crew. */
   onOpenGame?: (gameId: string) => void;
 }
 
-export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam, onOpenRosters, onOpenGame }: Props) {
+export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam, onOpenGame }: Props) {
   const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
@@ -226,9 +223,8 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
           border: "1px solid var(--color-bt-border)",
         }}
       >
-        {/* Magic-number subtitle + the Rosters entry point (member-visible:
-            anyone can glance up to see the lineup — W-TEAMSURFACE-01). */}
-        <div className="flex items-center justify-between gap-2 px-4 pt-3 pb-2">
+        {/* Magic-number subtitle */}
+        <div className="px-4 pt-3 pb-2">
           <p
             className="text-[11px] font-semibold uppercase tracking-wider"
             style={{ color: "var(--color-bt-text-dim)" }}
@@ -239,22 +235,6 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
               ? `First to ${fmtPts(winNumber)} wins`
               : "Competition standings"}
           </p>
-          {onOpenRosters && teams.length > 0 && (
-            <button
-              type="button"
-              onClick={onOpenRosters}
-              className="flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1 text-[12px] font-semibold"
-              style={{
-                background: "var(--color-bt-card-raised)",
-                color: "var(--color-bt-text)",
-                border: "0.5px solid var(--color-bt-border)",
-              }}
-              data-testid="open-rosters"
-            >
-              <Users size={13} style={{ color: "var(--color-bt-accent)" }} />
-              Rosters
-            </button>
-          )}
         </div>
 
         {teams.length === 2 ? (

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo } from "react";
-import { Trophy, CloudOff, RefreshCw, Plus } from "lucide-react";
+import { Trophy, CloudOff, RefreshCw, Plus, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { GameRow, fmtPts } from "./GameRow";
 
@@ -73,14 +73,17 @@ interface Props {
    *  the home now). Crew (non-editors) get none of these. */
   canEdit?: boolean;
   onAddGame?: () => void;
-  /** Tap a team name on the hero → its in-place editor (routed by the face). */
+  /** Tap a team name on the hero → opens the Rosters overlay (routed by the face). */
   onEditTeam?: () => void;
+  /** Open the Rosters overlay — the header "Rosters" button. Member-visible
+   *  (the overlay reads are member-accessible); routed by the face. */
+  onOpenRosters?: () => void;
   /** Tap a non-golf game row (no route) → open its manual run sheet (routed by
    *  the face). Editors only; omitted for crew. */
   onOpenGame?: (gameId: string) => void;
 }
 
-export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam, onOpenGame }: Props) {
+export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam, onOpenRosters, onOpenGame }: Props) {
   const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
@@ -223,8 +226,9 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
           border: "1px solid var(--color-bt-border)",
         }}
       >
-        {/* Magic-number subtitle */}
-        <div className="px-4 pt-3 pb-2">
+        {/* Magic-number subtitle + the Rosters entry point (member-visible:
+            anyone can glance up to see the lineup — W-TEAMSURFACE-01). */}
+        <div className="flex items-center justify-between gap-2 px-4 pt-3 pb-2">
           <p
             className="text-[11px] font-semibold uppercase tracking-wider"
             style={{ color: "var(--color-bt-text-dim)" }}
@@ -235,6 +239,22 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
               ? `First to ${fmtPts(winNumber)} wins`
               : "Competition standings"}
           </p>
+          {onOpenRosters && teams.length > 0 && (
+            <button
+              type="button"
+              onClick={onOpenRosters}
+              className="flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1 text-[12px] font-semibold"
+              style={{
+                background: "var(--color-bt-card-raised)",
+                color: "var(--color-bt-text)",
+                border: "0.5px solid var(--color-bt-border)",
+              }}
+              data-testid="open-rosters"
+            >
+              <Users size={13} style={{ color: "var(--color-bt-accent)" }} />
+              Rosters
+            </button>
+          )}
         </div>
 
         {teams.length === 2 ? (

--- a/src/components/competition/CompetitionSettings.tsx
+++ b/src/components/competition/CompetitionSettings.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Trash2, RotateCcw, Eraser } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
-import { TeamsPanel } from "./TeamsPanel";
 
 interface Competition {
   id: string;
@@ -18,24 +17,19 @@ interface Props {
   tripId: string;
   canEdit: boolean;
   isOwner: boolean;
-  /** Live = structure locked (TeamsPanel can't restructure mid-competition). */
-  isLive: boolean;
-  /** Roster-build phase — show the one-way "Save rosters" commit button. */
-  rosterBuilding: boolean;
-  /** Commit the roster build (advances the flag to `saved` + returns to board). */
-  onSaveRosters: () => void;
   /** Fired after the owner deletes the competition (host resets its flag). */
   onDeleted?: () => void;
 }
 
 /**
- * CompetitionSettings — the single home for everything that used to be scattered
- * across the header (edit modal, delete trash) and the retired setup guide
- * (all-teams roster page). Reached from the header gear and the board's pre-save
- * "Team Rosters" button. Three sections:
+ * CompetitionSettings — competition META + danger zone. Reached from the header
+ * gear. Two sections:
  *   1. Details   — name + tagline, inline-edited (was the header pencil modal)
- *   2. Rosters   — the all-teams TeamsPanel (+ the one-way "Save rosters" commit)
- *   3. Danger    — delete the competition (was the header trash; owner + pre-live)
+ *   2. Danger    — reset / delete the competition (owner + pre-live)
+ *
+ * Team management is NO LONGER here — it moved to the member-visible Rosters
+ * overlay opened from the leaderboard header (W-TEAMSURFACE-01), where roster
+ * editing is live + drag-based rather than form-and-save.
  *
  * STANDARD PALETTE ONLY — no competition accent / tonal shift.
  */
@@ -44,35 +38,11 @@ export function CompetitionSettings({
   tripId,
   canEdit,
   isOwner,
-  isLive,
-  rosterBuilding,
-  onSaveRosters,
   onDeleted,
 }: Props) {
   return (
     <div className="space-y-6">
       <DetailsSection competition={competition} tripId={tripId} canEdit={canEdit} />
-
-      <section className="space-y-3">
-        <SectionLabel>Team Rosters</SectionLabel>
-        <TeamsPanel
-          competitionId={competition.id}
-          tripId={tripId}
-          canEdit={canEdit}
-          structureLocked={isLive}
-        />
-        {canEdit && rosterBuilding && (
-          <button
-            type="button"
-            onClick={onSaveRosters}
-            className="w-full"
-            style={{ height: 48, borderRadius: 12, background: "var(--color-bt-accent)", color: "var(--color-bt-base)", fontSize: 15, fontWeight: 600 }}
-            data-testid="comp-save-rosters"
-          >
-            Save rosters
-          </button>
-        )}
-      </section>
 
       {isOwner && competition.status === "upcoming" && (
         <DangerSection competition={competition} tripId={tripId} onDeleted={onDeleted} />

--- a/src/components/competition/RostersOverlay.tsx
+++ b/src/components/competition/RostersOverlay.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { X } from "lucide-react";
+import { ScrollLock } from "@/hooks/useScrollLock";
+import { TeamsPanel } from "./TeamsPanel";
+
+/**
+ * RostersOverlay (W-TEAMSURFACE-01) — the one home for team management, opened
+ * from the leaderboard header (stadium-scoreboard model: glance up to see the
+ * lineup). It floats ON TOP of the leaderboard (the board is never demoted), with
+ * the lighter drawer scrim so the standings read as still-present context.
+ *
+ * ONE surface, role-gated:
+ *  - any trip member opens it and SEES the rosters (reads are member-accessible);
+ *  - edit affordances (add/remove/move players, add/delete team, tap-to-edit a
+ *    team) are OWNER-only — `canEdit={isOwner}` flows into TeamsPanel, which
+ *    already renders view-only when canEdit is false.
+ *
+ * It hosts the relocated TeamsPanel in `embedded` mode (this overlay owns the
+ * card chrome + the "Rosters" title) and carries the one-way "Save rosters"
+ * commit (owner, during the roster-build phase) that used to live in Settings.
+ */
+export function RostersOverlay({
+  tripId,
+  competitionId,
+  isOwner,
+  structureLocked,
+  rosterBuilding,
+  onSaveRosters,
+  onClose,
+}: {
+  tripId: string;
+  competitionId: string;
+  /** Owner gates every edit affordance; everyone else gets a read-only view. */
+  isOwner: boolean;
+  /** Live: team STRUCTURE is frozen (no add/delete team) — rename + swap stay. */
+  structureLocked: boolean;
+  /** Roster-build phase: show the one-way "Save rosters" commit (owner only). */
+  rosterBuilding: boolean;
+  /** Commit the roster build (advances roster_setup → saved) + closes. */
+  onSaveRosters: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <ScrollLock>
+      <div
+        className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+        style={{ background: "var(--color-bt-overlay-drawer)" }}
+        onClick={onClose}
+        data-testid="rosters-overlay"
+      >
+        <div
+          className="flex max-h-[90vh] w-full max-w-3xl flex-col rounded-t-2xl sm:rounded-2xl"
+          style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div
+            className="flex items-center justify-between px-4 py-3"
+            style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+          >
+            <div>
+              <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
+                Rosters
+              </h3>
+              <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                {isOwner
+                  ? "Tap a team to edit · drag a player onto a team to assign"
+                  : "Who’s on which team"}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="flex h-8 w-8 items-center justify-center rounded-lg"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Body — the relocated team-builder (read-only for non-owners). */}
+          <div className="flex-1 overflow-y-auto p-4">
+            <TeamsPanel
+              tripId={tripId}
+              competitionId={competitionId}
+              canEdit={isOwner}
+              structureLocked={structureLocked}
+              embedded
+            />
+          </div>
+
+          {/* Footer — the one-way roster-build commit (owner, building phase). */}
+          {isOwner && rosterBuilding && (
+            <div className="border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>
+              <button
+                type="button"
+                onClick={onSaveRosters}
+                className="w-full rounded-xl py-3 text-sm font-semibold"
+                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+                data-testid="rosters-save"
+              >
+                Save rosters
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </ScrollLock>
+  );
+}

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -15,7 +15,6 @@ import {
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Avatar } from "@/components/Avatar";
-import { TeamMemberChip } from "./TeamMemberChip";
 
 interface Props {
   competitionId: string;
@@ -33,6 +32,12 @@ interface Props {
    * structure lock, not a data lock — same builder, fewer affordances.
    */
   structureLocked?: boolean;
+  /**
+   * Embedded mode: the panel is hosted inside the Rosters overlay (W-TEAMSURFACE-01),
+   * which already supplies the card chrome + "Rosters" title. Drop the bordered
+   * wrapper + the redundant section title; keep the status + add-team toolbar.
+   */
+  embedded?: boolean;
 }
 
 interface Team {
@@ -211,8 +216,11 @@ export function TeamsPanel({
   creating: creatingProp,
   onCreatingChange,
   structureLocked = false,
+  embedded = false,
 }: Props) {
+  const utils = trpc.useUtils();
   const [editingTeam, setEditingTeam] = useState<Team | null>(null);
+  const [deletingTeam, setDeletingTeam] = useState<Team | null>(null);
   const [creatingLocal, setCreatingLocal] = useState(false);
   const creating = creatingProp ?? creatingLocal;
   const setCreating = (v: boolean) => {
@@ -239,31 +247,53 @@ export function TeamsPanel({
     ? "Not set up"
     : `${teamsTyped.length} team${teamsTyped.length === 1 ? "" : "s"} · ${assignedCount} of ${totalMembers} assigned`;
 
+  // List-level delete (W-TEAMDEL-01): the delete affordance lives on each team
+  // card, NOT buried in the edit modal. Lifted here so one confirm + mutation
+  // serves the whole list. Same invalidations the edit modal used.
+  const deleteTeam = trpc.teams.delete.useMutation({
+    onSettled: () => {
+      utils.teams.list.invalidate({ tripId, competitionId });
+      utils.teamAssignments.list.invalidate({ tripId, competitionId });
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+    },
+    onSuccess: () => setDeletingTeam(null),
+  });
+  const deletingMemberCount = deletingTeam
+    ? (assignments as Assignment[]).filter((a) => a.team_id === deletingTeam.id).length
+    : 0;
+
   return (
     <div
       data-testid="teams-panel"
-      className="overflow-hidden rounded-xl"
-      style={{ border: "1px solid var(--color-bt-border)" }}
+      className={embedded ? "" : "overflow-hidden rounded-xl"}
+      style={embedded ? undefined : { border: "1px solid var(--color-bt-border)" }}
     >
-      {/* Section header */}
-      <div className="flex items-center justify-between px-4 py-3">
-        <div className="flex items-center gap-2.5">
-          <span style={{ color: "var(--color-bt-accent)" }} aria-hidden>
-            <div className="flex items-center">
-              <User size={14} />
-              <ArrowRight size={11} className="mx-0.5" />
-              <Users size={14} />
+      {/* Header — full section header standalone; a slim status+add toolbar when
+          embedded in the Rosters overlay (which owns the title). */}
+      <div className={`flex items-center justify-between px-4 ${embedded ? "pt-1 pb-3" : "py-3"}`}>
+        {embedded ? (
+          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+            {statusText}
+          </p>
+        ) : (
+          <div className="flex items-center gap-2.5">
+            <span style={{ color: "var(--color-bt-accent)" }} aria-hidden>
+              <div className="flex items-center">
+                <User size={14} />
+                <ArrowRight size={11} className="mx-0.5" />
+                <Users size={14} />
+              </div>
+            </span>
+            <div>
+              <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                Team Rosters
+              </p>
+              <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                {statusText}
+              </p>
             </div>
-          </span>
-          <div>
-            <p className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-              Team Rosters
-            </p>
-            <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-              {statusText}
-            </p>
           </div>
-        </div>
+        )}
         {canEdit && !structureLocked && (
           <button
             type="button"
@@ -273,6 +303,7 @@ export function TeamsPanel({
               background: "var(--color-bt-accent)",
               color: "var(--color-bt-base)",
             }}
+            data-testid="teams-add"
           >
             <Plus size={12} />
             Team
@@ -289,8 +320,8 @@ export function TeamsPanel({
 
       {/* Content */}
       <div
-        className="space-y-4 px-4 pb-4 pt-3"
-        style={{ borderTop: "1px solid var(--color-bt-border)" }}
+        className={`space-y-4 px-4 pb-4 ${embedded ? "" : "pt-3"}`}
+        style={embedded ? undefined : { borderTop: "1px solid var(--color-bt-border)" }}
       >
         {!teamsExist && (
           <NoTeamsEmptyState
@@ -347,7 +378,9 @@ export function TeamsPanel({
                   members={members as Member[]}
                   assignments={assignments as Assignment[]}
                   canEdit={canEdit}
+                  structureLocked={structureLocked}
                   onEdit={() => setEditingTeam(team)}
+                  onDelete={() => setDeletingTeam(team)}
                   tripId={tripId}
                   competitionId={competitionId}
                 />
@@ -363,12 +396,21 @@ export function TeamsPanel({
           tripId={tripId}
           competitionId={competitionId}
           team={editingTeam}
-          structureLocked={structureLocked}
           existingTeamNames={teamsTyped.map((t) => t.name.toLowerCase())}
           onClose={() => {
             setCreating(false);
             setEditingTeam(null);
           }}
+        />
+      )}
+
+      {deletingTeam && (
+        <DeleteTeamConfirmModal
+          teamName={deletingTeam.name}
+          memberCount={deletingMemberCount}
+          isPending={deleteTeam.isPending}
+          onCancel={() => setDeletingTeam(null)}
+          onConfirm={() => deleteTeam.mutate({ tripId, teamId: deletingTeam.id })}
         />
       )}
     </div>
@@ -439,7 +481,9 @@ function TeamCard({
   members,
   assignments,
   canEdit,
+  structureLocked,
   onEdit,
+  onDelete,
   tripId,
   competitionId,
 }: {
@@ -447,7 +491,9 @@ function TeamCard({
   members: Member[];
   assignments: Assignment[];
   canEdit: boolean;
+  structureLocked: boolean;
   onEdit: () => void;
+  onDelete: () => void;
   tripId: string;
   competitionId: string;
 }) {
@@ -460,9 +506,9 @@ function TeamCard({
     teamMemberIds.includes(m.user_id ?? m.memberId)
   );
 
-  // Optimistic — the dropped chip needs to land in the target team
+  // Optimistic — the dropped player needs to land in the target team
   // instantly, not after the server round-trip. `remove` powers the
-  // per-chip × button (Owner-only) inside the team card.
+  // per-row × button inside the team card.
   const { assign, remove } = useTeamAssignmentMutations(tripId, competitionId);
 
   function handleDrop(e: React.DragEvent) {
@@ -472,6 +518,12 @@ function TeamCard({
     if (!userId) return;
     assign.mutate({ tripId, competitionId, userId, teamId: team.id });
   }
+
+  const headerBg = {
+    background: dragOver
+      ? `color-mix(in srgb, ${team.color} 14%, var(--color-bt-card-raised))`
+      : `color-mix(in srgb, ${team.color} 8%, var(--color-bt-card-raised))`,
+  };
 
   return (
     <div
@@ -494,69 +546,72 @@ function TeamCard({
       onDrop={canEdit ? handleDrop : undefined}
       data-testid={`team-card-${team.id}`}
     >
-      <div
-        className="flex items-center gap-3 px-3 py-2.5"
-        style={{
-          background: dragOver
-            ? `color-mix(in srgb, ${team.color} 14%, var(--color-bt-card-raised))`
-            : `color-mix(in srgb, ${team.color} 8%, var(--color-bt-card-raised))`,
-        }}
-      >
-        <span
-          className="h-6 w-6 flex-shrink-0 rounded-full"
-          style={{ background: team.color }}
-          aria-hidden
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <p
-              className="truncate text-sm font-semibold"
-              style={{ color: "var(--color-bt-text)" }}
-            >
-              {team.name}
-            </p>
-            <span
-              className="rounded px-1.5 py-0.5 text-[10px] font-bold"
-              style={{
-                background: "var(--color-bt-card)",
-                color: "var(--color-bt-text-dim)",
-                border: "1px solid var(--color-bt-border)",
-              }}
-            >
-              {team.short_name}
-            </span>
-            <span className="ml-auto text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-              {teamMembers.length} member{teamMembers.length === 1 ? "" : "s"}
-            </span>
-          </div>
-        </div>
-        {canEdit && (
+      {/* Header — the team identity is tap-to-edit for the owner (W-TEAMTAP-01):
+          the whole name area is a button with a pencil cue, not a buried icon.
+          Delete is a sibling list-level affordance (W-TEAMDEL-01), not inside the
+          edit modal. */}
+      <div className="flex items-center gap-1 px-3 py-2.5" style={headerBg}>
+        {canEdit ? (
           <button
             type="button"
             onClick={onEdit}
             aria-label={`Edit ${team.name}`}
-            className="flex h-7 w-7 items-center justify-center rounded-lg"
-            style={{ color: "var(--color-bt-text-dim)" }}
+            className="group flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-1 py-1 text-left transition-opacity hover:opacity-80"
+            data-testid={`team-edit-${team.id}`}
           >
-            <Pencil size={13} />
+            <span className="h-6 w-6 flex-shrink-0 rounded-full" style={{ background: team.color }} aria-hidden />
+            <span className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {team.name}
+            </span>
+            <span
+              className="flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold"
+              style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+            >
+              {team.short_name}
+            </span>
+            <Pencil size={12} className="flex-shrink-0 opacity-60 group-hover:opacity-100" style={{ color: "var(--color-bt-accent)" }} />
+          </button>
+        ) : (
+          <div className="flex min-w-0 flex-1 items-center gap-2.5 px-1 py-1">
+            <span className="h-6 w-6 flex-shrink-0 rounded-full" style={{ background: team.color }} aria-hidden />
+            <span className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              {team.name}
+            </span>
+            <span
+              className="flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold"
+              style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+            >
+              {team.short_name}
+            </span>
+          </div>
+        )}
+        <span className="flex-shrink-0 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          {teamMembers.length}
+        </span>
+        {canEdit && !structureLocked && (
+          // Delete-team lives at the list level (W-TEAMDEL-01). Hidden once live —
+          // removing a team is a structure change (§9).
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label={`Delete ${team.name}`}
+            className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+            style={{ color: "var(--color-bt-danger)" }}
+            data-testid={`team-delete-${team.id}`}
+          >
+            <Trash2 size={13} />
           </button>
         )}
       </div>
 
-      {/* Members area — chips sit directly on the team card, no inner box */}
-      <div
-        className="flex flex-wrap gap-2 px-3 pb-3 pt-2"
-        style={{ minHeight: 40 }}
-      >
+      {/* Members — full-width player rows (W-TEAMBUILD-01), via the Avatar
+          team-color disc. A row is the drag source (owner, desktop); its × is
+          the per-player remove. The captain ★ slot lands here in PR (b). */}
+      <div className="space-y-1.5 px-3 pb-3 pt-1" style={{ minHeight: 40 }}>
         {teamMembers.length === 0 && (
-          <p
-            className="text-[11px] italic"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
+          <p className="px-1 py-1.5 text-[11px] italic" style={{ color: "var(--color-bt-text-dim)" }}>
             {canEdit ? (
               <>
-                {/* Drag affordance lives on lg+ only — fall back to a
-                    neutral phrase on touch widths (tablet + phone) */}
                 <span className="hidden lg:inline">Drop a crew member here</span>
                 <span className="lg:hidden">No members yet</span>
               </>
@@ -568,11 +623,10 @@ function TeamCard({
         {teamMembers.map((m) => {
           const id = m.user_id ?? m.memberId;
           return (
-            <TeamMemberChip
+            <PlayerRow
               key={id}
-              displayName={m.displayName}
-              avatarIcon={m.user?.avatar_icon}
-              isGuest={m.isGuest}
+              name={m.displayName}
+              avatarIcon={m.user?.avatar_icon ?? null}
               teamColor={team.color}
               draggable={canEdit}
               onDragStart={
@@ -583,19 +637,63 @@ function TeamCard({
                     }
                   : undefined
               }
-              onRemove={
-                // Swapping/unassigning a player is co-admin team-editing, not
-                // competition-destructive — owner & co-admins both do it.
-                canEdit
-                  ? () => remove.mutate({ tripId, competitionId, userId: id })
-                  : undefined
-              }
+              onRemove={canEdit ? () => remove.mutate({ tripId, competitionId, userId: id }) : undefined}
               removeAriaLabel={`Remove ${m.displayName} from ${team.name}`}
             />
           );
         })}
       </div>
+    </div>
+  );
+}
 
+// ── PlayerRow ───────────────────────────────────────────────────────────────
+// Full-width player card (W-TEAMBUILD-01): the team-color Avatar disc (R3) + name
+// + (owner) remove. Draggable for the desktop assign-by-drag flow. The captain ★
+// affordance lands to the right of the name in PR (b).
+
+function PlayerRow({
+  name,
+  avatarIcon,
+  teamColor,
+  draggable,
+  onDragStart,
+  onRemove,
+  removeAriaLabel,
+}: {
+  name: string;
+  avatarIcon: string | null;
+  teamColor: string;
+  draggable: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+  onRemove?: () => void;
+  removeAriaLabel: string;
+}) {
+  return (
+    <div
+      draggable={draggable}
+      onDragStart={onDragStart}
+      className={`flex items-center gap-2.5 rounded-lg px-2.5 py-2 ${draggable ? "cursor-grab active:cursor-grabbing" : ""}`}
+      style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+    >
+      {draggable && (
+        <GripVertical size={14} className="hidden flex-shrink-0 lg:block" style={{ color: "var(--color-bt-text-dim)" }} />
+      )}
+      <Avatar name={name} avatarIcon={avatarIcon} teamColor={teamColor} sizePx={28} />
+      <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--color-bt-text)" }}>
+        {name}
+      </span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={removeAriaLabel}
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <X size={14} />
+        </button>
+      )}
     </div>
   );
 }
@@ -955,15 +1053,12 @@ function TeamSheet({
   tripId,
   competitionId,
   team,
-  structureLocked = false,
   existingTeamNames,
   onClose,
 }: {
   tripId: string;
   competitionId: string;
   team: Team | null;
-  /** Live structure-lock (§9): hide the delete-team affordance (rename stays). */
-  structureLocked?: boolean;
   /** Lowercased names of teams already in this competition — used to skip
    *  collisions when rolling a name from a theme. The current team's own
    *  name is excluded by the caller in edit mode. */
@@ -983,16 +1078,6 @@ function TeamSheet({
   });
   const [suggesterOpen, setSuggesterOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
-
-  // Snapshot member count for the confirm dialog before delete fires.
-  const { data: assignments = [] } = trpc.teamAssignments.list.useQuery(
-    { tripId, competitionId },
-    { enabled: isEdit && !structureLocked }
-  );
-  const memberCount = team
-    ? (assignments as Assignment[]).filter((a) => a.team_id === team.id).length
-    : 0;
 
   // The leaderboard roll-up (competitions.leaderboard) bakes in each team's
   // color / name / short_name, and the board renders from that bootstrap-seeded
@@ -1009,17 +1094,6 @@ function TeamSheet({
     onSettled: () => {
       utils.teams.list.invalidate({ tripId, competitionId });
       utils.competitions.leaderboard.invalidate({ tripId, competitionId });
-    },
-  });
-  const deleteTeam = trpc.teams.delete.useMutation({
-    onSettled: () => {
-      utils.teams.list.invalidate({ tripId, competitionId });
-      utils.teamAssignments.list.invalidate({ tripId, competitionId });
-      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
-    },
-    onSuccess: () => {
-      setConfirmingDelete(false);
-      onClose();
     },
   });
 
@@ -1235,46 +1309,16 @@ function TeamSheet({
             </p>
           )}
 
-          <div className="flex items-center gap-2">
-            {isEdit && !structureLocked && team && (
-              // Delete-team is co-admin team-editing (reaching this sheet already
-              // requires edit access) — not competition-destructive. Hidden once
-              // live: removing a team is a structure change (§9).
-              <button
-                type="button"
-                onClick={() => setConfirmingDelete(true)}
-                aria-label={`Delete ${team.name}`}
-                className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl"
-                style={{
-                  background: "transparent",
-                  color: "var(--color-bt-danger)",
-                  border: "1px solid var(--color-bt-border)",
-                }}
-              >
-                <Trash2 size={15} />
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={create.isPending || update.isPending}
-              className="flex-1 rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
-              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-            >
-              {isEdit ? "Save Team" : "Add Team"}
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={create.isPending || update.isPending}
+            className="w-full rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+          >
+            {isEdit ? "Save Team" : "Add Team"}
+          </button>
         </div>
-
-        {confirmingDelete && team && (
-          <DeleteTeamConfirmModal
-            teamName={team.name}
-            memberCount={memberCount}
-            isPending={deleteTeam.isPending}
-            onCancel={() => setConfirmingDelete(false)}
-            onConfirm={() => deleteTeam.mutate({ tripId, teamId: team.id })}
-          />
-        )}
       </div>
     </div>
     </ScrollLock>


### PR DESCRIPTION
Team/roster management was buried in owner-only Settings — members couldn't see rosters there, and the form-and-save shape fought the live/drag editing it really is. This moves it to a dedicated, **member-visible Rosters overlay** opened from the leaderboard header: one surface, role-gated controls.

**This is PR (a)** — the overlay + member-view + relocation + reshapes. **Captain ★ is PR (b)** (net-new schema, follows).

## What changed
- **New `RostersOverlay`** — floats ON TOP of the leaderboard (drawer scrim, so the board reads as present context, never demoted). The **"Rosters" button** in the standings header (`CompetitionLeaderboard`) is **member-visible** (the `teams.list`/`teamAssignments.list` reads are already `requireTripMember`).
- **Owner-editable, one surface** — `canEdit={isOwner}` flows into the relocated `TeamsPanel` (now `embedded`; the overlay owns the card chrome + "Rosters" title). Members get the **identical** surface, view-only (TeamsPanel's pre-existing `canEdit=false` path).
- **Re-homed findings, all built here:**
  - **W-TEAMBUILD-01** — players render as **full-width rows** (`Avatar` team-color disc + name + remove), replacing flex-wrap chips. Leaves room for the captain ★.
  - **W-TEAMDEL-01** — **delete-team is a list-level affordance** on each team card (with confirm), lifted out of the edit modal.
  - **W-TEAMTAP-01** — the team identity is an obvious **tap-to-edit** button (pencil cue), not a buried icon.
- **Settings stripped** to Details + Danger zone (TeamsPanel + the "Save rosters" commit removed). The one-way **Save-rosters commit moved onto the overlay** (owner, building phase). The old board "Team Rosters" button + "moved to Settings" signpost are gone (the header button replaces them).

## Phase 0 decisions (confirmed)
Owner-only edit gating (matches the strictest existing gate + danger-zone convention); simple name+dot team identity (TeamID primitive deferred); reuse existing team/assignment procedures (no new mutations); captain ★ split to PR (b).

## Verification (by eye on the BBMI cup, as owner — via DOM; screenshot tooling was hung)
- Header **Rosters** button → overlay opens with both teams + **16 players as Avatar discs** in full-width rows; owner subtitle + add/delete/edit affordances present.
- **Tap a team** → "Edit Team" opens (W-TEAMTAP-01).
- **Added a 3rd team live** → N-team layout held (3 teams), then **deleted it from the list** (confirm modal) → back to 2. Net-zero on BBMI.
- **Settings** shows Details only — **no team panel**.
- Member view is `canEdit`-gated (view-only path); members only reach the board once the cup is live, then glance up for the lineup.

`tsc` + lint clean. No tests referenced the removed roster chrome. Captain ★ = PR (b).

Refs #444.