### PR TITLE
feat(competition): 9-hole courses → retained two-nines 18 + Course-before-Handicaps (W-9HOLE-01)

### DIFF
--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -24,6 +24,8 @@ let admin: SupabaseClient;
 let tripId: string;
 let ownerId: string;
 let memberId: string;
+let courseName: string;
+let courseId: string;
 
 async function ensureUser(email: string, name: string): Promise<string> {
   const { data: list, error } = await admin.auth.admin.listUsers();
@@ -56,6 +58,27 @@ test.beforeAll(async () => {
     { trip_id: tripId, user_id: memberId, role: "Member", status: "in", nickname: "MP Member" },
   ]);
   if (mErr) throw new Error(`seed members failed: ${mErr.message}`);
+
+  // Handicaps is now gated on a resolved Course (W-9HOLE-01) — seed an 18-hole
+  // course (1 tee, valid stroke index) so the standalone game can apply it and
+  // reach Handicaps. Unique name + newest created_at → it leads the picker.
+  courseName = `E2E Course ${Date.now()}`;
+  const { data: course, error: cErr } = await admin
+    .from("courses")
+    .insert({
+      name: courseName,
+      hole_count: 18,
+      par: Array(18).fill(4),
+      handicap_index: Array.from({ length: 18 }, (_, i) => i + 1),
+      has_stroke_index: true,
+      tee_sets: [{ name: "White", yards: Array(18).fill(350) }],
+      source: "manual",
+      created_by: ownerId,
+    })
+    .select("id")
+    .single();
+  if (cErr || !course) throw new Error(`seed course failed: ${cErr?.message}`);
+  courseId = course.id as string;
 });
 
 test.afterAll(async () => {
@@ -69,6 +92,7 @@ test.afterAll(async () => {
   }
   await admin.from("trip_members").delete().eq("trip_id", tripId);
   await admin.from("trips").delete().eq("id", tripId);
+  if (courseId) await admin.from("courses").delete().eq("id", courseId);
 });
 
 /** Latest game in the trip (tests run serially; each makes one game). */
@@ -132,16 +156,23 @@ async function driveToSetupWithHandicap(page: Page) {
   await expect(selector).toBeHidden({ timeout: 10_000 });
   await expect(addPlayer).toHaveCount(0, { timeout: 10_000 }); // both slots filled
 
-  // Open the HANDICAPS row DIRECTLY (no explicit collapse of Matches first). The
-  // one-open rule collapses Matches — and persist-on-collapse must commit its
-  // pairing in the background. Gate on the row leaving "Set matches first" (which
-  // reflects the client draft, so it's ready as soon as both slots are filled).
-  await expect(page.getByTestId("row-handicaps")).not.toContainText("Set matches first", { timeout: 10_000 });
-  await toggle("row-handicaps").click();
+  // Course is gated BEFORE Handicaps now (W-9HOLE-01) — apply the seeded 18-hole
+  // course so Handicaps unlocks. Opening Course collapses Matches, committing the
+  // pairing via persist-on-collapse (the same commit the handicaps step relied on).
+  await toggle("row-course").click();
+  const coursePanel = page.getByTestId("course-search-panel");
+  await expect(coursePanel).toBeVisible({ timeout: 10_000 });
+  await coursePanel.getByRole("button", { name: new RegExp(courseName) }).click();
+  // 1 tee → applies directly; the row resolves to the course name.
+  await expect(page.getByTestId("row-course")).toContainText(courseName, { timeout: 10_000 });
 
-  // persist-on-collapse, isolated from Enable: opening Handicaps collapsed Matches,
+  // persist-on-collapse, isolated from Enable: opening Course collapsed Matches,
   // which must have written the filled pairing to the server already.
   await expect.poll(async () => filledMatchCount(await latestGameId()), { timeout: 15_000 }).toBeGreaterThan(0);
+
+  // Open the HANDICAPS row — now ungated (Matches + Course both resolved).
+  await expect(page.getByTestId("row-handicaps")).not.toContainText(/first/, { timeout: 10_000 });
+  await toggle("row-handicaps").click();
 
   // The Handicaps panel is now open in place → give MP Member a stroke via the
   // relocated control. Picking a side defaults to 1 stroke → "on hole …"; gate on

--- a/src/app/courses/new/page.tsx
+++ b/src/app/courses/new/page.tsx
@@ -34,9 +34,13 @@ function NewCourseInner() {
   const tripId = params.get("trip");
   const gameId = params.get("game");
   const provider = params.get("provider");
+  // slot=back (W-9HOLE-01): the saved course is the BACK nine — compose it onto
+  // the game's front via setBackNine instead of applyCourse-ing it as the course.
+  const isBack = params.get("slot") === "back";
 
   const createCourse = trpc.courses.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
+  const setBackNine = trpc.games.setBackNine.useMutation();
   const utils = trpc.useUtils();
 
   const leave = () => { if (window.history.length > 1) router.back(); else router.push(tripId ? `/trips/${tripId}` : "/dashboard"); };
@@ -49,7 +53,8 @@ function NewCourseInner() {
       // Apply to the originating game (when we came from one) so the Course row
       // returns resolved. No game → just saved to the library.
       if (tripId && gameId) {
-        await applyCourse.mutateAsync({ tripId, gameId, courseId, teeSetName: teeName });
+        if (isBack) await setBackNine.mutateAsync({ tripId, gameId, backCourseId: courseId, backTeeSetName: teeName });
+        else await applyCourse.mutateAsync({ tripId, gameId, courseId, teeSetName: teeName });
         utils.courses.getById.invalidate({ courseId });
         utils.games.getById.invalidate({ tripId, gameId });
         utils.games.listByTrip.invalidate({ tripId });
@@ -65,7 +70,8 @@ function NewCourseInner() {
   return (
     <CourseEntryFlow
       providerId={provider}
-      saving={createCourse.isPending || applyCourse.isPending}
+      defaultHoleCount={isBack ? 9 : 18}
+      saving={createCourse.isPending || applyCourse.isPending || setBackNine.isPending}
       onSave={handleSave}
       onCancel={leave}
     />

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -968,8 +968,24 @@ export default function NewMatchGamePage() {
         const matchesSummary = matchesExist
           ? `${filledDraft.length} match${filledDraft.length === 1 ? "" : "es"}${tA && tB ? ` · ${tA.name} vs ${tB.name}` : ""}`
           : "Not set";
-        const handicapsState: ChecklistRowState = !matchesExist ? "unresolved" : anyHandicap ? "resolved" : "acknowledged-empty";
-        const handicapsSummary = !matchesExist ? "Set matches first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
+        // Handicaps is hard-gated on Matches AND Course (W-9HOLE-01): the per-hole
+        // stroke allocation needs the course's stroke-index table, so a complete
+        // 18 must resolve first. "Course resolved" = a course applied AND an 18-hole
+        // schema (a lone 9-hole front still "needs a back nine" → not resolved).
+        const courseResolved =
+          !!gameQ.data?.course_id &&
+          (((gameQ.data?.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0) === 18;
+        const handicapsReady = matchesExist && courseResolved;
+        const handicapsState: ChecklistRowState = !handicapsReady ? "unresolved" : anyHandicap ? "resolved" : "acknowledged-empty";
+        const handicapsSummary = !matchesExist ? "Set matches first" : !courseResolved ? "Set the course first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
+        const onSetupChanged = () => {
+          void gameQ.refetch();
+          if (competitionId) {
+            utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+            utils.competitions.faceBootstrap.invalidate({ tripId });
+            utils.games.listByTrip.invalidate({ tripId });
+          }
+        };
         return (
           <div className="flex flex-col gap-2.5 pb-4">
             {/* Zone 1 — IDENTITY header (W-EDITMODAL-01): name (tap-to-edit) +
@@ -1031,16 +1047,33 @@ export default function NewMatchGamePage() {
               />
             </ChecklistRow>
 
-            {/* Handicaps — relocated; gated by Matches ("Off — scratch" is a valid
-                done). The one-open rule IS the gate: you can't open it while
-                Matches is open, and it stays non-tappable until matches exist. */}
+            {/* Course — BEFORE Handicaps (W-9HOLE-01 reorder). Handicaps' per-hole
+                stroke allocation needs the course's stroke-index table, so Course
+                resolves first; the one-open chain reads Matches → Course → Handicaps. */}
+            {gameQ.data && (
+              <GameSetupRows
+                slot="course"
+                tripId={tripId}
+                competitionId={gameCompId}
+                game={gameQ.data as unknown as GameRow}
+                canEdit={canEdit}
+                courseOpen={openRow === "course"}
+                onOpenCourse={() => changeOpenRow("course")}
+                onCloseEditor={() => changeOpenRow(null)}
+                onChanged={onSetupChanged}
+              />
+            )}
+
+            {/* Handicaps — hard-gated on Matches AND Course (W-9HOLE-01): both must
+                resolve (a complete 18) before per-hole strokes can be allocated. The
+                one-open rule physically enforces the chain. */}
             <ChecklistRow
               label="Handicaps"
               value={handicapsSummary}
               state={handicapsState}
               optional
               expanded={openRow === "handicaps"}
-              onToggle={matchesExist ? () => toggleRow("handicaps") : undefined}
+              onToggle={handicapsReady ? () => toggleRow("handicaps") : undefined}
               testId="row-handicaps"
             >
               <HandicapsSection
@@ -1053,28 +1086,18 @@ export default function NewMatchGamePage() {
               />
             </ChecklistRow>
 
-            {/* Golf Course + Name·Format·Points — shared canonical rows. These two
-                stay OVERLAYS this pass (CoursePicker split + config modal-shed are
-                tracked follow-ons), but ride the page's one-open via openRow. */}
+            {/* Format · Points — AFTER Handicaps (the reorder). */}
             {gameQ.data && (
               <GameSetupRows
+                slot="config"
                 tripId={tripId}
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
                 canEdit={canEdit}
-                courseOpen={openRow === "course"}
                 configOpen={openRow === "config"}
-                onOpenCourse={() => changeOpenRow("course")}
                 onOpenConfig={() => changeOpenRow("config")}
                 onCloseEditor={() => changeOpenRow(null)}
-                onChanged={() => {
-                  void gameQ.refetch();
-                  if (competitionId) {
-                    utils.competitions.leaderboard.invalidate({ tripId, competitionId });
-                    utils.competitions.faceBootstrap.invalidate({ tripId });
-                    utils.games.listByTrip.invalidate({ tripId });
-                  }
-                }}
+                onChanged={onSetupChanged}
               />
             )}
 

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -76,6 +76,8 @@ export interface GameRow {
   modifiers: Record<string, Record<string, unknown>> | null;
   scorecard_schema: unknown | null;
   course_id: string | null;
+  /** The BACK nine of a retained two-nines 18 (W-9HOLE-01); null otherwise. */
+  back_course_id: string | null;
   schedule_item_id: string | null;
   corrections_open: boolean;
 }

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { trpc } from "@/lib/trpc-client";
-import { CourseSearchPanel } from "@/components/games/course/CourseSearchPanel";
+import { CourseRowContent } from "@/components/games/course/CourseRowContent";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { formatLabel, type GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
@@ -29,6 +29,7 @@ export function GameSetupRows({
   game,
   canEdit,
   onChanged,
+  slot = "both",
   courseOpen: courseOpenProp,
   configOpen: configOpenProp,
   onOpenCourse,
@@ -42,6 +43,10 @@ export function GameSetupRows({
   game: GameRow;
   canEdit: boolean;
   onChanged: () => void;
+  /** Which rows to render (W-9HOLE-01 reorder): "course" or "config" lets the
+   *  match page place Course BEFORE Handicaps and Format·Points after. Default
+   *  "both" — the other surfaces render them together as one block. */
+  slot?: "course" | "config" | "both";
   /** Page-owned one-open state (controlled). Omit → self-managed (uncontrolled). */
   courseOpen?: boolean;
   configOpen?: boolean;
@@ -62,48 +67,42 @@ export function GameSetupRows({
   const openConfig = onOpenConfig ?? (() => setConfigOpenLocal(true));
   const closeEditor = onCloseEditor ?? (() => { setCourseOpenLocal(false); setConfigOpenLocal(false); });
 
-  const applyCourse = trpc.games.applyCourse.useMutation();
-  const utils = trpc.useUtils();
-
-  const courseQ = trpc.courses.getById.useQuery(
-    { courseId: game.course_id ?? "" },
-    { enabled: !!game.course_id }
-  );
-  const courseName = (courseQ.data?.name as string | undefined) ?? null;
+  // Course resolved = a complete 18 (W-9HOLE-01): a real 18-hole course, or a
+  // 9-hole front with a back nine composed in. A lone 9-hole front (schema count
+  // 9) is NOT resolved — it "needs a back nine", which keeps Handicaps gated.
+  const frontId = game.course_id ?? null;
+  const backId = (game.back_course_id as string | null) ?? null;
+  const count = ((game.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0;
+  const courseResolved = !!frontId && count === 18;
+  const frontQ = trpc.courses.getById.useQuery({ courseId: frontId ?? "" }, { enabled: !!frontId });
+  const backQ = trpc.courses.getById.useQuery({ courseId: backId ?? "" }, { enabled: !!backId });
+  const frontName = (frontQ.data?.name as string | undefined) ?? null;
+  const backName = (backQ.data?.name as string | undefined) ?? null;
+  const courseValue =
+    !frontId ? "Add a course"
+    : count === 9 ? `${frontName ?? "Front nine"} · needs a back nine`
+    : backId ? `${frontName ?? "Front"} + ${backName ?? "Back"}`
+    : (frontName ?? "Course");
 
   return (
     <>
-      <ChecklistRow
-        label="Course / tee"
-        optional
-        value={courseName ?? "Add a course"}
-        state={courseName ? "resolved" : "unresolved"}
-        disabled={!canEdit}
-        expanded={courseOpen}
-        onToggle={courseOpen ? closeEditor : openCourse}
-        testId="row-course"
-      >
-        {/* The PICKER, inline (W-COURSESPLIT-01): search/select an existing course
-            applies live; "Add course manually" + API results navigate to the heavy
-            entry page (/courses/new) and return with the course applied. */}
-        <CourseSearchPanel
-          tripId={tripId}
-          gameId={game.id}
-          onApply={({ id, teeName }) => {
-            applyCourse.mutate(
-              { tripId, gameId: game.id, courseId: id, teeSetName: teeName },
-              {
-                onSuccess: () => {
-                  utils.courses.getById.invalidate({ courseId: id });
-                  onChanged();
-                },
-              }
-            );
-            closeEditor();
-          }}
-        />
-      </ChecklistRow>
-      {competitionId && (
+      {slot !== "config" && (
+        <ChecklistRow
+          label="Course / tee"
+          optional
+          value={courseValue}
+          state={courseResolved ? "resolved" : "unresolved"}
+          disabled={!canEdit}
+          expanded={courseOpen}
+          onToggle={courseOpen ? closeEditor : openCourse}
+          testId="row-course"
+        >
+          {/* W-9HOLE-01: front picker → a 9-hole course "needs a back nine" → the
+              back picker composes a retained two-nines 18, swappable day-of. */}
+          <CourseRowContent tripId={tripId} game={game} canEdit={canEdit} onChanged={onChanged} />
+        </ChecklistRow>
+      )}
+      {slot !== "course" && competitionId && (
         <ChecklistRow
           label="Format · Points"
           value={formatPointsSummary(game)}

--- a/src/components/games/course/CourseEntryFlow.tsx
+++ b/src/components/games/course/CourseEntryFlow.tsx
@@ -29,12 +29,15 @@ const blankTee = (n: number, name: string) => ({ name, yards: Array(n).fill(null
  */
 export function CourseEntryFlow({
   providerId,
+  defaultHoleCount = 18,
   saving,
   onSave,
   onCancel,
 }: {
   /** golfcourseapi summary id → seed the draft from a pull (review). Null → blank. */
   providerId?: string | null;
+  /** A back nine (W-9HOLE-01) starts as a 9-hole build (it composes onto a front). */
+  defaultHoleCount?: 9 | 18;
   /** The parent's create+apply is in-flight (disables the primary CTA). */
   saving?: boolean;
   /** Persist + apply + return. Receives the finished draft as a create payload. */
@@ -47,7 +50,7 @@ export function CourseEntryFlow({
   onCancel: () => void;
 }) {
   const [screen, setScreen] = useState<"new" | "entry" | "confirm">(providerId ? "confirm" : "new");
-  const [draft, setDraft] = useState<Draft>(() => blankDraft(18));
+  const [draft, setDraft] = useState<Draft>(() => blankDraft(defaultHoleCount));
   const [activeTee, setActiveTee] = useState(0);
   const [hole, setHole] = useState(1);
   const [editingHole, setEditingHole] = useState<number | null>(null);

--- a/src/components/games/course/CourseRowContent.tsx
+++ b/src/components/games/course/CourseRowContent.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { Check, RefreshCw, X } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { CourseSearchPanel } from "./CourseSearchPanel";
+import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
+
+/**
+ * CourseRowContent (W-9HOLE-01) — the Course accordion body's state machine.
+ *
+ *  - No course → the front PICKER (CourseSearchPanel). Picking an 18-hole course
+ *    resolves the row as today; a 9-hole course lands as the FRONT nine.
+ *  - 9-hole front, no back → "needs a back nine": shows the front + a BACK picker
+ *    (9-hole courses only). The row is NOT resolved until the back is composed.
+ *  - Composed/18 → the resolved view: a real 18 shows the course; a two-nines 18
+ *    shows Front + Back with a "Swap back nine" (clears the back, keeps the front)
+ *    and "Change course" (clears all → re-pick).
+ *
+ * All course mutations live here (applyCourse = front, setBackNine = back/swap,
+ * clearCourse). They're live — the accordion collapse just recedes.
+ */
+export function CourseRowContent({
+  tripId, game, canEdit, onChanged,
+}: {
+  tripId: string;
+  game: GameRow;
+  canEdit: boolean;
+  onChanged: () => void;
+}) {
+  const gameId = game.id;
+  const utils = trpc.useUtils();
+  const applyCourse = trpc.games.applyCourse.useMutation();
+  const setBackNine = trpc.games.setBackNine.useMutation();
+  const clearCourse = trpc.games.clearCourse.useMutation();
+
+  const frontId = game.course_id ?? null;
+  const backId = (game.back_course_id as string | null) ?? null;
+  const count = ((game.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0;
+  const needsBack = !!frontId && count === 9;
+
+  const frontQ = trpc.courses.getById.useQuery({ courseId: frontId ?? "" }, { enabled: !!frontId });
+  const backQ = trpc.courses.getById.useQuery({ courseId: backId ?? "" }, { enabled: !!backId });
+  const frontName = (frontQ.data?.name as string | undefined) ?? "Front nine";
+  const backName = (backQ.data?.name as string | undefined) ?? "Back nine";
+
+  // Swap/change sub-views (only meaningful in the resolved state).
+  const [view, setView] = useState<"default" | "swapBack">("default");
+
+  function refresh(courseId?: string) {
+    if (courseId) utils.courses.getById.invalidate({ courseId });
+    onChanged();
+  }
+  const onPickFront = ({ id, teeName }: { id: string; teeName?: string }) =>
+    applyCourse.mutate({ tripId, gameId, courseId: id, teeSetName: teeName }, { onSuccess: () => { setView("default"); refresh(id); } });
+  const onPickBack = ({ id, teeName }: { id: string; teeName?: string }) =>
+    setBackNine.mutate({ tripId, gameId, backCourseId: id, backTeeSetName: teeName }, { onSuccess: () => { setView("default"); refresh(id); } });
+
+  // ── No course → front picker ──────────────────────────────────────────────
+  if (!frontId) {
+    return <CourseSearchPanel tripId={tripId} gameId={gameId} onApply={onPickFront} />;
+  }
+
+  // ── 9-hole front, no back → needs a back nine ─────────────────────────────
+  if (needsBack) {
+    return (
+      <div className="flex flex-col gap-3" data-testid="course-needs-back">
+        <NineSummary label="Front nine" name={frontName} onClear={canEdit ? () => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => refresh() }) : undefined} />
+        <div>
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-accent)" }}>Add the back nine</span>
+          <p className="mb-2 mt-0.5 text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>A 9-hole course needs a back nine to make a full 18.</p>
+          <CourseSearchPanel tripId={tripId} gameId={gameId} mode="back" onApply={onPickBack} />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Resolved (18) — swap sub-view ─────────────────────────────────────────
+  if (view === "swapBack") {
+    return (
+      <div className="flex flex-col gap-2" data-testid="course-swap-back">
+        <button onClick={() => setView("default")} className="self-start text-[13px]" style={{ color: "var(--color-bt-accent)" }}>‹ Cancel</button>
+        <p className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>Pick the new back nine. Front nine + its scores stay; back-nine scores are cleared.</p>
+        <CourseSearchPanel tripId={tripId} gameId={gameId} mode="back" onApply={onPickBack} />
+      </div>
+    );
+  }
+
+  // ── Resolved (18) — default view ──────────────────────────────────────────
+  const twoNines = !!backId;
+  return (
+    <div className="flex flex-col gap-3" data-testid="course-resolved">
+      {twoNines ? (
+        <div className="flex flex-col gap-2">
+          <NineSummary label="Front nine" name={frontName} />
+          <NineSummary label="Back nine" name={backName} />
+        </div>
+      ) : (
+        <NineSummary label="Course" name={frontName} />
+      )}
+      {canEdit && (
+        <div className="flex flex-wrap gap-2">
+          {twoNines && (
+            <button
+              onClick={() => setView("swapBack")}
+              data-testid="course-swap-back-btn"
+              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[13px] font-semibold"
+              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+            >
+              <RefreshCw size={13} style={{ color: "var(--color-bt-accent)" }} /> Swap back nine
+            </button>
+          )}
+          <button
+            onClick={() => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => refresh() })}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[13px] font-semibold"
+            style={{ background: "transparent", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+          >
+            <X size={13} /> Change course
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NineSummary({ label, name, onClear }: { label: string; name: string; onClear?: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-lg px-3 py-2.5" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}>
+      <span className="flex min-w-0 items-center gap-2">
+        <Check size={14} style={{ color: "var(--color-bt-accent)", flexShrink: 0 }} />
+        <span className="flex min-w-0 flex-col">
+          <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{label}</span>
+          <span className="truncate text-sm" style={{ color: "var(--color-bt-text)" }}>{name}</span>
+        </span>
+      </span>
+      {onClear && (
+        <button onClick={onClear} aria-label={`Clear ${label}`} className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md" style={{ color: "var(--color-bt-text-dim)" }}>
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/course/CourseSearchPanel.tsx
+++ b/src/components/games/course/CourseSearchPanel.tsx
@@ -21,13 +21,18 @@ import type { RecentCourse } from "./CoursePicker";
  * applied tee is what the row's loud value shows).
  */
 export function CourseSearchPanel({
-  tripId, gameId, onApply,
+  tripId, gameId, onApply, mode = "front",
 }: {
   tripId: string;
   gameId: string;
-  /** Apply a SAVED course (the parent runs applyCourse). */
+  /** Apply a SAVED course (the parent runs applyCourse / setBackNine). */
   onApply: (course: { id: string; name: string; teeName?: string }) => void;
+  /** "back" (W-9HOLE-01) → pick the BACK nine: restrict to 9-hole courses, hide
+   *  the golfcourseapi search (a back nine is a saved/manual 9-holer), and the
+   *  entry page lands in back-slot mode. Default "front" (the whole course). */
+  mode?: "front" | "back";
 }) {
+  const back = mode === "back";
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [debounced, setDebounced] = useState("");
@@ -72,10 +77,12 @@ export function CourseSearchPanel({
     setTeePickFor(c);
   }
   const entryHref = (provider?: string) =>
-    `/courses/new?trip=${encodeURIComponent(tripId)}&game=${encodeURIComponent(gameId)}${provider ? `&provider=${encodeURIComponent(provider)}` : ""}`;
+    `/courses/new?trip=${encodeURIComponent(tripId)}&game=${encodeURIComponent(gameId)}${back ? "&slot=back" : ""}${provider ? `&provider=${encodeURIComponent(provider)}` : ""}`;
 
-  const local = (localSearch.data as RecentCourse[]) ?? [];
-  const recents = (recent.data as RecentCourse[]) ?? [];
+  // The back nine must be a 9-hole course — filter the saved lists to nines.
+  const nine = (cs: RecentCourse[]) => (back ? cs.filter((c) => c.hole_count === 9) : cs);
+  const local = nine((localSearch.data as RecentCourse[]) ?? []);
+  const recents = nine((recent.data as RecentCourse[]) ?? []);
   const showResults = query.trim().length >= 2;
   const courseSub = useMemo(() => (c: RecentCourse) => {
     const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
@@ -115,8 +122,8 @@ export function CourseSearchPanel({
         <input
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (!localSearch.isFetching && local.length === 0) void searchFullDatabase(); } }}
-          placeholder="Search your courses"
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); if (!back && !localSearch.isFetching && local.length === 0) void searchFullDatabase(); } }}
+          placeholder={back ? "Search your 9-hole courses" : "Search your courses"}
           className="w-full bg-transparent py-2.5 text-sm outline-none"
           style={{ color: "var(--color-bt-text)" }}
         />
@@ -130,7 +137,9 @@ export function CourseSearchPanel({
             {local.map((c) => <PickRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => selectSaved(c)} />)}
           </div>
 
-          {atCap ? (
+          {/* The golfcourseapi search is front-only — a back nine is a saved or
+              hand-entered 9-holer (API results carry no hole-count to filter). */}
+          {back ? null : atCap ? (
             <div className="flex items-start gap-2 rounded-xl border px-3 py-2.5" style={{ background: "var(--color-bt-card-raised)", borderColor: "var(--color-bt-border)" }}>
               <AlertTriangle size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0, marginTop: 1 }} />
               <span style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)" }}>Course search is temporarily unavailable — add the course manually below.</span>
@@ -161,12 +170,11 @@ export function CourseSearchPanel({
           )}
         </>
       ) : (
-        recents.length > 0 && (
-          <div className="flex flex-col gap-2">
-            <p className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Recent courses</p>
-            {recents.map((c) => <PickRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => selectSaved(c)} />)}
-          </div>
-        )
+        <div className="flex flex-col gap-2">
+          {recents.length > 0 && <p className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{back ? "Your 9-hole courses" : "Recent courses"}</p>}
+          {recents.map((c) => <PickRow key={c.id} name={c.name} sub={courseSub(c)} onClick={() => selectSaved(c)} />)}
+          {back && recents.length === 0 && <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No saved 9-hole courses yet — add one below.</p>}
+        </div>
       )}
 
       <button
@@ -176,7 +184,7 @@ export function CourseSearchPanel({
         style={{ borderColor: "var(--color-bt-accent-border)", borderStyle: "dashed", color: "var(--color-bt-accent)", background: "transparent" }}
       >
         <PencilLine size={16} />
-        <span style={{ fontSize: 14, fontWeight: 600 }}>Add course manually</span>
+        <span style={{ fontSize: 14, fontWeight: 600 }}>{back ? "Add a 9-hole course manually" : "Add course manually"}</span>
       </button>
     </div>
   );

--- a/src/lib/courseIndex.test.ts
+++ b/src/lib/courseIndex.test.ts
@@ -3,9 +3,50 @@ import {
   validateStrokeIndex,
   applyStrokeIndexSwap,
   buildScorecardSchema,
+  composeTwoNines,
   type ScorecardSchema,
   type IndexEntry,
 } from "./courseIndex";
+
+describe("composeTwoNines (W-9HOLE-01)", () => {
+  const fPar = [4, 3, 5, 4, 4, 3, 5, 4, 4];
+  const bPar = [4, 4, 3, 5, 4, 4, 3, 5, 4];
+  const fIdx = [1, 9, 3, 5, 7, 8, 2, 6, 4]; // 1..9 permutation
+  const bIdx = [2, 4, 8, 6, 1, 3, 9, 5, 7]; // 1..9 permutation
+
+  it("concatenates par front then back (18 holes)", () => {
+    expect(composeTwoNines({ par: fPar }, { par: bPar }).par).toEqual([...fPar, ...bPar]);
+  });
+
+  it("interleaves the stroke index — front gets ODD ranks, back gets EVEN", () => {
+    const { index } = composeTwoNines({ par: fPar, index: fIdx }, { par: bPar, index: bIdx });
+    expect(index!.slice(0, 9)).toEqual(fIdx.map((s) => 2 * s - 1));
+    expect(index!.slice(9)).toEqual(bIdx.map((s) => 2 * s));
+  });
+
+  it("produces a valid 1..18 permutation", () => {
+    const { index } = composeTwoNines({ par: fPar, index: fIdx }, { par: bPar, index: bIdx });
+    expect(validateStrokeIndex(index!, 18).valid).toBe(true);
+  });
+
+  it("spreads strokes across BOTH nines (the fairness reason) — not all on the front", () => {
+    const { index } = composeTwoNines({ par: fPar, index: fIdx }, { par: bPar, index: bIdx });
+    const hardest9 = index!.map((v, i) => ({ v, hole: i + 1 })).filter((x) => x.v <= 9).map((x) => x.hole).sort((a, b) => a - b);
+    expect(hardest9).not.toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(hardest9.some((h) => h >= 10)).toBe(true);
+  });
+
+  it("drops the index when either nine is index-off (sequential fallback downstream)", () => {
+    expect(composeTwoNines({ par: fPar, index: fIdx }, { par: bPar, index: null }).index).toBeNull();
+    expect(composeTwoNines({ par: fPar, index: null }, { par: bPar, index: bIdx }).index).toBeNull();
+  });
+
+  it("concatenates yards, padding nulls when absent", () => {
+    const { yards } = composeTwoNines({ par: fPar, yards: [100, 200, 300, 400, 500, 600, 700, 800, 900] }, { par: bPar });
+    expect(yards.slice(0, 9)).toEqual([100, 200, 300, 400, 500, 600, 700, 800, 900]);
+    expect(yards.slice(9)).toEqual(Array(9).fill(null));
+  });
+});
 
 describe("validateStrokeIndex", () => {
   it("accepts a complete permutation of 1..N", () => {

--- a/src/lib/courseIndex.ts
+++ b/src/lib/courseIndex.ts
@@ -117,6 +117,34 @@ const range = (from: number, to: number): string[] =>
   Array.from({ length: to - from + 1 }, (_, i) => String(from + i));
 
 /**
+ * Compose two 9-hole nines into a retained two-nines 18 (W-9HOLE-01).
+ *
+ * Par + yards concatenate (front 1-9, back 10-18). The stroke index is the
+ * load-bearing part: the two nines each carry their own 1..9 ranking, so they're
+ * INTERLEAVED into a 1..18 permutation the golf-correct way — the FRONT takes the
+ * ODD overall ranks (`2·SI−1`: 1→1, 2→3, …, 9→17) and the BACK takes the EVEN
+ * (`2·SI`: 1→2, …, 9→18). That spreads a player's handicap strokes across both
+ * nines (naive front-then-back would dump every stroke on the front and mis-
+ * allocate match-play strokes — wrong for a real competition). Index is composed
+ * only when BOTH nines have one; if either is index-off the 18 is index-off too
+ * (sequential fallback downstream).
+ */
+export function composeTwoNines(
+  front: { par: number[]; index?: number[] | null; yards?: (number | null)[] | null },
+  back: { par: number[]; index?: number[] | null; yards?: (number | null)[] | null }
+): { par: number[]; index: number[] | null; yards: (number | null)[] } {
+  const f9 = <T>(a: T[] | null | undefined, fill: T): T[] => (a ?? []).slice(0, 9).concat(Array(9).fill(fill)).slice(0, 9);
+  const par = [...f9(front.par, 4), ...f9(back.par, 4)];
+  const yards = [...f9(front.yards, null), ...f9(back.yards, null)];
+  const fIdx = front.index, bIdx = back.index;
+  const index =
+    fIdx?.length === 9 && bIdx?.length === 9
+      ? [...fIdx.map((si) => 2 * si - 1), ...bIdx.map((si) => 2 * si)]
+      : null;
+  return { par, index, yards };
+}
+
+/**
  * Build the per-game scorecard_schema snapshot (§0 contract): clone the template
  * and overwrite the hole layout (count/labels/sections) + metadata.par +
  * metadata.handicap_index with the applied course's data. Front/back sections

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -9,7 +9,7 @@ import { computeRackNStackResults } from "../lib/rackNStack";
 import type { MatchOutcome } from "../lib/matchPlay";
 import type { RackTeamOutcome } from "../lib/rackNStack";
 import type { StrokeStanding } from "@/lib/strokePlay";
-import { buildScorecardSchema, validateStrokeIndex, type SnapshotTee } from "@/lib/courseIndex";
+import { buildScorecardSchema, composeTwoNines, validateStrokeIndex, type SnapshotTee, type ScorecardSchema } from "@/lib/courseIndex";
 import { validatePlacement } from "@/lib/gameConfig";
 import { GAME_TYPES, getGameTypeDefinition } from "@/lib/gameTypes";
 
@@ -301,9 +301,11 @@ export const gamesRouter = router({
       }
 
       const snapshot = buildScorecardSchema(baseSchema, par, handicapIndex, holeCount, selectedTee);
+      // Applying a (fresh) front course resets any prior two-nines back ref — a
+      // 9-hole course lands as a lone front "needs a back nine" until setBackNine.
       const { error } = await ctx.supabase
         .from("games")
-        .update({ scorecard_schema: snapshot, course_id: input.courseId })
+        .update({ scorecard_schema: snapshot, course_id: input.courseId, back_course_id: null })
         .eq("id", input.gameId);
       if (error) {
         throw new TRPCError({
@@ -350,7 +352,7 @@ export const gamesRouter = router({
 
       const { error } = await ctx.supabase
         .from("games")
-        .update({ scorecard_schema: baseSchema, course_id: null })
+        .update({ scorecard_schema: baseSchema, course_id: null, back_course_id: null })
         .eq("id", input.gameId);
       if (error) {
         throw new TRPCError({
@@ -358,6 +360,86 @@ export const gamesRouter = router({
           message: `Failed to clear course: ${error.message}`,
         });
       }
+
+      const { data } = await ctx.supabase.from("games").select("*").eq("id", input.gameId).single();
+      return data;
+    }),
+
+  // setBackNine — compose (or SWAP) the BACK nine of a retained two-nines 18
+  // (W-9HOLE-01). The FRONT (course_id) must be a 9-hole course; its frozen 9 is
+  // read from the existing snapshot (provenance: the front never changes on a
+  // back swap). The back is a 9-hole course supplied here. The two nines compose
+  // into an 18 (interleaved stroke index) snapshotted onto the game.
+  //
+  // Unlike applyCourse, this does NOT freeze on front scores — a back swap is a
+  // legitimate day-of move. It CLEARS only holes 10-18 (the back's scores belong
+  // to the old nine), leaving holes 1-9 (front) + their scores untouched. Net and
+  // back-nine handicap allocation re-derive on read from the new index for free.
+  setBackNine: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string(), backCourseId: z.string().min(1), backTeeSetName: z.string().optional() }))
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, game_type_id, course_id, back_course_id, scorecard_schema")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      if (!game.course_id) throw new TRPCError({ code: "BAD_REQUEST", message: "Set a front nine first." });
+
+      const schema = game.scorecard_schema as ScorecardSchema | null;
+      const frontMeta = schema?.units?.metadata;
+      const frontCount = schema?.units?.count ?? frontMeta?.par?.length ?? 0;
+      // Only a two-nines game gets a back: a 9-hole front (count 9) composing its
+      // first back, or an already-composed 18 (count 18 + a back ref) swapping it.
+      // A real 18-hole course (count 18, no back ref) is rejected.
+      if (!frontMeta?.par?.length || (frontCount === 18 && !game.back_course_id)) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "This isn't a 9-hole front — it doesn't take a back nine." });
+      }
+
+      const { data: back } = await ctx.supabase
+        .from("courses")
+        .select("hole_count, par, handicap_index, has_stroke_index, tee_sets")
+        .eq("id", input.backCourseId)
+        .maybeSingle();
+      if (!back) throw new TRPCError({ code: "NOT_FOUND", message: "Back-nine course not found" });
+      if ((back.hole_count as number) !== 9) throw new TRPCError({ code: "BAD_REQUEST", message: "The back nine must be a 9-hole course." });
+      const backHasIndex = ((back.has_stroke_index as boolean | null) ?? true) && Array.isArray(back.handicap_index);
+      if (backHasIndex && !validateStrokeIndex(back.handicap_index as number[], 9).valid) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Back-nine stroke index is not a valid permutation." });
+      }
+
+      const backTees = (back.tee_sets as SnapshotTee[] | null) ?? [];
+      const backTee = (input.backTeeSetName ? backTees.find((t) => t.name === input.backTeeSetName) : undefined) ?? backTees[0] ?? null;
+
+      // The frozen FRONT 9 comes from the snapshot (works whether the current
+      // schema is a 9 front or an 18 being re-swapped — slice the first 9).
+      const composed = composeTwoNines(
+        { par: frontMeta.par, index: frontMeta.handicap_index ?? null, yards: frontMeta.tee?.yards ?? null },
+        { par: back.par as number[], index: backHasIndex ? (back.handicap_index as number[]) : null, yards: backTee?.yards ?? null }
+      );
+      const composedTee: SnapshotTee | null = frontMeta.tee
+        ? { ...frontMeta.tee, yards: composed.yards }
+        : (backTee ? { ...backTee, yards: composed.yards } : null);
+
+      const baseSchema = getGameTypeDefinition(game.game_type_id as string)?.scorecardSchema ?? null;
+      if (!baseSchema?.units) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Game type has no scorecard schema." });
+      const snapshot = buildScorecardSchema(baseSchema, composed.par, composed.index, 18, composedTee);
+
+      // Clear the BACK nine's scores (holes 10-18) — they were the old nine's. The
+      // front (1-9) is left intact. (A no-op on the first compose.)
+      await ctx.supabase
+        .from("score_entries")
+        .delete()
+        .eq("game_id", input.gameId)
+        .in("unit_label", ["10", "11", "12", "13", "14", "15", "16", "17", "18"]);
+
+      const { error } = await ctx.supabase
+        .from("games")
+        .update({ scorecard_schema: snapshot, back_course_id: input.backCourseId })
+        .eq("id", input.gameId);
+      if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set back nine: ${error.message}` });
 
       const { data } = await ctx.supabase.from("games").select("*").eq("id", input.gameId).single();
       return data;

--- a/supabase/migrations/20260625120000_067_games_back_course_id.sql
+++ b/supabase/migrations/20260625120000_067_games_back_course_id.sql
@@ -1,0 +1,21 @@
+-- W-9HOLE-01: retained two-nines composition.
+--
+-- A 9-hole course can't stand alone — it's slotted as the FRONT nine and a BACK
+-- nine (another 9-hole course) is composed in to make a retained two-nines 18.
+-- `games.course_id` stays the FRONT ref (unchanged for the 99% 18-hole case);
+-- `back_course_id` is the BACK ref, set only for a composed two-nines game. The
+-- composed 18's par/index/yards are snapshotted into `scorecard_schema` as usual
+-- (present-as-18); the two refs are RETAINED so the back can swap day-of without
+-- touching the front (setBackNine clears holes 10-18 + recomposes, front intact).
+-- NULL back_course_id = a normal single-course game (18-hole, or a 9-hole front
+-- still awaiting its back nine — "needs a back nine", derivable from the schema's
+-- 9-unit count).
+
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS back_course_id text REFERENCES public.courses(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.games.back_course_id IS
+  'The BACK nine of a retained two-nines 18 (W-9HOLE-01). NULL for a normal '
+  'single-course game; set when a 9-hole front (course_id) has a 9-hole back '
+  'composed in. The composed par/index lives in scorecard_schema; this retains '
+  'the back ref so it can swap independently of the front.';


### PR DESCRIPTION
Follow-on to #464. The BBMI-September-real capability: a **9-hole course** slots as the **front nine** and composes a **back nine** (another 9-holer) into a retained **two-nines 18**, swappable day-of; and **Course moves before Handicaps**, which is now hard-gated on a complete 18.

## Data model (migration 067)
`games.back_course_id` (front stays `course_id`). The composed 18's par/index/yards snapshot into `scorecard_schema` as usual (**present-as-18**); the two refs are **retained** so the back swaps independently.

- **`composeTwoNines`** (`courseIndex.ts`): par/yards concatenate; the stroke index **interleaves golf-correct** — front takes ODD overall ranks (`2·SI−1`), back EVEN (`2·SI`). Naive front-then-back would dump every stroke on the front and mis-allocate match-play strokes; interleaving spreads them across both nines. Index-off if either nine lacks one. **Unit-tested** (interleave, valid 1..18 permutation, fairness, fallback).
- **`setBackNine`** (games router): composes (or **swaps**) the back. Reads the **frozen front 9** from the snapshot (the front never changes on a swap), validates the back is a 9-hole course, clears **only holes 10-18** (the old nine's scores — front 1-9 + its scores untouched), and is **not frozen** by front scores (a back swap is a legit day-of move). `applyCourse`/`clearCourse` null `back_course_id`.
- **Net derives on read** (confirmed in Phase 0) — swapping the back's stroke-index re-derives net + re-allocates the back's strokes for free; the handicap **count** is hole-agnostic and preserved.

## UI
- **`CourseRowContent`**: front picker → a 9-hole course shows "Front nine: X" + **"needs a back nine"** (not resolved) + a back picker (`CourseSearchPanel` `mode=back`: 9-hole courses only, no API search, `/courses/new?slot=back` manual). Resolved **only at a complete 18** → Front + Back + **Swap back nine** / Change course.
- **Reorder** (match page): Players → Matches → **COURSE → HANDICAPS** → Points → Modifiers, via a `GameSetupRows` `slot` prop (`course`|`config`|`both` — the other 3 surfaces unchanged). **Handicaps hard-gated on Matches AND Course-resolved-as-full-18** ("Set the course first"); the one-open chain enforces Matches → Course → Handicaps. Course stays *optional for the game*, *required for in-app handicaps* (per Zach).

## Decisions (confirmed)
- **Interleaved** stroke-index composition — golf-correct; naive append breaks match fairness.
- **9-hole always composes to 18** — correct for BBMI's 3×9. ⚠ Pure-9 games are no longer reachable via this path (flagged; revisitable if casual-9 matters).

## Verification
- **End-to-end, light + dark, on a real competition game** (via the preview): 18-hole unchanged + Handicaps enabled; 9-hole → "needs a back nine" + Handicaps gated → add back → **composed 18** (DB: 18 holes, par len 18, both refs) → **Handicaps unlocks**; **swap** preserves the front (DB: front `Split Test 9` unchanged, back `Cypress → Lakes`).
- **Match-play E2E updated** — Handicaps now needs a course, so the test seeds + applies an 18-hole course before it. Both merge-blocking spines green (`--repeat-each=2`).
- `composeTwoNines` + games unit tests pass; `tsc` + eslint clean.
- Migration applied to the DB (additive nullable column; CI re-applies idempotently — `ADD COLUMN IF NOT EXISTS`, no history-row written, so no version mismatch).

## Next / flagged
- Styling pass (convert-all-then-style-once) — every row is now accordion + functionally complete.
- Score-clear-on-swap is covered by the server `DELETE … unit_label IN ('10'..'18')` (the verified game had no back scores to clear); a dedicated swap-with-scores E2E is a nice-to-have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)