### PR TITLE
feat(competition): team captain — is_captain + atomic setCaptain + the ★ (Rosters PR b1)

### DIFF
--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -7,6 +7,7 @@ import {
   Pencil,
   Plus,
   Sparkles,
+  Star,
   Trash2,
   User,
   Users,
@@ -52,6 +53,7 @@ interface Assignment {
   competition_id: string;
   user_id: string;
   team_id: string;
+  is_captain?: boolean;
 }
 
 interface Member {
@@ -204,7 +206,36 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
     },
   });
 
-  return { assign, remove };
+  // setCaptain (PR b) — optimistic: the target gets the flag; any other captain
+  // on the SAME team is cleared (one-per-team). faceBootstrap also seeds
+  // teamAssignments.list, so re-resolve it (#10) — the captain survives an
+  // overlay close/reopen, not just the live optimistic state.
+  const setCaptain = trpc.teamAssignments.setCaptain.useMutation({
+    onMutate: async (vars) => {
+      await utils.teamAssignments.list.cancel(queryKey);
+      const previous = utils.teamAssignments.list.getData(queryKey);
+      utils.teamAssignments.list.setData(queryKey, (old) => {
+        const list = (old as Assignment[] | undefined) ?? [];
+        return list.map((a) => {
+          if (a.team_id !== vars.teamId) return a;
+          if (a.user_id === vars.userId) return { ...a, is_captain: vars.isCaptain };
+          return a.is_captain ? { ...a, is_captain: false } : a;
+        }) as never;
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, ctxRollback) => {
+      if (ctxRollback?.previous) {
+        utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
+      }
+    },
+    onSettled: () => {
+      utils.teamAssignments.list.invalidate(queryKey);
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+    },
+  });
+
+  return { assign, remove, setCaptain };
 }
 
 // ── TeamsPanel ──────────────────────────────────────────────────────────────
@@ -508,8 +539,11 @@ function TeamCard({
 
   // Optimistic — the dropped player needs to land in the target team
   // instantly, not after the server round-trip. `remove` powers the
-  // per-row × button inside the team card.
-  const { assign, remove } = useTeamAssignmentMutations(tripId, competitionId);
+  // per-row × button; `setCaptain` powers the ★ (owner only).
+  const { assign, remove, setCaptain } = useTeamAssignmentMutations(tripId, competitionId);
+
+  const captainOf = (userId: string) =>
+    assignments.find((a) => a.user_id === userId && a.team_id === team.id)?.is_captain ?? false;
 
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
@@ -622,6 +656,7 @@ function TeamCard({
         )}
         {teamMembers.map((m) => {
           const id = m.user_id ?? m.memberId;
+          const isCaptain = captainOf(id);
           return (
             <PlayerRow
               key={id}
@@ -629,6 +664,7 @@ function TeamCard({
               avatarIcon={m.user?.avatar_icon ?? null}
               teamColor={team.color}
               draggable={canEdit}
+              isCaptain={isCaptain}
               onDragStart={
                 canEdit
                   ? (e) => {
@@ -639,6 +675,13 @@ function TeamCard({
               }
               onRemove={canEdit ? () => remove.mutate({ tripId, competitionId, userId: id }) : undefined}
               removeAriaLabel={`Remove ${m.displayName} from ${team.name}`}
+              // Owner sets captain (PR b); members see the filled ★ read-only.
+              onToggleCaptain={
+                canEdit
+                  ? () => setCaptain.mutate({ tripId, competitionId, teamId: team.id, userId: id, isCaptain: !isCaptain })
+                  : undefined
+              }
+              captainAriaLabel={isCaptain ? `Remove ${m.displayName} as captain` : `Make ${m.displayName} captain`}
             />
           );
         })}
@@ -649,25 +692,31 @@ function TeamCard({
 
 // ── PlayerRow ───────────────────────────────────────────────────────────────
 // Full-width player card (W-TEAMBUILD-01): the team-color Avatar disc (R3) + name
-// + (owner) remove. Draggable for the desktop assign-by-drag flow. The captain ★
-// affordance lands to the right of the name in PR (b).
+// + captain ★ + (owner) remove. Draggable for the desktop assign-by-drag flow.
 
 function PlayerRow({
   name,
   avatarIcon,
   teamColor,
   draggable,
+  isCaptain,
   onDragStart,
   onRemove,
   removeAriaLabel,
+  onToggleCaptain,
+  captainAriaLabel,
 }: {
   name: string;
   avatarIcon: string | null;
   teamColor: string;
   draggable: boolean;
+  isCaptain: boolean;
   onDragStart?: (e: React.DragEvent) => void;
   onRemove?: () => void;
   removeAriaLabel: string;
+  /** Owner-only: tap the ★ to mark/unmark captain. Absent for members. */
+  onToggleCaptain?: () => void;
+  captainAriaLabel: string;
 }) {
   return (
     <div
@@ -683,6 +732,35 @@ function PlayerRow({
       <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--color-bt-text)" }}>
         {name}
       </span>
+
+      {/* Captain ★ — owner taps to mark/unmark (filled = captain, outline = not);
+          a member sees only the filled ★ on the captain, read-only. One per team
+          (the server clears the prior). */}
+      {onToggleCaptain ? (
+        <button
+          type="button"
+          onClick={onToggleCaptain}
+          aria-label={captainAriaLabel}
+          aria-pressed={isCaptain}
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+          style={{ color: isCaptain ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+          data-testid="captain-toggle"
+        >
+          <Star size={15} fill={isCaptain ? "currentColor" : "none"} />
+        </button>
+      ) : (
+        isCaptain && (
+          <span
+            className="flex h-7 w-7 flex-shrink-0 items-center justify-center"
+            style={{ color: "var(--color-bt-accent)" }}
+            aria-label={`${name} is captain`}
+            title="Captain"
+          >
+            <Star size={15} fill="currentColor" />
+          </span>
+        )
+      )}
+
       {onRemove && (
         <button
           type="button"

--- a/src/server/routers/teamAssignments.captain.test.ts
+++ b/src/server/routers/teamAssignments.captain.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Captain (Rosters PR b) — teamAssignments.setCaptain + the atomic plpgsql swap
+ * (migration 064). Owner-gated, one-captain-per-team, target-must-be-on-team.
+ */
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let ownerId: string;
+let memberId: string;
+let plannerId: string;
+
+async function captainsOf(teamId: string): Promise<string[]> {
+  const { data } = await ctx.admin
+    .from("team_assignments")
+    .select("user_id")
+    .eq("team_id", teamId)
+    .eq("is_captain", true);
+  return (data ?? []).map((r) => r.user_id as string);
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  ownerId = ctx.user.id;
+  tripId = await ctx.createTrip("Captain Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // co_admin — NOT owner
+  await ctx.addTripMember(tripId, "member", "Member");
+  memberId = ctx.getUser("member").id;
+  plannerId = ctx.getUser("planner").id;
+  competitionId = await ctx.createCompetition(tripId, "Captain Cup");
+  teamA = await ctx.createTeam(competitionId, "Alpha", { shortName: "ALP" });
+  teamB = await ctx.createTeam(competitionId, "Bravo", { shortName: "BRV" });
+  // owner + member on A, planner on B
+  await ctx.admin.from("team_assignments").insert([
+    { competition_id: competitionId, user_id: ownerId, team_id: teamA },
+    { competition_id: competitionId, user_id: memberId, team_id: teamA },
+    { competition_id: competitionId, user_id: plannerId, team_id: teamB },
+  ]);
+}, 30000);
+
+afterAll(async () => {
+  await ctx.admin.from("team_assignments").delete().eq("competition_id", competitionId);
+  await ctx.cleanup();
+}, 30000);
+
+describe("teamAssignments.setCaptain", () => {
+  it("owner sets a captain; setting another on the same team CLEARS the first (one per team)", async () => {
+    await ctx.caller().teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: memberId, isCaptain: true });
+    expect(await captainsOf(teamA)).toEqual([memberId]);
+
+    await ctx.caller().teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: ownerId, isCaptain: true });
+    expect(await captainsOf(teamA)).toEqual([ownerId]); // member cleared — exactly one
+  });
+
+  it("unmark clears just that captain (team left with none)", async () => {
+    await ctx.caller().teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: ownerId, isCaptain: false });
+    expect(await captainsOf(teamA)).toEqual([]);
+  });
+
+  it("target must be assigned to the team", async () => {
+    // plannerId is on team B, not A
+    await expect(
+      ctx.caller().teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: plannerId, isCaptain: true })
+    ).rejects.toThrow();
+    expect(await captainsOf(teamA)).toEqual([]); // unchanged
+  });
+
+  it("owner-only: a co-admin (Organizer) and a plain member cannot set captain", async () => {
+    await expect(
+      ctx.callerAs("planner").teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: memberId, isCaptain: true })
+    ).rejects.toThrow();
+    await expect(
+      ctx.callerAs("member").teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: memberId, isCaptain: true })
+    ).rejects.toThrow();
+    expect(await captainsOf(teamA)).toEqual([]); // neither write landed
+  });
+
+  it("captains are independent per team (N-team)", async () => {
+    await ctx.caller().teamAssignments.setCaptain({ tripId, competitionId, teamId: teamA, userId: memberId, isCaptain: true });
+    await ctx.caller().teamAssignments.setCaptain({ tripId, competitionId, teamId: teamB, userId: plannerId, isCaptain: true });
+    expect(await captainsOf(teamA)).toEqual([memberId]);
+    expect(await captainsOf(teamB)).toEqual([plannerId]);
+  });
+});

--- a/src/server/routers/teamAssignments.ts
+++ b/src/server/routers/teamAssignments.ts
@@ -104,4 +104,40 @@ export const teamAssignmentsRouter = router({
 
       return { success: true };
     }),
+
+  // -----------------------------------------------------------------------
+  // setCaptain — mark/unmark a player as their team's captain (Owner only).
+  // Appointing a captain is a STRUCTURE act (the owner appoints; the captain
+  // doesn't pass it on). Delegates to the atomic plpgsql swap (migration 064):
+  // isCaptain=true clears the team's prior captain then sets this one (one per
+  // team, declaratively enforced); isCaptain=false unmarks just this user.
+  // Throws if the target isn't assigned to the team.
+  // -----------------------------------------------------------------------
+  setCaptain: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        competitionId: z.string(),
+        teamId: z.string(),
+        userId: z.string(),
+        isCaptain: z.boolean(),
+      })
+    )
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase.rpc("set_team_captain", {
+        p_trip_id: input.tripId,
+        p_competition_id: input.competitionId,
+        p_team_id: input.teamId,
+        p_user_id: input.userId,
+        p_is_captain: input.isCaptain,
+      });
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to set captain: ${error.message}`,
+        });
+      }
+      return { success: true };
+    }),
 });

--- a/supabase/migrations/20260623120000_064_team_captain.sql
+++ b/supabase/migrations/20260623120000_064_team_captain.sql
@@ -1,0 +1,74 @@
+-- 064 — Team captain (Rosters PR b): the captain flag + atomic setter.
+--
+-- Captain is a PERMISSION TIER, not just a badge. Team data splits two ways:
+--   structure (owner-only): create/delete teams, assign/remove players;
+--   identity  (owner OR the team's captain): name, short name, color.
+-- This migration adds the flag the identity tier keys off and the owner-gated,
+-- atomic setter. The identity-edit re-gating (teams.update) is the next PR (b2).
+--
+-- is_captain lives on team_assignments (not a pointer on teams): captaincy is a
+-- property of THIS user's membership on THIS team, and rides the assignment's
+-- lifecycle — unassign the player and the captaincy goes with the row.
+
+ALTER TABLE public.team_assignments
+  ADD COLUMN IF NOT EXISTS is_captain boolean NOT NULL DEFAULT false;
+
+-- One captain per team, enforced declaratively. The partial predicate lets every
+-- non-captain row coexist while capping is_captain=true at one per (comp, team).
+CREATE UNIQUE INDEX IF NOT EXISTS team_assignments_one_captain_per_team
+  ON public.team_assignments (competition_id, team_id)
+  WHERE is_captain;
+
+-- ── set_team_captain — owner-only, ATOMIC ────────────────────────────────────
+-- Appointing a captain is a structure act (the owner appoints; the captain does
+-- not pass it on), so this is owner-gated via assert_competition_owner (mig 063).
+-- SECURITY DEFINER for the one atomic swap; the internal owner check closes the
+-- direct-PostgREST hole that DEFINER + EXECUTE-to-authenticated would open.
+--
+-- p_is_captain = true  → make p_user_id the captain: CLEAR the team's current
+--   captain first, then SET — so the one-per-team unique index never sees two.
+-- p_is_captain = false → unmark JUST p_user_id (never touches a different
+--   captain). Tapping the current ★ off leaves the team with no captain (allowed).
+-- Throws if the target isn't assigned to the team.
+CREATE OR REPLACE FUNCTION public.set_team_captain(
+  p_trip_id text,
+  p_competition_id text,
+  p_team_id text,
+  p_user_id text,
+  p_is_captain boolean
+)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  PERFORM public.assert_competition_owner(p_trip_id, p_competition_id);
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.team_assignments
+    WHERE competition_id = p_competition_id AND team_id = p_team_id AND user_id = p_user_id
+  ) THEN
+    RAISE EXCEPTION 'User % is not assigned to team %', p_user_id, p_team_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF p_is_captain THEN
+    -- Atomic swap: clear the prior captain, then set the new one.
+    UPDATE public.team_assignments
+      SET is_captain = false
+      WHERE competition_id = p_competition_id AND team_id = p_team_id AND is_captain;
+    UPDATE public.team_assignments
+      SET is_captain = true
+      WHERE competition_id = p_competition_id AND team_id = p_team_id AND user_id = p_user_id;
+  ELSE
+    -- Unmark only this user (leaves any other captain alone — though one-per-team
+    -- means there isn't one; defensive).
+    UPDATE public.team_assignments
+      SET is_captain = false
+      WHERE competition_id = p_competition_id AND team_id = p_team_id AND user_id = p_user_id;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_team_captain(text, text, text, text, boolean) TO authenticated;


### PR DESCRIPTION
Captain isn't just a badge — it's a **permission tier** (the Ryder-Cup-buddies model: the owner builds the skeleton, each captain names + colors their own squad). Team data splits **structure** (owner-only) vs **identity** (owner OR the team's captain). **PR b1** lays the foundation — the flag, the owner-gated atomic setter, and the ★. **PR b2** (follow-up) is the identity-edit re-gating + the leaderboard-tap captain entry point.

## Phase 0 (reported + confirmed)
`team_assignments` had no captain; `is_captain` belongs there (rides the membership lifecycle). Partial unique index > trigger. Owner-only sets captain. `is_captain` reaches the client free — both `teamAssignments.list` and `faceBootstrap` already `select("*")`.

## What's in b1
- **Migration 064** — `team_assignments.is_captain boolean not null default false` + `team_assignments_one_captain_per_team` **partial unique index** `(competition_id, team_id) WHERE is_captain` (declarative one-per-team). `set_team_captain` — an **atomic plpgsql swap** (clear prior captain → set new, so the index never sees two), owner-guarded via `assert_competition_owner` (mig 063), throws if the target isn't on the team.
- **`teamAssignments.setCaptain`** — owner-gated (`requireTripRole("Owner")`) wrapper over the RPC. `isCaptain=true` clears the team's prior captain then sets; `false` unmarks just that user (team may have no captain).
- **The ★** in the Rosters overlay player rows — owner taps to mark/unmark (filled = captain, **accent token, never hardcoded**); a member sees the filled ★ **read-only**. Optimistic, with `faceBootstrap` invalidated so it survives an overlay reopen (#10).

## Tests (5, green)
set→swap clears prior (one per team), unmark clears just that user, target-must-be-on-team throws, **owner-only** (co_admin + member rejected), N-team independent captains.

## Verified by eye (Test Competition, owner)
★ on every player row; set Zach captain (persisted to DB), then set his teammate Rob → **Zach cleared** (one-per-team, confirmed in UI *and* DB); the other team's players unaffected. Cleared the captain after, leaving Test Competition tidy.

`tsc` + lint clean. Migration applied via raw `execute_sql`; CI's `db push` records it (no apply-timestamp mismatch).

**PR b2 next:** `teams.update` re-gated `isOwner || isCaptainOf(team)` (new `requireTeamIdentityEdit` middleware), `TeamSheet` open gated the same, the leaderboard team-name tap → captain-scoped identity editor with a graceful read-only fallback. Structure stays owner-only.

Refs #446.