### PR TITLE
feat(competition): checklist editors → in-place accordion panels

### DIFF
--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -84,48 +84,75 @@ async function handicapByUser(gameId: string): Promise<Map<string, number>> {
   return new Map((data ?? []).map((p) => [p.user_id as string, p.handicap_strokes as number]));
 }
 
+/** Number of FULLY-paired (both sides set) matches persisted for the latest game.
+ *  "Create game" seeds an empty-sided row, so we count only the filled ones —
+ *  that's what persist-on-collapse must write. */
+async function filledMatchCount(gameId: string): Promise<number> {
+  const { data } = await admin.from("game_matches").select("side_a,side_b").eq("game_id", gameId);
+  return (data ?? []).filter((m) => m.side_a && m.side_b).length;
+}
+
 /** Drive a fresh 1v1 to fully-set-up-but-not-enabled: create → pair MP Owner (A)
  *  vs MP Member (B) → give MP Member a stroke via the RELOCATED Handicaps row.
- *  Leaves the page on the checklist with Save / Enable available. */
+ *  Leaves the page on the checklist with Enable available. */
 async function driveToSetupWithHandicap(page: Page) {
   await page.goto(`/trips/${tripId}/games/match/new`);
   const createBtn = page.getByRole("button", { name: "Create game" });
   await expect(createBtn).toBeVisible({ timeout: 20_000 });
   await createBtn.click();
 
-  // The checklist model: each editor is a Sheet behind its row. Open the MATCHES
-  // row → its Sheet → pair both slots (scoped to the sheet's pairing builder so the
-  // slot-fill check isn't fooled by the player-selector modal) → dismiss (the
-  // recede). The player selector renders at page level OVER the sheet.
-  await page.getByTestId("row-matches").click();
-  const matchesSheet = page.getByTestId("matches-sheet");
-  await expect(matchesSheet).toBeVisible({ timeout: 20_000 });
-  const addPlayer = matchesSheet.getByRole("button", { name: "Add player" });
-  await expect(addPlayer.first()).toBeVisible({ timeout: 10_000 });
-  await addPlayer.first().click();
-  await page.getByRole("button", { name: /MP Owner/ }).click();
-  await expect(matchesSheet.getByRole("button", { name: /MP Owner/ })).toBeVisible({ timeout: 10_000 }); // slot A filled
-  await addPlayer.first().click();
-  await page.getByRole("button", { name: /MP Member/ }).click();
-  await expect(matchesSheet.getByRole("button", { name: /MP Member/ })).toBeVisible({ timeout: 10_000 }); // slot B filled
-  await page.getByRole("button", { name: "Close" }).click(); // dismiss → recede to the row
-  await expect(matchesSheet).toBeHidden({ timeout: 10_000 });
+  // Accordion toggle = the row's HEADER button (the first button in the row). When
+  // a panel is expanded its body fills the row, so clicking the row CENTER would
+  // land in the editor, not the header — target the header explicitly to collapse.
+  const toggle = (tid: string) => page.getByTestId(tid).getByRole("button").first();
 
-  // Open the HANDICAPS row → its Sheet → give MP Member a stroke via the relocated
-  // control. The Handicaps row is read-only ("Set matches first") until the pairing
-  // reflects — gate on it leaving that state so the tap can't hit the non-tappable
-  // row. Picking a side defaults to 1 stroke → resolves to "on hole …"; gate on
-  // that too so the tap can't race the sheet's just-rendered control.
+  // The accordion model: each editor expands IN PLACE beneath its row (no Sheet).
+  // Tap the MATCHES row → its panel drops down → pair both slots (scoped to the
+  // pairing builder so the slot-fill check isn't fooled by the player-selector
+  // modal, which renders at page level OVER the panel).
+  await toggle("row-matches").click();
+  const pairings = page.getByTestId("match-pairings");
+  await expect(pairings).toBeVisible({ timeout: 20_000 });
+  // Fill slot A then slot B. Each pick is gated open→pick→closed so the picks can't
+  // race the picker mount/unmount: open the slot, wait for the picker, pick (scoped
+  // to the picker so the click can't hit a filled-slot button), wait for it to
+  // close, then confirm the slot filled (Add-player count dropped) before the next.
+  // (1 match = 2 slots; the count is read only when the picker is closed.)
+  const selector = page.getByTestId("player-selector");
+  const addPlayer = pairings.getByRole("button", { name: "Add player" });
+  await expect(addPlayer).toHaveCount(2, { timeout: 10_000 });
+  await addPlayer.first().click();
+  await expect(selector).toBeVisible({ timeout: 10_000 });
+  await selector.getByRole("button", { name: /MP Owner/ }).click();
+  await expect(selector).toBeHidden({ timeout: 10_000 });
+  await expect(addPlayer).toHaveCount(1, { timeout: 10_000 }); // slot A filled
+  await addPlayer.click(); // the single remaining add = slot B
+  await expect(selector).toBeVisible({ timeout: 10_000 });
+  await selector.getByRole("button", { name: /MP Member/ }).click();
+  await expect(selector).toBeHidden({ timeout: 10_000 });
+  await expect(addPlayer).toHaveCount(0, { timeout: 10_000 }); // both slots filled
+
+  // Open the HANDICAPS row DIRECTLY (no explicit collapse of Matches first). The
+  // one-open rule collapses Matches — and persist-on-collapse must commit its
+  // pairing in the background. Gate on the row leaving "Set matches first" (which
+  // reflects the client draft, so it's ready as soon as both slots are filled).
   await expect(page.getByTestId("row-handicaps")).not.toContainText("Set matches first", { timeout: 10_000 });
-  await page.getByTestId("row-handicaps").click();
-  const handicapsSheet = page.getByTestId("handicaps-sheet");
-  await expect(handicapsSheet).toBeVisible({ timeout: 10_000 });
+  await toggle("row-handicaps").click();
+
+  // persist-on-collapse, isolated from Enable: opening Handicaps collapsed Matches,
+  // which must have written the filled pairing to the server already.
+  await expect.poll(async () => filledMatchCount(await latestGameId()), { timeout: 15_000 }).toBeGreaterThan(0);
+
+  // The Handicaps panel is now open in place → give MP Member a stroke via the
+  // relocated control. Picking a side defaults to 1 stroke → "on hole …"; gate on
+  // that so the tap can't race the just-rendered control.
   const handicaps = page.getByTestId("handicaps-section");
   await expect(handicaps).toBeVisible({ timeout: 10_000 });
   await handicaps.getByRole("button", { name: /MP Member/ }).click();
   await expect(handicaps.getByText(/on hole/i)).toBeVisible({ timeout: 10_000 });
-  await page.getByRole("button", { name: "Close" }).click(); // dismiss → recede to the row
-  await expect(handicapsSheet).toBeHidden({ timeout: 10_000 });
+  // Collapse Handicaps (tap the header again) → persist-on-collapse commits the stroke.
+  await toggle("row-handicaps").click();
+  await expect(handicaps).toBeHidden({ timeout: 10_000 });
 }
 
 test("match-play spine — pair + relocated handicap → enable → enter a hole → scorecard", async ({ page }) => {
@@ -165,8 +192,8 @@ test("match-play spine — pair + relocated handicap → enable → enter a hole
 
   // The handicap RELOCATION, gated end-to-end: the stroke set in the relocated row
   // persisted (setHandicap → game_participants.handicap_strokes; recipient = n,
-  // other side = 0). This same saveSetup is what the decoupled "Save setup" CTA
-  // calls (minus enableScoring), so the enable-decouple's persistence rides on it.
+  // other side = 0). The accordion's persist-on-collapse is what wrote it (the
+  // stroke committed when the Handicaps panel collapsed, before Enable).
   const hcap = await handicapByUser(await latestGameId());
   expect(hcap.get(memberId)).toBe(1);
   expect(hcap.get(ownerId)).toBe(0);

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
@@ -10,7 +10,6 @@ import { useTripRole } from "@/hooks/useTripRole";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
-import { Sheet } from "@/components/Sheet";
 import { ChecklistRow, type ChecklistRowState } from "@/components/games/ChecklistRow";
 import { MatchCard } from "@/components/games/MatchCard";
 import { StandardGrid } from "@/components/games/StandardGrid";
@@ -100,10 +99,32 @@ export default function NewMatchGamePage() {
   const [teeTime, setTeeTime] = useState(""); // "HH:MM" 24h
   // Setup editing state
   const [draft, setDraft] = useState<DraftMatch[]>([]);
+  // Once the user TOUCHES the draft in a setup session, the server must never
+  // re-derive over it. The seed effect's `draft.length` guard alone is not enough:
+  // under concurrent renders its closure can read a stale length and re-seed,
+  // wiping in-progress edits when serverMatches lands mid-setup (the create-refetch
+  // race the accordion's instant-open exposed). A ref is always current, so it's
+  // the reliable lock. Reset on every fresh seed entry (create / Edit).
+  const draftTouched = useRef(false);
+  // The user-edit setter: marks the draft touched, then updates it. Use this for
+  // EVERY user edit (picks, reorder, remove, add, handicap); use raw setDraft only
+  // for SEEDING (create / resume / Edit), which must NOT set the touched lock.
+  const editDraft = (fn: (prev: DraftMatch[]) => DraftMatch[]) => {
+    draftTouched.current = true;
+    setDraft(fn);
+  };
   const [selector, setSelector] = useState<{ matchIdx: number; slot: "a" | "b"; memberIdx: number } | null>(null);
-  // Which checklist editor is open as a Sheet overlay (config-checklist model —
-  // the row is home, the editor surfaces over it and recedes on dismiss).
-  const [editorSheet, setEditorSheet] = useState<"matches" | "handicaps" | null>(null);
+  // Which checklist row's editor is OPEN — the accordion model's single source of
+  // truth, owned by the page so ONE panel is open at a time across EVERY row (the
+  // Matches/Handicaps/Players accordions AND the Course/Config overlays). Opening
+  // one collapses any other; collapsing a draft editor (matches/handicaps) commits
+  // it (persist-on-collapse). The one-open rule physically gates Handicaps: it
+  // can't be open while Matches is, so you set matches → collapse → open handicaps.
+  const [openRow, setOpenRow] = useState<"matches" | "handicaps" | "players" | "course" | "config" | null>(null);
+  // Surfaced when a persist-on-collapse save fails — the draft is kept (edits are
+  // never discarded on a transient error), so this offers a retry rather than a
+  // silent loss.
+  const [collapseError, setCollapseError] = useState(false);
   // Back-stack: forward transitions push the screen they left; Back pops to it.
   // Empty stack means we arrived directly (derived screen) → leave to trip home.
   const [navStack, setNavStack] = useState<Screen[]>([]);
@@ -414,8 +435,10 @@ export default function NewMatchGamePage() {
   // Seed the editable draft from the server when we land on setup for an
   // existing game (e.g. owner opens a pending game, or taps Edit) and the local
   // draft is empty. Create + Edit also seed via their handlers; this covers a
-  // direct/derived landing.
+  // direct/derived landing. Once the user has TOUCHED the draft, never re-derive
+  // (the ref guard, immune to the stale-closure race the length guard alone hits).
   useEffect(() => {
+    if (draftTouched.current) return;
     if (screen !== "setup" || draft.length > 0) return;
     if (serverMatches.length > 0) {
       setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide, sided));
@@ -469,12 +492,22 @@ export default function NewMatchGamePage() {
     if (sided) await setDoublesPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
     else await setPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
     await refreshAfterMatchCountChange();
-    setDraft(Array.from({ length: count }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
+    // The DERIVED screen flips to "setup" the instant setGameId ran (above), so the
+    // checklist is already interactive — and the user may have started pairing while
+    // this create flow finished its awaits. Only seed the blank cards if they
+    // HAVEN'T (the seed effect already seeded them otherwise); never clobber a draft
+    // the user has touched. (Don't reset draftTouched here either — that would
+    // re-arm the seed effect to overwrite live edits.)
+    if (!draftTouched.current) {
+      setDraft(Array.from({ length: count }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
+    }
     go("setup");
   }
 
   function startSetup() {
-    // Seed the draft from server (or blank cards).
+    // Seed the draft from server (or blank cards). Fresh seed entry → clear the
+    // touched lock so the server can re-derive until the user edits again.
+    draftTouched.current = false;
     if (serverMatches.length > 0) {
       setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide, sided));
     } else if (draft.length === 0) {
@@ -490,6 +523,9 @@ export default function NewMatchGamePage() {
   // nothing filled there's no match to play, so it's a no-op.
   function attemptReady() {
     if (filledDraft.length === 0) return;
+    // Enable commits everything itself (commitReady → saveSetup) — collapse any
+    // open row WITHOUT re-firing persist-on-collapse (raw setter, not changeOpenRow).
+    setOpenRow(null);
     if (filledDraft.length < draft.length) {
       setConfirmCollapse(true);
       return;
@@ -547,15 +583,9 @@ export default function NewMatchGamePage() {
     return true;
   }
 
-  // Save without enabling — the standalone "configure now, open later" path the
-  // decouple unlocks. Persists everything (pairings + handicaps), then refreshes
-  // the board so the saved match count / "first to XX" reflect it; STAYS on the
-  // checklist (no enable).
-  async function handleSaveSetup() {
-    setConfirmCollapse(false);
-    const ok = await saveSetup();
-    if (ok) await refreshAfterMatchCountChange();
-  }
+  // ("Configure now, open later" no longer needs an explicit Save — collapsing a
+  // draft editor persists it via persistDraftOnCollapse, so leaving the checklist
+  // with rows collapsed has already saved everything.)
 
   // Enable scoring = save THEN enable, land on the overview. The save carries the
   // full config; enabling is the separate, readiness-gated step. The board refresh
@@ -576,6 +606,47 @@ export default function NewMatchGamePage() {
     await refreshAfterMatchCountChange();
     go("overview");
   }
+
+  // ── Accordion control (one panel open at a time) ──────────────────────────
+  // Persist-on-collapse: closing a draft editor (Matches/Handicaps) commits its
+  // pairings + handicaps in the BACKGROUND. The row already reads resolved from
+  // the client draft (optimistic — the check/value land on tap, not on the
+  // server return); this just syncs it. No-op until a real match exists. On
+  // failure the draft is KEPT (never discard edits) and an inline retry surfaces.
+  async function persistDraftOnCollapse() {
+    if (filledDraft.length === 0) return;
+    try {
+      const ok = await saveSetup();
+      if (ok) {
+        setCollapseError(false);
+        // Mark the competition board stale so a LATER view refetches — but do NOT
+        // refetch matchesQ here. Refetching mid-setup updates serverMatches with
+        // the just-written (read-after-write racy) rows, which re-derives the
+        // STILL-OPEN draft from server and wipes in-progress edits. The board
+        // isn't visible during setup; it refreshes on Enable (commitReady) or on
+        // the next mount. (These invalidates are no-op refetch here since those
+        // queries aren't active on this page — they just go stale.)
+        if (competitionId) {
+          utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+          utils.games.listByTrip.invalidate({ tripId });
+          utils.competitions.faceBootstrap.invalidate({ tripId });
+        }
+      }
+    } catch {
+      setCollapseError(true);
+    }
+  }
+
+  // The single entry point for changing which row is open. Leaving a draft editor
+  // commits it (covers BOTH collapse paths: tapping the row to close it AND
+  // opening another row, since one-at-a-time collapses the current one first).
+  function changeOpenRow(next: typeof openRow) {
+    if (next === openRow) return;
+    if (openRow === "matches" || openRow === "handicaps") void persistDraftOnCollapse();
+    setOpenRow(next);
+  }
+  // Accordion header tap: toggle this row (collapsing whatever else was open).
+  const toggleRow = (row: typeof openRow) => changeOpenRow(openRow === row ? null : row);
 
   // Dynamic match count — mid-life +1 / −1 (the explicit "arm with 1, add a 2nd
   // mid-life" path). Each persists incrementally (NOT a bulk re-save, so
@@ -865,57 +936,125 @@ export default function NewMatchGamePage() {
       {screen === "member-wait" && <MemberNotReady gameName={gameQ.data?.name as string | undefined} />}
 
       {screen === "setup" && (() => {
-        // The config CHECKLIST — six UNIFORM canonical rows; each opens its editor
-        // as a Sheet overlay (the row is home, the editor surfaces and recedes on
-        // dismiss). Matches is the unit row; Handicaps relocated, gated by Matches.
+        // The config CHECKLIST — UNIFORM canonical rows; each EXPANDS its editor IN
+        // PLACE (the row is the frame; the panel drops down beneath it, sheds all
+        // modal chrome). One open at a time (page-owned `openRow`) — which also
+        // physically gates Handicaps behind Matches. Collapse = acknowledge +
+        // persist (the draft editors commit on close). Course + Name·Format·Points
+        // stay overlays this pass (tracked follow-ons) but ride the same one-open.
         const allFilled = draft.length > 0 && filledDraft.length === draft.length;
         const anyHandicap = draft.some((d) => d.handicap !== 0);
         const matchesExist = filledDraft.length > 0;
         const savingSetup =
           setPairings.isPending || setHandicap.isPending ||
           setDoublesPairings.isPending || setDoublesHandicap.isPending;
-        const availableCount = (gameCompId && rosterIds.length > 0 ? rosterIds.length : (crew.data?.length ?? 0));
         const tA = teamForSlot("a");
         const tB = teamForSlot("b");
+        // The pool, revealed: the two team rosters (a 2-team competition game) or
+        // the flat crew (standalone). "16 players" alone is useless — show WHO.
+        const pool: { heading: string | null; color?: string; members: string[] }[] =
+          twoTeams
+            ? teams.map((t) => ({ heading: t.name, color: t.color, members: rosterOfTeam(t.id) }))
+            : [{ heading: null, members: (crew.data ?? []).map((c) => c.user_id) }];
+        const availableCount = (gameCompId && rosterIds.length > 0 ? rosterIds.length : (crew.data?.length ?? 0));
         const matchesSummary = matchesExist
           ? `${filledDraft.length} match${filledDraft.length === 1 ? "" : "es"}${tA && tB ? ` · ${tA.name} vs ${tB.name}` : ""}`
           : "Not set";
         const handicapsState: ChecklistRowState = !matchesExist ? "unresolved" : anyHandicap ? "resolved" : "acknowledged-empty";
         const handicapsSummary = !matchesExist ? "Set matches first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
         return (
-        <>
           <div className="flex flex-col gap-2.5 pb-4">
-            {/* Available Players — read-only summary (pool = roster/crew; a
-                pluggable source is W-STANDALONE-01). */}
-            <ChecklistRow label="Available players" value={`${availableCount} player${availableCount === 1 ? "" : "s"}`} state="resolved" />
+            {/* Available Players — expands to the actual rosters (read-only). */}
+            <ChecklistRow
+              label="Available players"
+              value={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
+              state="resolved"
+              expanded={openRow === "players"}
+              onToggle={() => toggleRow("players")}
+              testId="row-players"
+            >
+              <div className="flex flex-col gap-3" data-testid="players-rosters">
+                {pool.map((grp, gi) => (
+                  <div key={gi} className="flex flex-col gap-1.5">
+                    {grp.heading && (
+                      <span className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                        {grp.color && <span className="h-2 w-2 rounded-full" style={{ background: grp.color }} />}
+                        {grp.heading}
+                      </span>
+                    )}
+                    {grp.members.length === 0 ? (
+                      <span className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>No players yet</span>
+                    ) : (
+                      grp.members.map((uid) => (
+                        <span key={uid} className="text-sm" style={{ color: "var(--color-bt-text)" }}>
+                          {nameOf.get(uid) ?? "Player"}
+                        </span>
+                      ))
+                    )}
+                  </div>
+                ))}
+              </div>
+            </ChecklistRow>
 
-            {/* Matches — the pairing builder (the score-entry unit), behind a Sheet. */}
+            {/* Matches — the pairing builder (the score-entry unit), in place. */}
             <ChecklistRow
               label="Matches"
               value={matchesSummary}
               state={matchesExist ? "resolved" : "unresolved"}
-              onClick={() => setEditorSheet("matches")}
+              expanded={openRow === "matches"}
+              onToggle={() => toggleRow("matches")}
               testId="row-matches"
-            />
+            >
+              <MatchSetup
+                tripId={tripId}
+                draft={draft}
+                setDraft={editDraft}
+                playersPerSide={playersPerSide}
+                teamA={tA}
+                teamB={tB}
+                nameOf={nameOf}
+                colorOf={colorOf}
+                avatarIconOf={avatarIconOf}
+                openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
+              />
+            </ChecklistRow>
 
             {/* Handicaps — relocated; gated by Matches ("Off — scratch" is a valid
-                done). Read-only (no editor) until matches exist. */}
+                done). The one-open rule IS the gate: you can't open it while
+                Matches is open, and it stays non-tappable until matches exist. */}
             <ChecklistRow
               label="Handicaps"
               value={handicapsSummary}
               state={handicapsState}
               optional
-              onClick={matchesExist ? () => setEditorSheet("handicaps") : undefined}
+              expanded={openRow === "handicaps"}
+              onToggle={matchesExist ? () => toggleRow("handicaps") : undefined}
               testId="row-handicaps"
-            />
+            >
+              <HandicapsSection
+                draft={draft}
+                setDraft={editDraft}
+                playersPerSide={playersPerSide}
+                nameOf={nameOf}
+                colorOf={colorOf}
+                avatarIconOf={avatarIconOf}
+              />
+            </ChecklistRow>
 
-            {/* Golf Course + Name·Format·Points — the shared canonical rows. */}
+            {/* Golf Course + Name·Format·Points — shared canonical rows. These two
+                stay OVERLAYS this pass (CoursePicker split + config modal-shed are
+                tracked follow-ons), but ride the page's one-open via openRow. */}
             {gameQ.data && (
               <GameSetupRows
                 tripId={tripId}
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
                 canEdit={canEdit}
+                courseOpen={openRow === "course"}
+                configOpen={openRow === "config"}
+                onOpenCourse={() => changeOpenRow("course")}
+                onOpenConfig={() => changeOpenRow("config")}
+                onCloseEditor={() => changeOpenRow(null)}
                 onChanged={() => {
                   void gameQ.refetch();
                   if (competitionId) {
@@ -931,19 +1070,20 @@ export default function NewMatchGamePage() {
                 modifier has a scoring effect yet, so the row is inert until then. */}
             <ChecklistRow label="Modifiers" value="None — coming soon" state="acknowledged-empty" />
 
-            {/* The decoupled CTAs: Save persists config WITHOUT enabling; Enable
-                scoring saves + enables, readiness-gated on a real match. */}
-            <div className="flex flex-col gap-2 pt-2">
+            {collapseError && (
               <button
                 type="button"
-                onClick={handleSaveSetup}
-                disabled={filledDraft.length === 0 || savingSetup}
-                className="w-full disabled:opacity-40"
-                style={{ height: 48, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
-                data-testid="match-save-setup"
+                onClick={() => void persistDraftOnCollapse()}
+                className="text-left text-[13px]"
+                style={{ color: "var(--color-bt-danger)" }}
               >
-                {savingSetup ? "Saving…" : "Save setup"}
+                Couldn’t save your changes — tap to retry.
               </button>
+            )}
+
+            {/* The CTA: Enable scoring saves the config + enables, readiness-gated
+                on a real match. (No "Save setup" — edits persist on collapse now.) */}
+            <div className="flex flex-col gap-2 pt-2">
               <PrimaryButton
                 label={enableScoring.isPending ? "Enabling…" : "Enable scoring"}
                 onClick={attemptReady}
@@ -952,38 +1092,6 @@ export default function NewMatchGamePage() {
               />
             </div>
           </div>
-
-          {/* ── Editor overlays (the recede): the heavy editors live BEHIND their
-              rows, surfacing as Sheets and dismissing back to the updated row. ── */}
-          {editorSheet === "matches" && (
-            <Sheet title="Matches" subtitle="Who plays whom — the score-entry unit" onClose={() => setEditorSheet(null)} testId="matches-sheet">
-              <MatchSetup
-                tripId={tripId}
-                draft={draft}
-                setDraft={setDraft}
-                playersPerSide={playersPerSide}
-                teamA={tA}
-                teamB={tB}
-                nameOf={nameOf}
-                colorOf={colorOf}
-                avatarIconOf={avatarIconOf}
-                openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
-              />
-            </Sheet>
-          )}
-          {editorSheet === "handicaps" && (
-            <Sheet title="Handicaps" subtitle="Strokes per matchup — Off is a valid done" onClose={() => setEditorSheet(null)} testId="handicaps-sheet">
-              <HandicapsSection
-                draft={draft}
-                setDraft={setDraft}
-                playersPerSide={playersPerSide}
-                nameOf={nameOf}
-                colorOf={colorOf}
-                avatarIconOf={avatarIconOf}
-              />
-            </Sheet>
-          )}
-        </>
         );
       })()}
 
@@ -1048,7 +1156,7 @@ export default function NewMatchGamePage() {
             nameOf={nameOf}
             avatarIconOf={avatarIconOf}
             onPick={(userId) => {
-              setDraft((prev) => assignInDraft(prev, selector.matchIdx, selector.slot, selector.memberIdx, userId, playersPerSide));
+              editDraft((prev) => assignInDraft(prev, selector.matchIdx, selector.slot, selector.memberIdx, userId, playersPerSide));
               setSelector(null);
             }}
             onClose={() => setSelector(null)}
@@ -1779,7 +1887,7 @@ function PlayerSelector({
       : `Match ${matchIdx + 1} · Player ${slot === "a" ? 1 : 2}`;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-end" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onClose} data-testid="player-selector">
       <div onClick={(e) => e.stopPropagation()} className="w-full" style={{ background: "var(--color-bt-card-float)", borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: "16px 16px 28px", maxHeight: "75vh", overflowY: "auto" }}>
         <div className="flex items-center gap-2" style={{ fontSize: 16, fontWeight: 700, color: "var(--color-bt-text)" }}>
           {teamColor && <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ background: teamColor }} />}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -18,6 +18,7 @@ import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { TeamsPanel } from "@/components/competition/TeamsPanel";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
@@ -950,12 +951,6 @@ export default function NewMatchGamePage() {
           setDoublesPairings.isPending || setDoublesHandicap.isPending;
         const tA = teamForSlot("a");
         const tB = teamForSlot("b");
-        // The pool, revealed: the two team rosters (a 2-team competition game) or
-        // the flat crew (standalone). "16 players" alone is useless — show WHO.
-        const pool: { heading: string | null; color?: string; members: string[] }[] =
-          twoTeams
-            ? teams.map((t) => ({ heading: t.name, color: t.color, members: rosterOfTeam(t.id) }))
-            : [{ heading: null, members: (crew.data ?? []).map((c) => c.user_id) }];
         const availableCount = (gameCompId && rosterIds.length > 0 ? rosterIds.length : (crew.data?.length ?? 0));
         const matchesSummary = matchesExist
           ? `${filledDraft.length} match${filledDraft.length === 1 ? "" : "es"}${tA && tB ? ` · ${tA.name} vs ${tB.name}` : ""}`
@@ -964,7 +959,11 @@ export default function NewMatchGamePage() {
         const handicapsSummary = !matchesExist ? "Set matches first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
         return (
           <div className="flex flex-col gap-2.5 pb-4">
-            {/* Available Players — expands to the actual rosters (read-only). */}
+            {/* Available Players — expands to the canonical rosters view. For a
+                competition game this is the SAME TeamsPanel the Rosters overlay
+                uses, but READ-ONLY (canEdit=false): the pool is revealed, not
+                editable — team setup isn't reachable from a game's setup, not even
+                for the owner. Standalone (no teams) falls back to the flat crew. */}
             <ChecklistRow
               label="Available players"
               value={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
@@ -973,26 +972,18 @@ export default function NewMatchGamePage() {
               onToggle={() => toggleRow("players")}
               testId="row-players"
             >
-              <div className="flex flex-col gap-3" data-testid="players-rosters">
-                {pool.map((grp, gi) => (
-                  <div key={gi} className="flex flex-col gap-1.5">
-                    {grp.heading && (
-                      <span className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-                        {grp.color && <span className="h-2 w-2 rounded-full" style={{ background: grp.color }} />}
-                        {grp.heading}
+              <div data-testid="players-rosters">
+                {gameCompId ? (
+                  <TeamsPanel tripId={tripId} competitionId={gameCompId} canEdit={false} structureLocked embedded />
+                ) : (
+                  <div className="flex flex-col gap-1">
+                    {(crew.data ?? []).map((c) => (
+                      <span key={c.user_id} className="text-sm" style={{ color: "var(--color-bt-text)" }}>
+                        {nameOf.get(c.user_id) ?? "Player"}
                       </span>
-                    )}
-                    {grp.members.length === 0 ? (
-                      <span className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>No players yet</span>
-                    ) : (
-                      grp.members.map((uid) => (
-                        <span key={uid} className="text-sm" style={{ color: "var(--color-bt-text)" }}>
-                          {nameOf.get(uid) ?? "Player"}
-                        </span>
-                      ))
-                    )}
+                    ))}
                   </div>
-                ))}
+                )}
               </div>
             </ChecklistRow>
 

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -105,16 +105,16 @@ export function ChecklistRow({
   // title. Unresolved / acknowledged-empty keep the quiet caption + dim summary.
   const content =
     isOpen ? (
-      <div className="flex min-w-0 flex-col">{labelCaption}</div>
+      <div className="flex min-w-0 flex-1 flex-col">{labelCaption}</div>
     ) : state === "resolved" ? (
-      <div className="flex min-w-0 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         {labelCaption}
         <span className="truncate text-[15px] font-semibold" style={{ color: "var(--color-bt-text)", marginTop: 1 }}>
           {value}
         </span>
       </div>
     ) : (
-      <div className="flex min-w-0 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         {labelCaption}
         <span className="truncate text-sm" style={{ color: "var(--color-bt-text-dim)", marginTop: 2 }}>
           {value}

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -1,25 +1,37 @@
 "use client";
 
-import { ChevronRight, Check } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { ChevronRight, ChevronDown, Check } from "lucide-react";
 
 /**
  * ChecklistRow — the ONE canonical config-checklist row (config-checklist model).
- * Every config aspect renders as this: uniform height + shape, `label · summary ·
- * trailing`. The heavy editor lives BEHIND it (a Sheet overlay opened on tap); the
- * row itself only ever shows a one-line summary, so the surface stays scannable
- * and CALMS as you resolve it (the recede). Tappable → opens its editor; omit
- * `onClick` → a read-only summary row (Available Players; Modifiers until effects
- * land).
+ * Every config aspect renders as this: uniform height + shape, `✓ LABEL · value ·
+ * chevron`. It now behaves like an actual checklist item — **tap to expand the
+ * editor IN PLACE** (a drop-down panel beneath the row, NOT a modal floating over
+ * the page), edit live, **collapse = acknowledge** (the check appears; closing IS
+ * accepting — no separate Accept button). The parent owns a single `openRowId` so
+ * only one panel is open at a time (which also physically gates dependent rows).
+ *
+ * Three presentations of a row:
+ *   - **accordion** (`onToggle` + `children`) — tap toggles an in-place panel.
+ *   - **overlay-tappable** (`onClick`, no children) — opens a separate editor
+ *     (the Course picker / the Game-config Sheet, which stay overlays this pass);
+ *     trailing chevron points right.
+ *   - **read-only** (neither) — a static summary row (Modifiers).
+ *
+ * Layout — **check LEADING (left), chevron TRAILING (right)** so the row reads as
+ * a checklist and the check + chevron never fight (the #461 right-side conflict).
  *
  * Three STATES as distinct visuals (reusing GameRow's language + the net-new one):
- *   - unresolved          → skeleton: dashed border, NO fill, dim summary
- *     ("Not set"); needs attention.
- *   - acknowledged-empty  → NET-NEW: solid border + `--color-bt-card-raised` fill
- *     + a check + dim "Off"/"None"; a valid done (you looked, chose nothing).
- *     Distinct from unresolved (not dashed) AND from resolved (raised, not the
- *     card fill).
- *   - resolved            → ready: `--color-bt-card` fill + solid border + the
- *     real summary.
+ *   - unresolved          → skeleton: dashed border, NO fill, NO check, dim
+ *     summary ("Not set"); needs attention.
+ *   - acknowledged-empty  → solid border + `--color-bt-card-raised` fill + a
+ *     leading check + dim "Off"/"None"; a valid done (you looked, chose nothing).
+ *   - resolved            → ready: `--color-bt-card` fill + solid border + a
+ *     leading check + the real summary announced LOUD (value is the prominent
+ *     element, label the quiet caption — answers shout, questions whisper).
+ * While EXPANDED the row shows its label as the active title (the loud-value
+ * treatment is the collapsed-resolved state) and the trailing chevron points up.
  */
 export type ChecklistRowState = "unresolved" | "acknowledged-empty" | "resolved";
 
@@ -29,6 +41,9 @@ export function ChecklistRow({
   state,
   optional,
   onClick,
+  expanded,
+  onToggle,
+  children,
   disabled,
   testId,
 }: {
@@ -37,50 +52,126 @@ export function ChecklistRow({
   value: string;
   state: ChecklistRowState;
   optional?: boolean;
-  /** Omit → read-only row (no chevron, not tappable). */
+  /** Overlay-tappable row (opens a separate editor). Omit for accordion/read-only. */
   onClick?: () => void;
+  /** Accordion: whether this row's in-place panel is open (parent-owned). */
+  expanded?: boolean;
+  /** Accordion: tap toggles the panel. Omit → not an accordion row. */
+  onToggle?: () => void;
+  /** Accordion: the dropped-down editor content (rendered beneath when expanded). */
+  children?: React.ReactNode;
   disabled?: boolean;
   testId?: string;
 }) {
-  const tappable = !!onClick && !disabled;
+  const accordion = !!onToggle && !disabled;
+  const overlay = !!onClick && !disabled && !accordion;
+  const acknowledged = state === "resolved" || state === "acknowledged-empty";
+  const isOpen = accordion && !!expanded;
+
   const fill =
-    state === "resolved" ? "var(--color-bt-card)"
+    isOpen ? "var(--color-bt-card-raised)"
+    : state === "resolved" ? "var(--color-bt-card)"
     : state === "acknowledged-empty" ? "var(--color-bt-card-raised)"
     : undefined; // unresolved: no fill
-  const border = state === "unresolved" ? "1.5px dashed var(--color-bt-border)" : "1px solid var(--color-bt-border)";
-  const valueColor = state === "resolved" ? "var(--color-bt-text)" : "var(--color-bt-text-dim)";
+  const border = state === "unresolved" && !isOpen ? "1.5px dashed var(--color-bt-border)" : "1px solid var(--color-bt-border)";
 
-  const inner = (
-    <>
+  // Auto-scroll: when the panel opens, lift the row's top to the top of the
+  // screen so the dropped-down editor has full vertical room. The page scrolls in
+  // the window (the setup header is in-flow, not sticky), so block:"start" lands
+  // the row at the viewport top; a little scroll-margin keeps it off the edge.
+  const rowRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isOpen) rowRef.current?.scrollIntoView({ block: "start" });
+  }, [isOpen]);
+
+  // Leading: the check (acknowledged + collapsed). While expanded the row is
+  // "being decided" → no check yet (collapse re-acknowledges). Reserve the slot
+  // either way so labels align across all rows (one styling language).
+  const leading = (
+    <span className="flex w-5 shrink-0 items-center justify-center">
+      {acknowledged && !isOpen && <Check size={16} style={{ color: "var(--color-bt-accent)" }} />}
+    </span>
+  );
+
+  const labelCaption = (
+    <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+      {label}
+      {optional && <span style={{ fontWeight: 500, textTransform: "none", letterSpacing: 0 }}>· optional</span>}
+    </span>
+  );
+
+  // Content column — by state. Resolved + collapsed announces the VALUE loud
+  // (label demoted to a quiet caption). Expanded shows the label as the active
+  // title. Unresolved / acknowledged-empty keep the quiet caption + dim summary.
+  const content =
+    isOpen ? (
+      <div className="flex min-w-0 flex-col">{labelCaption}</div>
+    ) : state === "resolved" ? (
       <div className="flex min-w-0 flex-col">
-        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-          {label}
-          {optional && <span style={{ fontWeight: 500, textTransform: "none", letterSpacing: 0 }}>· optional</span>}
-        </span>
-        <span className="truncate text-sm" style={{ color: valueColor, marginTop: 2 }}>
+        {labelCaption}
+        <span className="truncate text-[15px] font-semibold" style={{ color: "var(--color-bt-text)", marginTop: 1 }}>
           {value}
         </span>
       </div>
-      <span className="flex shrink-0 items-center gap-1.5">
-        {state === "acknowledged-empty" && <Check size={15} style={{ color: "var(--color-bt-text-dim)" }} />}
-        {tappable && <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />}
-      </span>
-    </>
+    ) : (
+      <div className="flex min-w-0 flex-col">
+        {labelCaption}
+        <span className="truncate text-sm" style={{ color: "var(--color-bt-text-dim)", marginTop: 2 }}>
+          {value}
+        </span>
+      </div>
+    );
+
+  const trailing = (
+    <span className="flex shrink-0 items-center">
+      {accordion ? (
+        <ChevronDown size={16} style={{ color: "var(--color-bt-text-dim)", transform: isOpen ? "rotate(180deg)" : undefined, transition: "transform 120ms" }} />
+      ) : overlay ? (
+        <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />
+      ) : null}
+    </span>
   );
 
-  const className = "flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60";
-  const style = { background: fill, border } as React.CSSProperties;
+  const headerInner = (
+    <>
+      {leading}
+      {content}
+      {trailing}
+    </>
+  );
+  const headerClass = "flex w-full items-center gap-2.5 px-3.5 py-3 text-left disabled:opacity-60";
+  const containerStyle = { background: fill, border } as React.CSSProperties;
 
-  if (tappable) {
+  // Accordion: a header button toggling an in-place panel below (same bordered
+  // frame — the row IS the frame; the panel sheds all modal chrome).
+  if (accordion) {
     return (
-      <button type="button" onClick={onClick} disabled={disabled} className={className} style={style} data-testid={testId}>
-        {inner}
+      <div ref={rowRef} className="rounded-xl" style={{ ...containerStyle, scrollMarginTop: 12 }} data-testid={testId}>
+        <button type="button" onClick={onToggle} className={headerClass} aria-expanded={isOpen}>
+          {headerInner}
+        </button>
+        {isOpen && (
+          <div className="px-3.5 pb-3.5 pt-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Overlay-tappable (Course / Game-config) — opens a separate editor.
+  if (overlay) {
+    return (
+      <button type="button" onClick={onClick} disabled={disabled} className={`${headerClass} rounded-xl`} style={containerStyle} data-testid={testId}>
+        {headerInner}
       </button>
     );
   }
+
+  // Read-only summary row.
   return (
-    <div className={className} style={style} data-testid={testId}>
-      {inner}
+    <div className={`${headerClass} rounded-xl`} style={containerStyle} data-testid={testId}>
+      {headerInner}
     </div>
   );
 }

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -15,6 +15,14 @@ import { GAME_TYPES } from "@/lib/gameTypes";
  * renders BELOW this, and "Enable scoring" is the bottom CTA — this component is
  * just the shared hull header. Course is optional and never gates readiness.
  *
+ * Open-state is **optionally controlled by the page** (`courseOpen`/`configOpen`
+ * + the open/close callbacks). When the match-setup checklist drives it, the
+ * one-panel-at-a-time rule spans EVERY row (tapping Course collapses any open
+ * accordion row). Every OTHER consumer (stroke/rack/new/config-view) omits the
+ * props and gets the original self-managed behavior — so this lift doesn't ripple
+ * across them. These two editors stay OVERLAYS this pass (the CoursePicker split +
+ * the Game-config modal-shed are tracked follow-ons).
+ *
  * No checklist, no top-level Save: edits are live (CoursePicker applies on pick;
  * GameSheet persists on its own Save), and `onChanged` refetches the game so the
  * row summaries and the body update in place.
@@ -25,6 +33,11 @@ export function GameSetupRows({
   game,
   canEdit,
   onChanged,
+  courseOpen: courseOpenProp,
+  configOpen: configOpenProp,
+  onOpenCourse,
+  onOpenConfig,
+  onCloseEditor,
 }: {
   tripId: string;
   /** Null for a standalone game — the Name·Format·Points editor is competition-
@@ -33,9 +46,25 @@ export function GameSetupRows({
   game: GameRow;
   canEdit: boolean;
   onChanged: () => void;
+  /** Page-owned one-open state (controlled). Omit → self-managed (uncontrolled). */
+  courseOpen?: boolean;
+  configOpen?: boolean;
+  /** Tapping a row asks the page to open it (which collapses any other row). */
+  onOpenCourse?: () => void;
+  onOpenConfig?: () => void;
+  /** The editor dismissed itself → clear the page's openRow. */
+  onCloseEditor?: () => void;
 }) {
-  const [coursePickerOpen, setCoursePickerOpen] = useState(false);
-  const [configOpen, setConfigOpen] = useState(false);
+  // Controlled when the page supplies open-state; else self-manage (the original
+  // behavior, kept for every non-checklist consumer).
+  const controlled = courseOpenProp !== undefined || configOpenProp !== undefined;
+  const [courseOpenLocal, setCourseOpenLocal] = useState(false);
+  const [configOpenLocal, setConfigOpenLocal] = useState(false);
+  const courseOpen = controlled ? !!courseOpenProp : courseOpenLocal;
+  const configOpen = controlled ? !!configOpenProp : configOpenLocal;
+  const openCourse = onOpenCourse ?? (() => setCourseOpenLocal(true));
+  const openConfig = onOpenConfig ?? (() => setConfigOpenLocal(true));
+  const closeEditor = onCloseEditor ?? (() => { setCourseOpenLocal(false); setConfigOpenLocal(false); });
 
   // Format definitions live in code (W-PERF-01) — no fetch, always available.
   const types = GAME_TYPES;
@@ -56,7 +85,7 @@ export function GameSetupRows({
         value={courseName ?? "Add a course"}
         state={courseName ? "resolved" : "unresolved"}
         disabled={!canEdit}
-        onClick={() => setCoursePickerOpen(true)}
+        onClick={openCourse}
       />
       {competitionId && (
         <ChecklistRow
@@ -64,13 +93,13 @@ export function GameSetupRows({
           value={`${game.name ?? "Untitled"}${pointsSummary(game) ? ` · ${pointsSummary(game)}` : ""}`}
           state="resolved"
           disabled={!canEdit}
-          onClick={() => setConfigOpen(true)}
+          onClick={openConfig}
         />
       )}
 
-      {coursePickerOpen && (
+      {courseOpen && (
         <CoursePicker
-          onClose={() => setCoursePickerOpen(false)}
+          onClose={closeEditor}
           onApply={({ id, teeName }) => {
             applyCourse.mutate(
               { tripId, gameId: game.id, courseId: id, teeSetName: teeName },
@@ -81,7 +110,7 @@ export function GameSetupRows({
                 },
               }
             );
-            setCoursePickerOpen(false);
+            closeEditor();
           }}
         />
       )}
@@ -94,7 +123,7 @@ export function GameSetupRows({
           types={types}
           canEdit={canEdit}
           onClose={() => {
-            setConfigOpen(false);
+            closeEditor();
             onChanged();
           }}
         />


### PR DESCRIPTION
Follow-on to #461 (the checklist MODEL). #461 built the right structure (canonical row, three state-visuals, flatten, retired ChecklistSection, the `<Sheet>` primitive) with editors presenting as **modal Sheets**. This pass changes the **editor presentation** for checklist rows to **in-place drop-down panels (accordion)**.

## The model
Tap a row → it **expands in place**, the editor drops down *beneath* it (not a modal) → **auto-scroll** the row's top to screen-top → edit **live** → **collapse = acknowledge** (a check appears; closing IS accepting — no Accept button). **One panel open at a time**, which physically enforces matches→handicaps (can't open both).

## Scope (per the confirmed Phase 0 decisions)
- **Converted to accordion:** Matches, Handicaps, Available Players (→ the two team rosters, read-only).
- **Kept as overlays this pass** (tracked follow-ons, but they ride the same one-open state): Course (CoursePicker split), Name·Format·Points (**W-EDITMODAL-01** — the old Edit-Game modal).
- **`<Sheet>` untouched** for RostersOverlay / DangerConfirmModal / GameSheet / navigation.

## What changed
- **`ChecklistRow`** — expandable body slot + auto-scroll on open; **check LEADING, chevron TRAILING** (fixes #461's right-side check/chevron conflict); resolved **value announced LOUD**, label demoted to a quiet caption.
- **Page owns `openRow`** spanning every row (one-at-a-time). `GameSetupRows` made *optionally* controlled so Course/Config join one-open without rippling to the stroke/rack/config consumers.
- **Persist-on-collapse (Path B):** leaving a draft editor commits pairings + handicaps (both collapse paths — tap-to-close AND open-another-row). **"Save setup" button removed** — collapse is the save. Board invalidated (stale for next view) but `matchesQ` is **not** refetched mid-setup (that re-derives the open draft).

## A real bug this surfaced + fixed
The **derived** screen flips to `setup` the instant the game is created, so a fast user can pair **while `handleCreate` is still in its async tail** — whose blank-card seed then clobbered the picks. The old Sheet's open-delay masked it; the accordion's instant-open exposed it. Fix: a `draftTouched` ref (immune to the stale-closure race the length-guard alone hit) — once the user edits, the seed/server never overwrites the draft; `handleCreate`'s tail seed is guarded by it.

## Tests
E2E rewritten accordion-aware (`e2e/match-play.spec.ts`): tap row → expand → pick (gated open→pick→closed, scoped to the player-selector) → open Handicaps directly (commits Matches via persist-on-collapse, asserted by a **DB poll**) → set stroke → collapse → enable → score → scorecard. Keeps the handicap DB assertion.

- Both merge-blocking spines green (`--project=critical-path`).
- Stable at `--repeat-each=6`.
- `tsc --noEmit` + eslint clean.
- Verified by eye in **light + dark** (accordion expand-in-place, one-open collapse, rosters readout, check-left/loud-value, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)