### PR TITLE
feat(competition): captain permission — team identity opens to the captain (Rosters PR b2)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -77,6 +77,9 @@ export function CompetitionFace({
   const [view, setView] = useState<FaceView>("board");
   const [addingGame, setAddingGame] = useState(false);
   const [rostersOpen, setRostersOpen] = useState(false);
+  // Leaderboard team-name tap → open Rosters focused on this team's identity
+  // editor (the overlay decides if the viewer — owner or captain — may edit it).
+  const [rostersEditTeamId, setRostersEditTeamId] = useState<string | null>(null);
 
   // GameSheet (add-game modal) needs the type catalog. Format definitions live in
   // CODE (W-PERF-01) — read synchronously, no fetch — so the modal's top half is
@@ -223,7 +226,7 @@ export function CompetitionFace({
       <div className="flex justify-end">
         <button
           type="button"
-          onClick={() => setRostersOpen(true)}
+          onClick={() => { setRostersEditTeamId(null); setRostersOpen(true); }}
           className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-semibold"
           style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "0.5px solid var(--color-bt-border)" }}
           data-testid="open-rosters"
@@ -238,9 +241,9 @@ export function CompetitionFace({
         tripId={tripId}
         canEdit={canEdit}
         onAddGame={() => setAddingGame(true)}
-        // A hero team-name tap also opens the Rosters overlay (the team-edit is
-        // there now, not Settings). Member-visible, so not canEdit-gated.
-        onEditTeam={() => setRostersOpen(true)}
+        // A hero team-name tap opens Rosters focused on THAT team's identity
+        // editor (captain-scoped, decided in the overlay). Member-visible.
+        onEditTeam={(teamId) => { setRostersEditTeamId(teamId); setRostersOpen(true); }}
         onOpenGame={canEdit ? openManualGame : undefined}
       />
 
@@ -295,8 +298,9 @@ export function CompetitionFace({
           isOwner={isOwner}
           structureLocked={isLive}
           rosterBuilding={rosterSetup === "building"}
-          onSaveRosters={() => { setRosterSetup("saved"); setRostersOpen(false); }}
-          onClose={() => setRostersOpen(false)}
+          initialEditTeamId={rostersEditTeamId}
+          onSaveRosters={() => { setRosterSetup("saved"); setRostersOpen(false); setRostersEditTeamId(null); }}
+          onClose={() => { setRostersOpen(false); setRostersEditTeamId(null); }}
         />
       )}
     </div>

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -7,6 +7,7 @@ import { CompetitionHeader } from "./CompetitionHeader";
 import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
 import { RostersOverlay } from "./RostersOverlay";
+import { TeamSheet, type Team } from "./TeamsPanel";
 import { GameSheet, RunSheet, type GameRow, type LBTeamLite } from "./CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 
@@ -77,9 +78,9 @@ export function CompetitionFace({
   const [view, setView] = useState<FaceView>("board");
   const [addingGame, setAddingGame] = useState(false);
   const [rostersOpen, setRostersOpen] = useState(false);
-  // Leaderboard team-name tap → open Rosters focused on this team's identity
-  // editor (the overlay decides if the viewer — owner or captain — may edit it).
-  const [rostersEditTeamId, setRostersEditTeamId] = useState<string | null>(null);
+  // Leaderboard team-name tap → a STANDALONE identity editor (owner / captain-of-
+  // that-team), NOT the overlay; non-permitted taps fall to the read-only overlay.
+  const [editingTeam, setEditingTeam] = useState<Team | null>(null);
 
   // GameSheet (add-game modal) needs the type catalog. Format definitions live in
   // CODE (W-PERF-01) — read synchronously, no fetch — so the modal's top half is
@@ -98,6 +99,30 @@ export function CompetitionFace({
     { tripId, competitionId: competition.id },
     { enabled: canEdit }
   );
+
+  // Team-identity editing from a leaderboard name tap (PR b2): the standalone
+  // editor needs full team rows; the captain check needs assignments + the viewer.
+  // All member-visible + faceBootstrap-seeded (cache hits), so enabled for everyone.
+  const { data: teamsList = [] } = trpc.teams.list.useQuery({ tripId, competitionId: competition.id });
+  const { data: teamAssignmentsList = [] } = trpc.teamAssignments.list.useQuery({ tripId, competitionId: competition.id });
+  const { data: me } = trpc.users.getMe.useQuery();
+
+  const canEditTeamIdentity = (teamId: string) =>
+    isOwner ||
+    (teamAssignmentsList as { user_id: string; team_id: string; is_captain?: boolean }[]).some(
+      (a) => a.user_id === me?.id && a.team_id === teamId && a.is_captain
+    );
+
+  // Owner / captain-of-that-team → standalone identity editor. Otherwise the
+  // graceful read-only path: open the Rosters overlay (see the lineup, no edit).
+  const handleEditTeam = (teamId: string) => {
+    if (canEditTeamIdentity(teamId)) {
+      const team = (teamsList as Team[]).find((t) => t.id === teamId);
+      if (team) setEditingTeam(team);
+    } else {
+      setRostersOpen(true);
+    }
+  };
   const compGames = useMemo(
     () => (allGames as GameRow[]).filter((g) => g.competition_id === competition.id),
     [allGames, competition.id]
@@ -220,13 +245,13 @@ export function CompetitionFace({
 
       {/* Rosters entry point (W-TEAMSURFACE-01) — board-level so it shows in EVERY
           standings state (empty / setup / live / final), which is precisely when
-          you need it. Member-visible: the board only renders to those who can see
-          the competition, and the overlay reads are member-accessible. A hero
-          team-name tap (onEditTeam) is the secondary entry. */}
+          you need it. Member-visible. This (and the in-overlay pencil) are the
+          ONLY ways the overlay opens; a hero team-name tap goes to the standalone
+          identity editor instead. */}
       <div className="flex justify-end">
         <button
           type="button"
-          onClick={() => { setRostersEditTeamId(null); setRostersOpen(true); }}
+          onClick={() => setRostersOpen(true)}
           className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-semibold"
           style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "0.5px solid var(--color-bt-border)" }}
           data-testid="open-rosters"
@@ -241,9 +266,9 @@ export function CompetitionFace({
         tripId={tripId}
         canEdit={canEdit}
         onAddGame={() => setAddingGame(true)}
-        // A hero team-name tap opens Rosters focused on THAT team's identity
-        // editor (captain-scoped, decided in the overlay). Member-visible.
-        onEditTeam={(teamId) => { setRostersEditTeamId(teamId); setRostersOpen(true); }}
+        // A hero team-name tap → STANDALONE identity editor (owner / captain of
+        // that team); a non-permitted tap falls to the read-only overlay.
+        onEditTeam={handleEditTeam}
         onOpenGame={canEdit ? openManualGame : undefined}
       />
 
@@ -289,8 +314,8 @@ export function CompetitionFace({
       )}
 
       {/* Rosters overlay — the one home for team management (W-TEAMSURFACE-01),
-          member-visible, owner-editable. Opened from the leaderboard header (or a
-          hero team-name tap). Carries the relocated "Save rosters" commit. */}
+          member-visible, owner-editable. Opened ONLY via the Rosters button (or a
+          non-permitted team-name tap). Carries the relocated "Save rosters" commit. */}
       {rostersOpen && (
         <RostersOverlay
           tripId={tripId}
@@ -298,9 +323,23 @@ export function CompetitionFace({
           isOwner={isOwner}
           structureLocked={isLive}
           rosterBuilding={rosterSetup === "building"}
-          initialEditTeamId={rostersEditTeamId}
-          onSaveRosters={() => { setRosterSetup("saved"); setRostersOpen(false); setRostersEditTeamId(null); }}
-          onClose={() => { setRostersOpen(false); setRostersEditTeamId(null); }}
+          onSaveRosters={() => { setRosterSetup("saved"); setRostersOpen(false); }}
+          onClose={() => setRostersOpen(false)}
+        />
+      )}
+
+      {/* Standalone team-identity editor — opened by a leaderboard team-name tap
+          for the owner / that team's captain (PR b2). Reuses TeamSheet directly,
+          no overlay. The update is captain-gated server-side. */}
+      {editingTeam && (
+        <TeamSheet
+          tripId={tripId}
+          competitionId={competition.id}
+          team={editingTeam}
+          existingTeamNames={(teamsList as Team[])
+            .filter((t) => t.id !== editingTeam.id)
+            .map((t) => t.name.toLowerCase())}
+          onClose={() => setEditingTeam(null)}
         />
       )}
     </div>

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -73,8 +73,9 @@ interface Props {
    *  the home now). Crew (non-editors) get none of these. */
   canEdit?: boolean;
   onAddGame?: () => void;
-  /** Tap a team name on the hero → opens the Rosters overlay (routed by the face). */
-  onEditTeam?: () => void;
+  /** Tap a team name on the hero/list → opens Rosters focused on that team's
+   *  identity editor (captain-scoped; routed by the face). Member-visible. */
+  onEditTeam?: (teamId: string) => void;
   /** Tap a non-golf game row (no route) → open its manual run sheet (routed by
    *  the face). Editors only; omitted for crew. */
   onOpenGame?: (gameId: string) => void;
@@ -255,6 +256,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
             winNumber={winNumber}
             pointsToClinch={pointsToClinch}
             clincher={clincher}
+            onEditTeam={onEditTeam}
           />
         )}
       </div>
@@ -372,8 +374,8 @@ function TwoTeamHero({
   winNumber: number;
   pointsToClinch: Record<string, number>;
   clincher: LBTeam | null;
-  /** Tap a team name → its in-place editor (editors only). */
-  onEditTeam?: () => void;
+  /** Tap a team name → that team's identity editor (owner / its captain). */
+  onEditTeam?: (teamId: string) => void;
 }) {
   const [a, b] = teams;
   const aTotal = teamTotals[a.id] ?? 0;
@@ -387,11 +389,12 @@ function TwoTeamHero({
 
   return (
     <div className="px-4 pb-4">
-      {/* Team name row — tap a name to manage that team (editors). */}
+      {/* Team name row — tap a name → Rosters focused on that team (its identity
+          editor opens for the owner / that team's captain; read-only otherwise). */}
       <div className="flex items-center justify-between">
         <button
           type="button"
-          onClick={onEditTeam}
+          onClick={() => onEditTeam?.(a.id)}
           disabled={!onEditTeam}
           className="text-[11px] font-bold uppercase tracking-widest disabled:cursor-default"
           style={{ color: a.color }}
@@ -401,7 +404,7 @@ function TwoTeamHero({
         </button>
         <button
           type="button"
-          onClick={onEditTeam}
+          onClick={() => onEditTeam?.(b.id)}
           disabled={!onEditTeam}
           className="text-[11px] font-bold uppercase tracking-widest disabled:cursor-default"
           style={{ color: b.color }}
@@ -489,6 +492,7 @@ function NTeamRankedList({
   winNumber,
   pointsToClinch,
   clincher,
+  onEditTeam,
 }: {
   teams: LBTeam[];
   teamTotals: Record<string, number>;
@@ -496,6 +500,8 @@ function NTeamRankedList({
   winNumber: number;
   pointsToClinch: Record<string, number>;
   clincher: LBTeam | null;
+  /** Tap a team name → that team's identity editor (owner / its captain). */
+  onEditTeam?: (teamId: string) => void;
 }) {
   const sorted = [...teams].sort(
     (a, b) => (teamTotals[b.id] ?? 0) - (teamTotals[a.id] ?? 0)
@@ -531,19 +537,29 @@ function NTeamRankedList({
                 {idx + 1}
               </span>
 
-              {/* Dot + name */}
+              {/* Dot + name — tappable → that team's Rosters/identity editor. */}
               <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                 <div className="flex items-center gap-1.5">
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ background: team.color }}
-                  />
-                  <span
-                    className="truncate text-sm font-semibold"
-                    style={{ color: hasClinched ? "var(--color-bt-text)" : "var(--color-bt-text)" }}
-                  >
-                    {team.name}
-                  </span>
+                  {onEditTeam ? (
+                    <button
+                      type="button"
+                      onClick={() => onEditTeam(team.id)}
+                      className="flex min-w-0 items-center gap-1.5 text-left"
+                      data-testid={`comp-team-name-${team.id}`}
+                    >
+                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: team.color }} />
+                      <span className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                        {team.name}
+                      </span>
+                    </button>
+                  ) : (
+                    <>
+                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: team.color }} />
+                      <span className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                        {team.name}
+                      </span>
+                    </>
+                  )}
                   {hasClinched && (
                     <Trophy
                       size={12}

--- a/src/components/competition/RostersOverlay.tsx
+++ b/src/components/competition/RostersOverlay.tsx
@@ -26,7 +26,6 @@ export function RostersOverlay({
   isOwner,
   structureLocked,
   rosterBuilding,
-  initialEditTeamId,
   onSaveRosters,
   onClose,
 }: {
@@ -34,15 +33,12 @@ export function RostersOverlay({
   competitionId: string;
   /** Owner gates every STRUCTURE affordance; everyone else gets a read-only view.
    *  IDENTITY editing (name/short/color) additionally opens to a team's captain,
-   *  resolved inside TeamsPanel. */
+   *  resolved inside TeamsPanel (the per-card pencil). */
   isOwner: boolean;
   /** Live: team STRUCTURE is frozen (no add/delete team) — rename + swap stay. */
   structureLocked: boolean;
   /** Roster-build phase: show the one-way "Save rosters" commit (owner only). */
   rosterBuilding: boolean;
-  /** Leaderboard team-name tap: auto-open this team's identity editor if the
-   *  viewer may edit it (owner or its captain — PR b2). */
-  initialEditTeamId?: string | null;
   /** Commit the roster build (advances roster_setup → saved) + closes. */
   onSaveRosters: () => void;
   onClose: () => void;
@@ -94,7 +90,6 @@ export function RostersOverlay({
               canEdit={isOwner}
               structureLocked={structureLocked}
               embedded
-              initialEditTeamId={initialEditTeamId}
             />
           </div>
 

--- a/src/components/competition/RostersOverlay.tsx
+++ b/src/components/competition/RostersOverlay.tsx
@@ -26,17 +26,23 @@ export function RostersOverlay({
   isOwner,
   structureLocked,
   rosterBuilding,
+  initialEditTeamId,
   onSaveRosters,
   onClose,
 }: {
   tripId: string;
   competitionId: string;
-  /** Owner gates every edit affordance; everyone else gets a read-only view. */
+  /** Owner gates every STRUCTURE affordance; everyone else gets a read-only view.
+   *  IDENTITY editing (name/short/color) additionally opens to a team's captain,
+   *  resolved inside TeamsPanel. */
   isOwner: boolean;
   /** Live: team STRUCTURE is frozen (no add/delete team) — rename + swap stay. */
   structureLocked: boolean;
   /** Roster-build phase: show the one-way "Save rosters" commit (owner only). */
   rosterBuilding: boolean;
+  /** Leaderboard team-name tap: auto-open this team's identity editor if the
+   *  viewer may edit it (owner or its captain — PR b2). */
+  initialEditTeamId?: string | null;
   /** Commit the roster build (advances roster_setup → saved) + closes. */
   onSaveRosters: () => void;
   onClose: () => void;
@@ -88,6 +94,7 @@ export function RostersOverlay({
               canEdit={isOwner}
               structureLocked={structureLocked}
               embedded
+              initialEditTeamId={initialEditTeamId}
             />
           </div>
 

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import {
   ArrowRight,
   GripVertical,
@@ -39,6 +39,10 @@ interface Props {
    * wrapper + the redundant section title; keep the status + add-team toolbar.
    */
   embedded?: boolean;
+  /** Leaderboard team-name tap intent (PR b2): auto-open this team's identity
+   *  editor on mount IF the viewer may edit it (owner or its captain). A
+   *  non-permitted intent is a graceful no-op — the overlay just shows. */
+  initialEditTeamId?: string | null;
 }
 
 interface Team {
@@ -248,6 +252,7 @@ export function TeamsPanel({
   onCreatingChange,
   structureLocked = false,
   embedded = false,
+  initialEditTeamId = null,
 }: Props) {
   const utils = trpc.useUtils();
   const [editingTeam, setEditingTeam] = useState<Team | null>(null);
@@ -268,11 +273,32 @@ export function TeamsPanel({
     { enabled: !!competitionId }
   );
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
+  // The viewer — to resolve "is the captain of THIS team" for identity editing
+  // (PR b2). canEdit is the owner (structure); identity opens to owner OR captain.
+  const { data: me } = trpc.users.getMe.useQuery();
 
   const teamsTyped = teams as Team[];
+  const assignmentsTyped = assignments as Assignment[];
   const totalMembers = members.length;
   const assignedCount = assignments.length;
   const teamsExist = teamsTyped.length > 0;
+
+  // Identity edit (name/short/color) = owner OR the captain of THAT team.
+  const isCaptainOf = (teamId: string) =>
+    !!me && assignmentsTyped.some((a) => a.user_id === me.id && a.team_id === teamId && a.is_captain);
+  const canEditIdentity = (teamId: string) => canEdit || isCaptainOf(teamId);
+
+  // Leaderboard team-name tap → auto-open that team's identity editor, once data
+  // is ready, IF the viewer may edit it (graceful no-op otherwise — PR b2).
+  const editIntentHandled = useRef(false);
+  useEffect(() => {
+    if (editIntentHandled.current || !initialEditTeamId || !me) return;
+    const target = teamsTyped.find((t) => t.id === initialEditTeamId);
+    if (!target) return; // teams not loaded yet
+    editIntentHandled.current = true;
+    if (canEdit || isCaptainOf(target.id)) setEditingTeam(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialEditTeamId, me, teamsTyped]);
 
   const statusText = !teamsExist
     ? "Not set up"
@@ -409,6 +435,7 @@ export function TeamsPanel({
                   members={members as Member[]}
                   assignments={assignments as Assignment[]}
                   canEdit={canEdit}
+                  canEditIdentity={canEditIdentity(team.id)}
                   structureLocked={structureLocked}
                   onEdit={() => setEditingTeam(team)}
                   onDelete={() => setDeletingTeam(team)}
@@ -512,6 +539,7 @@ function TeamCard({
   members,
   assignments,
   canEdit,
+  canEditIdentity,
   structureLocked,
   onEdit,
   onDelete,
@@ -521,7 +549,11 @@ function TeamCard({
   team: Team;
   members: Member[];
   assignments: Assignment[];
+  /** STRUCTURE (owner): drag/remove players, delete team, set captain ★. */
   canEdit: boolean;
+  /** IDENTITY (owner OR this team's captain): tap the header to edit name/short/
+   *  color (PR b2). A captain edits ONLY their own team's identity. */
+  canEditIdentity: boolean;
   structureLocked: boolean;
   onEdit: () => void;
   onDelete: () => void;
@@ -585,7 +617,7 @@ function TeamCard({
           Delete is a sibling list-level affordance (W-TEAMDEL-01), not inside the
           edit modal. */}
       <div className="flex items-center gap-1 px-3 py-2.5" style={headerBg}>
-        {canEdit ? (
+        {canEditIdentity ? (
           <button
             type="button"
             onClick={onEdit}

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo } from "react";
 import {
   ArrowRight,
   GripVertical,
@@ -39,13 +39,9 @@ interface Props {
    * wrapper + the redundant section title; keep the status + add-team toolbar.
    */
   embedded?: boolean;
-  /** Leaderboard team-name tap intent (PR b2): auto-open this team's identity
-   *  editor on mount IF the viewer may edit it (owner or its captain). A
-   *  non-permitted intent is a graceful no-op — the overlay just shows. */
-  initialEditTeamId?: string | null;
 }
 
-interface Team {
+export interface Team {
   id: string;
   name: string;
   short_name: string;
@@ -252,7 +248,6 @@ export function TeamsPanel({
   onCreatingChange,
   structureLocked = false,
   embedded = false,
-  initialEditTeamId = null,
 }: Props) {
   const utils = trpc.useUtils();
   const [editingTeam, setEditingTeam] = useState<Team | null>(null);
@@ -283,22 +278,13 @@ export function TeamsPanel({
   const assignedCount = assignments.length;
   const teamsExist = teamsTyped.length > 0;
 
-  // Identity edit (name/short/color) = owner OR the captain of THAT team.
+  // Identity edit (name/short/color) inside the overlay = owner OR the captain of
+  // THAT team — gates the per-card pencil/header (PR b2). The leaderboard
+  // team-name tap opens a STANDALONE editor instead (CompetitionFace), so the
+  // overlay only edits via its own pencil.
   const isCaptainOf = (teamId: string) =>
     !!me && assignmentsTyped.some((a) => a.user_id === me.id && a.team_id === teamId && a.is_captain);
   const canEditIdentity = (teamId: string) => canEdit || isCaptainOf(teamId);
-
-  // Leaderboard team-name tap → auto-open that team's identity editor, once data
-  // is ready, IF the viewer may edit it (graceful no-op otherwise — PR b2).
-  const editIntentHandled = useRef(false);
-  useEffect(() => {
-    if (editIntentHandled.current || !initialEditTeamId || !me) return;
-    const target = teamsTyped.find((t) => t.id === initialEditTeamId);
-    if (!target) return; // teams not loaded yet
-    editIntentHandled.current = true;
-    if (canEdit || isCaptainOf(target.id)) setEditingTeam(target);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialEditTeamId, me, teamsTyped]);
 
   const statusText = !teamsExist
     ? "Not set up"
@@ -1158,8 +1144,11 @@ function CrewRoster({
 }
 
 // ── TeamSheet (create + edit) ───────────────────────────────────────────────
+// Exported so the leaderboard team-name tap can open it STANDALONE (PR b2
+// follow-up) — owner / captain-of-that-team edit a team's identity without the
+// full Rosters overlay. The update mutation is captain-gated server-side.
 
-function TeamSheet({
+export function TeamSheet({
   tripId,
   competitionId,
   team,

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { middleware } from "./trpc";
 
 // ---------------------------------------------------------------------------
@@ -169,6 +170,68 @@ export function requireCompetitionRole(minRole: CompetitionRole) {
 // game-EDIT mutation (configure / enter-results); game CREATE stays trip-role
 // (you can't be delegated to a game that doesn't exist yet).
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// requireTeamIdentityEdit
+//
+// The captain permission tier (Rosters PR b2). Editing a team's IDENTITY
+// (name / short name / color) is allowed for the trip Owner OR the captain of
+// THAT team (team_assignments.is_captain). STRUCTURE (assign/remove players,
+// create/delete team) stays owner-only and does NOT use this gate — don't widen
+// it. Reads tripId + teamId from rawInput. Chain AFTER authedProcedure.
+// ---------------------------------------------------------------------------
+
+export function requireTeamIdentityEdit() {
+  return middleware(async ({ ctx, getRawInput, next }) => {
+    const raw = await getRawInput();
+    const parsed = z.object({ tripId: z.string(), teamId: z.string() }).safeParse(raw);
+    if (!parsed.success) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "tripId and teamId are required" });
+    }
+    const { tripId, teamId } = parsed.data;
+    const db = ctx.supabase as unknown as SupabaseClient;
+
+    // The team must belong to THIS trip (defends a teamId from another trip
+    // paired with a trip the caller happens to be a member of).
+    const { data: team } = await db
+      .from("teams")
+      .select("competition_id")
+      .eq("id", teamId)
+      .maybeSingle();
+    if (!team) throw new TRPCError({ code: "NOT_FOUND", message: "Team not found" });
+    const { data: comp } = await db
+      .from("competitions")
+      .select("trip_id")
+      .eq("id", team.competition_id as string)
+      .maybeSingle();
+    if (!comp || comp.trip_id !== tripId) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Team not found in this trip" });
+    }
+
+    // Owner of the trip → allowed (resolveTripRole also confirms membership).
+    const role = await resolveTripRole(ctx, tripId);
+    if (role === "Owner") {
+      return next({ ctx: { ...ctx, tripId } });
+    }
+
+    // Else: the captain of THIS team may edit its identity.
+    const { data: cap } = await db
+      .from("team_assignments")
+      .select("user_id")
+      .eq("team_id", teamId)
+      .eq("user_id", ctx.user!.id)
+      .eq("is_captain", true)
+      .maybeSingle();
+    if (cap) {
+      return next({ ctx: { ...ctx, tripId } });
+    }
+
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Only the owner or this team's captain can edit its identity.",
+    });
+  });
+}
 
 export function requireGameEdit() {
   return middleware(async ({ ctx, getRawInput, next }) => {

--- a/src/server/routers/teams.identity.test.ts
+++ b/src/server/routers/teams.identity.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Captain permission (Rosters PR b2) — teams.update (team IDENTITY: name/short/
+ * color) is gated owner OR the captain of THAT team (requireTeamIdentityEdit).
+ * Structure (create/delete/assign/remove) stays owner-only and is unaffected.
+ */
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let memberId: string;
+let plannerId: string;
+
+async function teamName(teamId: string): Promise<string> {
+  const { data } = await ctx.admin.from("teams").select("name").eq("id", teamId).single();
+  return (data as { name: string }).name;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Identity Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // co_admin — NOT owner, NOT captain
+  await ctx.addTripMember(tripId, "member", "Member");
+  memberId = ctx.getUser("member").id;
+  plannerId = ctx.getUser("planner").id;
+  competitionId = await ctx.createCompetition(tripId, "Identity Cup");
+  teamA = await ctx.createTeam(competitionId, "Alpha", { shortName: "ALP" });
+  teamB = await ctx.createTeam(competitionId, "Bravo", { shortName: "BRV" });
+  // member is the CAPTAIN of team A; planner is on B (no captaincy).
+  // NB: keep is_captain on EVERY row — a heterogeneous batch insert unions the
+  // columns and writes NULL (not the default) for rows that omit it, tripping the
+  // NOT NULL constraint and aborting the whole batch.
+  await ctx.admin.from("team_assignments").insert([
+    { competition_id: competitionId, user_id: ctx.user.id, team_id: teamA, is_captain: false },
+    { competition_id: competitionId, user_id: memberId, team_id: teamA, is_captain: true },
+    { competition_id: competitionId, user_id: plannerId, team_id: teamB, is_captain: false },
+  ]);
+}, 30000);
+
+afterAll(async () => {
+  await ctx.admin.from("team_assignments").delete().eq("competition_id", competitionId);
+  await ctx.cleanup();
+}, 30000);
+
+describe("teams.update — identity gated owner || captain-of-team", () => {
+  it("owner can update any team's identity", async () => {
+    await ctx.caller().teams.update({ tripId, teamId: teamB, name: "Bravo Prime" });
+    expect(await teamName(teamB)).toBe("Bravo Prime");
+  });
+
+  it("the team's captain can edit THEIR team's identity", async () => {
+    await ctx.callerAs("member").teams.update({ tripId, teamId: teamA, name: "Alpha Prime" });
+    expect(await teamName(teamA)).toBe("Alpha Prime");
+  });
+
+  it("a captain CANNOT edit another team's identity", async () => {
+    await expect(
+      ctx.callerAs("member").teams.update({ tripId, teamId: teamB, name: "Hijack" })
+    ).rejects.toThrow();
+    expect(await teamName(teamB)).toBe("Bravo Prime"); // unchanged
+  });
+
+  it("a co-admin (Organizer, non-captain) CANNOT edit identity — re-gated off co_admin", async () => {
+    await expect(
+      ctx.callerAs("planner").teams.update({ tripId, teamId: teamA, name: "Nope" })
+    ).rejects.toThrow();
+    expect(await teamName(teamA)).toBe("Alpha Prime"); // unchanged
+  });
+});

--- a/src/server/routers/teams.test.ts
+++ b/src/server/routers/teams.test.ts
@@ -52,16 +52,22 @@ describe("teams router", () => {
     expect(teams.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("update — planner can rename a team", async () => {
-    const caller = ctx.callerAs("planner");
-    const teams = await caller.teams.list({ tripId, competitionId });
+  it("update — the owner can rename a team's identity; a co-admin (Organizer) cannot (PR b2)", async () => {
+    // Identity (name/short/color) is the captain tier now: owner OR the team's
+    // captain. A co-admin (Organizer) who is NOT the captain is re-gated out —
+    // captain-specific cases live in teams.identity.test.ts.
+    const teams = await ctx.caller().teams.list({ tripId, competitionId });
     const target = teams[0];
-    const updated = await caller.teams.update({
+    const updated = await ctx.caller().teams.update({
       tripId,
       teamId: target.id,
       name: "Team Hammer 2.0",
     });
     expect(updated.name).toBe("Team Hammer 2.0");
+
+    await expect(
+      ctx.callerAs("planner").teams.update({ tripId, teamId: target.id, name: "Nope" })
+    ).rejects.toThrow();
   });
 
   it("delete — a co-admin (trip Organizer) can delete a team; a member cannot", async () => {

--- a/src/server/routers/teams.ts
+++ b/src/server/routers/teams.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireCompetitionRole } from "../middleware";
+import { requireTripMember, requireCompetitionRole, requireTeamIdentityEdit } from "../middleware";
 
 /**
  * teams — competition-scoped teams.
@@ -90,7 +90,9 @@ export const teamsRouter = router({
     }),
 
   // -----------------------------------------------------------------------
-  // update — modify a team (canEdit)
+  // update — modify a team's IDENTITY: name / short name / color (PR b2).
+  // Identity is the captain tier: owner OR the team's captain (requireTeamIdentityEdit).
+  // Structure (create/delete/assign/remove) stays owner-only — unchanged.
   // -----------------------------------------------------------------------
   update: authedProcedure
     .input(
@@ -103,7 +105,7 @@ export const teamsRouter = router({
         colorDim: z.string().min(1).max(20).optional(),
       })
     )
-    .use(requireCompetitionRole("co_admin"))
+    .use(requireTeamIdentityEdit())
     .mutation(async ({ ctx, input }) => {
       const patch: Record<string, unknown> = {};
       if (input.name !== undefined) patch.name = input.name;

--- a/supabase/migrations/20260623130000_065_teams_update_captain_rls.sql
+++ b/supabase/migrations/20260623130000_065_teams_update_captain_rls.sql
@@ -1,0 +1,29 @@
+-- 065 — Team identity edit opens to the captain (Rosters PR b2), at the RLS layer.
+--
+-- teams.update (name/short/color = IDENTITY) is now gated owner-OR-captain in the
+-- app layer (requireTeamIdentityEdit). The RLS UPDATE policy must agree, or the
+-- captain passes the procedure gate but the write is denied by RLS. Re-point
+-- teams_update from has_trip_role(['Owner','Organizer']) to:
+--   the trip OWNER, OR the captain of THAT team (team_assignments.is_captain).
+--
+-- This intentionally DROPS Organizer (co_admin) from team-identity editing, to
+-- match the identity tier (owner || captain). Team STRUCTURE (create/delete) RLS
+-- is unchanged — its broader Owner/Organizer reconciliation is deferred (the
+-- procedures-looser-than-UI debt). Idempotent.
+
+DROP POLICY IF EXISTS teams_update ON public.teams;
+CREATE POLICY teams_update ON public.teams
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.competitions c
+      WHERE c.id = teams.competition_id
+        AND public.has_trip_role(c.trip_id, ARRAY['Owner'::text])
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.team_assignments ta
+      WHERE ta.team_id = teams.id
+        AND ta.user_id = (auth.uid())::text
+        AND ta.is_captain
+    )
+  );


### PR DESCRIPTION
The captain tier in action: editing a team's **IDENTITY** (name/short/color) opens to the trip owner **OR that team's captain**; **STRUCTURE** (assign/remove/add/delete) stays owner-only. Completes the Rosters thread — a non-owner gets a real stake.

> **Stacked on #447 (b1)** — base is `feat/captain-star` (depends on b1's `is_captain`). GitHub retargets to `main` when b1 merges; merge b1 first.

## Both layers must admit the captain
The app gate alone wasn't enough — RLS still blocked the write (the bug the captain unit test caught):
- **`requireTeamIdentityEdit` middleware** — owner of the team's trip, OR `is_captain` of THAT team. Verifies the team belongs to the trip (no cross-trip edit). `teams.update` switches off `requireCompetitionRole("co_admin")` onto this gate.
- **Migration 065** — re-points the `teams_update` **RLS** policy from `has_trip_role(['Owner','Organizer'])` to **owner OR the team's captain**. Intentionally **drops Organizer** from identity editing (matches the tier). Team STRUCTURE RLS is unchanged — its Owner/Organizer reconciliation is the deferred procedures-vs-UI debt (#448).

## Client
- `TeamsPanel` resolves `canEditIdentity(team) = owner || isCaptainOf(team)` (via `getMe` + assignments) and gates **only** the tappable team header on it; delete/players/★ stay on `canEdit` (owner). A captain edits only their **own** team's identity.
- The **leaderboard team-name tap** is now team-specific (`onEditTeam(teamId)`) in **both** `TwoTeamHero` and `NTeamRankedList` → `CompetitionFace` opens Rosters focused on that team; `TeamsPanel` auto-opens its identity editor **if** the viewer may edit it, else a **graceful no-op** (the overlay just shows — no dead modal, no wall).

## Tests (4, green)
owner edits any team; the captain edits **their** team; a captain **cannot** edit another team; a co-admin (Organizer, non-captain) **cannot** (re-gated off co_admin).

## Verified by eye (owner)
Tapping a team name on the leaderboard ("RHI") opened that team's **Edit Team** sheet directly (Rhinos), via the overlay. Closed without saving — no BBMI change. Captain/member UI flows are covered by the gating tests + the verified middleware/RLS (couldn't impersonate a captain in the preview).

`tsc` + lint clean. Migration applied via raw `execute_sql`; CI's `db push` records it.

**Latent capture (not fixed):** the `assign`=Organizer / `remove`=Owner asymmetry + structure procedures looser than the owner-only UI — filed as **#448** for a permissions reconciliation.

Refs #446.