### PR TITLE
perf(competition): structure/state cache cut — load structure once, keep it (alive-face Phase 1)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -51,6 +51,33 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_BUILD_DATE: buildDate,
     NEXT_PUBLIC_BUILD_SHA: buildSha,
   },
+  experimental: {
+    // ── Structure/State separation — kill the per-navigation SERVER re-resolve ──
+    //
+    // The Live face route (/trips/[id]/leaderboard) is a Server Component that
+    // resolves competitions.faceBootstrap — the whole competition STRUCTURE +
+    // standings — on the server for first paint. By default Next's Router Cache
+    // treats dynamic routes as stale immediately (dynamic: 0), so EVERY warm
+    // navigation back to the Live face (trip→live, game→back→live) re-runs the
+    // server component and re-pays that resolve. That blocking server RSC fetch is
+    // the "loading a foreign webpage every time" reload — and a long client-side
+    // (React Query) cache canNOT fix it, because the navigation waits on the RSC,
+    // not on the client query.
+    //
+    // Retaining the dynamic RSC for a window lets warm navigations REUSE the
+    // already-rendered payload — the server component does not re-run, faceBootstrap
+    // is not re-resolved — while the kept client cache (STRUCTURE_QUERY) serves the
+    // data. The SSR seed is still paid ONCE on a cold document load. Structural
+    // mutations already invalidate the client faceBootstrap cache (pattern #10) and
+    // the kept client query — not the cached RSC's stale initialData — wins on
+    // remount (initialData is ignored when the query already has data), so a real
+    // structural change still propagates. 5 min comfortably covers the rapid
+    // trip↔live↔game ping-ponging that happens in seconds; gcTime (30 min) outlives
+    // it, so the client query can't be GC'd while a cached RSC is still in play.
+    staleTimes: {
+      dynamic: 300,
+    },
+  },
 };
 
 export default nextConfig;

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useTripRole } from "@/hooks/useTripRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -63,29 +64,29 @@ export default function NewMatchGamePage() {
   const search = useSearchParams();
 
   const isId = UUID_RE.test(param);
-  const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { enabled: !isId, retry: false });
+  const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { ...STRUCTURE_QUERY, enabled: !isId, retry: false });
   const tripId = isId ? param : resolved.data?.id;
 
   const { canEdit: tripCanEdit, loading: roleLoading } = useTripRole(tripId);
   const me = useCurrentUser();
-  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
   // Competition roster (Slice D): a competition game pairs from the players
   // assigned to its teams, not the whole trip crew. Names still resolve from
-  // crew (the roster is a subset of trip members).
-  const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  // crew (the roster is a subset of trip members). All STRUCTURE — kept.
+  const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
   const competitionId = competition.data?.id as string | undefined;
   const utils = trpc.useUtils();
   const assignQ = trpc.teamAssignments.list.useQuery(
     { tripId: tripId!, competitionId: competitionId! },
-    { enabled: !!tripId && !!competitionId }
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!competitionId }
   );
   // Teams (Slice D, ordered by created_at). A Ryder-cup match binds a side to a
   // team: side A → team[0], side B → team[1]. That makes the pair picker
   // constrainable to one team (no cross-team pair) and the strip team-colored.
   const teamsQ = trpc.teams.list.useQuery(
     { tripId: tripId!, competitionId: competitionId! },
-    { enabled: !!tripId && !!competitionId }
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!competitionId }
   );
 
   const [gameId, setGameId] = useState<string | null>(search.get("game"));
