### PR TITLE
feat(competition): per-game reset primitives — one home for "reset a game" (config-checklist Phase A)

### DIFF
--- a/src/__tests__/helpers/test-setup.ts
+++ b/src/__tests__/helpers/test-setup.ts
@@ -148,6 +148,14 @@ export class TestContext {
     return createCallerForUser(getSharedUser(role));
   }
 
+  /** A raw Supabase client carrying a role's authenticated JWT (anon key +
+   *  Bearer) — the `authenticated` Postgres role, RLS + function grants applied.
+   *  Use to test what a logged-in user can reach DIRECTLY (e.g. an rpc() call to
+   *  a SECURITY DEFINER function), bypassing the tRPC layer. */
+  authedClient(role: UserRole): SupabaseClient {
+    return createAuthenticatedClient(getSharedUser(role));
+  }
+
   // ---- Trip helpers ----
 
   /** Create a trip with the primary user as Owner. */

--- a/src/server/routers/games.reset.test.ts
+++ b/src/server/routers/games.reset.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext, genId } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Per-game reset primitives (config-checklist Phase A, migration 066) —
+ * games.resetScoring / resetToSkeleton.
+ *
+ * These are the level-down siblings of the competition-level reset (#442 / mig
+ * 063). The competition functions are now REFACTORED to loop the un-guarded
+ * per-game core; that refactor's behavior-preservation is guarded by the
+ * existing competitions.reset.test.ts (unchanged). This file covers the new
+ * per-game surface:
+ *  - resetScoring: clears ONE game's results, keeps its config + identity.
+ *  - resetToSkeleton: also clears ONE game's config, keeps identity (incl. the
+ *    per-match point VALUE — §E-1).
+ *  - a sibling game in the same competition is NOT touched.
+ *  - owner-only (co_admin + a game delegate are both rejected).
+ *  - the un-guarded cores are not callable by the `authenticated` role directly.
+ */
+
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let ownerId: string;
+let memberId: string;
+const gameIds: string[] = [];
+
+/** A scored 1v1 MATCH game: pairing (config) + result (scoring) on the
+ *  dual-bucket game_matches row; roster + handicaps (config); per-match point
+ *  value (§E-1 identity). */
+async function makeMatchGame(name: string): Promise<string> {
+  const id = genId("pgreset-match");
+  gameIds.push(id);
+  await ctx.admin.from("games").insert({
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play_singles",
+    name, status: "complete", corrections_open: true, scoring_enabled: true,
+    scorecard_schema: { units: { metadata: { par: [4, 4] } } },
+    points_distribution: { type: "per_match", value: 2 }, points_total: null,
+    modifiers: { glorious_holes: {} }, rules_for_today: "be nice", competition_format: "head_to_head",
+    pairings_published_at: new Date(0).toISOString(),
+  });
+  await ctx.admin.from("game_participants").insert([
+    { id: genId("p"), game_id: id, user_id: ownerId, handicap_strokes: 3 },
+    { id: genId("p"), game_id: id, user_id: memberId, handicap_strokes: 0 },
+  ]);
+  await ctx.admin.from("score_entries").insert([
+    { id: genId("se"), game_id: id, participant_id: ownerId, participant_type: "user", unit_label: "1", value: 4 },
+    { id: genId("se"), game_id: id, participant_id: memberId, participant_type: "user", unit_label: "1", value: 5 },
+  ]);
+  const { error: gmErr } = await ctx.admin.from("game_matches").insert({
+    id: genId("gm"), game_id: id, match_number: 1, display_order: 0,
+    side_a: { type: "user", id: ownerId }, side_b: { type: "user", id: memberId },
+    result: "a_win", margin: "2up", status: "complete",
+  });
+  if (gmErr) throw new Error(`game_matches insert failed: ${gmErr.message}`);
+  await ctx.admin.from("game_results").insert({
+    id: genId("gr"), game_id: id, entity_id: ownerId, entity_type: "user", position: 1, raw_score: 1,
+  });
+  return id;
+}
+
+async function gameRow(id: string) {
+  const { data } = await ctx.admin.from("games").select("*").eq("id", id).single();
+  return data as Record<string, unknown>;
+}
+async function count(table: string, gameId: string): Promise<number> {
+  const { count: c } = await ctx.admin.from(table).select("id", { count: "exact", head: true }).eq("game_id", gameId);
+  return c ?? 0;
+}
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  ownerId = ctx.user.id;
+  tripId = await ctx.createTrip("PG Reset Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // co_admin — NOT owner
+  await ctx.addTripMember(tripId, "member", "Member");
+  memberId = ctx.getUser("member").id;
+  competitionId = await ctx.createCompetition(tripId, "PG Reset Cup", { scoringModel: "points" });
+});
+
+afterAll(async () => {
+  if (gameIds.length) await ctx.admin.from("games").delete().in("id", gameIds);
+  await ctx.cleanup();
+}, 30000);
+
+describe("games.resetScoring — one game's results cleared, config + identity kept, siblings untouched", () => {
+  it("clears the target's scoring; leaves config/identity; a sibling is untouched", async () => {
+    const target = await makeMatchGame("Target");
+    const sibling = await makeMatchGame("Sibling");
+
+    await ctx.caller().games.resetScoring({ tripId, gameId: target });
+
+    // TARGET scoring cleared.
+    expect(await count("game_results", target)).toBe(0);
+    expect(await count("score_entries", target)).toBe(0);
+    const { data: tgm } = await ctx.admin.from("game_matches").select("*").eq("game_id", target).single();
+    const tm = tgm as Record<string, unknown>;
+    expect(tm.side_a).toMatchObject({ type: "user", id: ownerId }); // pairing (config) kept
+    expect(tm.result).toBeNull();
+    expect(tm.margin).toBeNull();
+    expect(tm.status).toBe("pending");
+    // TARGET config + identity intact, still armed.
+    expect(await count("game_participants", target)).toBe(2);
+    const tg = await gameRow(target);
+    expect(tg.scorecard_schema).not.toBeNull();
+    expect(tg.competition_format).toBe("head_to_head");
+    expect(tg.points_distribution).toMatchObject({ type: "per_match", value: 2 });
+    expect(tg.status).toBe("pending");
+    expect(tg.corrections_open).toBe(false);
+    expect(tg.scoring_enabled).toBe(true); // stays armed
+
+    // SIBLING fully untouched — results + result columns survive.
+    expect(await count("game_results", sibling)).toBe(1);
+    expect(await count("score_entries", sibling)).toBe(2);
+    const { data: sgm } = await ctx.admin.from("game_matches").select("*").eq("game_id", sibling).single();
+    const sm = sgm as Record<string, unknown>;
+    expect(sm.result).toBe("a_win");
+    expect(sm.status).toBe("complete");
+    const sg = await gameRow(sibling);
+    expect(sg.status).toBe("complete");
+  });
+
+  it("a co-admin (Organizer) and a game delegate are both rejected — owner only", async () => {
+    const target = await makeMatchGame("OwnerOnly");
+    // Make the member a DELEGATE of this game (can edit/score) — still not reset.
+    await ctx.admin.from("game_delegates").insert({ game_id: target, user_id: memberId, granted_by: ownerId });
+
+    await expect(
+      ctx.callerAs("planner").games.resetScoring({ tripId, gameId: target })
+    ).rejects.toThrow();
+    await expect(
+      ctx.callerAs("member").games.resetScoring({ tripId, gameId: target })
+    ).rejects.toThrow();
+    // Neither write landed — scoring intact.
+    expect(await count("game_results", target)).toBe(1);
+  });
+});
+
+describe("games.resetToSkeleton — one game's config cleared, identity kept (incl. §E-1 value)", () => {
+  it("clears the target's config to a shell; keeps the per-match point value; sibling untouched", async () => {
+    const target = await makeMatchGame("SkelTarget");
+    const sibling = await makeMatchGame("SkelSibling");
+
+    await ctx.caller().games.resetToSkeleton({ tripId, gameId: target });
+
+    // TARGET config cleared: roster, pairings rows, columns.
+    expect(await count("game_participants", target)).toBe(0);
+    expect(await count("game_matches", target)).toBe(0);
+    const tg = await gameRow(target);
+    expect(tg.scorecard_schema).toBeNull();
+    expect(tg.modifiers).toMatchObject({});
+    expect(tg.rules_for_today).toBeNull();
+    expect(tg.competition_format).toBeNull();
+    expect(tg.pairings_published_at).toBeNull();
+    expect(tg.scoring_enabled).toBe(false); // un-armed
+    // IDENTITY kept: shell + the per-match point VALUE survives (§E-1).
+    expect(tg.name).toBe("SkelTarget");
+    expect(tg.game_type_id).toBe("gtt_match_play_singles");
+    expect(tg.points_distribution).toMatchObject({ type: "per_match", value: 2 });
+
+    // SIBLING untouched: config + scoring all survive.
+    expect(await count("game_participants", sibling)).toBe(2);
+    expect(await count("game_matches", sibling)).toBe(1);
+    expect(await count("game_results", sibling)).toBe(1);
+    const sg = await gameRow(sibling);
+    expect(sg.scoring_enabled).toBe(true);
+    expect(sg.scorecard_schema).not.toBeNull();
+  });
+
+  it("a plain member cannot reset a game to skeleton", async () => {
+    const target = await makeMatchGame("SkelOwnerOnly");
+    await expect(
+      ctx.callerAs("member").games.resetToSkeleton({ tripId, gameId: target })
+    ).rejects.toThrow();
+    expect(await count("game_participants", target)).toBe(2); // unchanged
+  });
+});
+
+describe("the un-guarded cores are not callable by the authenticated role", () => {
+  it("a direct rpc() to _reset_game_scoring / _reset_game_to_skeleton is denied", async () => {
+    const target = await makeMatchGame("CoreGuard");
+    const owner = ctx.authedClient("owner"); // the trip OWNER — yet the CORE is off-limits
+
+    const r1 = await owner.rpc("_reset_game_scoring", { p_game_id: target });
+    expect(r1.error).not.toBeNull(); // no EXECUTE grant → PostgREST refuses
+    const r2 = await owner.rpc("_reset_game_to_skeleton", { p_game_id: target });
+    expect(r2.error).not.toBeNull();
+
+    // The core calls were refused, so the game is still fully scored.
+    expect(await count("game_results", target)).toBe(1);
+    expect(await count("game_participants", target)).toBe(2);
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -821,4 +821,47 @@ export const gamesRouter = router({
         .eq("user_id", ctx.user!.id);
       return (data ?? []).map((r) => r.game_id as string);
     }),
+
+  // resetScoring — owner-only, ONE game. Clears this game's RESULTS back to
+  // unscored; keeps config + identity (incl. its per-match point value). The
+  // per-game rung of the danger-zone ladder (below it: resetToSkeleton; below
+  // that: delete) — the level-down sibling of competitions.resetScoring (#442).
+  // Delegates to the transactional plpgsql primitive (migration 066); the SQL
+  // wrapper re-asserts owner on the game's REAL trip (authoritative), so this
+  // can't be spoofed by passing a trip you own + a foreign gameId.
+  resetScoring: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase.rpc("reset_game_scoring", {
+        p_game_id: input.gameId,
+      });
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to reset game scoring: ${error.message}`,
+        });
+      }
+      return { success: true };
+    }),
+
+  // resetToSkeleton — owner-only, ONE game. SUPERSET of resetScoring: the SQL
+  // primitive clears scoring then additionally clears config back to an
+  // unconfigured shell (keeps identity + the per-match point value, §E-1).
+  // The level-down sibling of competitions.resetToSkeleton.
+  resetToSkeleton: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { error } = await ctx.supabase.rpc("reset_game_to_skeleton", {
+        p_game_id: input.gameId,
+      });
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to reset game to skeleton: ${error.message}`,
+        });
+      }
+      return { success: true };
+    }),
 });

