### PR TITLE
feat(competition): the checklist MODEL — Sheet primitive, canonical row + states, editor overlays, flatten

### DIFF
--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -93,24 +93,39 @@ async function driveToSetupWithHandicap(page: Page) {
   await expect(createBtn).toBeVisible({ timeout: 20_000 });
   await createBtn.click();
 
-  // Pair each slot — tap "Add player", pick from the selector. After slot A fills,
-  // the remaining "Add player" is slot B.
-  const addPlayer = page.getByRole("button", { name: "Add player" });
-  await expect(addPlayer.first()).toBeVisible({ timeout: 20_000 });
+  // The checklist model: each editor is a Sheet behind its row. Open the MATCHES
+  // row → its Sheet → pair both slots (scoped to the sheet's pairing builder so the
+  // slot-fill check isn't fooled by the player-selector modal) → dismiss (the
+  // recede). The player selector renders at page level OVER the sheet.
+  await page.getByTestId("row-matches").click();
+  const matchesSheet = page.getByTestId("matches-sheet");
+  await expect(matchesSheet).toBeVisible({ timeout: 20_000 });
+  const addPlayer = matchesSheet.getByRole("button", { name: "Add player" });
+  await expect(addPlayer.first()).toBeVisible({ timeout: 10_000 });
   await addPlayer.first().click();
   await page.getByRole("button", { name: /MP Owner/ }).click();
-  await expect(page.getByRole("button", { name: /MP Owner/ })).toBeVisible(); // slot A filled
+  await expect(matchesSheet.getByRole("button", { name: /MP Owner/ })).toBeVisible({ timeout: 10_000 }); // slot A filled
   await addPlayer.first().click();
   await page.getByRole("button", { name: /MP Member/ }).click();
+  await expect(matchesSheet.getByRole("button", { name: /MP Member/ })).toBeVisible({ timeout: 10_000 }); // slot B filled
+  await page.getByRole("button", { name: "Close" }).click(); // dismiss → recede to the row
+  await expect(matchesSheet).toBeHidden({ timeout: 10_000 });
 
-  // Give MP Member a stroke via the RELOCATED Handicaps row (no longer inline in
-  // the pairing builder). Scoped to the handicaps section so it's the relocated
-  // control, not a pairing slot. Picking a side defaults to 1 stroke → the control
-  // resolves to "on hole …"; gate on that so the tap can't silently race the row.
+  // Open the HANDICAPS row → its Sheet → give MP Member a stroke via the relocated
+  // control. The Handicaps row is read-only ("Set matches first") until the pairing
+  // reflects — gate on it leaving that state so the tap can't hit the non-tappable
+  // row. Picking a side defaults to 1 stroke → resolves to "on hole …"; gate on
+  // that too so the tap can't race the sheet's just-rendered control.
+  await expect(page.getByTestId("row-handicaps")).not.toContainText("Set matches first", { timeout: 10_000 });
+  await page.getByTestId("row-handicaps").click();
+  const handicapsSheet = page.getByTestId("handicaps-sheet");
+  await expect(handicapsSheet).toBeVisible({ timeout: 10_000 });
   const handicaps = page.getByTestId("handicaps-section");
   await expect(handicaps).toBeVisible({ timeout: 10_000 });
   await handicaps.getByRole("button", { name: /MP Member/ }).click();
   await expect(handicaps.getByText(/on hole/i)).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Close" }).click(); // dismiss → recede to the row
+  await expect(handicapsSheet).toBeHidden({ timeout: 10_000 });
 }
 
 test("match-play spine — pair + relocated handicap → enable → enter a hole → scorecard", async ({ page }) => {

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus, Check, Circle } from "lucide-react";
+import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
@@ -10,6 +10,8 @@ import { useTripRole } from "@/hooks/useTripRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
+import { Sheet } from "@/components/Sheet";
+import { ChecklistRow, type ChecklistRowState } from "@/components/games/ChecklistRow";
 import { MatchCard } from "@/components/games/MatchCard";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { RelHandicapControl } from "@/components/games/RelHandicapControl";
@@ -99,6 +101,9 @@ export default function NewMatchGamePage() {
   // Setup editing state
   const [draft, setDraft] = useState<DraftMatch[]>([]);
   const [selector, setSelector] = useState<{ matchIdx: number; slot: "a" | "b"; memberIdx: number } | null>(null);
+  // Which checklist editor is open as a Sheet overlay (config-checklist model —
+  // the row is home, the editor surfaces over it and recedes on dismiss).
+  const [editorSheet, setEditorSheet] = useState<"matches" | "handicaps" | null>(null);
   // Back-stack: forward transitions push the screen they left; Back pops to it.
   // Empty stack means we arrived directly (derived screen) → leave to trip home.
   const [navStack, setNavStack] = useState<Screen[]>([]);
@@ -809,7 +814,7 @@ export default function NewMatchGamePage() {
   }
 
   // ── Shell for the setup screens ──
-  const headerTitle = screen === "new" ? "New game" : screen === "setup" ? "Set Pairings" : "Matches";
+  const headerTitle = screen === "new" ? "New game" : screen === "setup" ? "Game Setup" : "Matches";
   return (
     <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: "100vh" }}>
       <SetupHeader
@@ -860,94 +865,125 @@ export default function NewMatchGamePage() {
       {screen === "member-wait" && <MemberNotReady gameName={gameQ.data?.name as string | undefined} />}
 
       {screen === "setup" && (() => {
-        // The config CHECKLIST (Phase 1) — the rows you resolve to ready a match
-        // game, the same surface pre- and post-live. Matches is the unit row (the
-        // pairing builder); Handicaps relocated to its own row, gated by Matches.
+        // The config CHECKLIST — six UNIFORM canonical rows; each opens its editor
+        // as a Sheet overlay (the row is home, the editor surfaces and recedes on
+        // dismiss). Matches is the unit row; Handicaps relocated, gated by Matches.
         const allFilled = draft.length > 0 && filledDraft.length === draft.length;
         const anyHandicap = draft.some((d) => d.handicap !== 0);
+        const matchesExist = filledDraft.length > 0;
         const savingSetup =
           setPairings.isPending || setHandicap.isPending ||
           setDoublesPairings.isPending || setDoublesHandicap.isPending;
         const availableCount = (gameCompId && rosterIds.length > 0 ? rosterIds.length : (crew.data?.length ?? 0));
+        const tA = teamForSlot("a");
+        const tB = teamForSlot("b");
+        const matchesSummary = matchesExist
+          ? `${filledDraft.length} match${filledDraft.length === 1 ? "" : "es"}${tA && tB ? ` · ${tA.name} vs ${tB.name}` : ""}`
+          : "Not set";
+        const handicapsState: ChecklistRowState = !matchesExist ? "unresolved" : anyHandicap ? "resolved" : "acknowledged-empty";
+        const handicapsSummary = !matchesExist ? "Set matches first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
         return (
-        <div className="flex flex-col gap-5 pb-4">
-          {/* Available Players — read-only summary (the pool the game draws from;
-              a pluggable source is W-STANDALONE-01). */}
-          <ChecklistRow label="Available players" value={`${availableCount} player${availableCount === 1 ? "" : "s"}`} muted />
+        <>
+          <div className="flex flex-col gap-2.5 pb-4">
+            {/* Available Players — read-only summary (pool = roster/crew; a
+                pluggable source is W-STANDALONE-01). */}
+            <ChecklistRow label="Available players" value={`${availableCount} player${availableCount === 1 ? "" : "s"}`} state="resolved" />
 
-          {/* Matches — the pairing builder (the score-entry unit). */}
-          <ChecklistSection label="Matches" resolved={filledDraft.length > 0}>
-            <MatchSetup
-              tripId={tripId}
-              draft={draft}
-              setDraft={setDraft}
-              playersPerSide={playersPerSide}
-              teamA={teamForSlot("a")}
-              teamB={teamForSlot("b")}
-              nameOf={nameOf}
-              colorOf={colorOf}
-              avatarIconOf={avatarIconOf}
-              openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
+            {/* Matches — the pairing builder (the score-entry unit), behind a Sheet. */}
+            <ChecklistRow
+              label="Matches"
+              value={matchesSummary}
+              state={matchesExist ? "resolved" : "unresolved"}
+              onClick={() => setEditorSheet("matches")}
+              testId="row-matches"
             />
-          </ChecklistSection>
 
-          {/* Handicaps — relocated from the pairing builder; gated by Matches.
-              "Off — scratch" (no strokes) is a valid done. */}
-          <ChecklistSection label="Handicaps" optional resolved={anyHandicap} acknowledgedEmpty={filledDraft.length > 0 && !anyHandicap}>
-            <HandicapsSection
-              draft={draft}
-              setDraft={setDraft}
-              playersPerSide={playersPerSide}
-              nameOf={nameOf}
-              colorOf={colorOf}
-              avatarIconOf={avatarIconOf}
+            {/* Handicaps — relocated; gated by Matches ("Off — scratch" is a valid
+                done). Read-only (no editor) until matches exist. */}
+            <ChecklistRow
+              label="Handicaps"
+              value={handicapsSummary}
+              state={handicapsState}
+              optional
+              onClick={matchesExist ? () => setEditorSheet("handicaps") : undefined}
+              testId="row-handicaps"
             />
-          </ChecklistSection>
 
-          {/* Golf Course + Name·Format·Points — the existing standardized drill rows. */}
-          {gameQ.data && (
-            <GameSetupRows
-              tripId={tripId}
-              competitionId={gameCompId}
-              game={gameQ.data as unknown as GameRow}
-              canEdit={canEdit}
-              onChanged={() => {
-                void gameQ.refetch();
-                if (competitionId) {
-                  utils.competitions.leaderboard.invalidate({ tripId, competitionId });
-                  utils.competitions.faceBootstrap.invalidate({ tripId });
-                  utils.games.listByTrip.invalidate({ tripId });
-                }
-              }}
-            />
-          )}
+            {/* Golf Course + Name·Format·Points — the shared canonical rows. */}
+            {gameQ.data && (
+              <GameSetupRows
+                tripId={tripId}
+                competitionId={gameCompId}
+                game={gameQ.data as unknown as GameRow}
+                canEdit={canEdit}
+                onChanged={() => {
+                  void gameQ.refetch();
+                  if (competitionId) {
+                    utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+                    utils.competitions.faceBootstrap.invalidate({ tripId });
+                    utils.games.listByTrip.invalidate({ tripId });
+                  }
+                }}
+              />
+            )}
 
-          {/* Modifiers — acknowledge-only: the toggle targets exist but no modifier
-              has a scoring effect yet, so the row is inert until those land. */}
-          <ChecklistRow label="Modifiers" value="None — coming soon" muted />
+            {/* Modifiers — acknowledge-only: the toggle targets exist but no
+                modifier has a scoring effect yet, so the row is inert until then. */}
+            <ChecklistRow label="Modifiers" value="None — coming soon" state="acknowledged-empty" />
 
-          {/* The decoupled CTAs (Phase 2b): Save persists the config WITHOUT
-              enabling (configure now, open later); Enable scoring saves + enables,
-              readiness-gated on a real match. */}
-          <div className="flex flex-col gap-2">
-            <button
-              type="button"
-              onClick={handleSaveSetup}
-              disabled={filledDraft.length === 0 || savingSetup}
-              className="w-full disabled:opacity-40"
-              style={{ height: 48, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
-              data-testid="match-save-setup"
-            >
-              {savingSetup ? "Saving…" : "Save setup"}
-            </button>
-            <PrimaryButton
-              label={enableScoring.isPending ? "Enabling…" : "Enable scoring"}
-              onClick={attemptReady}
-              disabled={savingSetup || enableScoring.isPending || filledDraft.length === 0}
-              outlined={!allFilled}
-            />
+            {/* The decoupled CTAs: Save persists config WITHOUT enabling; Enable
+                scoring saves + enables, readiness-gated on a real match. */}
+            <div className="flex flex-col gap-2 pt-2">
+              <button
+                type="button"
+                onClick={handleSaveSetup}
+                disabled={filledDraft.length === 0 || savingSetup}
+                className="w-full disabled:opacity-40"
+                style={{ height: 48, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
+                data-testid="match-save-setup"
+              >
+                {savingSetup ? "Saving…" : "Save setup"}
+              </button>
+              <PrimaryButton
+                label={enableScoring.isPending ? "Enabling…" : "Enable scoring"}
+                onClick={attemptReady}
+                disabled={savingSetup || enableScoring.isPending || filledDraft.length === 0}
+                outlined={!allFilled}
+              />
+            </div>
           </div>
-        </div>
+
+          {/* ── Editor overlays (the recede): the heavy editors live BEHIND their
+              rows, surfacing as Sheets and dismissing back to the updated row. ── */}
+          {editorSheet === "matches" && (
+            <Sheet title="Matches" subtitle="Who plays whom — the score-entry unit" onClose={() => setEditorSheet(null)} testId="matches-sheet">
+              <MatchSetup
+                tripId={tripId}
+                draft={draft}
+                setDraft={setDraft}
+                playersPerSide={playersPerSide}
+                teamA={tA}
+                teamB={tB}
+                nameOf={nameOf}
+                colorOf={colorOf}
+                avatarIconOf={avatarIconOf}
+                openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
+              />
+            </Sheet>
+          )}
+          {editorSheet === "handicaps" && (
+            <Sheet title="Handicaps" subtitle="Strokes per matchup — Off is a valid done" onClose={() => setEditorSheet(null)} testId="handicaps-sheet">
+              <HandicapsSection
+                draft={draft}
+                setDraft={setDraft}
+                playersPerSide={playersPerSide}
+                nameOf={nameOf}
+                colorOf={colorOf}
+                avatarIconOf={avatarIconOf}
+              />
+            </Sheet>
+          )}
+        </>
         );
       })()}
 
@@ -1344,16 +1380,13 @@ function MatchSetup({
   // The member slots for one side — 1 for singles, 2 stacked for doubles. Each
   // sub-slot picks a single player into that member position. A team header
   // (Blue / Red) names the side's team so the constraint is legible.
+  // A side's slots — FLAT (config-checklist flatten): no bordered per-team panel /
+  // team-name header; team identity rides as the slot's color marker (dot/ring).
+  // Visual weight = conceptual weight: a side is just its player slot(s).
   const sideSlots = (members: string[], matchIdx: number, slot: "a" | "b") => {
     const team = slot === "a" ? teamA : teamB;
     return (
       <div className="flex flex-col gap-1.5">
-        {team && (
-          <div className="flex items-center gap-1.5" style={{ paddingLeft: 2, marginBottom: 1 }}>
-            <span className="inline-block h-2 w-2 rounded-full" style={{ background: team.color }} />
-            <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", color: team.color }}>{team.name}</span>
-          </div>
-        )}
         {Array.from({ length: playersPerSide }).map((_, k) => (
           <Slot key={k} player={memberPart(members[k])} teamColor={team?.color} onTap={() => openSelector(matchIdx, slot, k)} />
         ))}
@@ -1535,67 +1568,6 @@ function HandicapsSection({
           />
         </div>
       ))}
-    </div>
-  );
-}
-
-/**
- * Checklist primitives (config-checklist Phase 1) — the row STATES, reusing the
- * surface language. A section header carries the resolve state:
- *   - unresolved        → hollow circle, dim label ("needs attention")
- *   - resolved          → accent check ("set up with real content")
- *   - acknowledged-empty→ a muted check ("Off"/"None" — a valid done; the net-new
- *     state, distinct from unresolved (not dashed/hollow) AND from resolved
- *     (muted, not accent)).
- */
-function ChecklistSection({
-  label,
-  optional,
-  resolved,
-  acknowledgedEmpty,
-  children,
-}: {
-  label: string;
-  optional?: boolean;
-  resolved?: boolean;
-  acknowledgedEmpty?: boolean;
-  children: React.ReactNode;
-}) {
-  const glyph = resolved ? (
-    <Check size={13} style={{ color: "var(--color-bt-accent)" }} />
-  ) : acknowledgedEmpty ? (
-    <Check size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-  ) : (
-    <Circle size={13} style={{ color: "var(--color-bt-text-dim)" }} />
-  );
-  return (
-    <section className="flex flex-col gap-2">
-      <div className="flex items-center gap-1.5 px-0.5">
-        {glyph}
-        <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-          {label}
-        </span>
-        {optional && <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)", fontWeight: 500 }}>· optional</span>}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-/** A read-only checklist summary row (no editor) — the resolved-but-not-editable
- *  rows (Available Players; Modifiers until effects land). */
-function ChecklistRow({ label, value, muted }: { label: string; value: string; muted?: boolean }) {
-  return (
-    <div
-      className="flex items-center justify-between gap-3 rounded-xl px-3.5 py-3"
-      style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
-    >
-      <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-        {label}
-      </span>
-      <span className="truncate text-sm" style={{ color: muted ? "var(--color-bt-text-dim)" : "var(--color-bt-text)" }}>
-        {value}
-      </span>
     </div>
   );
 }

--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { X } from "lucide-react";
+import { ScrollLock } from "@/hooks/useScrollLock";
+
+/**
+ * Sheet — the ONE overlay primitive. A focused editor/task that surfaces OVER a
+ * still-present home (the lighter drawer scrim keeps the home readable behind it)
+ * and dismisses back to it. This is the layered-surface model the navigation
+ * system reuses one level up (leaderboard → game → scorecard); the config
+ * checklist's editor overlays are that same model one level down — so this is the
+ * shared primitive, not a one-off.
+ *
+ * Replaces the four bespoke copies of the same scrim+panel+dismiss skeleton
+ * (RostersOverlay, DangerConfirmModal-ish, GameSheet, PlayerSelector). Bottom
+ * sheet on mobile, centered card on desktop; `useScrollLock` (react-remove-scroll)
+ * locks the body and stacks correctly when sheets nest. Dismiss = tap the scrim,
+ * the ✕, or whatever the body calls `onClose` from.
+ */
+export function Sheet({
+  title,
+  subtitle,
+  onClose,
+  children,
+  footer,
+  testId,
+  maxWidthClass = "max-w-lg",
+}: {
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  children: React.ReactNode;
+  /** Optional pinned footer (e.g. a commit CTA). */
+  footer?: React.ReactNode;
+  testId?: string;
+  /** Panel max width (Tailwind class). Default max-w-lg; rosters wants max-w-3xl. */
+  maxWidthClass?: string;
+}) {
+  return (
+    <ScrollLock>
+      <div
+        className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+        style={{ background: "var(--color-bt-overlay-drawer)" }}
+        onClick={onClose}
+        data-testid={testId}
+      >
+        <div
+          className={`flex max-h-[90vh] w-full ${maxWidthClass} flex-col rounded-t-2xl sm:rounded-2xl`}
+          style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div
+            className="flex items-center justify-between px-4 py-3"
+            style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+          >
+            <div className="min-w-0">
+              <h3 className="truncate text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
+                {title}
+              </h3>
+              {subtitle && (
+                <p className="truncate text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                  {subtitle}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto p-4">{children}</div>
+
+          {/* Footer (optional) */}
+          {footer && (
+            <div className="border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>
+              {footer}
+            </div>
+          )}
+        </div>
+      </div>
+    </ScrollLock>
+  );
+}

--- a/src/components/competition/RostersOverlay.tsx
+++ b/src/components/competition/RostersOverlay.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { X } from "lucide-react";
-import { ScrollLock } from "@/hooks/useScrollLock";
+import { Sheet } from "@/components/Sheet";
 import { TeamsPanel } from "./TeamsPanel";
 
 /**
@@ -44,71 +43,34 @@ export function RostersOverlay({
   onClose: () => void;
 }) {
   return (
-    <ScrollLock>
-      <div
-        className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
-        style={{ background: "var(--color-bt-overlay-drawer)" }}
-        onClick={onClose}
-        data-testid="rosters-overlay"
-      >
-        <div
-          className="flex max-h-[90vh] w-full max-w-3xl flex-col rounded-t-2xl sm:rounded-2xl"
-          style={{ background: "var(--color-bt-card-float)", border: "1px solid var(--color-bt-border)" }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {/* Header */}
-          <div
-            className="flex items-center justify-between px-4 py-3"
-            style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+    <Sheet
+      title="Rosters"
+      subtitle={isOwner ? "Tap a team to edit · drag a player onto a team to assign" : "Who’s on which team"}
+      onClose={onClose}
+      testId="rosters-overlay"
+      maxWidthClass="max-w-3xl"
+      footer={
+        isOwner && rosterBuilding ? (
+          <button
+            type="button"
+            onClick={onSaveRosters}
+            className="w-full rounded-xl py-3 text-sm font-semibold"
+            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            data-testid="rosters-save"
           >
-            <div>
-              <h3 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>
-                Rosters
-              </h3>
-              <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                {isOwner
-                  ? "Tap a team to edit · drag a player onto a team to assign"
-                  : "Who’s on which team"}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close"
-              className="flex h-8 w-8 items-center justify-center rounded-lg"
-              style={{ color: "var(--color-bt-text-dim)" }}
-            >
-              <X size={16} />
-            </button>
-          </div>
-
-          {/* Body — the relocated team-builder (read-only for non-owners). */}
-          <div className="flex-1 overflow-y-auto p-4">
-            <TeamsPanel
-              tripId={tripId}
-              competitionId={competitionId}
-              canEdit={isOwner}
-              structureLocked={structureLocked}
-              embedded
-            />
-          </div>
-
-          {/* Footer — the one-way roster-build commit (owner, building phase). */}
-          {isOwner && rosterBuilding && (
-            <div className="border-t p-4" style={{ borderColor: "var(--color-bt-border)" }}>
-              <button
-                type="button"
-                onClick={onSaveRosters}
-                className="w-full rounded-xl py-3 text-sm font-semibold"
-                style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-                data-testid="rosters-save"
-              >
-                Save rosters
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-    </ScrollLock>
+            Save rosters
+          </button>
+        ) : undefined
+      }
+    >
+      {/* The relocated team-builder (read-only for non-owners). */}
+      <TeamsPanel
+        tripId={tripId}
+        competitionId={competitionId}
+        canEdit={isOwner}
+        structureLocked={structureLocked}
+        embedded
+      />
+    </Sheet>
   );
 }

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { ChevronRight, Check } from "lucide-react";
+
+/**
+ * ChecklistRow — the ONE canonical config-checklist row (config-checklist model).
+ * Every config aspect renders as this: uniform height + shape, `label · summary ·
+ * trailing`. The heavy editor lives BEHIND it (a Sheet overlay opened on tap); the
+ * row itself only ever shows a one-line summary, so the surface stays scannable
+ * and CALMS as you resolve it (the recede). Tappable → opens its editor; omit
+ * `onClick` → a read-only summary row (Available Players; Modifiers until effects
+ * land).
+ *
+ * Three STATES as distinct visuals (reusing GameRow's language + the net-new one):
+ *   - unresolved          → skeleton: dashed border, NO fill, dim summary
+ *     ("Not set"); needs attention.
+ *   - acknowledged-empty  → NET-NEW: solid border + `--color-bt-card-raised` fill
+ *     + a check + dim "Off"/"None"; a valid done (you looked, chose nothing).
+ *     Distinct from unresolved (not dashed) AND from resolved (raised, not the
+ *     card fill).
+ *   - resolved            → ready: `--color-bt-card` fill + solid border + the
+ *     real summary.
+ */
+export type ChecklistRowState = "unresolved" | "acknowledged-empty" | "resolved";
+
+export function ChecklistRow({
+  label,
+  value,
+  state,
+  optional,
+  onClick,
+  disabled,
+  testId,
+}: {
+  label: string;
+  /** One-line summary (the resolved content, or "Not set" / "Off" / "None"). */
+  value: string;
+  state: ChecklistRowState;
+  optional?: boolean;
+  /** Omit → read-only row (no chevron, not tappable). */
+  onClick?: () => void;
+  disabled?: boolean;
+  testId?: string;
+}) {
+  const tappable = !!onClick && !disabled;
+  const fill =
+    state === "resolved" ? "var(--color-bt-card)"
+    : state === "acknowledged-empty" ? "var(--color-bt-card-raised)"
+    : undefined; // unresolved: no fill
+  const border = state === "unresolved" ? "1.5px dashed var(--color-bt-border)" : "1px solid var(--color-bt-border)";
+  const valueColor = state === "resolved" ? "var(--color-bt-text)" : "var(--color-bt-text-dim)";
+
+  const inner = (
+    <>
+      <div className="flex min-w-0 flex-col">
+        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          {label}
+          {optional && <span style={{ fontWeight: 500, textTransform: "none", letterSpacing: 0 }}>· optional</span>}
+        </span>
+        <span className="truncate text-sm" style={{ color: valueColor, marginTop: 2 }}>
+          {value}
+        </span>
+      </div>
+      <span className="flex shrink-0 items-center gap-1.5">
+        {state === "acknowledged-empty" && <Check size={15} style={{ color: "var(--color-bt-text-dim)" }} />}
+        {tappable && <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />}
+      </span>
+    </>
+  );
+
+  const className = "flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60";
+  const style = { background: fill, border } as React.CSSProperties;
+
+  if (tappable) {
+    return (
+      <button type="button" onClick={onClick} disabled={disabled} className={className} style={style} data-testid={testId}>
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <div className={className} style={style} data-testid={testId}>
+      {inner}
+    </div>
+  );
+}

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { GameSheet, type GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 
@@ -49,19 +49,20 @@ export function GameSetupRows({
   const courseName = (courseQ.data?.name as string | undefined) ?? null;
 
   return (
-    <div className="flex flex-col gap-2">
-      <DrillRow
+    <>
+      <ChecklistRow
         label="Course / tee"
         optional
         value={courseName ?? "Add a course"}
-        muted={!courseName}
+        state={courseName ? "resolved" : "unresolved"}
         disabled={!canEdit}
         onClick={() => setCoursePickerOpen(true)}
       />
       {competitionId && (
-        <DrillRow
+        <ChecklistRow
           label="Name · Format · Points"
           value={`${game.name ?? "Untitled"}${pointsSummary(game) ? ` · ${pointsSummary(game)}` : ""}`}
+          state="resolved"
           disabled={!canEdit}
           onClick={() => setConfigOpen(true)}
         />
@@ -98,7 +99,7 @@ export function GameSetupRows({
           }}
         />
       )}
-    </div>
+    </>
   );
 }
 
@@ -114,41 +115,3 @@ function pointsSummary(game: GameRow): string | null {
   return null;
 }
 
-/** One drill-down setup row: label (+ optional tag), summary value, chevron. The
- *  emptiness of an unfilled value is a neutral "more to add" cue, not an error. */
-function DrillRow({
-  label,
-  value,
-  optional,
-  muted,
-  disabled,
-  onClick,
-}: {
-  label: string;
-  value: string;
-  optional?: boolean;
-  muted?: boolean;
-  disabled?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className="flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
-      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-    >
-      <div className="flex min-w-0 flex-col">
-        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-          {label}
-          {optional && <span style={{ fontWeight: 500, textTransform: "none", letterSpacing: 0 }}>· optional</span>}
-        </span>
-        <span className="truncate text-sm" style={{ color: muted ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", marginTop: 2 }}>
-          {value}
-        </span>
-      </div>
-      <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
-    </button>
-  );
-}


### PR DESCRIPTION
Follow-on to Phase B's reshape (#460). The reshape landed the right **rows**; this lands the **checklist-ness** — uniform receding rows whose editors surface and dismiss, on the one Sheet primitive.

## The four coordinated moves
1. **`<Sheet>` — the one overlay primitive** (the nav-consistent artifact). A focused editor that surfaces over a still-present home (lighter drawer scrim) and dismisses back. Replaces four bespoke scrim+panel copies. **Proven by genuinely refactoring `RostersOverlay` onto it** (hard requirement) — rosters renders identically, ~30 lines of chrome lighter.
2. **ONE canonical row** (`ChecklistRow`, extracted from `DrillRow`): every aspect is `label · summary · trailing`, uniform height. Three state-visuals incl. the **net-new acknowledged-empty** (`--color-bt-card-raised` + check, distinct from dashed-unresolved and card-fill-resolved). `GameSetupRows` emits canonical rows (Course/Points) as a fragment so they sit uniformly.
3. **Editors as overlays — the recede.** Tap Matches → Sheet with the pairing builder; tap Handicaps → Sheet with the relocated control; dismiss → the row collapses to its summary ("4 matches", "Off — scratch") and the checklist stays scannable. Handicaps gated by Matches.
4. **Flatten the match builder** — the per-team bordered panels + team-name headers are gone; a match is now flat `slot vs slot`, team identity carried by the slot color. Visual weight matches conceptual weight.
5. **`<ChecklistSection>` RETIRED** — the inline-editor section was the whole problem.
6. Rename **"Set Pairings" → "Game Setup"**.

## Verified
- By eye: "Game Setup" title, uniform canonical rows, Matches sheet opens with the **flattened** builder (no team-name panels), the recede.
- **E2E (regression net) is overlay-aware**: it taps the Matches/Handicaps rows to open their Sheets, drives them, and dismisses (the recede), keeping the DB handicap-relocation assertion. Green `--repeat-each=3`.
- tsc/lint clean.

## Deferred (deliberately)
The **Course-picker-as-overlay split** (picker → overlay, manual entry → navigate) is a real decomposition of the working, BBMI-load-bearing `CoursePicker` and deserves careful both-path verification — I'm doing it as a focused follow-up rather than rushing it at the tail of this build. The Course row still opens the existing full-screen picker meanwhile. (This is the riskiest of the three emphases; treating it with the care it was flagged for.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)