@@ -113,14 +114,18 @@ export default function NewMatchGamePage() {
   const [courseName, setCourseName] = useState<string | null>(null);
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
 
-  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
-  const matchesQ = trpc.matches.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+  // game config + pairings are STRUCTURE (kept); scores are STATE (the match
+  // RESULTS within matches.listByGame change on finish/recompute, which invalidate
+  // it — not on the fast score cadence — so it caches as structure too). Only the
+  // raw scores stay short, so a reopen refreshes them while the rest is instant.
+  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
+  const matchesQ = trpc.matches.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
   // Per-game delegate (§10): a member granted as this game's organizer runs it
   // like an editor — config, pairings, score, finish. The server gate
   // (requireGameEdit) admits them; the UI must light up the same way. Trip
   // Owner/Organizer keep edit on every game; a delegate only on theirs.
-  const orgQ = trpc.games.listOrganizers.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+  const orgQ = trpc.games.listOrganizers.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
 
   // Format: the resumed game's type is authoritative; a brand-new game (no game
   // yet) reads the `?format=doubles` hint. `sided` switches the whole flow

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
@@ -41,19 +42,22 @@ export default function NewGamePage() {
   const isId = UUID_RE.test(param);
   const resolved = trpc.trips.resolveSlug.useQuery(
     { slugOrId: param },
-    { enabled: !isId, retry: false }
+    { ...STRUCTURE_QUERY, enabled: !isId, retry: false }
   );
   const tripId = isId ? param : resolved.data?.id;
   const utils = trpc.useUtils();
   const { canEdit } = useTripRole(tripId);
 
-  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
   // The game-to-resume (its roster) + its saved scores. Enabled only when we
   // arrived with ?game — the standalone "new game" flow leaves these idle.
+  // The game (config/roster) is STRUCTURE — kept; the scores are STATE — they
+  // keep the default short staleTime so a reopen refreshes them (the cut: reopen
+  // a game and the structure is instant, only the scores re-fetch).
   const gameQ = trpc.games.getById.useQuery(
     { tripId: tripId!, gameId: urlGameId! },
-    { enabled: !!tripId && !!urlGameId }
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!urlGameId }
   );
   const scoresQ = trpc.scores.listByGame.useQuery(
     { tripId: tripId!, gameId: urlGameId! },

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useTripRole } from "@/hooks/useTripRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
@@ -59,7 +60,7 @@ export default function RackNStackPage() {
   const router = useRouter();
   const search = useSearchParams();
   const isId = UUID_RE.test(param);
-  const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { enabled: !isId, retry: false });
+  const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { ...STRUCTURE_QUERY, enabled: !isId, retry: false });
   const tripId = isId ? param : resolved.data?.id;
 
   const { canEdit: tripCanEdit, loading: roleLoading } = useTripRole(tripId);
@@ -70,7 +71,7 @@ export default function RackNStackPage() {
   // Resume the trip's latest in-progress rack game so returning here (no nav
   // entry yet) lands on the SAME game instead of starting a fresh one — which
   // would look like the handicaps/scores were lost.
-  const gamesList = trpc.games.listByTrip.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const gamesList = trpc.games.listByTrip.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
   const resumeId = useMemo(() => {
     const g = (gamesList.data ?? []).find((x) => x.game_type_id === RACK && x.status !== "complete");
     return (g?.id as string | undefined) ?? null;
@@ -86,18 +87,20 @@ export default function RackNStackPage() {
   const [currentHole, setCurrentHole] = useState(1);
   const [values, setValues] = useState<ScoreValues>({});
 
-  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { enabled: !!tripId });
-  const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { enabled: !!tripId });
+  const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
+  const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
   const competitionId = competition.data?.id as string | undefined;
-  const teamsQ = trpc.teams.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { enabled: !!tripId && !!competitionId });
-  const assignQ = trpc.teamAssignments.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { enabled: !!tripId && !!competitionId });
+  const teamsQ = trpc.teams.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!competitionId });
+  const assignQ = trpc.teamAssignments.list.useQuery({ tripId: tripId!, competitionId: competitionId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!competitionId });
 
-  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
-  const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
+  // game config + foursomes are STRUCTURE (kept); only the raw scores stay short
+  // (STATE) so a reopen is instant while the scores re-fetch.
+  const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
+  const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
   // Per-game delegate (§10): this game's delegate runs it like an editor (the
   // server's requireGameEdit admits them); trip staff keep edit everywhere.
