### PR TITLE
feat(competition): re-zone game setup → identity/checklist/notes (W-EDITMODAL-01)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -19,6 +19,8 @@ import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { TeamsPanel } from "@/components/competition/TeamsPanel";
+import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
+import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/GameRulesNote";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
@@ -126,6 +128,10 @@ export default function NewMatchGamePage() {
   // never discarded on a transient error), so this offers a retry rather than a
   // silent loss.
   const [collapseError, setCollapseError] = useState(false);
+  // Zone-3 rules note (W-EDITMODAL-01) — "Save & exit" flushes any typed-but-
+  // unsaved rules through this handle before navigating (the one field with no
+  // collapse event of its own).
+  const rulesRef = useRef<GameRulesNoteHandle>(null);
   // Back-stack: forward transitions push the screen they left; Back pops to it.
   // Empty stack means we arrived directly (derived screen) → leave to trip home.
   const [navStack, setNavStack] = useState<Screen[]>([]);
@@ -432,6 +438,13 @@ export default function NewMatchGamePage() {
     setManualScreen(navStack[navStack.length - 1]);
     setNavStack((s) => s.slice(0, -1));
   };
+  // "Save & exit" (W-EDITMODAL-01): flush the Zone-3 rules note (its only commit
+  // event) then leave. Checklist rows already persisted on collapse; this just
+  // guarantees the rules textarea isn't lost. Always available — leaving is too.
+  async function handleSaveExit() {
+    await rulesRef.current?.flush();
+    goBack();
+  }
 
   // Seed the editable draft from the server when we land on setup for an
   // existing game (e.g. owner opens a pending game, or taps Edit) and the local
@@ -959,6 +972,14 @@ export default function NewMatchGamePage() {
         const handicapsSummary = !matchesExist ? "Set matches first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
         return (
           <div className="flex flex-col gap-2.5 pb-4">
+            {/* Zone 1 — IDENTITY header (W-EDITMODAL-01): name (tap-to-edit) +
+                "Assigned to" frame. Display-first, above the checklist. Competition
+                games only — it re-homes the modal's name/delegate, which were
+                competition-scoped (a standalone game has no delegate/config row). */}
+            {gameCompId && gameQ.data && (
+              <GameIdentityHeader tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} isOwner={isOwner} />
+            )}
+
             {/* Available Players — expands to the canonical rosters view. For a
                 competition game this is the SAME TeamsPanel the Rosters overlay
                 uses, but READ-ONLY (canEdit=false): the pool is revealed, not
@@ -1061,6 +1082,13 @@ export default function NewMatchGamePage() {
                 modifier has a scoring effect yet, so the row is inert until then. */}
             <ChecklistRow label="Modifiers" value="None — coming soon" state="acknowledged-empty" />
 
+            {/* Zone 3 — RULES / notes (W-EDITMODAL-01): freeform, below the
+                checklist. Saves on blur; "Save & exit" flushes it via rulesRef.
+                Competition games only (re-homes the modal's rules field). */}
+            {gameCompId && gameQ.data && (
+              <GameRulesNote ref={rulesRef} tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} />
+            )}
+
             {collapseError && (
               <button
                 type="button"
@@ -1072,8 +1100,9 @@ export default function NewMatchGamePage() {
               </button>
             )}
 
-            {/* The CTA: Enable scoring saves the config + enables, readiness-gated
-                on a real match. (No "Save setup" — edits persist on collapse now.) */}
+            {/* Exit (W-EDITMODAL-01): Enable scoring (primary, readiness-gated, the
+                commit-to-play) + Save & exit (secondary, always enabled — the
+                leave-and-resume door; flushes the rules note then navigates). */}
             <div className="flex flex-col gap-2 pt-2">
               <PrimaryButton
                 label={enableScoring.isPending ? "Enabling…" : "Enable scoring"}
@@ -1081,6 +1110,17 @@ export default function NewMatchGamePage() {
                 disabled={savingSetup || enableScoring.isPending || filledDraft.length === 0}
                 outlined={!allFilled}
               />
+              {gameCompId && (
+                <button
+                  type="button"
+                  onClick={handleSaveExit}
+                  className="w-full"
+                  style={{ height: 48, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
+                  data-testid="match-save-exit"
+                >
+                  Save &amp; exit
+                </button>
+              )}
             </div>
           </div>
         );

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -14,6 +14,8 @@ import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
+import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/GameRulesNote";
 import { useTripRole } from "@/hooks/useTripRole";
 import type { StrokeStanding } from "@/lib/strokePlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
@@ -47,6 +49,7 @@ export default function NewGamePage() {
   const tripId = isId ? param : resolved.data?.id;
   const utils = trpc.useUtils();
   const { canEdit, isOwner } = useTripRole(tripId);
+  const rulesRef = useRef<GameRulesNoteHandle>(null);
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
@@ -315,6 +318,13 @@ export default function NewGamePage() {
         onEnable={handleEnable}
         onBack={() => router.back()}
         pending={enableScoring.isPending}
+        identityHeader={gameCompetitionId && gameQ.data
+          ? <GameIdentityHeader tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} isOwner={isOwner} />
+          : undefined}
+        rulesNote={gameCompetitionId && gameQ.data
+          ? <GameRulesNote ref={rulesRef} tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} />
+          : undefined}
+        onSaveExit={gameCompetitionId ? async () => { await rulesRef.current?.flush(); router.back(); } : undefined}
         setupRows={
           gameQ.data ? (
             <>

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
@@ -17,6 +17,8 @@ import { EnableScoringGate } from "@/components/games/EnableScoringGate";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
+import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/GameRulesNote";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
 import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
@@ -64,6 +66,7 @@ export default function RackNStackPage() {
   const tripId = isId ? param : resolved.data?.id;
 
   const { canEdit: tripCanEdit, isOwner, loading: roleLoading } = useTripRole(tripId);
+  const rulesRef = useRef<GameRulesNoteHandle>(null);
   const me = useCurrentUser();
   const utils = trpc.useUtils();
 
@@ -546,6 +549,13 @@ export default function RackNStackPage() {
         onEnable={handleEnable}
         onBack={() => router.back()}
         pending={enableScoring.isPending}
+        identityHeader={competitionId && gameQ.data
+          ? <GameIdentityHeader tripId={tripId!} game={gameQ.data as unknown as GameRow} canEdit={canEdit} isOwner={isOwner} />
+          : undefined}
+        rulesNote={competitionId && gameQ.data
+          ? <GameRulesNote ref={rulesRef} tripId={tripId!} game={gameQ.data as unknown as GameRow} canEdit={canEdit} />
+          : undefined}
+        onSaveExit={competitionId ? async () => { await rulesRef.current?.flush(); router.back(); } : undefined}
         setupRows={
           gameQ.data ? (
             <GameSetupRows

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -101,7 +101,7 @@ const COMP_FORMATS = [
   { key: "live_results", label: "Live Results", desc: "A running tally that updates as it plays (e.g. Pick'em).", Icon: Radio },
 ] as const;
 
-function formatLabel(key: string | null): string | null {
+export function formatLabel(key: string | null): string | null {
   return COMP_FORMATS.find((f) => f.key === key)?.label ?? null;
 }
 
@@ -982,7 +982,7 @@ function GameTab({
 }
 
 /** The integrated −/value/+ point control (matches the mock). */
-function PointStepper({
+export function PointStepper({
   label, caption, value, onChange, footer, max,
 }: {
   label: string; caption: string; value: number; onChange: (n: number) => void; footer?: React.ReactNode; max?: number;
@@ -1023,7 +1023,7 @@ function StepBtn({ dir, onClick, disabled }: { dir: "inc" | "dec"; onClick: () =
   );
 }
 
-function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout> }) {
+export function MatchReadoutLine({ readout }: { readout: ReturnType<typeof matchReadout> }) {
   return (
     <div className="flex items-center justify-between">
       <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -1299,7 +1299,7 @@ function FitWarning({ message }: { message: string }) {
 
 // ── Placement editor (distributes the owner total) ────────────────────────────
 
-function PlacementEditor({
+export function PlacementEditor({
   total, placeInputs, setPlaceInputs, placement,
 }: {
   total: number; placeInputs: string[]; setPlaceInputs: (v: string[]) => void;
@@ -1382,7 +1382,7 @@ function PlacementEditor({
 
 // ── "How's it played?" format sheet ───────────────────────────────────────────
 
-function FormatSheet({
+export function FormatSheet({
   current, onPick, onClose,
 }: {
   current: string | null; onPick: (k: string) => void; onClose: () => void;
@@ -1806,7 +1806,7 @@ function Chip({ active, onClick, children }: { active: boolean; onClick: () => v
   );
 }
 
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
+export function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
   return (
     <div>
       <div className="mb-1.5 flex items-center gap-1.5">
@@ -1818,14 +1818,14 @@ function Field({ label, required, children }: { label: string; required?: boolea
   );
 }
 
-function ordinalShort(n: number): string {
+export function ordinalShort(n: number): string {
   const s = ["th", "st", "nd", "rd"];
   const v = n % 100;
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
 /** Whole numbers as-is, halves as ½ (0.5 → "½", 1.5 → "1½"). */
-function fmtValue(n: number): string {
+export function fmtValue(n: number): string {
   const whole = Math.floor(n);
   const isHalf = Math.abs(n - whole - 0.5) < 0.001;
   if (!isHalf) return String(whole);

--- a/src/components/games/EnableScoringGate.tsx
+++ b/src/components/games/EnableScoringGate.tsx
@@ -22,6 +22,9 @@ export function EnableScoringGate({
   onBack,
   pending,
   setupRows,
+  identityHeader,
+  rulesNote,
+  onSaveExit,
 }: {
   title: string;
   subtitle: string;
@@ -31,6 +34,13 @@ export function EnableScoringGate({
   /** The standardized setup drill-down rows (GameSetupRows). Omitted for a
    *  standalone game with nothing competition-scoped to configure. */
   setupRows?: React.ReactNode;
+  /** Zone-1 identity header (name + assigned-to), above the rows (W-EDITMODAL-01). */
+  identityHeader?: React.ReactNode;
+  /** Zone-3 rules note, below the rows (W-EDITMODAL-01). */
+  rulesNote?: React.ReactNode;
+  /** "Save & exit" (secondary, always-enabled) — flushes rules + navigates back.
+   *  Omitted → only "Enable scoring" + the back arrow (e.g. standalone games). */
+  onSaveExit?: () => void;
 }) {
   return (
     <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
@@ -48,7 +58,9 @@ export function EnableScoringGate({
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+        {identityHeader}
         {setupRows}
+        {rulesNote}
 
         <div
           className="mt-4 flex items-center gap-3 rounded-xl px-4 py-3.5"
@@ -71,6 +83,15 @@ export function EnableScoringGate({
         >
           {pending ? "Enabling…" : "Enable scoring"}
         </button>
+        {onSaveExit && (
+          <button
+            onClick={onSaveExit}
+            className="mt-2 w-full"
+            style={{ height: 48, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
+          >
+            Save &amp; exit
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/games/FormatPointsPanel.tsx
+++ b/src/components/games/FormatPointsPanel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc-client";
+import { GAME_TYPES } from "@/lib/gameTypes";
+import { validatePlacement } from "@/lib/gameConfig";
+import {
+  Field, PointStepper, PlacementEditor, FormatSheet, formatLabel,
+  type GameRow,
+} from "@/components/competition/CompetitionGamesPanel";
+import { ChevronRight } from "lucide-react";
+import type { PointsDistribution } from "@/lib/pointsDistribution";
+
+/**
+ * Zone 2 "Format · Points" accordion body (W-EDITMODAL-01) — the focused points +
+ * competition-format editor that replaces the old Edit-Game modal for this row.
+ * Name moved to the Zone-1 header; Course/Matches/Modifiers/Rules/Delegate live in
+ * their own rows/zones — so this panel is JUST format + points.
+ *
+ * Persistence: format saves on pick (independent `update{competitionFormat}`);
+ * points save as the **total + distribution PAIR** (`setPointsTotal` +
+ * `setPointsDistribution` together — never one without the other). Saved on-change
+ * rather than on-collapse: every intermediate points value is VALID (unlike the
+ * draft editors' half-filled matches), so there's no invalid-intermediate to hide,
+ * and it sidesteps fragile cross-component collapse-flush coordination. The pair
+ * is what matters, and it's always written atomically. Optimistic via `setData`.
+ */
+export function FormatPointsPanel({
+  tripId, game, canEdit,
+}: {
+  tripId: string;
+  game: GameRow;
+  canEdit: boolean;
+}) {
+  const gameId = game.id;
+  const utils = trpc.useUtils();
+
+  const type = GAME_TYPES.find((t) => t.id === game.game_type_id);
+  const isMatchPlay = type?.resultStrategy === "match_play" || type?.resultStrategy === "rack_n_stack";
+
+  const dist0 = game.points_distribution;
+  const [perMatchValue, setPerMatchValue] = useState<number>(dist0?.type === "per_match" ? dist0.value : 1);
+  const [total, setTotal] = useState<number>(game.points_total ?? 8);
+  const [placeInputs, setPlaceInputs] = useState<string[]>(
+    dist0?.type === "placement" && dist0.values.length > 0 ? dist0.values.map(String) : [""]
+  );
+  const [compFormat, setCompFormat] = useState<string | null>(game.competition_format ?? null);
+  const [formatSheetOpen, setFormatSheetOpen] = useState(false);
+
+  const update = trpc.games.update.useMutation();
+  const setTotalM = trpc.games.setPointsTotal.useMutation();
+  const setDistM = trpc.games.setPointsDistribution.useMutation();
+
+  const started = !isMatchPlay && (placeInputs[0]?.trim() ?? "") !== "";
+  const enteredValues = started ? placeInputs.map((s) => Number(s.trim() || "0")) : [];
+  const placement = validatePlacement(total, enteredValues);
+
+  function optimisticGame(patch: Partial<GameRow>) {
+    const cur = utils.games.getById.getData({ tripId, gameId });
+    if (cur) utils.games.getById.setData({ tripId, gameId }, { ...cur, ...patch } as typeof cur);
+  }
+  function refresh() {
+    utils.games.getById.invalidate({ tripId, gameId });
+    utils.games.listByTrip.invalidate({ tripId });
+    if (game.competition_id) utils.competitions.faceBootstrap.invalidate({ tripId });
+  }
+
+  // Save the total + distribution PAIR together (never one without the other).
+  async function savePoints(nextDist: PointsDistribution | null, nextTotal: number | null) {
+    optimisticGame({ points_total: nextTotal, points_distribution: nextDist } as Partial<GameRow>);
+    try {
+      await setTotalM.mutateAsync({ tripId, gameId, total: nextTotal });
+      await setDistM.mutateAsync({ tripId, gameId, distribution: nextDist });
+      refresh();
+    } catch { refresh(); }
+  }
+
+  function onPerMatch(v: number) {
+    setPerMatchValue(v);
+    void savePoints({ type: "per_match", value: v > 0 ? v : 1 }, null);
+  }
+  function onTotal(v: number) {
+    setTotal(v);
+    // Re-save the placement pair against the new total (valid only if it still fits).
+    const d: PointsDistribution | null = started ? { type: "placement", values: enteredValues } : null;
+    if (!started || validatePlacement(v, enteredValues).saveable) void savePoints(d, v);
+    else optimisticGame({ points_total: v } as Partial<GameRow>);
+  }
+  function onPlaceInputs(next: string[]) {
+    setPlaceInputs(next);
+    const startedNext = (next[0]?.trim() ?? "") !== "";
+    const vals = startedNext ? next.map((s) => Number(s.trim() || "0")) : [];
+    const p = validatePlacement(total, vals);
+    if (!startedNext) void savePoints(null, total);
+    else if (p.saveable) void savePoints({ type: "placement", values: vals }, total);
+  }
+  function onFormat(key: string | null) {
+    setCompFormat(key);
+    setFormatSheetOpen(false);
+    optimisticGame({ competition_format: key } as Partial<GameRow>);
+    update.mutate({ tripId, gameId, competitionFormat: (key as never) ?? null }, { onSuccess: refresh });
+  }
+
+  const readOnly = !canEdit;
+  return (
+    <div className="flex flex-col gap-4" data-testid="format-points-panel">
+      {/* Competition format */}
+      <Field label="Competition format">
+        <button
+          type="button"
+          onClick={() => { if (!readOnly) setFormatSheetOpen(true); }}
+          disabled={readOnly}
+          className="flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-sm"
+          style={{ background: "var(--color-bt-card-raised)", color: compFormat ? "var(--color-bt-text)" : "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <span>{formatLabel(compFormat) ?? "How's it played?"}</span>
+          <ChevronRight size={15} style={{ color: "var(--color-bt-text-dim)" }} />
+        </button>
+        <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+          Sets the label on the leaderboard. Running it up in-app comes later — until then you enter results by hand.
+        </p>
+      </Field>
+
+      {/* Points */}
+      {isMatchPlay ? (
+        <PointStepper
+          label="Points per match"
+          caption="POINTS PER MATCH"
+          value={perMatchValue}
+          onChange={readOnly ? () => {} : onPerMatch}
+        />
+      ) : (
+        <>
+          <PointStepper
+            label="Point value"
+            caption="POINTS FOR THIS GAME"
+            value={total}
+            onChange={readOnly ? () => {} : onTotal}
+          />
+          <PlacementEditor total={total} placeInputs={placeInputs} setPlaceInputs={readOnly ? () => {} : onPlaceInputs} placement={placement} />
+        </>
+      )}
+
+      {formatSheetOpen && (
+        <FormatSheet current={compFormat} onPick={(k) => onFormat(k)} onClose={() => setFormatSheetOpen(false)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -3,6 +3,8 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { GameDangerZone } from "@/components/games/GameDangerZone";
+import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
+import { GameRulesNote } from "@/components/games/GameRulesNote";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 
 /**
@@ -71,6 +73,11 @@ export function GameConfigurationView({
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+        {/* Zone 1 — IDENTITY (W-EDITMODAL-01): name (tap-to-edit) + assigned-to. */}
+        {competitionId && (
+          <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
+        )}
+
         {/* Same editors as the setup hull — reused, never rebuilt. */}
         <GameSetupRows
           tripId={tripId}
@@ -96,6 +103,10 @@ export function GameConfigurationView({
             <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
           </button>
         )}
+
+        {/* Zone 3 — RULES note (W-EDITMODAL-01): saves on blur (no Save&exit here —
+            the back arrow navigates; the blur commit is the flush). */}
+        {competitionId && <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />}
 
         {/* Enabled / Disabled — the pressed-state control. */}
         <div className="mt-6">

--- a/src/components/games/GameIdentityHeader.tsx
+++ b/src/components/games/GameIdentityHeader.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, Pencil, UserCircle2, X } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+
+/**
+ * Zone 1 (W-EDITMODAL-01) — the IDENTITY header at the top of the game-setup page:
+ * *what is this game, and whose is it?* Display-first, NOT a checklist row — the
+ * game is already named, so this is display-with-edit, not resolve-from-empty.
+ *
+ *  - **Name** as the page title, tap-to-edit inline (commit on blur/Enter →
+ *    `games.update{name}`). Owner or delegate.
+ *  - **"Assigned to: [owner / delegate]"** — the FRAME for the whole page: empty →
+ *    the owner fills the checklist; filled → it's that delegate's assignment. The
+ *    delegate grant is owner-only (`addOrganizer`/`removeOrganizer`), so non-owners
+ *    see it read-only. A delegate landing here reads "… · Assigned to: you".
+ */
+export function GameIdentityHeader({
+  tripId, game, canEdit, isOwner,
+}: {
+  tripId: string;
+  game: GameRow;
+  /** Can edit the NAME (owner or delegate). */
+  canEdit: boolean;
+  /** Can change the ASSIGNMENT (owner-only — matches the server gate). */
+  isOwner: boolean;
+}) {
+  const gameId = game.id;
+  const me = useCurrentUser();
+  const utils = trpc.useUtils();
+
+  // ── Name (tap-to-edit inline) ──────────────────────────────────────────────
+  const name = (game.name as string | null) ?? "Untitled game";
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const updateName = trpc.games.update.useMutation();
+  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
+
+  function commitName() {
+    setEditing(false);
+    const next = draft.trim();
+    if (!next || next === name) { setDraft(name); return; }
+    updateName.mutate(
+      { tripId, gameId, name: next },
+      { onSuccess: () => utils.games.getById.invalidate({ tripId, gameId }) }
+    );
+  }
+
+  // ── Assigned to (delegate, owner-gated) ────────────────────────────────────
+  const membersQ = trpc.tripMembers.list.useQuery({ tripId }, { enabled: isOwner });
+  const members = (membersQ.data ?? []) as { memberId: string; displayName: string }[];
+  const orgQ = trpc.games.listOrganizers.useQuery({ tripId, gameId });
+  const delegateId = ((orgQ.data as { user_id: string }[] | undefined)?.[0]?.user_id) ?? null;
+  const addOrg = trpc.games.addOrganizer.useMutation();
+  const removeOrg = trpc.games.removeOrganizer.useMutation();
+  const [picking, setPicking] = useState(false);
+
+  const delegateName = delegateId
+    ? (delegateId === me?.id ? "you" : members.find((m) => m.memberId === delegateId)?.displayName ?? "a delegate")
+    : null;
+
+  async function assign(next: string | null) {
+    setPicking(false);
+    if (next === delegateId) return;
+    try {
+      if (delegateId) await removeOrg.mutateAsync({ tripId, gameId, userId: delegateId });
+      if (next) await addOrg.mutateAsync({ tripId, gameId, userId: next });
+      utils.games.listOrganizers.setData(
+        { tripId, gameId },
+        next ? ([{ user_id: next, granted_by: null, created_at: null }] as never) : []
+      );
+      utils.games.listOrganizers.invalidate({ tripId, gameId });
+    } catch {
+      utils.games.listOrganizers.invalidate({ tripId, gameId });
+    }
+  }
+
+  return (
+    <div className="mb-4">
+      {/* Name — title + tap-to-edit */}
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitName}
+          onKeyDown={(e) => { if (e.key === "Enter") commitName(); if (e.key === "Escape") { setDraft(name); setEditing(false); } }}
+          maxLength={200}
+          className="w-full rounded-lg px-2 py-1 outline-none"
+          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-accent-border)", fontSize: 22, fontWeight: 800 }}
+          data-testid="game-name-input"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => { if (canEdit) { setDraft(name); setEditing(true); } }}
+          disabled={!canEdit}
+          className="flex max-w-full items-center gap-2 text-left"
+          data-testid="game-name-title"
+        >
+          <span className="truncate" style={{ fontSize: 22, fontWeight: 800, color: "var(--color-bt-text)" }}>{name}</span>
+          {canEdit && <Pencil size={14} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />}
+        </button>
+      )}
+
+      {/* Assigned to — the page frame */}
+      <div className="mt-1.5">
+        {picking ? (
+          <div className="flex flex-col gap-1.5 rounded-xl p-2" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}>
+            <span className="px-1 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Assign to</span>
+            <button type="button" onClick={() => void assign(null)} className="rounded-lg px-3 py-2 text-left text-sm" style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text)" }}>
+              The owner (you)
+            </button>
+            {members.map((m) => (
+              <button key={m.memberId} type="button" onClick={() => void assign(m.memberId)} className="rounded-lg px-3 py-2 text-left text-sm" style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text)" }}>
+                {m.displayName}
+              </button>
+            ))}
+            {members.length === 0 && <span className="px-3 py-2 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>No crew to assign yet.</span>}
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => { if (isOwner) setPicking(true); }}
+            disabled={!isOwner}
+            className="flex items-center gap-1.5 text-sm"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="game-assigned-to"
+          >
+            <UserCircle2 size={14} style={{ color: delegateName ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }} />
+            <span>
+              Assigned to{" "}
+              <span style={{ color: delegateName ? "var(--color-bt-accent)" : "var(--color-bt-text)", fontWeight: 600 }}>
+                {delegateName ?? "the owner"}
+              </span>
+            </span>
+            {isOwner && (delegateName
+              ? <X size={13} style={{ color: "var(--color-bt-text-dim)" }} onClick={(e) => { e.stopPropagation(); void assign(null); }} />
+              : <Check size={13} style={{ color: "var(--color-bt-text-dim)", opacity: 0 }} />)}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/games/GameRulesNote.tsx
+++ b/src/components/games/GameRulesNote.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from "react";
+import { trpc } from "@/lib/trpc-client";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+
+export interface GameRulesNoteHandle {
+  /** Commit any unsaved text NOW (the page's "Save & exit" calls this before
+   *  navigating). Resolves once the write settles (or immediately if clean). */
+  flush: () => Promise<void>;
+}
+
+/**
+ * Zone 3 (W-EDITMODAL-01) — the "rules of the day" freeform note, at the bottom of
+ * the game-setup page BELOW the checklist. It's notes, not a task: nothing to
+ * "resolve", so it is NOT a ChecklistRow — a plain textarea.
+ *
+ * The one field with no collapse event, so it can't ride persist-on-collapse: it
+ * saves on **blur** (self-contained — works on surfaces with no Save&exit, like
+ * the Configuration screen) AND exposes `flush()` so the page's "Save & exit" can
+ * commit it before navigating (the honest "I typed a rules sheet, save it" door).
+ */
+export const GameRulesNote = forwardRef<GameRulesNoteHandle, {
+  tripId: string;
+  game: GameRow;
+  canEdit: boolean;
+}>(function GameRulesNote({ tripId, game, canEdit }, ref) {
+  const initial = (game.rules_for_today as string | null) ?? "";
+  const [text, setText] = useState(initial);
+  // The last value we persisted — so flush/blur is a no-op when nothing changed.
+  const savedRef = useRef(initial);
+  const update = trpc.games.update.useMutation();
+  const utils = trpc.useUtils();
+
+  const commit = useCallback(async () => {
+    const next = text.trim();
+    if (next === savedRef.current.trim()) return; // nothing changed
+    savedRef.current = text;
+    await update.mutateAsync({ tripId, gameId: game.id, rulesForToday: next || null });
+    utils.games.getById.invalidate({ tripId, gameId: game.id });
+  }, [text, tripId, game.id, update, utils]);
+
+  useImperativeHandle(ref, () => ({ flush: () => commit().catch(() => {}) }), [commit]);
+
+  return (
+    <div className="mt-6">
+      <label className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+        Rules of the day
+      </label>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={() => void commit()}
+        readOnly={!canEdit}
+        rows={3}
+        maxLength={2000}
+        placeholder="Tap out the rules of the day — formats, gimmes, mulligans, tiebreakers…"
+        className="mt-2 w-full resize-none rounded-xl px-3 py-2.5 text-sm outline-none"
+        style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", opacity: canEdit ? 1 : 0.7 }}
+        data-testid="game-rules-note"
+      />
+    </div>
+  );
+});

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -4,28 +4,24 @@ import { useState } from "react";
 import { trpc } from "@/lib/trpc-client";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
-import { GameSheet, type GameRow } from "@/components/competition/CompetitionGamesPanel";
-import { GAME_TYPES } from "@/lib/gameTypes";
+import { formatLabel, type GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
 
 /**
- * §B setup-shell drill-down rows (Phase 2B.2). The standardized top of every
- * format's setup phase: the **course pre-step** then **Name · Format · Points**,
- * each opening its ALREADY-BUILT editor (CoursePicker / the GameSheet add-edit
- * modal — reuse, never rebuild). The format's own who's-playing + handicaps body
- * renders BELOW this, and "Enable scoring" is the bottom CTA — this component is
- * just the shared hull header. Course is optional and never gates readiness.
+ * §B setup-shell drill-down rows: the **course pre-step** then **Format · Points**.
+ * Course opens the CoursePicker overlay (deferred-split, unchanged); Format·Points
+ * is an **in-place accordion panel** (W-EDITMODAL-01 — the old two-tab Edit-Game
+ * modal is retired for this row). The game's NAME + assignment moved to the Zone-1
+ * identity header and its RULES to the Zone-3 note (both page-level), so this row
+ * is just competition-format + points now.
  *
  * Open-state is **optionally controlled by the page** (`courseOpen`/`configOpen`
  * + the open/close callbacks). When the match-setup checklist drives it, the
- * one-panel-at-a-time rule spans EVERY row (tapping Course collapses any open
- * accordion row). Every OTHER consumer (stroke/rack/new/config-view) omits the
- * props and gets the original self-managed behavior — so this lift doesn't ripple
- * across them. These two editors stay OVERLAYS this pass (the CoursePicker split +
- * the Game-config modal-shed are tracked follow-ons).
- *
- * No checklist, no top-level Save: edits are live (CoursePicker applies on pick;
- * GameSheet persists on its own Save), and `onChanged` refetches the game so the
- * row summaries and the body update in place.
+ * one-panel-at-a-time rule spans EVERY row. Every OTHER consumer (stroke/rack/new/
+ * config-view) omits the props and self-manages (the accordion opens/closes
+ * locally) — so the conversion fixes the modal leak on all of them without a
+ * ripple. `onChanged` refetches the game so the Course row summary updates; the
+ * Format·Points panel persists + invalidates itself.
  */
 export function GameSetupRows({
   tripId,
@@ -66,8 +62,6 @@ export function GameSetupRows({
   const openConfig = onOpenConfig ?? (() => setConfigOpenLocal(true));
   const closeEditor = onCloseEditor ?? (() => { setCourseOpenLocal(false); setConfigOpenLocal(false); });
 
-  // Format definitions live in code (W-PERF-01) — no fetch, always available.
-  const types = GAME_TYPES;
   const applyCourse = trpc.games.applyCourse.useMutation();
   const utils = trpc.useUtils();
 
@@ -89,12 +83,16 @@ export function GameSetupRows({
       />
       {competitionId && (
         <ChecklistRow
-          label="Name · Format · Points"
-          value={`${game.name ?? "Untitled"}${pointsSummary(game) ? ` · ${pointsSummary(game)}` : ""}`}
+          label="Format · Points"
+          value={formatPointsSummary(game)}
           state="resolved"
           disabled={!canEdit}
-          onClick={openConfig}
-        />
+          expanded={configOpen}
+          onToggle={configOpen ? closeEditor : openConfig}
+          testId="row-format-points"
+        >
+          <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} />
+        </ChecklistRow>
       )}
 
       {courseOpen && (
@@ -115,21 +113,14 @@ export function GameSetupRows({
         />
       )}
 
-      {configOpen && competitionId && (
-        <GameSheet
-          tripId={tripId}
-          competitionId={competitionId}
-          game={game}
-          types={types}
-          canEdit={canEdit}
-          onClose={() => {
-            closeEditor();
-            onChanged();
-          }}
-        />
-      )}
     </>
   );
+}
+
+/** "Head to head · 2/match" — the Format·Points row's loud summary. */
+function formatPointsSummary(game: GameRow): string {
+  const parts = [formatLabel(game.competition_format ?? null), pointsSummary(game)].filter(Boolean);
+  return parts.length > 0 ? parts.join(" · ") : "Set format & points";
 }
 
 /** A compact points summary for the config row: "2/match" · "8 pts". */


### PR DESCRIPTION
Follow-on to #462 (accordion). The **"Name·Format·Points" row** still opened the heavy two-tab **GameSheet / Edit-Game modal** — a jarring modal leak from a checklist. Phase 0 showed the modal's fields don't fold into one panel; they each belong to a different **zone**. So the game-setup page is re-zoned into **IDENTITY / CHECKLIST / NOTES**, and the modal is retired for this entry point.

## The three zones (competition games)
- **Zone 1 — IDENTITY** (`GameIdentityHeader`, top): game **name** as the title with **tap-to-edit inline** (`update{name}`); **"Assigned to: owner/delegate"** — the frame for the whole page (`addOrganizer`/`removeOrganizer`, owner-gated). Display-first, visually distinct from the checklist.
- **Zone 2 — CHECKLIST**: the old row loses its name → **"Format · Points"**, a #462 accordion panel (`FormatPointsPanel`) — competition-format + points only. **Points save as the total+distribution PAIR** (never one without the other); format saves on pick.
- **Zone 3 — NOTES** (`GameRulesNote`, bottom): rules-of-the-day textarea. Saves on blur + `flush()` via ref (the one field with no collapse event).

## Exit model
**"Enable scoring"** (primary, readiness-gated, unchanged) + **"Save & exit"** (secondary, always-enabled) — flushes the rules note then navigates (the honest leave-and-resume door; checklist rows already persist on collapse).

## Scope (Phase 0)
- **GameSheet is NOT retired** — it stays for **create** (CompetitionGamesPanel, CompetitionFace) and non-golf edit. Only the shared row stops opening it.
- ⚠ **The row renders on 4 surfaces, not 2** (match/new, GameConfigurationView, games/new, rack/new — last two via `EnableScoringGate`). The conversion + re-zone applies to **all four** (reusable Zone-1/Zone-3 components; `EnableScoringGate` gains `identityHeader`/`rulesNote`/`onSaveExit` slots) — name/rules/delegate re-homed everywhere, **no capability dropped**.
- **Drop/Abandon deleted outright** (per Zach); **Delete** lives in the danger zone + the board's game edit; Course/Matches/Modifiers stay their own rows; the MAKE-IT-READY stub is gone.

## Notes
- **Points save on-change (as an atomic pair)** rather than on-collapse: every intermediate points value is valid (no half-filled hazard like the draft editors), which sidesteps fragile cross-component collapse-flush coordination while honoring the pair constraint. Optimistic via `setData`.
- Reuses the modal's controls (`PointStepper`/`PlacementEditor`/`FormatSheet`/`Field`/`formatLabel` now exported) + the shared validators in `lib/gameConfig`.

## Verification
- Verified by-eye **light + dark** on a real competition game: identity header (name tap-to-edit + assigned-to), Format·Points panel (no name/course/matches duplication), rules note, Enable + Save&exit.
- `tsc --noEmit` + eslint clean.
- Match-play E2E green (`--repeat-each=2`). The standalone match path has no competition → no config row → **zero test steps change** (this zone is competition-only; a competition-scoped E2E is a flagged follow-up).
- GameSheet intact for create + non-golf edit.

## Captured (NOT this PR)
- Two-column rosters for large formats (shared rosters component).
- Delegate as an optional last step in the lean Add-Game flow (W-ADDGAME-01).
- Cross-panel styling pass once all rows are accordion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)