--- a/supabase/migrations/20260623140000_066_per_game_reset_primitives.sql
+++ b/supabase/migrations/20260623140000_066_per_game_reset_primitives.sql
@@ -1,0 +1,225 @@
+-- 066 — Per-game reset primitives (config-checklist Phase A).
+--
+-- Pushes the reset primitive ONE LEVEL DOWN: "reset a game" gets a single home,
+-- and competition-reset becomes the loop. Same "one known home, callers don't
+-- reimplement" principle as migration 063 (which this refactors), applied per
+-- game so Phase B's per-game danger zone has the capability before the UI.
+--
+-- Layering (by blast radius AND by guard):
+--   _reset_game_scoring / _reset_game_to_skeleton  — UN-GUARDED cores. Do the
+--     work for ONE game; NO auth check; NOT granted to authenticated (granting
+--     them would be a direct-PostgREST bypass of the owner gate — the exact hole
+--     063's assert_competition_owner closed). Callable only by the guarded
+--     wrappers / other DEFINER functions.
+--   reset_game_scoring / reset_game_to_skeleton    — owner-guarded public
+--     wrappers. Granted to authenticated.
+--   reset_competition_scoring / reset_competition_to_skeleton  — REFACTORED to
+--     guard owner ONCE then loop the un-guarded core. The guard does NOT ride the
+--     loop. Same EXTERNAL behavior as 063 (this is a behavior-preserving refactor
+--     to share the core, not a behavior change).
+--
+-- Owner-only, per 063: resetting a game is destructive; the burden of proof is on
+-- WIDENING destructive capability, so delegates are not granted reset.
+--
+-- THE BEHAVIOR-CRITICAL DETAIL (carried verbatim from 063): the clears are split.
+-- The DELETEs (results/scores, and in skeleton the pairing/roster/foursome rows)
+-- run UNCONDITIONALLY by game_id — incl. dropped games. The games-ROW UPDATEs
+-- (status/corrections, and the config columns + the §E-1 point-value CASE) are
+-- gated `status <> 'dropped'`, so a dropped game keeps its dropped status and
+-- (in skeleton) its config columns. The per-game cores reproduce that split
+-- exactly; a uniform clear would change 063's behavior and fail its regression.
+--
+-- §E-1 (per-match point value survives skeleton): the survives-logic is a per-ROW
+-- CASE on points_distribution — it carries to the per-game core unchanged
+-- (scoping the row UPDATE to id = $1 doesn't touch the CASE).
+
+-- ── Per-game owner guard ─────────────────────────────────────────────────────
+-- Resolves the game's TRIP (games.trip_id — always present) and asserts the
+-- caller is that trip's Owner. Deliberately NOT routed through
+-- assert_competition_owner: games.competition_id is NULLABLE (migration 056,
+-- ON DELETE SET NULL) — a standalone game, or a game whose competition was
+-- deleted, has no competition, so a game→competition→trip chain would break.
+-- trip_id covers competition and non-competition games alike. Reuses
+-- assert_competition_owner's owner-check MECHANISM, not its signature.
+CREATE OR REPLACE FUNCTION public.assert_game_owner(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+DECLARE
+  v_trip_id text;
+BEGIN
+  SELECT trip_id INTO v_trip_id FROM public.games WHERE id = p_game_id;
+
+  IF v_trip_id IS NULL THEN
+    RAISE EXCEPTION 'Game % not found', p_game_id USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.trip_members tm
+    WHERE tm.trip_id = v_trip_id
+      AND tm.user_id = (auth.uid())::text
+      AND tm.role = 'Owner'
+  ) THEN
+    RAISE EXCEPTION 'Only the trip owner can reset a game' USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+-- ── Un-guarded core: scoring ─────────────────────────────────────────────────
+-- Clears ONE game's SCORING bucket; keeps config + identity; keeps scoring_enabled
+-- (the game stays armed). DELETEs unconditional; games-row UPDATE skips dropped.
+CREATE OR REPLACE FUNCTION public._reset_game_scoring(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  -- Results + raw scores (all game types that score).
+  DELETE FROM public.game_results WHERE game_id = p_game_id;
+  DELETE FROM public.score_entries WHERE game_id = p_game_id;
+
+  -- Match-play RESULT columns only — keep the pairings (side_a/side_b). No-op for
+  -- non-match types (no game_matches rows).
+  UPDATE public.game_matches
+    SET result = NULL, margin = NULL, status = 'pending'
+    WHERE game_id = p_game_id;
+
+  -- Unscored lifecycle: active/complete → pending, corrections closed.
+  -- scoring_enabled KEPT (re-scoreable). A dropped game stays dropped.
+  UPDATE public.games
+    SET status = 'pending', corrections_open = false
+    WHERE id = p_game_id AND status <> 'dropped';
+END;
+$$;
+
+-- ── Un-guarded core: skeleton ────────────────────────────────────────────────
+-- SUPERSET of scoring (CALLS it), then clears ONE game's CONFIG bucket, leaving
+-- the identity shell. scoring_enabled → false (un-armed). Per-match point VALUE
+-- survives (§E-1): placement games clear only the split (points_distribution →
+-- NULL); a per-match distribution holds the value itself, so it is kept.
+CREATE OR REPLACE FUNCTION public._reset_game_to_skeleton(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  -- Built ON the scoring core — NOT reimplemented (results can't outlive config).
+  PERFORM public._reset_game_scoring(p_game_id);
+
+  -- Config rows: pairings, roster, foursomes/pairs. (game_matches results were
+  -- already nulled above; here the rows go entirely.) Unconditional by game_id.
+  DELETE FROM public.game_matches WHERE game_id = p_game_id;
+  DELETE FROM public.game_participants WHERE game_id = p_game_id;
+  DELETE FROM public.play_groups WHERE game_id = p_game_id;
+
+  -- Per-game config columns. Point VALUE survives (identity): for placement games
+  -- clear only the SPLIT (points_distribution → NULL, keep points_total); a
+  -- per-match distribution holds the value itself, so it is kept untouched.
+  UPDATE public.games
+    SET course_id = NULL,
+        scorecard_schema = NULL,
+        modifiers = '{}'::jsonb,
+        rules_for_today = NULL,
+        competition_format = NULL,
+        pairings_published_at = NULL,
+        scoring_enabled = false,
+        points_distribution = CASE
+          WHEN points_distribution->>'type' = 'placement' THEN NULL
+          ELSE points_distribution
+        END
+    WHERE id = p_game_id AND status <> 'dropped';
+END;
+$$;
+
+-- ── Owner-guarded public wrappers ────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.reset_game_scoring(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  PERFORM public.assert_game_owner(p_game_id);
+  PERFORM public._reset_game_scoring(p_game_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reset_game_to_skeleton(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  PERFORM public.assert_game_owner(p_game_id);
+  PERFORM public._reset_game_to_skeleton(p_game_id);
+END;
+$$;
+
+-- ── Competition functions: REFACTORED to guard-once + loop the core ──────────
+-- Same external behavior as 063; internal refactor to share the per-game core.
+-- The owner guard runs ONCE (not per game); the loop drives the un-guarded core.
+-- The loop selects ALL games (incl. dropped) and the core self-skips dropped on
+-- its games-row UPDATEs — reproducing 063's split exactly.
+CREATE OR REPLACE FUNCTION public.reset_competition_scoring(p_trip_id text, p_competition_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+DECLARE
+  v_game_id text;
+BEGIN
+  PERFORM public.assert_competition_owner(p_trip_id, p_competition_id);
+
+  FOR v_game_id IN
+    SELECT id FROM public.games WHERE competition_id = p_competition_id
+  LOOP
+    PERFORM public._reset_game_scoring(v_game_id);
+  END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reset_competition_to_skeleton(p_trip_id text, p_competition_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+DECLARE
+  v_game_id text;
+BEGIN
+  -- Guard ONCE here (no longer via reset_competition_scoring — that would
+  -- double-guard). The scoring-clear nesting now lives in the per-game core
+  -- (_reset_game_to_skeleton calls _reset_game_scoring).
+  PERFORM public.assert_competition_owner(p_trip_id, p_competition_id);
+
+  FOR v_game_id IN
+    SELECT id FROM public.games WHERE competition_id = p_competition_id
+  LOOP
+    PERFORM public._reset_game_to_skeleton(v_game_id);
+  END LOOP;
+END;
+$$;
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+-- Wrappers + the guard helper to authenticated. The un-guarded cores are locked
+-- to DEFINER context (the wrappers call them as the owner): they must be callable
+-- by NO client role.
+--
+-- ⚠ CRITICAL: Supabase's default privileges auto-GRANT EXECUTE on every new
+-- public function to PUBLIC + anon + authenticated + service_role. So revoking
+-- only `authenticated` leaves the core callable by anon AND via the PUBLIC grant
+-- (authenticated inherits PUBLIC) — a direct-PostgREST bypass of the owner gate.
+-- The cores must be revoked FROM PUBLIC, anon, authenticated (service_role is the
+-- trusted backend key and may keep it). The DEFINER wrappers run as the function
+-- owner, so they reach the cores regardless of the cores' client grants.
+GRANT EXECUTE ON FUNCTION public.assert_game_owner(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_game_scoring(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_game_to_skeleton(text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public._reset_game_scoring(text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public._reset_game_to_skeleton(text) FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
Phase A of the config-checklist work (`config_checklist_matchplay_design.md` §4). A **contained backend refactor** — independent of Phase B and of the `ryder_cup` diagnosis.

## What
Pushes the reset primitive **one level down**: per-**game** reset operations, and the competition-level functions (migration 063) refactored to **call** them — so "reset a game" has one home and competition-reset is the loop.

## Migration 066
- `_reset_game_scoring` / `_reset_game_to_skeleton` — **un-guarded cores**, one game each (skeleton calls scoring then clears config). Locked to DEFINER context.
- `reset_game_scoring` / `reset_game_to_skeleton` — **owner-guarded public wrappers** via a new `assert_game_owner(game_id)`. It resolves the game's **trip** (`games.trip_id`, always present — deliberately **not** `assert_competition_owner`, because `games.competition_id` is nullable per mig 056) and asserts trip-Owner.
- `reset_competition_scoring` / `reset_competition_to_skeleton` — **refactored** to guard owner **once** then loop the un-guarded core. Same external behavior as 063; the guard no longer rides the loop.

**Behavior preservation (the load-bearing detail):** 063 isn't uniformly set-based — its DELETEs run unconditionally by `game_id` (incl. dropped games) while the `games`-row UPDATEs are gated `status <> 'dropped'`. The per-game cores reproduce that split exactly, so the dropped-game handling and the §E-1 per-match-value `CASE` carry over unchanged.

## Security
Supabase default privileges auto-grant `EXECUTE` on new public functions to **PUBLIC/anon/authenticated**. Revoking only `authenticated` would leave the cores callable by anon and via the PUBLIC grant (a direct-PostgREST bypass of the owner gate). The cores are revoked `FROM PUBLIC, anon, authenticated`; verified end-state ACL is `postgres + service_role` only. A unit test calls the cores directly as the authenticated owner and asserts the rpc is denied.

## tRPC
`games.resetScoring` / `games.resetToSkeleton` — thin, `requireTripRole("Owner")`, calling the wrappers. The SQL guard re-checks owner on the game's **real** trip, so a spoofed `tripId` + foreign `gameId` is still rejected. Owner-only (delegates not granted reset).

## Tests
- **5 new per-game**: sibling-untouched scoring + skeleton, §E-1 per-match value survives skeleton, owner-only (co_admin **and** a game-delegate both rejected), and the direct-rpc **grant check** (cores not client-callable).
- **The 4 existing competition-reset tests (#442) pass UNCHANGED** — the refactor is behavior-preserving.
- Added a small `TestContext.authedClient(role)` accessor for the grant-check.
- tsc/lint clean.

## Note — pre-existing local test noise (not this PR)
`tripStatus.test.ts` (countdown labels, wall-clock/TZ-sensitive via `dayOffset(new Date())`) + `news.test.ts` unreadCount fail in my **local** sandbox (TZ/clock + shared-test-DB state). Confirmed they fail identically on clean `main` (906380c2) and **pass in CI** (#450's `test` job was green minutes ago running the same files). Filed separately as a polish issue. Zero new failures from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)