### PR TITLE
test(e2e): match-play scoring spine — the second merge-blocking gate (config-checklist Phase B)

### DIFF
--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Match-play E2E — the SECOND merge-blocking spine, alongside the stroke
+ * critical-path. Match-play is the reference format the config-checklist + future
+ * formats build on, so its core path gets a repeatable gate instead of by-hand
+ * verification: **create a 1v1 match game → set the pairing → enter a hole → the
+ * scorecard reflects it**, driven through the real UI as the logged-in owner
+ * (storageState from auth.setup.ts).
+ *
+ * Standalone (no competition) on purpose: a 1v1 match with no competition pairs
+ * from the whole trip crew, so the seed is the same minimal trip + 2 members as
+ * the stroke spine — the match-specific surface (pairing builder, single-match
+ * entry) is what's actually walked. Runs against the remote project; a UNIQUE
+ * trip per run + full teardown.
+ */
+
+const OWNER_EMAIL = "test-owner@buddytrip.app";
+const MEMBER_EMAIL = "test-member@buddytrip.app";
+const PASSWORD = "BuddyTripTest2026!";
+
+let admin: SupabaseClient;
+let tripId: string;
+let ownerId: string;
+let memberId: string;
+
+async function ensureUser(email: string, name: string): Promise<string> {
+  const { data: list, error } = await admin.auth.admin.listUsers();
+  if (error) throw new Error(`listUsers failed: ${error.message}`);
+  const found = list?.users?.find((u) => u.email === email);
+  if (found) return found.id;
+  const { data, error: createErr } = await admin.auth.admin.createUser({
+    email, password: PASSWORD, email_confirm: true, user_metadata: { name },
+  });
+  if (createErr || !data.user) throw new Error(`createUser ${email} failed: ${createErr?.message}`);
+  return data.user.id;
+}
+
+test.beforeAll(async () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("E2E needs NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY");
+  admin = createClient(url, key);
+
+  ownerId = await ensureUser(OWNER_EMAIL, "Test Owner");
+  memberId = await ensureUser(MEMBER_EMAIL, "Test Member");
+
+  tripId = `e2e-mp-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const { error: tErr } = await admin.from("trips").insert({ id: tripId, title: "E2E Match Play" });
+  if (tErr) throw new Error(`seed trip failed: ${tErr.message}`);
+  // Trip-scoped nicknames make the player picker deterministic regardless of the
+  // shared users' drifting account names.
+  const { error: mErr } = await admin.from("trip_members").insert([
+    { trip_id: tripId, user_id: ownerId, role: "Owner", status: "in", nickname: "MP Owner" },
+    { trip_id: tripId, user_id: memberId, role: "Member", status: "in", nickname: "MP Member" },
+  ]);
+  if (mErr) throw new Error(`seed members failed: ${mErr.message}`);
+});
+
+test.afterAll(async () => {
+  if (!admin || !tripId) return;
+  const { data: games } = await admin.from("games").select("id").eq("trip_id", tripId);
+  for (const g of games ?? []) {
+    await admin.from("score_entries").delete().eq("game_id", g.id);
+    await admin.from("game_matches").delete().eq("game_id", g.id);
+    await admin.from("game_participants").delete().eq("game_id", g.id);
+    await admin.from("games").delete().eq("id", g.id);
+  }
+  await admin.from("trip_members").delete().eq("trip_id", tripId);
+  await admin.from("trips").delete().eq("id", tripId);
+});
+
+test("match-play spine — 1v1: create → pair → enter a hole → scorecard reflects it", async ({ page }) => {
+  // Several sequential remote round-trips (create, pairing, enable, score writes).
+  test.setTimeout(60_000);
+
+  // 1. New 1v1 match game (no ?format → singles).
+  await page.goto(`/trips/${tripId}/games/match/new`);
+  const createBtn = page.getByRole("button", { name: "Create game" });
+  await expect(createBtn).toBeVisible({ timeout: 20_000 });
+  await createBtn.click();
+
+  // 2. Set the pairing on the "Set Pairings" setup screen: tap each empty slot →
+  //    pick a player from the selector (waiting for the selector to open before
+  //    picking). After slot A is filled the remaining "Add player" is slot B.
+  const addPlayer = page.getByRole("button", { name: "Add player" });
+  await expect(addPlayer.first()).toBeVisible({ timeout: 20_000 });
+  await addPlayer.first().click();
+  const ownerRow = page.getByRole("button", { name: /MP Owner/ });
+  await expect(ownerRow).toBeVisible({ timeout: 10_000 });
+  await ownerRow.click();
+
+  // Slot A now shows MP Owner; the remaining "Add player" is slot B.
+  await expect(page.getByRole("button", { name: /MP Owner/ })).toBeVisible(); // slot A filled
+  await addPlayer.first().click();
+  const memberRow = page.getByRole("button", { name: /MP Member/ });
+  await expect(memberRow).toBeVisible({ timeout: 10_000 });
+  await memberRow.click();
+
+  // 3. Enable scoring → the overview. Gate on the button being ENABLED — that's
+  //    the signal both slots are filled (filledCount > 0), so the click can't race
+  //    an incomplete pairing and trip the collapse confirm.
+  const enableBtn = page.getByRole("button", { name: "Enable scoring" });
+  await expect(enableBtn).toBeEnabled({ timeout: 10_000 });
+  await enableBtn.click();
+
+  // 4. Open the single match (the strip card button) → the per-hole entry view.
+  const matchCard = page.getByRole("button", { name: /Match 1.*MP Owner/ });
+  await expect(matchCard).toBeVisible({ timeout: 20_000 });
+  await matchCard.click();
+
+  // 5. Enter hole 1 for both sides. The keypad targets the first un-scored
+  //    participant (side A = MP Owner), then Confirm advances to side B. Distinct
+  //    values so the assertion can't pass on coincidence (Owner 4 beats Member 6).
+  const score4 = page.getByRole("button", { name: "Score 4", exact: true });
+  await expect(score4).toBeVisible({ timeout: 20_000 });
+  await score4.click();
+  await page.getByRole("button", { name: "Confirm score" }).click();
+  const score6 = page.getByRole("button", { name: "Score 6", exact: true });
+  await expect(score6).toBeVisible({ timeout: 20_000 });
+  await score6.click();
+  await page.getByRole("button", { name: "Confirm score" }).click();
+
+  // 6. Open the scorecard grid and assert BOTH scores landed in the right cells
+  //    (keyed by participant id = user id, hole "1").
+  await page.getByRole("button", { name: "Scorecard grid" }).click();
+  await expect(page.getByTestId(`score-cell-${ownerId}-1`)).toHaveText("4");
+  await expect(page.getByTestId(`score-cell-${memberId}-1`)).toHaveText("6");
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,11 +25,12 @@ export default defineConfig({
     // does a server-side getUser() that route-mocks can't satisfy).
     { name: "setup", testMatch: /auth\.setup\.ts/ },
     {
-      // Scoped to the ONE critical-path spec — the merge-blocking CI gate. The
-      // other e2e/*.spec.ts files are the deferred mocked set (Issue #29) and
-      // match no project, so they don't run.
+      // The merge-blocking CI gate: the real-UI scoring SPINES — stroke
+      // (critical-path) and match-play (the reference format the config-checklist
+      // + future formats build on). The other e2e/*.spec.ts files are the
+      // deferred mocked set (Issue #29) and match no project, so they don't run.
       name: "critical-path",
-      testMatch: /critical-path\.spec\.ts/,
+      testMatch: /(critical-path|match-play)\.spec\.ts/,
       use: { ...devices["Desktop Chrome"], storageState: STORAGE_STATE },
       dependencies: ["setup"],
     },


### PR DESCRIPTION
Adds the **match-play E2E** — turning the manual verification burden into a repeatable gate, and covering the reference path the config-checklist + future formats build on.

## What
The core match-play path through the real UI as the owner: **create a 1v1 match → set the pairing → enter a hole → the scorecard reflects it**. Standalone (no competition) on purpose — a 1v1 with no competition pairs from the whole crew, so the seed is the same minimal trip + 2 members as the stroke spine; the match-specific surface (pairing builder, single-match entry) is what's actually walked.

The merge-blocking `critical-path` Playwright project now matches **both** spines (`critical-path` + `match-play`).

## Hardened up front
Built with the lessons from the stroke keypad flake (#454): wait for the player selector to open before picking, gate "Enable scoring" on being **enabled** (the signal both slots are filled, so the click can't race an incomplete pairing), wait for each keypad key, and `test.setTimeout(60s)` for the remote round-trips.

## Verified
`--repeat-each=3` green; both spines together green (16.3s). Lands **before** the checklist reshape so it guards the reference path through the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)