### PR TITLE
feat(competition): CoursePicker split — picker → accordion, manual entry → its own page (W-COURSESPLIT-01)

### DIFF
--- a/src/app/courses/new/page.tsx
+++ b/src/app/courses/new/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { trpc } from "@/lib/trpc-client";
+import { CourseEntryFlow } from "@/components/games/course/CourseEntryFlow";
+
+/**
+ * Manual course-entry page (W-COURSESPLIT-01) — the heavy "place" the Course-row
+ * picker steps out to. **Trip-agnostic** (`/courses/new`, not under `/trips/...`):
+ * a course is a global library row the group reuses across trips, not a property
+ * of one trip (migration 039 — `courses` has no `trip_id`). It already lives at
+ * the right level for the future Circle layer; this route matches.
+ *
+ * `?trip=&game=` are the return target — on save, create the global course, apply
+ * it to that game, and go back so the Course row lands resolved + checked. The
+ * game already exists (it's why the row can navigate while the pre-create pickers
+ * can't), so leaving and returning is safe. `?provider=` seeds a golfcourseapi
+ * pull for review; absent → a blank manual build.
+ */
+export default function NewCoursePage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const tripId = params.get("trip");
+  const gameId = params.get("game");
+  const provider = params.get("provider");
+
+  const createCourse = trpc.courses.create.useMutation();
+  const applyCourse = trpc.games.applyCourse.useMutation();
+  const utils = trpc.useUtils();
+
+  const leave = () => { if (window.history.length > 1) router.back(); else router.push(tripId ? `/trips/${tripId}` : "/dashboard"); };
+
+  async function handleSave(payload: Parameters<React.ComponentProps<typeof CourseEntryFlow>["onSave"]>[0]) {
+    const { teeName, ...createInput } = payload;
+    try {
+      const course = await createCourse.mutateAsync(createInput);
+      const courseId = course.id as string;
+      // Apply to the originating game (when we came from one) so the Course row
+      // returns resolved. No game → just saved to the library.
+      if (tripId && gameId) {
+        await applyCourse.mutateAsync({ tripId, gameId, courseId, teeSetName: teeName });
+        utils.courses.getById.invalidate({ courseId });
+        utils.games.getById.invalidate({ tripId, gameId });
+        utils.games.listByTrip.invalidate({ tripId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+      }
+      utils.courses.list.invalidate();
+      leave();
+    } catch {
+      // Surfaced via the flow's disabled/saving state; leave the user on the page.
+    }
+  }
+
+  return (
+    <CourseEntryFlow
+      providerId={provider}
+      saving={createCourse.isPending || applyCourse.isPending}
+      onSave={handleSave}
+      onCancel={leave}
+    />
+  );
+}

--- a/src/app/courses/new/page.tsx
+++ b/src/app/courses/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
 import { CourseEntryFlow } from "@/components/games/course/CourseEntryFlow";
@@ -17,7 +18,17 @@ import { CourseEntryFlow } from "@/components/games/course/CourseEntryFlow";
  * can't), so leaving and returning is safe. `?provider=` seeds a golfcourseapi
  * pull for review; absent → a blank manual build.
  */
+// useSearchParams() forces client-side rendering, so the page that calls it must
+// sit under a Suspense boundary (Next.js bails out of static prerender otherwise).
 export default function NewCoursePage() {
+  return (
+    <Suspense fallback={<div className="fixed inset-0" style={{ background: "var(--color-bt-base)" }} />}>
+      <NewCourseInner />
+    </Suspense>
+  );
+}
+
+function NewCourseInner() {
   const router = useRouter();
   const params = useSearchParams();
   const tripId = params.get("trip");

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { trpc } from "@/lib/trpc-client";
-import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { CourseSearchPanel } from "@/components/games/course/CourseSearchPanel";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { formatLabel, type GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
@@ -79,25 +79,16 @@ export function GameSetupRows({
         value={courseName ?? "Add a course"}
         state={courseName ? "resolved" : "unresolved"}
         disabled={!canEdit}
-        onClick={openCourse}
-      />
-      {competitionId && (
-        <ChecklistRow
-          label="Format · Points"
-          value={formatPointsSummary(game)}
-          state="resolved"
-          disabled={!canEdit}
-          expanded={configOpen}
-          onToggle={configOpen ? closeEditor : openConfig}
-          testId="row-format-points"
-        >
-          <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} />
-        </ChecklistRow>
-      )}
-
-      {courseOpen && (
-        <CoursePicker
-          onClose={closeEditor}
+        expanded={courseOpen}
+        onToggle={courseOpen ? closeEditor : openCourse}
+        testId="row-course"
+      >
+        {/* The PICKER, inline (W-COURSESPLIT-01): search/select an existing course
+            applies live; "Add course manually" + API results navigate to the heavy
+            entry page (/courses/new) and return with the course applied. */}
+        <CourseSearchPanel
+          tripId={tripId}
+          gameId={game.id}
           onApply={({ id, teeName }) => {
             applyCourse.mutate(
               { tripId, gameId: game.id, courseId: id, teeSetName: teeName },
@@ -111,8 +102,20 @@ export function GameSetupRows({
             closeEditor();
           }}
         />
+      </ChecklistRow>
+      {competitionId && (
+        <ChecklistRow
+          label="Format · Points"
+          value={formatPointsSummary(game)}
+          state="resolved"
+          disabled={!canEdit}
+          expanded={configOpen}
+          onToggle={configOpen ? closeEditor : openConfig}
+          testId="row-format-points"
+        >
+          <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} />
+        </ChecklistRow>
       )}
-
     </>
   );
 }

--- a/src/components/games/course/CourseEntryFlow.tsx
+++ b/src/components/games/course/CourseEntryFlow.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, X } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import {
+  NewCourseScreen, EntryScreen, ConfirmScreen, HoleEditScreen,
+  blankDraft, type Draft,
+} from "./CoursePicker";
+import {
+  getCourseDetail, parFromDetail, indexFromDetail, teeSetsFromDetail,
+} from "@/lib/courseService";
+import { validateStrokeIndex, applyStrokeIndexSwap } from "@/lib/courseIndex";
+
+const blankTee = (n: number, name: string) => ({ name, yards: Array(n).fill(null) });
+
+/**
+ * CourseEntryFlow (W-COURSESPLIT-01) — the MANUAL-ENTRY half of the old fused
+ * CoursePicker, extracted as a standalone flow: `new → per-hole entry → confirm →
+ * save`. Owns the mutable `draft`; reuses the (now exported) entry screens. This
+ * is the heavy "place" — it renders as its own page (`/courses/new`). A `provider`
+ * id seeds it from a golfcourseapi pull (review-before-save); absent → a blank
+ * manual build.
+ *
+ * On save it persists a GLOBAL `courses` row (course data isn't trip-scoped) and
+ * hands the caller `{ id, name, teeName }` to apply to the game + return. The
+ * picker half (search/select existing) stays inline on the Course row; only this
+ * heavy build navigates.
+ */
+export function CourseEntryFlow({
+  providerId,
+  saving,
+  onSave,
+  onCancel,
+}: {
+  /** golfcourseapi summary id → seed the draft from a pull (review). Null → blank. */
+  providerId?: string | null;
+  /** The parent's create+apply is in-flight (disables the primary CTA). */
+  saving?: boolean;
+  /** Persist + apply + return. Receives the finished draft as a create payload. */
+  onSave: (payload: {
+    name: string; location?: string; holeCount: 9 | 18; par: number[];
+    handicapIndex?: number[]; hasStrokeIndex: boolean;
+    teeSets: Draft["teeSets"]; source: Draft["source"]; providerId?: string;
+    teeName?: string;
+  }) => void;
+  onCancel: () => void;
+}) {
+  const [screen, setScreen] = useState<"new" | "entry" | "confirm">(providerId ? "confirm" : "new");
+  const [draft, setDraft] = useState<Draft>(() => blankDraft(18));
+  const [activeTee, setActiveTee] = useState(0);
+  const [hole, setHole] = useState(1);
+  const [editingHole, setEditingHole] = useState<number | null>(null);
+  const [indexOptedIn, setIndexOptedIn] = useState(false);
+  const [pulling, setPulling] = useState(!!providerId);
+
+  const recordApiCall = trpc.courses.recordApiCall.useMutation();
+  const utils = trpc.useUtils();
+
+  // Seed from a golfcourseapi pull (gated by the daily cap, like the old picker).
+  // At cap or on a missing detail, fall back to a blank manual build.
+  useEffect(() => {
+    if (!providerId) return;
+    let cancelled = false;
+    (async () => {
+      const gate = await recordApiCall.mutateAsync().catch(() => ({ permitted: false }));
+      await utils.courses.apiUsage.invalidate();
+      const detail = gate.permitted ? await getCourseDetail(providerId).catch(() => null) : null;
+      if (cancelled) return;
+      if (!detail || detail.holes.length === 0) { setPulling(false); setScreen("new"); return; }
+      const holeCount = (detail.holes.length >= 18 ? 18 : 9) as 9 | 18;
+      const tees = teeSetsFromDetail(detail);
+      const pulledIndex = indexFromDetail(detail).slice(0, holeCount);
+      const cleanIndex = validateStrokeIndex(pulledIndex, holeCount).valid ? pulledIndex : Array(holeCount).fill(null);
+      setDraft({
+        name: detail.name, location: detail.location, holeCount,
+        par: parFromDetail(detail).slice(0, holeCount), index: cleanIndex, hasStrokeIndex: true,
+        teeSets: tees.length ? tees.map((t) => ({ ...t, yards: t.yards.slice(0, holeCount) })) : [blankTee(holeCount, "White")],
+        source: "golfcourseapi", providerId: detail.externalId,
+      });
+      setPulling(false);
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [providerId]);
+
+  const validation = useMemo(() => validateStrokeIndex(draft.index, draft.holeCount), [draft.index, draft.holeCount]);
+  const indexStarted = draft.hasStrokeIndex && draft.index.some((v) => v != null);
+  const indexUsable = !indexStarted || validation.valid;
+  const flagged = useMemo(
+    () => (indexStarted && !validation.valid
+      ? new Set([...validation.unsetHoles, ...validation.duplicateHoles, ...validation.outOfRangeHoles])
+      : new Set<number>()),
+    [validation, indexStarted]
+  );
+
+  const setPar = (h: number, v: number) => setDraft((d) => ({ ...d, par: d.par.map((p, i) => (i === h - 1 ? v : p)) }));
+  const setIndex = (h: number, v: number) => setDraft((d) => ({ ...d, index: applyStrokeIndexSwap(d.index, h - 1, v) }));
+  const setYards = (h: number, v: number | null) => setDraft((d) => ({
+    ...d, teeSets: d.teeSets.map((t, ti) => (ti === activeTee ? { ...t, yards: t.yards.map((y, i) => (i === h - 1 ? v : y)) } : t)),
+  }));
+
+  function save() {
+    if (!indexUsable || !draft.name.trim()) return;
+    onSave({
+      name: draft.name.trim(), location: draft.location.trim() || undefined, holeCount: draft.holeCount,
+      par: draft.par, handicapIndex: validation.valid ? (draft.index as number[]) : undefined,
+      hasStrokeIndex: validation.valid, teeSets: draft.teeSets, source: draft.source, providerId: draft.providerId,
+      teeName: draft.teeSets[activeTee]?.name?.trim() || undefined,
+    });
+  }
+
+  const holeShown = editingHole ?? (screen === "entry" ? hole : null);
+  const title = holeShown != null ? (draft.name.trim() || "New course") : screen === "new" ? "New course" : "Course summary";
+  const subtitle = holeShown != null ? `Hole ${holeShown} of ${draft.holeCount}` : screen === "confirm" ? "Review what you entered" : null;
+  const back = () => {
+    if (editingHole != null) return setEditingHole(null);
+    if (screen === "entry") return setScreen("new");
+    if (screen === "confirm") return providerId ? onCancel() : setScreen("entry");
+    onCancel();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <header
+        className="flex shrink-0 items-center justify-between"
+        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        <button onClick={back} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div className="flex min-w-0 flex-col items-center text-center">
+          <div className="max-w-full truncate" style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
+          {subtitle && <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>}
+        </div>
+        <button onClick={onCancel} aria-label="Close" className="flex h-9 w-9 items-center justify-center">
+          <X size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+        </button>
+      </header>
+
+      {pulling ? (
+        <div className="flex flex-1 items-center justify-center" style={{ color: "var(--color-bt-text-dim)", fontSize: 14 }}>Pulling scorecard…</div>
+      ) : editingHole != null ? (
+        <HoleEditScreen
+          draft={draft} hole={editingHole} activeTee={activeTee} setActiveTee={setActiveTee}
+          flagged={flagged} indexOptedIn={indexOptedIn} onOptInIndex={() => setIndexOptedIn(true)}
+          setPar={setPar} setIndex={setIndex} setYards={setYards} onDone={() => setEditingHole(null)}
+        />
+      ) : screen === "new" ? (
+        <NewCourseScreen draft={draft} setDraft={setDraft} onStart={() => { setHole(1); setScreen("entry"); }} />
+      ) : screen === "confirm" ? (
+        <ConfirmScreen
+          draft={draft} mode="use" activeTee={activeTee} setActiveTee={setActiveTee}
+          indexUsable={indexUsable} flagged={flagged} saving={!!saving}
+          onEditHole={(h) => setEditingHole(h)} onPrimary={save}
+        />
+      ) : (
+        <EntryScreen
+          draft={draft} hole={hole} setHole={setHole} activeTee={activeTee} setActiveTee={setActiveTee}
+          indexOptedIn={indexOptedIn} onOptInIndex={() => setIndexOptedIn(true)} indexUsable={indexUsable}
+          setPar={setPar} setIndex={setIndex} setYards={setYards} onReview={() => setScreen("confirm")}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/games/course/CoursePicker.tsx
+++ b/src/components/games/course/CoursePicker.tsx
@@ -40,7 +40,7 @@ type TeeSet = {
   bogeyRating?: number | null;
   yards: (number | null)[];
 };
-interface Draft {
+export interface Draft {
   name: string;
   location: string;
   holeCount: 9 | 18;
@@ -54,11 +54,11 @@ interface Draft {
   existingId?: string;
 }
 
-type Screen = "search" | "confirm" | "new" | "entry" | "saved";
+export type Screen = "search" | "confirm" | "new" | "entry" | "saved";
 
 const blankTee = (n: number, name: string): TeeSet => ({ name, yards: Array(n).fill(null) });
 
-function blankDraft(holeCount: 9 | 18): Draft {
+export function blankDraft(holeCount: 9 | 18): Draft {
   return {
     name: "",
     location: "",
@@ -435,7 +435,7 @@ export function CoursePicker({
   );
 }
 
-interface RecentCourse {
+export interface RecentCourse {
   id: string;
   name: string;
   location: string | null;
@@ -593,7 +593,7 @@ function SearchScreen({
   );
 }
 
-function CourseRow({ name, sub, onClick }: { name: string; sub?: string | null; onClick: () => void }) {
+export function CourseRow({ name, sub, onClick }: { name: string; sub?: string | null; onClick: () => void }) {
   return (
     <button onClick={onClick} className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left" style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}>
       <span className="min-w-0">
@@ -606,7 +606,7 @@ function CourseRow({ name, sub, onClick }: { name: string; sub?: string | null; 
 }
 
 // ── Confirm (lookup) ──────────────────────────────────────────────────────────
-function ConfirmScreen({
+export function ConfirmScreen({
   draft,
   mode,
   activeTee,
@@ -730,7 +730,7 @@ function ConfirmScreen({
 }
 
 // ── New course (manual setup) ─────────────────────────────────────────────────
-function NewCourseScreen({
+export function NewCourseScreen({
   draft,
   setDraft,
   onStart,
@@ -884,7 +884,7 @@ function TeeList({
 }
 
 // ── Stepped per-hole entry (manual) ───────────────────────────────────────────
-function EntryScreen({
+export function EntryScreen({
   draft,
   hole,
   setHole,
@@ -998,7 +998,7 @@ function EntryScreen({
 }
 
 // ── Single-hole edit (from confirm) ───────────────────────────────────────────
-function HoleEditScreen({
+export function HoleEditScreen({
   draft,
   hole,
   activeTee,
@@ -1105,7 +1105,7 @@ function TeeChip({ name, on, onClick }: { name: string; on: boolean; onClick: ()
 // Lands here after "Save to my courses" — the new course is highlighted (NEW),
 // NOT auto-selected for play. Adding a course and using one are separate
 // concerns (spec §6); tapping a row reviews it (→ Confirm, mode 'use').
-function SavedScreen({
+export function SavedScreen({
   courses,
   savedId,
   onPick,
@@ -1195,7 +1195,7 @@ function IconCol({ children }: { children: React.ReactNode }) {
   return <span className="flex items-center justify-center" style={{ width: ICON_COL, flexShrink: 0 }}>{children}</span>;
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+export function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
       <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</label>
@@ -1204,7 +1204,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-function Footer({ label, disabled, onClick }: { label: string; disabled?: boolean; onClick: () => void }) {
+export function Footer({ label, disabled, onClick }: { label: string; disabled?: boolean; onClick: () => void }) {
   return (
     <div className="shrink-0" style={{ padding: 16, borderTop: "1px solid var(--color-bt-subtle-border)", background: "var(--color-bt-base)" }}>
       <button onClick={onClick} disabled={disabled} className="w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>

--- a/src/components/games/course/CourseSearchPanel.tsx
+++ b/src/components/games/course/CourseSearchPanel.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Search, AlertTriangle, PencilLine, ChevronRight } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { searchCourses, teeColor, type CourseSummary } from "@/lib/courseService";
+import type { RecentCourse } from "./CoursePicker";
+
+/**
+ * CourseSearchPanel (W-COURSESPLIT-01) — the PICKER half of the old fused
+ * CoursePicker, as inline accordion content on the Course row. **Read-only w.r.t.
+ * course data**: it searches (local typeahead + the explicit golfcourseapi call) +
+ * recents and SELECTS a saved course → `onApply` (the parent's `applyCourse`,
+ * live). It never owns a draft.
+ *
+ * The two draft-requiring paths NAVIGATE to the heavy entry page (`/courses/new`):
+ * "Add course manually" (blank) and selecting an API result (seeded by a pull).
+ * That's the clean cut — the picker stays inline + read-only; all building happens
+ * on the page. Multi-tee saved courses expand a tee chooser before applying (the
+ * applied tee is what the row's loud value shows).
+ */
+export function CourseSearchPanel({
+  tripId, gameId, onApply,
+}: {
+  tripId: string;
+  gameId: string;
+  /** Apply a SAVED course (the parent runs applyCourse). */
+  onApply: (course: { id: string; name: string; teeName?: string }) => void;
+}) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [apiResults, setApiResults] = useState<CourseSummary[]>([]);
+  const [apiSearching, setApiSearching] = useState(false);
+  const [apiSearched, setApiSearched] = useState(false);
+  // The saved course whose tee chooser is expanded (multi-tee select-before-apply).
+  const [teePickFor, setTeePickFor] = useState<RecentCourse | null>(null);
+
+  const recent = trpc.courses.list.useQuery({ limit: 8 });
+  const apiUsage = trpc.courses.apiUsage.useQuery(undefined, { staleTime: 0 });
+  const recordApiCall = trpc.courses.recordApiCall.useMutation();
+  const utils = trpc.useUtils();
+  const atCap = apiUsage.data?.atCap ?? false;
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const localSearch = trpc.courses.search.useQuery({ q: debounced, limit: 10 }, { enabled: debounced.length >= 2 });
+
+  const onQueryChange = (v: string) => { setQuery(v); setApiResults([]); setApiSearched(false); setTeePickFor(null); };
+
+  async function searchFullDatabase() {
+    const q = query.trim();
+    if (q.length < 2 || apiSearching || atCap) return;
+    setApiSearching(true);
+    const gate = await recordApiCall.mutateAsync().catch(() => ({ permitted: false }));
+    await utils.courses.apiUsage.invalidate();
+    if (!gate.permitted) { setApiSearching(false); return; }
+    const r = await searchCourses(q).catch(() => []);
+    setApiResults(r);
+    setApiSearched(true);
+    setApiSearching(false);
+  }
+
+  // Select a SAVED course: one tee → apply; many → expand the tee chooser.
+  function selectSaved(c: RecentCourse) {
+    const tees = c.tee_sets ?? [];
+    if (tees.length <= 1) { onApply({ id: c.id, name: c.name, teeName: tees[0]?.name?.trim() || undefined }); return; }
+    setTeePickFor(c);
+  }
+  const entryHref = (provider?: string) =>
+    `/courses/new?trip=${encodeURIComponent(tripId)}&game=${encodeURIComponent(gameId)}${provider ? `&provider=${encodeURIComponent(provider)}` : ""}`;
+
+  const local = (localSearch.data as RecentCourse[]) ?? [];
+  const recents = (recent.data as RecentCourse[]) ?? [];
+  const showResults = query.trim().length >= 2;
+  const courseSub = useMemo(() => (c: RecentCourse) => {
+    const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
+    return [c.location, par ? `Par ${par}` : "", `${c.hole_count} holes`].filter(Boolean).join(" · ");
+  }, []);
+
+  // Tee chooser (multi-tee saved course).
+  if (teePickFor) {
+    return (
+      <div data-testid="course-tee-picker" className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <button onClick={() => setTeePickFor(null)} className="text-[13px]" style={{ color: "var(--color-bt-accent)" }}>‹ Back</button>
+          <span className="truncate text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>{teePickFor.name}</span>
+        </div>
+        <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Choose a tee</span>
+        <div className="flex flex-wrap gap-2">
+          {(teePickFor.tee_sets ?? []).map((t, i) => (
+            <button
+              key={i}
+              onClick={() => onApply({ id: teePickFor.id, name: teePickFor.name, teeName: t.name?.trim() || undefined })}
+              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+            >
+              <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(t.name || `Tee ${i + 1}`) }} />
+              {t.name || `Tee ${i + 1}`}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="course-search-panel" className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 rounded-xl border px-3" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
+        <Search size={16} style={{ color: "var(--color-bt-text-dim)" }} />
+        <input
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (!localSearch.isFetching && local.length === 0) void searchFullDatabase(); } }}
+          placeholder="Search your courses"
+          className="w-full bg-transparent py-2.5 text-sm outline-none"
+          style={{ color: "var(--color-bt-text)" }}
+        />
+      </div>
+
+      {showResults ? (
+        <>
+          <div className="flex flex-col gap-2">
+            {localSearch.isFetching && local.length === 0 && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>Searching your courses…</p>}
+            {!localSearch.isFetching && local.length === 0 && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No saved courses match.</p>}
+            {local.map((c) => <PickRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => selectSaved(c)} />)}
+          </div>
+
+          {atCap ? (
+            <div className="flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
+              <AlertTriangle size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0, marginTop: 1 }} />
+              <span style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)" }}>Course search is temporarily unavailable — add the course manually below.</span>
+            </div>
+          ) : (
+            <button
+              onClick={() => void searchFullDatabase()}
+              disabled={apiSearching}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3 disabled:opacity-50"
+              style={{ borderColor: "var(--color-bt-border)", background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)" }}
+            >
+              <Search size={15} style={{ color: "var(--color-bt-text-dim)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600 }}>{apiSearching ? "Searching the full database…" : "Don't see it? Search the full course database →"}</span>
+            </button>
+          )}
+
+          {apiSearched && (
+            <div className="flex flex-col gap-2">
+              <p className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>From the course database</p>
+              {apiResults.length === 0 ? (
+                <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches in the database.</p>
+              ) : (
+                // Picking an API result NAVIGATES to the entry page (it needs a pull
+                // + review before it becomes a saved course).
+                apiResults.map((c) => <PickRow key={c.id} name={c.name} sub={c.location} onClick={() => router.push(entryHref(c.id))} />)
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        recents.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Recent courses</p>
+            {recents.map((c) => <PickRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => selectSaved(c)} />)}
+          </div>
+        )
+      )}
+
+      <button
+        onClick={() => router.push(entryHref())}
+        data-testid="course-add-manually"
+        className="flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3"
+        style={{ borderColor: "var(--color-bt-accent-border)", borderStyle: "dashed", color: "var(--color-bt-accent)", background: "transparent" }}
+      >
+        <PencilLine size={16} />
+        <span style={{ fontSize: 14, fontWeight: 600 }}>Add course manually</span>
+      </button>
+    </div>
+  );
+}
+
+function PickRow({ name, sub, onClick }: { name: string; sub?: string | null; onClick: () => void }) {
+  return (
+    <button onClick={onClick} className="flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-left" style={{ background: "var(--color-bt-card)", borderColor: "var(--color-bt-border)" }}>
+      <span className="min-w-0">
+        <span className="block truncate" style={{ fontSize: 15, color: "var(--color-bt-text)" }}>{name}</span>
+        {sub && <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>{sub}</span>}
+      </span>
+      <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+    </button>
+  );
+}


### PR DESCRIPTION
Follow-on to #463 — **the last non-accordion checklist row.** Course opened the full-screen `CoursePicker`, a fused 5-screen state machine doing BOTH the light **picker** (search/select existing) AND the heavy **manual 18-hole build**. Phase 0 mapped the boundary; this decomposes it.

## The split
- **Picker → inline accordion** (`CourseSearchPanel`) on the Course row: local typeahead + the explicit golfcourseapi search + recents → select a saved course → `applyCourse` (live, persist-on-collapse, one-open, recede). **Read-only** — never owns a draft.
- **Manual entry → its own navigable page** (`CourseEntryFlow` at `/courses/new`): the heavy "place", owning the mutable draft (`new → per-hole entry → review → save`). On save: create the global course → `applyCourse` to the originating game → `router.back()` → the Course row lands **resolved + checked**.

## The clean cut (Phase 0's decisive finding)
The picker's `confirm`/hole-editor mutated the shared draft, so a naive "picker read-only / entry mutable" cut didn't exist. Resolved by routing **both** draft-requiring paths to the entry page — "Add course manually" (blank) **and** selecting an API result (seeded by a pull). The picker stays read-only; the entry page owns the draft + hole-editor + confirm. Selecting a saved course applies directly (no confirm). One entry implementation (the BBMI-load-bearing flow), reused via the now-exported entry screens.

## Trip-agnostic route (the ownership correction)
A course is a **global library row** the group reuses across trips (migration 039 — `courses` has no `trip_id`), so the route is `/courses/new`, **not** under `/trips/[id]/`. It's already at the right level for the future Circle layer — no later un-scoping migration. `?trip=&game=` are the return target (the game already exists, which is exactly why the row can navigate while the pre-create pickers can't); `?provider=` seeds the golfcourseapi pull. **Route-only fix — the data was already global** (RE-CONFIRM checked the schema).

## Scope (Option A) + consumers
- The Course row (`GameSetupRows`) — all 4 #463 surfaces inherit it (match/new, GameConfigurationView, games/new, rack/new).
- ⚠ The **3 pre-create pickers** (NewGame on match/new + rack/new, GameSheet's create flow) pick *before* a game exists → they can't navigate without losing create-flow state, so they **keep the existing full-screen `CoursePicker` UNCHANGED**. `CoursePicker` gains only `export`s. Fully retiring the fused component (+ the pre-create rethink) pairs with **W-ADDGAME-01** — flagged.

## Verification
- **Both paths end-to-end, light + dark**, on a real competition game: pick-existing inline; **manual 9-hole build → page → "Use this course" → returned to the checklist with the Course row resolved** ("Split Test 9"). The new course then appears in the picker's recents.
- `tsc` + eslint clean. Match-play E2E green — Course isn't on the standalone path (no competition → no course pick), so zero test steps change (Course-row E2E remains a flagged gap).

## Next / flagged
- **W-9HOLE-01** (front/back-nine) — the immediate next piece, built on this stabilized row (attaches at the entry page's `holeCount` + the row's resolved value; not blocked).
- Fully retiring the fused CoursePicker + the pre-create course-pick rethink → with W-ADDGAME-01.
- Convert-all-then-style-once pass (every row is now accordion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)