### PR TITLE
feat(competition): W-TYPE-01 add-game filter on the reconciled scoring-model axis (config-checklist Phase 3)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -286,6 +286,7 @@ export function CompetitionFace({
           game={editing}
           types={gameTypes}
           canEdit={canEdit}
+          scoringModel={competition.scoring_model ?? "match_play"}
           onClose={() => {
             setAddingGame(false);
             setEditing(null);

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -16,7 +16,7 @@ import {
 // here, read synchronously, never fetched. Re-exported below so existing
 // consumers (CompetitionFace, GameSetupRows) keep their `from "./CompetitionGamesPanel"`
 // import path.
-import { GAME_TYPES, type GameType } from "@/lib/gameTypes";
+import { GAME_TYPES, gameTypesForScoringModel, type GameType, type ScoringModel } from "@/lib/gameTypes";
 
 export type { GameType };
 
@@ -372,22 +372,30 @@ function RunButton({ state, onClick }: { state: RunState; onClick: () => void })
 type Tab = "game" | "config";
 
 export function GameSheet({
-  tripId, competitionId, game, types, canEdit, onClose,
+  tripId, competitionId, game, types, canEdit, scoringModel, onClose,
 }: {
   tripId: string;
   competitionId: string;
   game: GameRow | null;
   types: GameType[];
   canEdit: boolean;
+  /** The competition's scoring-model (W-TYPE-01) — the create picker offers only
+   *  formats compatible with it. Omit/null → offer everything. */
+  scoringModel?: ScoringModel | null;
   onClose: () => void;
 }) {
   const isEdit = !!game;
   const utils = trpc.useUtils();
 
+  // W-TYPE-01: the CREATE picker offers only formats whose scoring-model matches
+  // the competition's (match_play → 1v1/2v2/rack + manual; points → Stroke +
+  // manual). Lookups for an EXISTING game's type read the full catalog (`types`)
+  // so editing never breaks even if a type weren't offerable.
+  const offerable = gameTypesForScoringModel(scoringModel, types);
   const initialType = types.find((t) => t.id === game?.game_type_id);
   const [category, setCategory] = useState<string>(initialType?.category ?? "golf");
   const [gameTypeId, setGameTypeId] = useState<string>(
-    game?.game_type_id ?? types.find((t) => t.category === "golf")?.id ?? types[0]?.id ?? ""
+    game?.game_type_id ?? offerable.find((t) => t.category === "golf")?.id ?? offerable[0]?.id ?? ""
   );
   const [title, setTitle] = useState(game?.name ?? "");
   const [tab, setTab] = useState<Tab>("game");
@@ -427,8 +435,8 @@ export function GameSheet({
   const [courseName, setCourseName] = useState<string | null>(null);
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
 
-  const categoriesPresent = CATEGORY_ORDER.filter((c) => types.some((t) => t.category === c));
-  const categoryTypes = types.filter((t) => t.category === category);
+  const categoriesPresent = CATEGORY_ORDER.filter((c) => offerable.some((t) => t.category === c));
+  const categoryTypes = offerable.filter((t) => t.category === category);
   const effectiveTypeId = categoryTypes.some((t) => t.id === gameTypeId) ? gameTypeId : categoryTypes[0]?.id ?? "";
   const selectedType = types.find((t) => t.id === effectiveTypeId);
   // Per-match formats: 1v1 match play AND rack-n-stack (a set of rank-paired

--- a/src/lib/gameTypes.test.ts
+++ b/src/lib/gameTypes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  GAME_TYPES,
+  isGameTypeForScoringModel,
+  gameTypesForScoringModel,
+} from "./gameTypes";
+
+/**
+ * W-TYPE-01 — the add-game compatibility filter. The competition's scoring-model
+ * (`match_play | points`) decides which formats the create picker offers. Pure
+ * data + a pure helper (the mechanism the modal calls); covered here so a re-tag
+ * regression is caught without driving the UI.
+ */
+
+const id = (t: { id: string }) => t.id;
+
+describe("isGameTypeForScoringModel", () => {
+  const stroke = GAME_TYPES.find((t) => t.id === "gtt_stroke_play")!;
+  const singles = GAME_TYPES.find((t) => t.id === "gtt_match_play_singles")!;
+  const rack = GAME_TYPES.find((t) => t.id === "gtt_rack_n_stack")!;
+  const manual = GAME_TYPES.find((t) => t.id === "gtt_manual")!;
+
+  it("stroke is points-only", () => {
+    expect(isGameTypeForScoringModel(stroke, "points")).toBe(true);
+    expect(isGameTypeForScoringModel(stroke, "match_play")).toBe(false);
+  });
+
+  it("match-play formats are match_play-only", () => {
+    expect(isGameTypeForScoringModel(singles, "match_play")).toBe(true);
+    expect(isGameTypeForScoringModel(singles, "points")).toBe(false);
+  });
+
+  it("rack-n-stack is match_play (net-stroke ENTRY is not the points scoring-model)", () => {
+    expect(isGameTypeForScoringModel(rack, "match_play")).toBe(true);
+    expect(isGameTypeForScoringModel(rack, "points")).toBe(false);
+  });
+
+  it("manual (null) fits any scoring-model", () => {
+    expect(isGameTypeForScoringModel(manual, "match_play")).toBe(true);
+    expect(isGameTypeForScoringModel(manual, "points")).toBe(true);
+  });
+
+  it("a null/absent scoring-model is permissive (never an empty menu)", () => {
+    expect(isGameTypeForScoringModel(stroke, null)).toBe(true);
+    expect(isGameTypeForScoringModel(singles, undefined)).toBe(true);
+  });
+});
+
+describe("gameTypesForScoringModel — the offered menu", () => {
+  it("a match_play comp offers 1v1/2v2/rack + manual, NOT stroke", () => {
+    const offered = gameTypesForScoringModel("match_play").map(id);
+    expect(offered).toContain("gtt_match_play_singles");
+    expect(offered).toContain("gtt_match_play_doubles");
+    expect(offered).toContain("gtt_rack_n_stack");
+    expect(offered).toContain("gtt_manual"); // manual types fit any comp
+    expect(offered).not.toContain("gtt_stroke_play");
+  });
+
+  it("a points comp offers Stroke + manual, NOT the match-play golf formats", () => {
+    const offered = gameTypesForScoringModel("points").map(id);
+    expect(offered).toContain("gtt_stroke_play");
+    expect(offered).toContain("gtt_manual");
+    expect(offered).not.toContain("gtt_match_play_singles");
+    expect(offered).not.toContain("gtt_match_play_doubles");
+    expect(offered).not.toContain("gtt_rack_n_stack");
+  });
+
+  it("points golf is Stroke-only today (stableford/sabotage/skins unbuilt)", () => {
+    const golfOffered = gameTypesForScoringModel("points").filter((t) => t.isGolf).map(id);
+    expect(golfOffered).toEqual(["gtt_stroke_play"]);
+  });
+
+  it("a null scoring-model offers the whole catalog", () => {
+    expect(gameTypesForScoringModel(null)).toHaveLength(GAME_TYPES.length);
+  });
+});

--- a/src/lib/gameTypes.ts
+++ b/src/lib/gameTypes.ts
@@ -68,8 +68,26 @@ export interface GameTypeDefinition {
   supportsSides: boolean | null;
   requiresSides: boolean | null;
   maxPlayersPerSide: number | null;
-  compatibleCompetitionFormats: string[] | null;
+  /**
+   * Which competition SCORING-MODELs (`match_play | points`) this format can be
+   * scored in — the canonical competition axis (`competitions.scoring_model`,
+   * W-NONGOLF-02), deliberately independent of team count. `null` = unconstrained
+   * (the manual non-engine types fit any competition).
+   *
+   * Renamed from the old `compatibleCompetitionFormats` (values `ryder_cup` /
+   * `free_for_all`): that was dead metadata — read by nothing — and named after
+   * competition ARCHETYPES that fused scoring-model + team-shape. The shape axis
+   * lives in supportsSides/requiresSides/maxPlayersPerSide, so this is purely the
+   * scoring-model compatibility, re-tagged to the axis the W-TYPE-01 add-game
+   * filter reads. NB rack-n-stack is `match_play` — its net-stroke ENTRY mechanics
+   * are not the points SCORING-model; it produces per-slot win/halve like match
+   * play and computes in a match-play cup (raw stroke does not).
+   */
+  compatibleScoringModels: ScoringModel[] | null;
 }
+
+/** The competition scoring-model axis (W-NONGOLF-02) — `competitions.scoring_model`. */
+export type ScoringModel = "match_play" | "points";
 
 // ── Shared golf scorecard schemas ────────────────────────────────────────────
 // Copied verbatim from the live `game_type_templates.scorecard_schema`. The
@@ -142,7 +160,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: false,
     requiresSides: false,
     maxPlayersPerSide: null,
-    compatibleCompetitionFormats: ["free_for_all"],
+    compatibleScoringModels: ["points"],
   },
   gtt_match_play_singles: {
     id: "gtt_match_play_singles",
@@ -159,7 +177,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: true,
     requiresSides: true,
     maxPlayersPerSide: 1,
-    compatibleCompetitionFormats: ["ryder_cup"],
+    compatibleScoringModels: ["match_play"],
   },
   gtt_match_play_doubles: {
     id: "gtt_match_play_doubles",
@@ -176,7 +194,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: true,
     requiresSides: true,
     maxPlayersPerSide: 2,
-    compatibleCompetitionFormats: ["ryder_cup"],
+    compatibleScoringModels: ["match_play"],
   },
   gtt_rack_n_stack: {
     id: "gtt_rack_n_stack",
@@ -193,7 +211,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: true,
     requiresSides: true,
     maxPlayersPerSide: null,
-    compatibleCompetitionFormats: ["ryder_cup"],
+    compatibleScoringModels: ["match_play"],
   },
   gtt_generic_card: {
     id: "gtt_generic_card",
@@ -210,7 +228,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: null,
     requiresSides: null,
     maxPlayersPerSide: null,
-    compatibleCompetitionFormats: null,
+    compatibleScoringModels: null,
   },
   gtt_generic_yard: {
     id: "gtt_generic_yard",
@@ -227,7 +245,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: null,
     requiresSides: null,
     maxPlayersPerSide: null,
-    compatibleCompetitionFormats: null,
+    compatibleScoringModels: null,
   },
   gtt_generic_bar: {
     id: "gtt_generic_bar",
@@ -244,7 +262,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: null,
     requiresSides: null,
     maxPlayersPerSide: null,
-    compatibleCompetitionFormats: null,
+    compatibleScoringModels: null,
   },
   gtt_manual: {
     id: "gtt_manual",
@@ -261,7 +279,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     supportsSides: true,
     requiresSides: false,
     maxPlayersPerSide: null,
-    compatibleCompetitionFormats: null,
+    compatibleScoringModels: null,
   },
 };
 
@@ -288,6 +306,9 @@ export interface GameType {
   resultStrategy: string | null;
   category: string;
   compatibleModifiers: string[];
+  /** Scoring-models this format can be scored in; `null` = any (manual types).
+   *  The W-TYPE-01 add-game filter reads this against `competitions.scoring_model`. */
+  compatibleScoringModels: ScoringModel[] | null;
 }
 
 /** Project a definition to the client `GameType` shape. */
@@ -302,11 +323,39 @@ export function toGameType(d: GameTypeDefinition): GameType {
     resultStrategy: d.resultStrategy,
     category: d.category,
     compatibleModifiers: d.compatibleModifiers,
+    compatibleScoringModels: d.compatibleScoringModels,
   };
 }
 
 /** The client format catalog — import this directly; never fetch it. */
 export const GAME_TYPES: GameType[] = GAME_TYPE_LIST.map(toGameType);
+
+// ── W-TYPE-01 — the add-game compatibility filter (data here, called by the modal) ──
+
+/**
+ * Is this format offerable in a competition of the given scoring-model? A format
+ * with `null` compatibility (the manual types) fits any competition; otherwise it
+ * must list the model. A `null`/absent scoring-model (a not-yet-classified comp)
+ * is permissive — show everything rather than an empty menu.
+ */
+export function isGameTypeForScoringModel(
+  type: Pick<GameType, "compatibleScoringModels">,
+  scoringModel: ScoringModel | null | undefined,
+): boolean {
+  if (!scoringModel) return true;
+  if (type.compatibleScoringModels == null) return true;
+  return type.compatibleScoringModels.includes(scoringModel);
+}
+
+/** The catalog filtered to a competition's scoring-model — what the add-game
+ *  modal offers (only WIRED types: match_play → 1v1/2v2/rack + manual; points →
+ *  Stroke + manual, until stableford/sabotage/skins are built). */
+export function gameTypesForScoringModel(
+  scoringModel: ScoringModel | null | undefined,
+  catalog: GameType[] = GAME_TYPES,
+): GameType[] {
+  return catalog.filter((t) => isGameTypeForScoringModel(t, scoringModel));
+}
 
 // ── Lookups (the server readers' synchronous replacement for the DB query) ────
 


### PR DESCRIPTION
Phase 3 of the config-checklist work — the add-game filter, built on the reconciled axis (Phase 0 track II).

## The reconciliation
`gameTypes.ts`'s `compatibleCompetitionFormats` was **dead metadata — read by nothing** — named after competition archetypes (`ryder_cup` / `free_for_all`) that fuse scoring-model + team-shape. The team-shape axis already lives in `supportsSides`/`requiresSides`/`maxPlayersPerSide`, so this field was purely a mis-named scoring-model tag. Renamed to **`compatibleScoringModels`** and re-tagged to the canonical `competitions.scoring_model` axis (`match_play | points`):

| Format | was | now |
|--------|-----|-----|
| Stroke Play | `free_for_all` | **points** |
| 1v1 / 2v2 Match Play | `ryder_cup` | **match_play** |
| Rack-n-Stack | `ryder_cup` | **match_play** (net-stroke *entry* ≠ points *scoring-model*; computes in a match-play cup) |
| manual types | `null` | `null` (any comp) |

Pure rename + re-tag, **zero behavioral risk** — there was no prior reader.

## The filter (W-TYPE-01)
A pure helper pair in the code-home (`isGameTypeForScoringModel` / `gameTypesForScoringModel`); the add-game modal (`GameSheet`) calls it to offer only formats compatible with the competition's `scoring_model` — **data in `gameTypes.ts`, mechanism in the modal, not hardcoded**. A `match_play` comp offers 1v1/2v2/rack + manual; a `points` comp offers Stroke + manual. Points-golf is **Stroke-only** until stableford/sabotage/skins are built (each a new `resultStrategy` + pure/DB split — captured as separate work). Edit-path lookups read the full catalog so an existing game's type always resolves.

## Verified
- By eye on BBMI (match_play): add-game golf picker shows Singles/2v2/Rack-n-Stack, **Stroke Play absent**.
- 9 filter unit tests, tsc/lint clean, critical-path E2E green.

Part of config-checklist Phase B (Phase 1 checklist + Phase 2 page-state/danger-zone follow in separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)