-  const orgQ = trpc.games.listOrganizers.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
+  const orgQ = trpc.games.listOrganizers.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
   const amDelegate = useMemo(
     () => !!me && (orgQ.data as { user_id: string }[] | undefined ?? []).some((o) => o.user_id === me.id),
     [orgQ.data, me]

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { ChevronLeft, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { CompetitionHeader } from "./CompetitionHeader";
 import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
@@ -94,7 +95,9 @@ export function CompetitionFace({
   // GameSheet. This restores the entry points the retired CompetitionGamesPanel
   // wired; the board only re-attaches them. Both queries are seeded by
   // faceBootstrap (cache hit — no extra waterfall) and editor-only.
-  const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { enabled: canEdit });
+  // STRUCTURE (games list) is kept (STRUCTURE_QUERY); the leaderboard is STATE —
+  // it keeps the default short staleTime + the board's own 30s poll.
+  const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { ...STRUCTURE_QUERY, enabled: canEdit });
   const { data: lb } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId: competition.id },
     { enabled: canEdit }
@@ -102,10 +105,10 @@ export function CompetitionFace({
 
   // Team-identity editing from a leaderboard name tap (PR b2): the standalone
   // editor needs full team rows; the captain check needs assignments + the viewer.
-  // All member-visible + faceBootstrap-seeded (cache hits), so enabled for everyone.
-  const { data: teamsList = [] } = trpc.teams.list.useQuery({ tripId, competitionId: competition.id });
-  const { data: teamAssignmentsList = [] } = trpc.teamAssignments.list.useQuery({ tripId, competitionId: competition.id });
-  const { data: me } = trpc.users.getMe.useQuery();
+  // All member-visible + faceBootstrap-seeded (cache hits) STRUCTURE, so kept.
+  const { data: teamsList = [] } = trpc.teams.list.useQuery({ tripId, competitionId: competition.id }, STRUCTURE_QUERY);
+  const { data: teamAssignmentsList = [] } = trpc.teamAssignments.list.useQuery({ tripId, competitionId: competition.id }, STRUCTURE_QUERY);
+  const { data: me } = trpc.users.getMe.useQuery(undefined, STRUCTURE_QUERY);
 
   const canEditTeamIdentity = (teamId: string) =>
     isOwner ||

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { Trophy, CloudOff, RefreshCw, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { GameRow, fmtPts } from "./GameRow";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -99,7 +100,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
   // sees (no filtered view). Empty for non-delegates, so the badge never shows.
   const { data: myDelegateIds = [] } = trpc.games.myDelegateGameIds.useQuery(
     { tripId },
-    { enabled: !!tripId }
+    { ...STRUCTURE_QUERY, enabled: !!tripId }
   );
   const mineSet = useMemo(
     () => new Set(myDelegateIds as string[]),
@@ -111,10 +112,10 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
   // viewer delegates render it. `getMe` + the team assignment list are both cheap
   // + cached. teamColor is null when the viewer isn't on a team → Avatar falls
   // back to its accent ("you") treatment.
-  const { data: me } = trpc.users.getMe.useQuery();
+  const { data: me } = trpc.users.getMe.useQuery(undefined, STRUCTURE_QUERY);
   const { data: assignments = [] } = trpc.teamAssignments.list.useQuery(
     { tripId, competitionId },
-    { enabled: !!competitionId }
+    { ...STRUCTURE_QUERY, enabled: !!competitionId }
   );
   const viewer = useMemo<LBViewer>(() => {
     const myTeamId =
@@ -153,14 +154,21 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
   // pattern — is the real mobile fix; logged in DEFERRED.md.)
   const utils = trpc.useUtils();
   useEffect(() => {
-    void utils.tripMembers.list.prefetch({ tripId });
+    void utils.tripMembers.list.prefetch({ tripId }, STRUCTURE_QUERY);
   }, [utils, tripId]);
+  // The STRUCTURE prefetches carry STRUCTURE_QUERY (staleTime Infinity) so they
+  // NO-OP when the structure is already cached at any age — without it the
+  // prefetch's own default 60s staleTime would re-fetch fresh structure in the
+  // background on every >60s reopen, defeating the kept-structure cut on the
+  // consuming page. (Invalidation still overrides Infinity, so a structural
+  // mutation re-warms them.) Only `scores` (STATE) stays on the short default so
+  // a reopen warms fresh scores.
   const prefetchGame = useCallback(
     (gameId: string) => {
-      void utils.games.getById.prefetch({ tripId, gameId });
+      void utils.games.getById.prefetch({ tripId, gameId }, STRUCTURE_QUERY);
       void utils.scores.listByGame.prefetch({ tripId, gameId });
-      void utils.matches.listByGame.prefetch({ tripId, gameId });
-      void utils.games.listOrganizers.prefetch({ tripId, gameId });
+      void utils.matches.listByGame.prefetch({ tripId, gameId }, STRUCTURE_QUERY);
+      void utils.games.listOrganizers.prefetch({ tripId, gameId }, STRUCTURE_QUERY);
     },
     [utils, tripId],
   );

--- a/src/components/competition/LiveFaceClient.tsx
+++ b/src/components/competition/LiveFaceClient.tsx
@@ -7,6 +7,7 @@ import { Trophy } from "lucide-react";
 import type { inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "@/server/router";
 import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { canAccessCompetition } from "@/lib/competitionAccess";
 import { useRealtimeCompetition } from "@/hooks/useRealtimeCompetition";
 import { useRealtimeMembers } from "@/hooks/useRealtimeMembers";
@@ -85,17 +86,25 @@ export function LiveFaceClient({
   //
   // Stage B: the server route resolves this and hands it down as initialData, so
   // `boot` is defined on the very first (SSR) render — the board/guide render
-  // populated in the server HTML, zero client round-trip for first paint. We
-  // stamp initialDataUpdatedAt = now so the freshly-resolved data counts as
-  // fresh under the 60s staleTime → no redundant refetch on mount (one resolve
-  // per load). Realtime + the leaderboard's own refetchInterval keep it live;
-  // soft navigation re-runs the server component for a fresh resolve.
+  // populated in the server HTML, zero client round-trip for first paint.
+  //
+  // STRUCTURE layer (the alive-face cut): faceBootstrap is the slow-changing
+  // competition shape, so it's KEPT — staleTime Infinity + a long gcTime
+  // (STRUCTURE_QUERY). A warm remount (trip↔live, game→back) reads the kept cache
+  // with no refetch, instead of re-fetching the whole blob on every boundary. It
+  // refreshes only by INVALIDATION: structural mutations (pattern #10) and the
+  // realtime competition hook (which now invalidates faceBootstrap, not just
+  // getByTrip — the go-live reveal rode on the old 60s staleTime + the soft-nav
+  // server re-run, both gone now). The warm soft-nav server re-resolve itself is
+  // suppressed by the Router Cache (experimental.staleTimes.dynamic). The STATE
+  // layer (standings) rides its own cadence — see the seed below + the
+  // leaderboard's 30s poll.
   const { data: boot, isLoading: loading } =
     trpc.competitions.faceBootstrap.useQuery(
       { tripId },
       initialBoot
-        ? { initialData: initialBoot, initialDataUpdatedAt: () => Date.now() }
-        : undefined,
+        ? { ...STRUCTURE_QUERY, initialData: initialBoot, initialDataUpdatedAt: () => Date.now() }
+        : STRUCTURE_QUERY,
     );
 
   const competition = boot?.competition ?? null;
@@ -110,23 +119,36 @@ export function LiveFaceClient({
 
   // Seed the child caches from the one bootstrap so the board/guide — and the
   // setup↔leaderboard toggle, and the sub-views — render from cache with NO
-  // extra round-trips. The global 60s staleTime keeps the seed fresh, so the
-  // children's own useQuery calls don't re-fetch. Keyed on `boot` so it runs
-  // exactly once per resolve, synchronously DURING render — before the face's
-  // children mount and fire their queries (an effect runs too late: child
-  // mount-effects fire before the parent's, so they'd re-fetch first). This
-  // also runs during the SSR render pass, so the children render populated in
-  // the server HTML (Stage B first paint).
+  // extra round-trips. Keyed on `boot` so it runs once per resolve, synchronously
+  // DURING render — before the face's children mount and fire their queries (an
+  // effect runs too late: child mount-effects fire before the parent's, so they'd
+  // re-fetch first). This also runs during the SSR render pass, so the children
+  // render populated in the server HTML (Stage B first paint).
+  //
+  // The STRUCTURE children (competition, games, teams, assignments) are seeded
+  // ALWAYS — they're kept (STRUCTURE_QUERY) and the seed value is the same kept
+  // structure, so re-seeding on remount is a harmless no-op overwrite. But the
+  // STATE child (competitions.leaderboard) is seeded ONLY-IF-ABSENT: with
+  // faceBootstrap now kept, `boot.leaderboard` can be staler than the live 30s
+  // poll (individual score entry doesn't invalidate faceBootstrap), so an
+  // always-seed would clobber fresher standings on every remount. Seed it for the
+  // cold first paint; thereafter the leaderboard's own poll + direct invalidation
+  // own it (the structure/state cut, applied at the seed).
   useMemo(() => {
     if (!boot) return;
     utils.competitions.getByTrip.setData({ tripId }, boot.competition as never);
     utils.games.myDelegateGameIds.setData({ tripId }, boot.myDelegateGameIds);
     if (boot.competition) {
       const cid = boot.competition.id as string;
-      utils.competitions.leaderboard.setData(
-        { tripId, competitionId: cid },
-        boot.leaderboard as never,
-      );
+      if (
+        utils.competitions.leaderboard.getData({ tripId, competitionId: cid }) ===
+        undefined
+      ) {
+        utils.competitions.leaderboard.setData(
+          { tripId, competitionId: cid },
+          boot.leaderboard as never,
+        );
+      }
       utils.games.listByTrip.setData({ tripId }, boot.games as never);
       utils.teams.list.setData({ tripId, competitionId: cid }, boot.teams as never);
       utils.teamAssignments.list.setData(

--- a/src/hooks/useRealtimeCompetition.ts
+++ b/src/hooks/useRealtimeCompetition.ts
@@ -15,6 +15,14 @@ import { trpc } from "@/lib/trpc-client";
  * on `competitions` filtered by `trip_id=eq.{tripId}`. On any change,
  * invalidates the `competitions.getByTrip` query so TanStack refetches
  * and re-renders consumers (the competition face / leaderboard, etc.).
+ *
+ * It ALSO invalidates competitions.faceBootstrap — the Live face's kept
+ * STRUCTURE snapshot (the board reads competition status/name from
+ * boot.competition). faceBootstrap is now staleTime: Infinity (STRUCTURE_QUERY)
+ * and warm soft-nav no longer re-resolves it server-side (Router Cache), so a
+ * watching member's go-live reveal can no longer ride the old 60s staleTime /
+ * soft-nav re-run — it must come from this invalidation (pattern #10: invalidate
+ * the bootstrap, not only the child).
  */
 export function useRealtimeCompetition(tripId: string | null) {
   const utils = trpc.useUtils();
@@ -23,8 +31,14 @@ export function useRealtimeCompetition(tripId: string | null) {
     if (!tripId) return;
 
     const supabase = getRealtimeClient();
-    const refresh = () => {
+    // On an ACTUAL competition change (go-live, name, tagline), invalidate BOTH
+    // getByTrip AND the Live face's kept structure snapshot (faceBootstrap) — the
+    // board reads competition status from boot.competition, and faceBootstrap is
+    // now staleTime: Infinity, so a watching member's go-live reveal must come
+    // from this invalidation (pattern #10).
+    const onChange = () => {
       utils.competitions.getByTrip.invalidate({ tripId });
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     };
     const channel = supabase
       .channel(`competition:${tripId}`)
@@ -36,13 +50,18 @@ export function useRealtimeCompetition(tripId: string | null) {
           table: "competitions",
           filter: `trip_id=eq.${tripId}`,
         },
-        refresh
+        onChange
       )
       // Backfill on (re)connect: a dead zone drops the socket, so any change
       // during it would otherwise sit stale up to the 60s staleTime. Refetching
       // on the SUBSCRIBED tick self-heals on reconnect (mirrors useRealtimeChat).
+      // NOTE: this fires on EVERY mount, not just reconnect — so it deliberately
+      // does NOT touch faceBootstrap. faceBootstrap is the kept STRUCTURE layer
+      // (load once, keep); re-invalidating it here would re-resolve the whole
+      // structure on every trip→live, the exact tap-around refetch the cut
+      // removes. getByTrip is cheap and stays on the per-mount heal.
       .subscribe((status) => {
-        if (status === "SUBSCRIBED") refresh();
+        if (status === "SUBSCRIBED") utils.competitions.getByTrip.invalidate({ tripId });
       });
 
     return () => {

--- a/src/lib/queryConfig.ts
+++ b/src/lib/queryConfig.ts
@@ -1,0 +1,45 @@
+/**
+ * Structure/State cache split — the "alive" competition face.
+ *
+ * Two kinds of competition data change at very different rates, and the app used
+ * to fetch them as one blob on every boundary-cross (trip↔live, open/close/reopen
+ * a game), which felt like loading a foreign webpage each time:
+ *
+ *   STRUCTURE — does the competition exist, teams + rosters, the games list, each
+ *   game's type/name/config/pairings/course/handicaps. SLOW-changing: only a
+ *   structural mutation (create/edit a game, set pairings, a roster/team edit, the
+ *   reset primitives, go-live) changes it. Once the cup is built it's ~static.
+ *
+ *   STATE — scores, match statuses, computed standings. FAST-changing (every score
+ *   entry), comparatively small. It has its OWN refresh cadence (the leaderboard's
+ *   30s poll / realtime) and must stay fresh.
+ *
+ * `STRUCTURE_QUERY` is the cache policy for the structure half — load once, KEEP:
+ *
+ *   - staleTime: Infinity — never refetched by TIME. The only thing that makes a
+ *     structure query stale is an explicit invalidation from a structural mutation
+ *     (invalidate overrides staleTime and refetches active observers / marks
+ *     inactive ones for refetch-on-mount). This is what makes reopen-a-game and
+ *     trip↔live INSTANT: a warm remount reads the kept cache, no refetch. (The old
+ *     60s default is exactly why structure refetched on every >60s remount.)
+ *   - gcTime: 30 min — long enough to OUTLIVE leaving the live face (a trip-page
+ *     visit, opening/closing a game) so returning is a cache hit, not a cold load.
+ *     (The global default gcTime is 5 min — too short to survive a longer detour.)
+ *
+ * Apply this ONLY to structure queries. Do NOT spread it onto a STATE query
+ * (scores.listByGame, competitions.leaderboard) — that's the "one blob tuned two
+ * ways" trap this split exists to undo: you'd freeze the scores along with the
+ * structure.
+ *
+ * ── The SERVER half is separate ──
+ * This fixes the CLIENT (React Query) half. The trip→live reload ALSO has a server
+ * half: the Live route is a Server Component that re-resolves faceBootstrap on
+ * every navigation. A long client cache can't touch a blocking server RSC fetch —
+ * that's killed by Router Cache retention (`experimental.staleTimes.dynamic` in
+ * next.config.ts). The two work together: the Router Cache stops the server
+ * re-resolve; STRUCTURE_QUERY makes the kept client cache the authority.
+ */
+export const STRUCTURE_QUERY = {
+  staleTime: Infinity,
+  gcTime: 30 * 60_000,
+} as const;


### PR DESCRIPTION
## The daily pain (Zach, from use)
Every boundary-cross on the competition face re-fetched the whole competition blob — trip→live re-resolved `faceBootstrap` **server-side on every navigation**, and reopen-a-game refetched its structure after the 60s staleTime. Moving within the live surface felt like loading a foreign webpage each time.

## The cut
Two change-rates were fetched as one blob; this separates them.

- **STRUCTURE** (teams/rosters/games list/game config/pairings/course) — slow, changes only on a structural mutation — is now **KEPT** via a shared `STRUCTURE_QUERY` (`staleTime: Infinity` + 30 min `gcTime`) on `faceBootstrap`, `games.getById`, `matches`/`playGroups.listByGame`, `teams`/`teamAssignments`/`games.listByTrip`/`getMe`, and the board's structure **prefetches**. Refreshed only by invalidation (structural mutations + the realtime competition change), never by time.
- **STATE** (scores, standings) is untouched — `scores.listByGame` and `competitions.leaderboard` keep the short default + the board's 30 s poll.

## The load-bearing part — killing the per-navigation SERVER fetch
The reload has **two independent causes**, and only one is the easy staleTime/gcTime half:

1. **SERVER half (trip→live).** The Live route is a Server Component that re-resolved `faceBootstrap` on **every** navigation (Next Router Cache default `dynamic: 0`). A long client cache **can't** touch this — the nav blocks on the RSC. Fixed by `experimental.staleTimes.dynamic = 300`: warm navs reuse the rendered RSC payload (server doesn't re-run). The SSR seed is still paid **once** on a cold load.
2. **CLIENT half (reopen-game).** The game pages are client components; their structure queries refetched after 60 s. `STRUCTURE_QUERY` keeps them.

### Two correctness obligations of keeping faceBootstrap
- `useRealtimeCompetition` now invalidates `faceBootstrap` on the actual competition **change** (the go-live reveal the board reads from `boot.competition`) — but **not** on the per-mount SUBSCRIBED backfill, which would re-resolve structure on every trip→live.
- the `boot`→child seed is **seed-if-absent** for the STATE child (`competitions.leaderboard`), so a kept-stale `boot` can't clobber the fresher poll.

## Verified by eye (React Query cache inspection on BBMI, owner)
- **trip↔live**: `faceBootstrap.dataUpdatedAt` stable across the boundary — no re-resolve; board renders instantly.
- **reopen-same-game**: `games.getById`/`matches` `dataUpdatedAt` stable (served from cache), observer `staleTime` = `Infinity`; only `scores` (state) on the 60 s default. The maddening case is gone.
- **structural mutation propagates**: invalidating `faceBootstrap` advances `dataUpdatedAt` — invalidation overrides `Infinity`, so reset/edit still propagate.
- No console errors.

## Tests
- `tsc --noEmit` clean · eslint clean
- 692 Vitest unit tests pass
- critical-path E2E green

## Scope
Phase 1 (the cut) + the Phase 2 state-cadence (already largely true — leaderboard poll + score-entry→state-only invalidation). **Phase 3 (the cold-load assembling animation) is a separate polish PR** — filed as a follow-up. This cut also de-risks the navigation redesign (a layered surface assumes structure stays present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)