### PR TITLE
feat(competition): per-game danger zone — reset scores / settings / delete (config-checklist Phase 2a)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -67,7 +67,7 @@ export default function NewMatchGamePage() {
   const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { ...STRUCTURE_QUERY, enabled: !isId, retry: false });
   const tripId = isId ? param : resolved.data?.id;
 
-  const { canEdit: tripCanEdit, loading: roleLoading } = useTripRole(tripId);
+  const { canEdit: tripCanEdit, isOwner, loading: roleLoading } = useTripRole(tripId);
   const me = useCurrentUser();
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
@@ -760,6 +760,7 @@ export default function NewMatchGamePage() {
         competitionId={gameCompId}
         game={gameQ.data as unknown as GameRow}
         canEdit={canEdit}
+        isOwner={isOwner}
         onChanged={() => {
           void gameQ.refetch();
           if (competitionId) {
@@ -768,6 +769,7 @@ export default function NewMatchGamePage() {
             utils.games.listByTrip.invalidate({ tripId });
           }
         }}
+        onDeleted={() => router.push(competitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
         whosPlayingLabel={`${groups.length} ${groups.length === 1 ? "matchup" : "matchups"} · pairings & strokes`}
         onEditWhosPlaying={startSetup}
         scoringEnabled={scoringEnabled}

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -46,7 +46,7 @@ export default function NewGamePage() {
   );
   const tripId = isId ? param : resolved.data?.id;
   const utils = trpc.useUtils();
-  const { canEdit } = useTripRole(tripId);
+  const { canEdit, isOwner } = useTripRole(tripId);
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
@@ -352,7 +352,9 @@ export default function NewGamePage() {
           competitionId={gameCompetitionId}
           game={gameQ.data as unknown as GameRow}
           canEdit={canEdit}
+          isOwner={isOwner}
           onChanged={() => void refreshGame()}
+          onDeleted={() => router.push(gameCompetitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
           whosPlayingLabel={`${game.participants.length} player${game.participants.length === 1 ? "" : "s"} · per-player strokes`}
           onEditWhosPlaying={() => { setShowConfig(false); setShowHandicaps(true); }}
           scoringEnabled={scoringEnabled}

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -63,7 +63,7 @@ export default function RackNStackPage() {
   const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { ...STRUCTURE_QUERY, enabled: !isId, retry: false });
   const tripId = isId ? param : resolved.data?.id;
 
-  const { canEdit: tripCanEdit, loading: roleLoading } = useTripRole(tripId);
+  const { canEdit: tripCanEdit, isOwner, loading: roleLoading } = useTripRole(tripId);
   const me = useCurrentUser();
   const utils = trpc.useUtils();
 
@@ -459,7 +459,9 @@ export default function RackNStackPage() {
         competitionId={competitionId ?? null}
         game={gameQ.data as unknown as GameRow}
         canEdit={canEdit}
+        isOwner={isOwner}
         onChanged={() => void refreshGame()}
+        onDeleted={() => router.push(competitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
         whosPlayingLabel={`${groupsQ.data?.groups?.length ?? 0} group${(groupsQ.data?.groups?.length ?? 0) === 1 ? "" : "s"} · auto-grouped · strokes`}
         onEditWhosPlaying={() => { setShowConfig(false); setShowHandicaps(true); }}
         scoringEnabled={scoringEnabled}

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { ScrollLock } from "@/hooks/useScrollLock";
+
+/**
+ * The shared danger-zone primitives — the one in-app confirm vocabulary for every
+ * destructive action (NO window.confirm anywhere, #433). Extracted from
+ * CompetitionSettings so the competition-level ladder (reset scoring → reset
+ * skeleton → delete) and the per-game ladder (reset scores → reset settings →
+ * delete) render the SAME escalating shape, one level apart.
+ *
+ *  - SectionLabel        — the uppercase danger-zone heading.
+ *  - DangerRow           — one action: a cost blurb + a tone-colored button.
+ *  - DangerConfirmModal  — the cost-naming confirm (warning = reversible-but-heavy;
+ *                          danger = gone).
+ *
+ * Purely presentational (no tRPC) — the caller owns the mutations.
+ */
+
+export function SectionLabel({ children, danger }: { children: React.ReactNode; danger?: boolean }) {
+  return (
+    <p
+      className="px-1 text-[11px] font-semibold uppercase tracking-wider"
+      style={{ color: danger ? "var(--color-bt-danger)" : "var(--color-bt-text-dim)" }}
+    >
+      {children}
+    </p>
+  );
+}
+
+/** One danger-zone action: a labelled button with a one-line cost blurb above it.
+ *  `tone` colors the text/icon (warning = reversible-but-heavy; danger = gone). */
+export function DangerRow({
+  icon, tone, label, blurb, onClick, testId, disabled,
+}: {
+  icon: React.ReactNode;
+  tone: "warning" | "danger";
+  label: string;
+  blurb: string;
+  onClick: () => void;
+  testId: string;
+  disabled?: boolean;
+}) {
+  const color = tone === "danger" ? "var(--color-bt-danger)" : "var(--color-bt-warning)";
+  return (
+    <div>
+      <p className="mb-1.5 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+        {blurb}
+      </p>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2.5 text-sm font-semibold disabled:opacity-50"
+        style={{ background: "transparent", color, border: "1px solid var(--color-bt-border)" }}
+        data-testid={testId}
+      >
+        {icon}
+        {label}
+      </button>
+    </div>
+  );
+}
+
+// ── DangerConfirmModal — the one in-app confirm for every danger-zone action ──
+// (No window.confirm anywhere — #433.) Cost-naming body, tone-colored icon/CTA.
+export function DangerConfirmModal({
+  tone,
+  icon,
+  title,
+  body,
+  confirmLabel,
+  pendingLabel,
+  isPending,
+  testId,
+  onCancel,
+  onConfirm,
+}: {
+  tone: "warning" | "danger";
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  confirmLabel: string;
+  pendingLabel: string;
+  isPending: boolean;
+  testId: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const accent = tone === "danger" ? "var(--color-bt-danger)" : "var(--color-bt-warning)";
+  const accentFaint = tone === "danger" ? "var(--color-bt-danger-faint)" : "var(--color-bt-warning-faint)";
+
+  return (
+    <ScrollLock>
+      <div
+        className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+        style={{ background: "var(--color-bt-overlay)" }}
+        onClick={onCancel}
+      >
+        <div
+          className="w-full max-w-sm rounded-t-2xl sm:rounded-2xl"
+          style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="px-5 pt-5 pb-3 text-center sm:text-left">
+            <div
+              className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl sm:mx-0"
+              style={{ background: accentFaint, color: accent }}
+            >
+              {icon}
+            </div>
+            <h3 className="mt-3 text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
+              {title}
+            </h3>
+            <p className="mt-1.5 text-sm leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
+              {body}
+            </p>
+          </div>
+          <div className="flex flex-col-reverse gap-2 px-5 pb-5 pt-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isPending}
+              className="rounded-xl px-4 py-2.5 text-sm font-medium disabled:opacity-50"
+              style={{ background: "transparent", color: "var(--color-bt-text-dim)", border: "0.5px solid var(--color-bt-border)" }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={isPending}
+              className="rounded-xl px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
+              style={{ background: accent }}
+              data-testid={testId}
+            >
+              {isPending ? pendingLabel : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </ScrollLock>
+  );
+}

--- a/src/components/competition/CompetitionSettings.tsx
+++ b/src/components/competition/CompetitionSettings.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Trash2, RotateCcw, Eraser } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
-import { ScrollLock } from "@/hooks/useScrollLock";
+import { SectionLabel, DangerRow, DangerConfirmModal } from "@/components/DangerZone";
 
 interface Competition {
   id: string;
@@ -313,131 +313,6 @@ function DangerSection({
         />
       )}
     </section>
-  );
-}
-
-/** One danger-zone action: a labelled button with a one-line cost blurb above it.
- *  `tone` colors the text/icon (warning = reversible-but-heavy; danger = gone). */
-function DangerRow({
-  icon, tone, label, blurb, onClick, testId,
-}: {
-  icon: React.ReactNode;
-  tone: "warning" | "danger";
-  label: string;
-  blurb: string;
-  onClick: () => void;
-  testId: string;
-}) {
-  const color = tone === "danger" ? "var(--color-bt-danger)" : "var(--color-bt-warning)";
-  return (
-    <div>
-      <p className="mb-1.5 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-        {blurb}
-      </p>
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2.5 text-sm font-semibold"
-        style={{ background: "transparent", color, border: "1px solid var(--color-bt-border)" }}
-        data-testid={testId}
-      >
-        {icon}
-        {label}
-      </button>
-    </div>
-  );
-}
-
-function SectionLabel({ children, danger }: { children: React.ReactNode; danger?: boolean }) {
-  return (
-    <p
-      className="px-1 text-[11px] font-semibold uppercase tracking-wider"
-      style={{ color: danger ? "var(--color-bt-danger)" : "var(--color-bt-text-dim)" }}
-    >
-      {children}
-    </p>
-  );
-}
-
-// ── DangerConfirmModal — the one in-app confirm for every danger-zone action ──
-// (No window.confirm anywhere — #433.) Cost-naming body, tone-colored icon/CTA.
-
-function DangerConfirmModal({
-  tone,
-  icon,
-  title,
-  body,
-  confirmLabel,
-  pendingLabel,
-  isPending,
-  testId,
-  onCancel,
-  onConfirm,
-}: {
-  tone: "warning" | "danger";
-  icon: React.ReactNode;
-  title: string;
-  body: string;
-  confirmLabel: string;
-  pendingLabel: string;
-  isPending: boolean;
-  testId: string;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  const accent = tone === "danger" ? "var(--color-bt-danger)" : "var(--color-bt-warning)";
-  const accentFaint = tone === "danger" ? "var(--color-bt-danger-faint)" : "var(--color-bt-warning-faint)";
-
-  return (
-    <ScrollLock>
-      <div
-        className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
-        style={{ background: "var(--color-bt-overlay)" }}
-        onClick={onCancel}
-      >
-        <div
-          className="w-full max-w-sm rounded-t-2xl sm:rounded-2xl"
-          style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className="px-5 pt-5 pb-3 text-center sm:text-left">
-            <div
-              className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl sm:mx-0"
-              style={{ background: accentFaint, color: accent }}
-            >
-              {icon}
-            </div>
-            <h3 className="mt-3 text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
-              {title}
-            </h3>
-            <p className="mt-1.5 text-sm leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-              {body}
-            </p>
-          </div>
-          <div className="flex flex-col-reverse gap-2 px-5 pb-5 pt-3 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              onClick={onCancel}
-              disabled={isPending}
-              className="rounded-xl px-4 py-2.5 text-sm font-medium disabled:opacity-50"
-              style={{ background: "transparent", color: "var(--color-bt-text-dim)", border: "0.5px solid var(--color-bt-border)" }}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={onConfirm}
-              disabled={isPending}
-              className="rounded-xl px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
-              style={{ background: accent }}
-              data-testid={testId}
-            >
-              {isPending ? pendingLabel : confirmLabel}
-            </button>
-          </div>
-        </div>
-      </div>
-    </ScrollLock>
   );
 }
 

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { GameDangerZone } from "@/components/games/GameDangerZone";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 
 /**
@@ -22,7 +23,9 @@ export function GameConfigurationView({
   competitionId,
   game,
   canEdit,
+  isOwner,
   onChanged,
+  onDeleted,
   whosPlayingLabel,
   onEditWhosPlaying,
   scoringEnabled,
@@ -36,7 +39,12 @@ export function GameConfigurationView({
   competitionId: string | null;
   game: GameRow;
   canEdit: boolean;
+  /** Owner gates the per-game danger zone (reset/delete) — owner-only, matching
+   *  the server. Co-admins/delegates configure but don't get the danger ladder. */
+  isOwner: boolean;
   onChanged: () => void;
+  /** Game deleted from the danger zone — leave the page (back to the board). */
+  onDeleted: () => void;
   /** Summary + drill-down into the format's existing who's-playing/handicaps
    *  editor (the setup body — pairings / groups). Omit when the format has no
    *  post-create roster editor (stroke today — its handicaps step lands in §3). */
@@ -105,6 +113,18 @@ export function GameConfigurationView({
               : "Disabled — closed to the crew. Keep configuring here; enable when you’re ready. Any scores already entered are kept."}
           </p>
         </div>
+
+        {/* Per-game danger zone — owner-only (reset scores → reset settings →
+            delete), reusing the shared confirm vocabulary + the Phase A resets. */}
+        {isOwner && (
+          <GameDangerZone
+            tripId={tripId}
+            gameId={game.id}
+            competitionId={competitionId}
+            onChanged={onChanged}
+            onDeleted={onDeleted}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/games/GameDangerZone.tsx
+++ b/src/components/games/GameDangerZone.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { RotateCcw, Eraser, Trash2 } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { SectionLabel, DangerRow, DangerConfirmModal } from "@/components/DangerZone";
+
+/**
+ * The per-game danger zone — the escalating ladder ONE LEVEL DOWN from the
+ * competition's (CompetitionSettings), reusing the same shared primitives:
+ *
+ *   Reset scores  → games.resetScoring   (clears this game's results; config kept)
+ *   Reset settings → games.resetToSkeleton (clears config to a shell; identity +
+ *                    per-match point VALUE kept — §E-1)
+ *   Delete game   → games.delete
+ *
+ * Owner-only (the resets are owner-gated server-side; the host renders this only
+ * for the owner). The resets call the Phase A primitives (migration 066). After a
+ * reset it invalidates the game's own caches AND the faceBootstrap-seeded board
+ * (pattern #10) so the page + the leaderboard reflect the cleared state without a
+ * hard reload; `onChanged` lets the host refetch its local game query.
+ */
+export function GameDangerZone({
+  tripId,
+  gameId,
+  competitionId,
+  onChanged,
+  onDeleted,
+}: {
+  tripId: string;
+  gameId: string;
+  competitionId: string | null;
+  /** Refetch the host's game view after a reset (config/scoring changed). */
+  onChanged: () => void;
+  /** Game removed — leave the page (back to the board / trip). */
+  onDeleted: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const [confirm, setConfirm] = useState<"scoring" | "skeleton" | "delete" | null>(null);
+
+  function invalidateAfterReset() {
+    void utils.games.getById.invalidate({ tripId, gameId });
+    void utils.scores.listByGame.invalidate({ tripId, gameId });
+    void utils.matches.listByGame.invalidate({ tripId, gameId });
+    void utils.playGroups.listByGame.invalidate({ tripId, gameId });
+    void utils.games.listByTrip.invalidate({ tripId });
+    if (competitionId) {
+      void utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+      void utils.competitions.faceBootstrap.invalidate({ tripId });
+    }
+    onChanged();
+  }
+
+  const resetScoring = trpc.games.resetScoring.useMutation({
+    onSuccess: () => { setConfirm(null); invalidateAfterReset(); },
+  });
+  const resetToSkeleton = trpc.games.resetToSkeleton.useMutation({
+    onSuccess: () => { setConfirm(null); invalidateAfterReset(); },
+  });
+  const deleteGame = trpc.games.delete.useMutation({
+    onSuccess: () => {
+      void utils.games.listByTrip.invalidate({ tripId });
+      if (competitionId) {
+        void utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+        void utils.competitions.faceBootstrap.invalidate({ tripId });
+      }
+      setConfirm(null);
+      onDeleted();
+    },
+  });
+
+  return (
+    <section className="mt-8 space-y-3">
+      <SectionLabel danger>Danger zone</SectionLabel>
+      <div
+        className="space-y-3 rounded-xl p-4"
+        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      >
+        <DangerRow
+          icon={<RotateCcw size={14} />}
+          tone="warning"
+          label="Reset scores"
+          blurb="Clears this game's scores. Pairings, course, handicaps, and points stay — the game is ready to re-score."
+          onClick={() => setConfirm("scoring")}
+          testId="game-reset-scoring-btn"
+        />
+        <DangerRow
+          icon={<Eraser size={14} />}
+          tone="warning"
+          label="Reset game settings"
+          blurb="Resets this game to unconfigured. Pairings, course, handicaps, and scores are cleared; the name and point value stay."
+          onClick={() => setConfirm("skeleton")}
+          testId="game-reset-skeleton-btn"
+        />
+        <DangerRow
+          icon={<Trash2 size={14} />}
+          tone="danger"
+          label="Delete game"
+          blurb="Removes this game and everything in it — pairings, scores, and results. This can't be undone."
+          onClick={() => setConfirm("delete")}
+          testId="game-delete-btn"
+        />
+      </div>
+
+      {confirm === "scoring" && (
+        <DangerConfirmModal
+          tone="warning"
+          icon={<RotateCcw size={18} />}
+          title="Reset this game's scores?"
+          body="Clears all scores for this game. Pairings, course, handicaps, and points stay — it's ready to re-score."
+          confirmLabel="Reset scores"
+          pendingLabel="Resetting…"
+          isPending={resetScoring.isPending}
+          testId="game-reset-scoring-confirm"
+          onCancel={() => setConfirm(null)}
+          onConfirm={() => resetScoring.mutate({ tripId, gameId })}
+        />
+      )}
+      {confirm === "skeleton" && (
+        <DangerConfirmModal
+          tone="warning"
+          icon={<Eraser size={18} />}
+          title="Reset this game to skeleton?"
+          body="Resets this game to unconfigured — pairings, course, handicaps, and scores are cleared. The name and point value stay; you'll set it up again."
+          confirmLabel="Reset settings"
+          pendingLabel="Resetting…"
+          isPending={resetToSkeleton.isPending}
+          testId="game-reset-skeleton-confirm"
+          onCancel={() => setConfirm(null)}
+          onConfirm={() => resetToSkeleton.mutate({ tripId, gameId })}
+        />
+      )}
+      {confirm === "delete" && (
+        <DangerConfirmModal
+          tone="danger"
+          icon={<Trash2 size={18} />}
+          title="Delete this game?"
+          body="This removes the game and all its pairings, scores, and results. This cannot be undone."
+          confirmLabel="Delete game"
+          pendingLabel="Deleting…"
+          isPending={deleteGame.isPending}
+          testId="game-delete-confirm"
+          onCancel={() => setConfirm(null)}
+          onConfirm={() => deleteGame.mutate({ tripId, gameId })}
+        />
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Part of config-checklist Phase B. Gives each **game** its own owner-only danger ladder, one level down from the competition's, reusing extracted primitives + the Phase A resets.

## What
- **Extract** `SectionLabel` + `DangerRow` + `DangerConfirmModal` out of `CompetitionSettings` into a shared **`src/components/DangerZone.tsx`** (purely presentational, no tRPC) — the one in-app confirm vocabulary (no `window.confirm`, #433). `CompetitionSettings` now imports them; its competition ladder is unchanged.
- **`GameDangerZone`** (new) — the escalating per-game ladder: **Reset scores** (`games.resetScoring`) → **Reset game settings** (`games.resetToSkeleton`, keeps identity + per-match value §E-1) → **Delete game** (`games.delete`). The resets are the **Phase A** primitives (migration 066). After a reset it invalidates the game's own caches **and** `faceBootstrap` (pattern #10) so the page + board reflect the cleared state without a hard reload.
- **Wired into `GameConfigurationView`** (the existing post-Enable per-game settings home, shared by stroke/match/rack), **owner-only** (`isOwner` from `useTripRole`; the resets are owner-gated server-side). `onDeleted` leaves to the board/trip.

## Verified
By eye on BBMI (owner): the Configuration screen shows the three rungs; the "Reset scores" confirm opens with cost-naming copy and **cancels clean — no BBMI data touched**. tsc/lint clean; critical-path E2E green.

Independent of the Phase 3 filter PR (#456) — no file overlap. The full checklist surface + page-state model land in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)