### PR TITLE
fix(competition): setBackNine swap recomposes the front index correctly + real-indexed test (W-9HOLE-01)

### DIFF
--- a/src/server/routers/games.9hole.test.ts
+++ b/src/server/routers/games.9hole.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+import { validateStrokeIndex } from "../../lib/courseIndex";
+import { unitsFromSchema, strokeIndexOf } from "../../lib/strokePlayConfig";
+import { strokeHoles } from "../../lib/matchPlay";
+
+const STROKE_PLAY = "gtt_stroke_play";
+
+/**
+ * W-9HOLE-01 — setBackNine integration, on REAL INDEXED data (the September/BBMI
+ * prerequisite flagged in W-GAMEPAGE-01 §6.4). #465 shipped the composeTwoNines
+ * unit test + an eye-check on an INDEX-OFF course, so the real server path
+ * (applyCourse 9-hole front → setBackNine 9-hole back → composed 18 snapshot) had
+ * never been asserted producing a correct interleaved stroke index + handicap
+ * allocation. This closes that: two real indexed nines through the actual router.
+ */
+describe("games.setBackNine — indexed two-nines compose (W-9HOLE-01)", () => {
+  let ctx: TestContext;
+  let tripId: string;
+  let gameId: string;
+  let frontId: string;
+  let backId: string;
+  let back2Id: string;
+
+  // Two real 1..9 stroke indexes (distinct, non-trivial permutations).
+  const fIdx = [5, 1, 7, 3, 9, 2, 8, 4, 6];
+  const bIdx = [3, 7, 1, 9, 5, 8, 2, 6, 4];
+  const b2Idx = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const par9 = [4, 3, 5, 4, 4, 3, 5, 4, 4];
+  const createdCourses: string[] = []; // courses are global — track for teardown
+
+  async function makeNine(name: string, index: number[]) {
+    const c = await ctx.caller().courses.create({
+      name, holeCount: 9, par: par9, handicapIndex: index, hasStrokeIndex: true,
+      teeSets: [{ name: "White", yards: Array(9).fill(350) }], source: "manual",
+    });
+    createdCourses.push(c.id as string);
+    return c.id as string;
+  }
+  async function make18(name: string) {
+    const c = await ctx.caller().courses.create({
+      name, holeCount: 18, par: Array(18).fill(4),
+      handicapIndex: Array.from({ length: 18 }, (_, i) => i + 1), hasStrokeIndex: true,
+      teeSets: [{ name: "White", yards: Array(18).fill(350) }], source: "manual",
+    });
+    createdCourses.push(c.id as string);
+    return c.id as string;
+  }
+  const schemaOf = async () => {
+    const g = await ctx.caller().games.getById({ tripId, gameId });
+    return (g as { scorecard_schema: { units: { count: number; metadata: { par: number[]; handicap_index?: number[] } } } | null }).scorecard_schema;
+  };
+
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    tripId = await ctx.createTrip("9-hole compose");
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Two Nines" });
+    gameId = game.id;
+    frontId = await makeNine(`Front 9 ${Date.now()}`, fIdx);
+    backId = await makeNine(`Back 9 ${Date.now()}`, bIdx);
+    back2Id = await makeNine(`Back 9b ${Date.now()}`, b2Idx);
+  });
+
+  afterAll(async () => {
+    if (createdCourses.length) await ctx.admin.from("courses").delete().in("id", createdCourses);
+    await ctx.cleanup();
+  });
+
+  it("a 9-hole front applies as a 9-hole schema (a lone front — needs a back)", async () => {
+    await ctx.caller().games.applyCourse({ tripId, gameId, courseId: frontId });
+    const s = await schemaOf();
+    expect(s?.units.count).toBe(9);
+    expect(s?.units.metadata.par).toHaveLength(9);
+  });
+
+  it("setBackNine composes a full 18 with the INTERLEAVED stroke index (front odd, back even)", async () => {
+    await ctx.caller().games.setBackNine({ tripId, gameId, backCourseId: backId });
+    const s = await schemaOf();
+    expect(s?.units.count).toBe(18);
+    // par concatenates front then back
+    expect(s?.units.metadata.par).toEqual([...par9, ...par9]);
+    const idx = s?.units.metadata.handicap_index;
+    expect(idx).toHaveLength(18);
+    // front holes 1-9 take ODD overall ranks (2·SI−1); back holes 10-18 take EVEN (2·SI)
+    expect(idx!.slice(0, 9)).toEqual(fIdx.map((s) => 2 * s - 1));
+    expect(idx!.slice(9)).toEqual(bIdx.map((s) => 2 * s));
+    // and it's a valid 1..18 permutation
+    expect(validateStrokeIndex(idx!, 18).valid).toBe(true);
+  });
+
+  it("handicap allocation spreads across BOTH nines on real indexed data (the fairness point)", async () => {
+    const strokeIndex = strokeIndexOf(unitsFromSchema(await schemaOf()));
+    // A 5-stroke player gets the 5 hardest holes (overall index 1..5).
+    const holes = [...strokeHoles(5, strokeIndex, 18)].sort((a, b) => a - b);
+    expect(holes).toHaveLength(5);
+    expect(holes.some((h) => h <= 9)).toBe(true);   // some on the front
+    expect(holes.some((h) => h >= 10)).toBe(true);  // some on the back — NOT all front
+  });
+
+  it("swap preserves the front nine's index and replaces only the back", async () => {
+    const before = (await schemaOf())!.units.metadata.handicap_index!;
+    await ctx.caller().games.setBackNine({ tripId, gameId, backCourseId: back2Id });
+    const after = (await schemaOf())!.units.metadata.handicap_index!;
+    expect(after.slice(0, 9)).toEqual(before.slice(0, 9));      // front untouched
+    expect(after.slice(9)).toEqual(b2Idx.map((s) => 2 * s));    // back is the new nine
+    expect(after.slice(9)).not.toEqual(before.slice(9));        // and it actually changed
+    expect(validateStrokeIndex(after, 18).valid).toBe(true);
+  });
+
+  it("rejects an 18-hole course as the back nine", async () => {
+    const eighteen = await make18(`Real 18 ${Date.now()}`);
+    await expect(
+      ctx.caller().games.setBackNine({ tripId, gameId, backCourseId: eighteen })
+    ).rejects.toThrow(/9-hole/);
+  });
+
+  it("rejects setBackNine on a real 18-hole course (not a two-nines front)", async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Real 18 game" });
+    const eighteen = await make18(`Real 18b ${Date.now()}`);
+    await ctx.caller().games.applyCourse({ tripId, gameId: g.id, courseId: eighteen });
+    await expect(
+      ctx.caller().games.setBackNine({ tripId, gameId: g.id, backCourseId: backId })
+    ).rejects.toThrow();
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -413,10 +413,19 @@ export const gamesRouter = router({
       const backTees = (back.tee_sets as SnapshotTee[] | null) ?? [];
       const backTee = (input.backTeeSetName ? backTees.find((t) => t.name === input.backTeeSetName) : undefined) ?? backTees[0] ?? null;
 
-      // The frozen FRONT 9 comes from the snapshot (works whether the current
-      // schema is a 9 front or an 18 being re-swapped — slice the first 9).
+      // Recover the FRONT nine's ORIGINAL 1..9 data from the snapshot. On the
+      // first compose the schema IS a 9-hole front (index already 1..9). On a
+      // SWAP the schema is the previously-composed 18, whose first 9 stroke-index
+      // values are the INTERLEAVED odd ranks (2·s−1) — de-interleave them back to
+      // 1..9 (`(v+1)/2`) so composeTwoNines re-interleaves correctly against the
+      // new back. (par/yards just slice; only the index is interleaved.)
+      const frontIdx9: number[] | null = frontMeta.handicap_index?.length
+        ? (frontCount === 18
+            ? frontMeta.handicap_index.slice(0, 9).map((v) => (v + 1) / 2)
+            : frontMeta.handicap_index.slice(0, 9))
+        : null;
       const composed = composeTwoNines(
-        { par: frontMeta.par, index: frontMeta.handicap_index ?? null, yards: frontMeta.tee?.yards ?? null },
+        { par: frontMeta.par.slice(0, 9), index: frontIdx9, yards: frontMeta.tee?.yards?.slice(0, 9) ?? null },
         { par: back.par as number[], index: backHasIndex ? (back.handicap_index as number[]) : null, yards: backTee?.yards ?? null }
       );
       const composedTee: SnapshotTee | null = frontMeta.tee


### PR DESCRIPTION
The W-GAMEPAGE-01 design doc (§6.4) flagged that #465's indexed-nine compose was **unit-tested but only eye-verified on an index-off course** — so Handicaps hole-allocation couldn't be trusted for BBMI September until checked on **real indexed data**. Closing that gap surfaced a real bug.

## The bug (in shipped #465)
`setBackNine` reads the front nine from the existing `scorecard_schema` snapshot:
- **First compose:** the schema is a 9-hole front → index is the original `1..9`. ✅
- **Swap:** the schema is the *already-composed 18*, whose first-9 index values are the **interleaved odd ranks** (`2·s−1`, length 18) — not `1..9`.

It passed that straight to `composeTwoNines`, which requires a 9-length front index, so it **dropped the index entirely** → every back swap silently produced an **index-off 18** (handicap strokes fall back to sequential allocation — wrong for a competition). Invisible in #465's eye-check because that course had no index to lose.

## The fix
Recover the front's original `1..9` from the snapshot: slice par/yards, and **de-interleave** the front index on a swap (`(v+1)/2`) so `composeTwoNines` re-interleaves correctly against the new back.

## The test that caught it
Adds `games.9hole.test.ts` — a real-indexed **integration** test (the rigorous form of the doc's "eye-verify on real data") that flows two indexed 9-hole courses through `applyCourse → setBackNine` and asserts:
- the **interleaved `1..18`** permutation (front odd / back even),
- **handicap allocation spreads across BOTH nines** (the fairness property, on real indexed data),
- **swap preserves the front index** + replaces only the back (the case that exposed the bug),
- the 9-hole-only guards (18-hole back rejected; setBackNine on a real 18 rejected).

#465 shipped only the `composeTwoNines` pure-fn unit test; this adds the through-the-router coverage. `tsc` + eslint clean; all 6 new tests pass.

This unblocks relying on the Handicaps panel for the BBMI 3×9 in September.

🤖 Generated with [Claude Code](https://claude.com/claude-code)