### PR TITLE
W-GAMEPAGE-01a — Structural Core: zones, hard-block matches, total points, hide competition roster

### DIFF
--- a/CC_SPEC_W-GAMEPAGE-01a_structural_core.md
+++ b/CC_SPEC_W-GAMEPAGE-01a_structural_core.md
@@ -1,0 +1,302 @@
+# CC SPEC — W-GAMEPAGE-01 Phase (a): Structural Core
+
+**Model:** Opus (multi-file, structural).
+**Branch:** one feature branch, merged before the next phase.
+**This is phase (a) of a multi-PR feature. Do NOT attempt the whole of W-GAMEPAGE-01.**
+
+---
+
+## 0. Read first (authority order)
+
+1. `W-GAMEPAGE-01_game_page_lifecycle.md` — the design. This spec implements a **subset** of it.
+2. `CLAUDE.md` — enforced patterns (optimistic updates, migration naming, RLS split, middleware
+   auth, what "done" means).
+3. `STYLE_GUIDE.md` — every color/surface via `--color-bt-*` tokens. No hex.
+4. `PERMISSIONS.md` — competition setup is `canEdit` (owner/planner).
+
+**Ground rules (from CLAUDE.md, restated because they bind every task):**
+- Code is ground truth. If this spec disagrees with the code, **STOP and flag** — do not silently
+  resolve.
+- Commit after each task, not at phase end. Clear messages.
+- `npx tsc --noEmit` AND `next lint` must pass after every commit (tsc-clean ≠ build-clean).
+- Audit before delete — sacred. Never remove a component/export without enumerating its references.
+- Derive, don't snapshot. Fail loud, not silent.
+- Verify the path you didn't test — eye-verify on real data, not just unit green.
+
+---
+
+## 1. Scope
+
+### In scope (phase a) — four contained, nav-decoupled items
+- **T1 — Zone grouping (§5).** Re-parent the existing setup-face rows into three labeled zones:
+  Game Management / Settings / Options. **Presentational only** — confirmed no data-model or route
+  change underneath.
+- **T2 — Matches reconcile (§6.1).** Bring Matches to: derived count (no count setting), start at
+  one empty match, trailing/unfilled match = invalid, and that invalidity feeds the Enable-scoring
+  gate.
+- **T3 — Total Points Available (§6.2).** Surface `matches × per-match` as a readout. Points
+  follows Matches.
+- **T4 — Available Players gating (§8).** Hide the team-roster readout panel for **competitions**
+  (it's team-derived redundancy). Extract-and-gate, **not delete** — it survives for standalone
+  games (W-STANDALONE-01).
+
+### Explicitly OUT of scope — do NOT build in this PR
+- ❌ The two-surface model, surface-2 settings-summary, and back-stack REPLACE rules (§2/§4) → **phase (d) / W-BACKNAV-01.**
+- ❌ Setup/Scoring toggle **lock behavior** + **directional confirms** (§3) → **phase (d).** The
+  existing toggle stays exactly as-is in this PR. Do not add confirms, do not add settings-lock,
+  do not change its current behavior.
+- ❌ Staged course-search refinement (§10) → already ~shipped (#464); remnant is phase (b).
+- ❌ Handicaps three-segment / collapse-when-Even / reveal-stepper (§6.4) → later phase.
+- ❌ Modifiers data-driven panel (§6.5) → separate small spec.
+- ❌ Destructive-edit guard (§11) → phase (c).
+- ❌ Anything touching `games.modifiers` jsonb, `game_type_templates`, or migrations.
+
+If a task seems to require an out-of-scope item to work, **STOP and report** — don't pull it in.
+
+---
+
+## 2. Phase 0 — Diagnose & Report, then STOP
+
+**Produce a report. Change no code. Wait for go.** Phase 0 has caught a wrong assumption on nearly
+every prior spec. Here the specific risk is staleness: the design-review notes predate the most recent
+Matches redesign, so treat any "what currently exists" claim in this spec as *to be confirmed against
+the code*, not as fact. Report the real current state and let it resize the tasks.
+
+Report the following:
+
+**Map**
+1. The setup-face component tree for a per-game config page: file path(s), the row components, how
+   rows are currently parented/ordered, and where the accordion single-open state lives (expected:
+   shipped in #462 — confirm).
+2. How a game is identified as a **competition** vs **standalone** in this code (the discriminator
+   field/prop). T4 depends on this.
+3. The Enable-scoring readiness check: where it lives, what it currently gates on.
+
+**Matches (report current post-redesign state — this is the main unknown)**
+4. The **current** Matches row implementation after the recent manual-match redesign. Expected (to
+   confirm): manual match building — add/remove/drag rows with player slots and "+ Add match" — and
+   **no count stepper** (an older audit referenced a count stepper, but that predates this redesign;
+   confirm it's gone). Give file + line refs and what data backs the match list.
+5. Does **drag-to-reorder** exist on matches? Does **per-match remove** exist? Does **"+ Add match"**
+   exist? (Expected: yes to all post-redesign. Confirm.)
+6. Fresh-game initial state when Matches first opens — zero rows, one row, or N?
+6a. **The genuine gap to find:** does **"unfilled match = invalid → blocks Enable-scoring"** already
+    exist, or not? Report the match-validity state (if any) and whether the readiness gate already
+    reads it. This single answer determines whether Task 2 is real work or already done.
+
+**Points**
+7. Current Points row: format-picker + per-match stepper confirmed shipped (#463)? Is there any
+   total-points display today? Where would `matches × per-match` read the match count from (must be
+   the same derived source as the Matches row — one canonical home, no second count)?
+
+**Available Players**
+8. The team-roster readout panel component name (the audit calls it `TeamsPanel`, added in #462).
+   **Enumerate every reference/mount site.** Is it mounted only on this setup surface, or elsewhere?
+   This determines whether T4 is a clean conditional-render or needs extract-to-preserve.
+
+**Flag**
+9. Any place where the current code already diverges from §5/§6.1/§6.2/§8 in a way that makes a task
+   smaller or larger than this spec assumes.
+
+End the report with a per-task **revised size estimate** (shrunk / as-specced / grew) and **STOP.**
+
+---
+
+## 2.5 — Phase 0 RESOLVED (findings + decisions; build from this, not the "expected" framing above)
+
+Phase 0 ran and the current state diverged from the spec's assumptions in two ways. Both were
+escalated and **decided**. The "expected" language above is superseded by these facts:
+
+**Findings (real current state):**
+- The competition setup face is the `match/new` page's `screen === "setup"` block
+  (`src/app/trips/[tripId]/games/match/new/page.tsx` ~952+). There are **two** config surfaces: this
+  `match/new` setup screen **and** `GameConfigurationView` (the *post-enable* edit surface). **Phase
+  (a) touches `match/new` only.** `GameConfigurationView`'s regroup is deferred to phase (d), where
+  the two-surface model (§2/§4) rationalizes it.
+- A **pre-create count stepper DOES exist** ("Matches to add" on the `NewGame` screen; `matchCount`
+  state, default 1; `handleCreate` seeds the draft with `matchCount` empty matches). The "confirm
+  it's gone" assumption in §2.4 was **wrong** — it's there.
+- **Collapse-on-incomplete (#460) is the current behavior, not a hard block.** An unfilled match
+  triggers `CollapseConfirm` (`confirmCollapse` state) → drop the unfilled match and tee off with the
+  filled ones. Enable-scoring is enabled with **≥1 fully-filled match** (`disabled` gates on
+  `filledDraft.length === 0`; `outlined={!allFilled}` already exists).
+- The Zone-2 controls (Setup/Scoring toggle, Reset) live on `GameConfigurationView` / `GameDangerZone`
+  (post-enable) — **not** on the `match/new` setup screen. Pre-enable, Zone 2 has nothing to hold.
+- `TeamsPanel` has 5 refs, **2 real renders**: `RostersOverlay` (leaderboard rosters — different
+  surface) and `match/new:1014` (the only setup-surface mount). The competition/standalone branch
+  **already exists** at the Available-players row.
+- `FormatPointsPanel` (#463) is a `GameSetupRows` child and **cannot see the match draft** — it has
+  `perMatchValue`/`total` but no match count. The canonical count lives in the page's
+  `draft`/`filledDraft`.
+
+**DECISION A (FLAG A — confirmed):** Phase (a) groups the `match/new` setup face into **Zone 1
+(Identity) / Zone 3 (Settings) / Zone 4 (Options)** only. **Zone 2 is N/A in phase (a)** — it
+populates in phase (d) when the toggle/reset move onto the setup face. T1 below is rewritten to this.
+
+**DECISION B (FLAG B — confirmed):** T2 **replaces** collapse-on-incomplete with a hard
+**no-unfilled-matches block**, and **removes the pre-create count stepper**. Rationale: build-as-you-go
+means matches are no longer pre-seeded as empties, so there is no "incomplete set" to collapse — an
+empty match only exists mid-add, and the model is fill-it-or-remove-it. The two behaviors are one
+coupled philosophy; they move together. T2 below is rewritten to this and treats the #460 removal as
+an explicit audit-before-delete.
+
+---
+
+## 3. Task 1 — Zone grouping (§5)
+
+**Goal:** the `match/new` setup face reads as labeled groups instead of flat equal-weight rows.
+**Target the `match/new` setup screen only.** `GameConfigurationView` (post-enable) is NOT regrouped
+here — that rides phase (d).
+
+- **Zone 1 — Identity header:** game name (tap-to-edit) + assigned-to/delegate frame. **Already
+  shipped (#463). Do not rebuild** — just ensure it sits above the zones.
+- **Zone 2 — Game Management: N/A in phase (a).** The Setup/Scoring toggle + Reset live on
+  `GameConfigurationView`/`GameDangerZone` (post-enable), not on this setup screen. There is nothing
+  to put in Zone 2 pre-enable. **Do not create an empty Zone 2; do not move the toggle/reset here**
+  (that's phase d). Skip straight from Zone 1 to Zone 3.
+- **Zone 3 — Settings:** Matches, Course/Tee, Format·Points — in that order (matches the current
+  surface order; the spine).
+- **Zone 4 — Options:** Handicaps, Modifiers, Rules-of-the-Day textarea. Optional rows keep their
+  "· optional" tag.
+
+**Rules**
+- Presentational re-parent + zone headers only. No change to row internals, data, routes, or the
+  accordion's single-open behavior (which stays **global across all zones** — §9).
+- Zone headers and surfaces use `--color-bt-*` tokens (STYLE_GUIDE §1/§2). No hex, no
+  Tailwind color utilities on themeable surfaces.
+- The single-open accordion slot is the **five config rows** (Matches, Points, Course, Handicaps,
+  Modifiers-when-present). Reset and the toggle are not accordion rows and don't participate.
+
+**DO-NOT:** don't introduce per-section accordion scoping; don't make zones into side-by-side panes
+(it's one scrolling column); don't restyle row internals.
+
+**Commit:** `feat(game-setup): group config rows into Game Management / Settings / Options zones`
+→ tsc + lint clean → eye-verify the three zones render with correct row membership and the
+accordion still closes cross-zone.
+
+---
+
+## 4. Task 2 — Matches: hard-block model + remove collapse-on-incomplete (§6.1)
+
+**Goal:** every match in the list is real; an empty match is an unfinished add, and you must
+**fill it or remove it** before Enable-scoring. This **replaces** the shipped collapse-on-incomplete
+behavior (#460) and **removes** the pre-create count stepper. (See §2.5 DECISION B.)
+
+Build-as-you-go already ships (manual rows, per-match remove, drag-reorder, "+ Add match" — leave all
+as-is). The net work is the gate flip plus two audit-before-delete removals.
+
+**Three pieces:**
+
+1. **Remove the pre-create count stepper.** On the `NewGame` screen, remove the "Matches to add"
+   stepper UI and the `matchCount` state. `handleCreate` seeds the draft with **exactly one** empty
+   match (start-at-one). Audit every reader of `matchCount` before removing it (fail loud if anything
+   else depends on it).
+
+2. **Flip the gate to a hard block (any empty slot = invalid).**
+   - The validity signal already exists: `allFilled` is computed today (it drives `outlined={!allFilled}`).
+     The flip is making the button **actually `disabled` when `!allFilled`**, not merely outlined.
+   - **Invalid = any match with one or more empty player slots** — not only the trailing match. A
+     middle match with one player and one empty slot also blocks. ("Trailing empty" in the design doc
+     was the common-case description, not the rule.)
+   - Gate reads the **derived match validity**, never a count field.
+   - Invalid-state styling via tokens (`--color-bt-danger` family, STYLE_GUIDE §2/§3).
+
+3. **Remove collapse-on-incomplete (#460) — audit-before-delete.** With the hard block, the
+   `confirmCollapse` flow and `CollapseConfirm` component are dead on this path. Before deleting:
+   **enumerate all references to `CollapseConfirm` and `confirmCollapse`.** If `CollapseConfirm` is
+   mounted only here, remove the component + its state + its trigger. If it's reused elsewhere, remove
+   only this path's usage and leave the component. Report what you found before deleting.
+
+**Rules**
+- One canonical home for the match list + derived count (the page `draft`/`filledDraft`). Points (T3)
+  and the gate both read from it. No second source of truth for the count.
+- Optimistic updates pattern (CLAUDE.md #1) for add/remove/edit if not already in place.
+
+**DO-NOT:** don't keep the count stepper "just in case"; don't leave `CollapseConfirm` wired on this
+path; don't let the gate read a count instead of validity; don't pre-seed empty matches.
+
+**Commit:** `feat(game-setup): hard-block scoring on unfilled matches; remove pre-create count + collapse-on-incomplete`
+→ tsc + lint clean → eye-verify: fresh game shows exactly one empty match; an empty slot (trailing OR
+middle) blocks Enable-scoring and shows invalid; removing or filling it clears the block; no
+collapse-confirm appears on enable.
+
+---
+
+## 5. Task 3 — Total Points Available (§6.2)
+
+**Goal:** stakes are visible — show `Total Points Available = valid match count × per-match`, for
+**match-format games only**.
+
+- **The piping is the work.** Phase 0 confirmed `FormatPointsPanel` (#463) is a `GameSetupRows` child
+  and **cannot see the match draft** today. Pass the derived count from the page's canonical source
+  (`draft`/`filledDraft`) into the panel — don't compute a second count inside it.
+- Use the **valid (fully-filled) match count**, so an in-progress empty slot doesn't inflate the total
+  with phantom points.
+- Recompute on every change to either the match count or per-match (derive, don't snapshot).
+- Display where the design shows "Total Points Available: N" (collapsed summary may still show
+  per-match).
+- Format-picker + per-match stepper already shipped (#463) — don't rebuild; just add the derived total.
+- Match-format games only (this is a match-play points readout).
+
+**DO-NOT:** don't store the total; don't add a second match-count source inside the Points panel.
+
+**Commit:** `feat(game-setup): surface Total Points Available (matches × per-match)`
+→ tsc + lint clean → eye-verify: total updates live when matches or per-match change.
+
+---
+
+## 6. Task 4 — Available Players gating (§8)
+
+**Goal:** the team-roster readout panel does not render for **competitions** (team-derived
+redundancy), but is **preserved** for standalone games.
+
+**Phase 0 confirmed this is the smallest task:** the competition/standalone branch **already exists**
+at the Available-players row (`match/new:~1014`), and `TeamsPanel` has only two real renders —
+`RostersOverlay` (a different surface) and that one setup-surface mount. So this is a one-row change.
+
+- **Stop rendering the competition (`TeamsPanel`) branch** at the Available-players row; keep the
+  standalone (flat crew list) branch exactly as-is.
+- **Leave `TeamsPanel` and `RostersOverlay` completely untouched** — `TeamsPanel` survives for the
+  standalone world (W-STANDALONE-01) and `RostersOverlay` is an unrelated leaderboard surface.
+- **Do NOT hard-delete `TeamsPanel`, its file, or its export.** Removing it now is the exact mistake
+  the audit-before-delete rule exists to prevent.
+- For a competition, the setup face shows **no player readout at all** — not a collapsed stub. (Note:
+  per DECISION A there is no Zone 2 on this screen; the readout simply doesn't render.)
+
+**DO-NOT:** don't delete `TeamsPanel`/its file; don't touch `RostersOverlay`; don't remove
+team-derivation logic; don't change the standalone path's behavior.
+
+**Commit:** `feat(game-setup): hide team-roster readout for competitions (keep for standalone)`
+→ tsc + lint clean → eye-verify: a competition game shows no player readout on the setup face; a
+standalone game (if reachable) still shows the crew list. If standalone isn't reachable yet, note the
+gate is in place and the path is untested-by-availability, not broken.
+
+---
+
+## 7. Global DO-NOT
+
+- ❌ No migrations, no schema, no `games.modifiers` / `game_type_templates` touches.
+- ❌ No surface-2, no back-stack, no toggle lock/confirms (phase d).
+- ❌ No hardcoded hex; no Tailwind color utilities on themeable surfaces (STYLE_GUIDE §6).
+- ❌ No hard deletes without an audit in the Phase 0 report.
+- ❌ No new dependencies — reuse existing utilities (CLAUDE.md / reuse-don't-rebuild).
+- ❌ Don't unify the global single-open accordion into per-section scoping.
+
+---
+
+## 8. Definition of done (all four tasks)
+
+Per CLAUDE.md "what done means":
+1. Each task implemented to its target behavior above.
+2. Tests: any new/changed tRPC procedure gets a Vitest unit test; the Matches validity → gate logic
+   gets a unit test; at least one Playwright happy-path covering open-game → fill matches →
+   Enable-scoring enables.
+3. Committed per-task with clear messages.
+4. `npx tsc --noEmit` clean AND `next lint` clean.
+5. No console errors in browser.
+6. Eye-verified on real data (not just unit green): zones render, Matches derive+gate works, Total
+   Points updates live, competition hides the roster while standalone keeps it.
+
+**Then:** open the PR, summarize per-task what changed and the Phase 0 deltas found. Do not merge with
+failing tests. After merge, the W-GAMEPAGE-01 doc's "already shipped vs remaining" delta should be
+updated (separate housekeeping, not part of this PR's code).

--- a/W-GAMEPAGE-01_game_page_lifecycle.md
+++ b/W-GAMEPAGE-01_game_page_lifecycle.md
@@ -1,0 +1,379 @@
+# W-GAMEPAGE-01 — Game-page lifecycle overhaul
+
+**Status:** DESIGN COMPLETE — not yet specced into PRs.
+**Scope of this file:** W-GAMEPAGE-01 only. The earlier WS4 reconciliation sections
+(consolidation audit, engine decisions, betting/Circle) are a *separate* recovery pass
+and are deliberately not rebuilt here.
+**Origin:** Began as a styling pass on the game-configuration page; grew into a
+re-architecture of the game page's whole lifecycle. Substantial parts are navigation-system
+design (back-stack, surface transitions) surfaced through the game-page slice — carry those
+into the nav session as **W-BACKNAV-01** input.
+**Captured:** 2026-06 design sessions + Zach's mocks (redesigned shell, staged course flow,
+Handicaps panel, Modifiers panel). Reviewed against the current shipped app (Images 2–7).
+
+**Document authority:** This is a design-intent doc. Where it touches data shape, the
+migrations remain authoritative (`games.modifiers` jsonb, `game_type_templates`). Where it
+touches patterns, `CLAUDE.md` wins. If this doc conflicts with code, code is ground truth —
+flag it, don't silently resolve.
+
+---
+
+## 1. Why this exists (what the current app gets wrong)
+
+Three concrete failures in the shipped game-config page (Images 2–7), each fixed structurally
+by the redesign rather than restyled:
+
+1. **Read-only redundancy eats a full screen.** "Available Players" (Image 3) is a
+   screen-height roster that, for a competition, is 100% derived from the teams — the team
+   list restated, nothing editable, captioned "Manage assignments from the team cards." It
+   carries zero decisions.
+2. **No hierarchy.** Six identical-weight rows with "· optional" as a grey whisper. Nothing
+   signals that Matches / Points / Course are the spine that gates *Enable scoring* while
+   Handicaps / Modifiers / Instructions are extras. This is the "hard to tell what task
+   you're on" complaint — a grouping problem, not a labeling one.
+3. **Dead controls render anyway.** Handicaps (Image 6) shows the full −/+ stepper and an
+   "Even match — no strokes given" caption on *every* match even when all are Even.
+   Empty match slots get the same height as filled ones. Controls should be live when shown
+   and summarized when not.
+
+Principle running through the fix: **show the control when it's live; summarize when it's not;
+don't render a dead affordance at all.**
+
+---
+
+## 2. The two-surface model
+
+The game page is two faces of one route plus one detour surface.
+
+| Surface | Reachable when | Entered from | Renders | Who |
+|---|---|---|---|---|
+| Game page — **setup face** | game in **setup** mode | leaderboard | editable settings (the config rows) | owner / delegate only |
+| Game page — **scoring face** | game in **scoring** mode | leaderboard | the scoreboard (live game) | everyone |
+| **Settings summary** (surface 2) | **scoring** mode only | the scoreboard (tap in) | read-only settings summary + danger zone + "switch to setup" | owner / delegate |
+
+- In setup mode, the settings **are** the page.
+- In scoring mode, the settings become a **separate read-only summary** reached from the
+  scoreboard — a different surface for a different moment (building vs. adjusting a live game).
+- **Reset to Defaults** (light skeleton-reset) lives on the setup face.
+- The full **danger zone** (already built: Phase A reset primitives + `GameDangerZone` #457)
+  lives on surface 2. The two never coexist — different surfaces.
+
+---
+
+## 3. The Setup/Scoring toggle
+
+A **non-destructive access-and-edit gate**, *not* a scoring on/off switch. (This is a tweak on
+the existing enable/disable-scoring concept, reframed.)
+
+- **Setup:** members can't open the game (not clickable for them); owner/delegate edits freely.
+- **Scoring:** members can open + play; settings **lock** (read-only summary on surface 2).
+- Flipping is **pause-mode** — scores are untouched in either direction.
+- **Settings lock during scoring is deliberate friction.** To edit a live game you flip back to
+  Setup. Changing a live game should feel deliberate, and it models real golf (format locks at
+  tee-off).
+- Each flip is **gated by a directional confirm** that explains that direction's consequence
+  (member access changes; scores are safe).
+
+---
+
+## 4. Back-stack (W-BACKNAV-01 input — these are nav rules)
+
+- **Mode transitions (Setup ↔ Scoring) REPLACE the stack, never push.** You always land with the
+  leaderboard behind you; stale prior-mode surfaces are cleared.
+  - Scoring→Setup: `leaderboard → scoreboard → settings-summary` ⇒ REPLACE ⇒
+    `leaderboard → game-page(setup)` → back = leaderboard. (Resolves the broken back-button.)
+  - Setup→Scoring: `leaderboard → game-page(setup)` ⇒ REPLACE ⇒
+    `leaderboard → scoreboard` → back = leaderboard.
+- **Tapping into the settings-summary from the scoreboard PUSHES** (it's a detour) → back returns
+  to the scoreboard.
+- **Back from any game page → leaderboard.**
+- ⚠ **Edge:** a deep-link into a game (notification / chat) may need to synthesize a leaderboard
+  entry so "back" always has somewhere to land.
+
+---
+
+## 5. Page structure (setup face)
+
+Three organizational zones over a single scrolling mobile column. **The zones are labels, not
+panes** — there is no side-by-side layout; it's still one column. This matters for accordion
+behavior (§9).
+
+### Zone 1 — Identity header
+- Game name, tap-to-edit inline (pencil affordance).
+- "Assigned to {delegate}" frame with × to clear the delegate.
+
+### Zone 2 — Game Management
+Pure game-lifecycle controls, **zero config**:
+- Setup/Scoring toggle (§3)
+- Reset to Defaults (§2)
+- Delegate / assigned-to frame
+
+> **⚠ Build reality (Phase 0, W-GAMEPAGE-01a):** the toggle + Reset currently live on
+> `GameConfigurationView` (the *post-enable* edit surface) and `GameDangerZone`, **not** on the
+> pre-enable `match/new` setup screen. So **Zone 2 is empty pre-enable and populates only in phase
+> (d)**, when the two-surface model (§2/§4) moves those controls onto the setup face. Phase (a)
+> groups the setup screen into **Zone 1 / Zone 3 / Zone 4 only** — no empty Zone 2 shell.
+
+> **Two config surfaces (Phase 0 finding):** there are two setup surfaces — the `match/new` setup
+> screen *and* `GameConfigurationView` (post-enable edit). The §2 two-surface model must rationalize
+> `GameConfigurationView` in phase (d); see §14(d). Phase (a) touches `match/new` only.
+
+> **Competition note:** for a competition there is **no player readout** on the setup face. Players
+> are fully derived from the teams (e.g. Rhinos vs Phoenix), so there's no player-context to
+> disclose. See §8 — the "16 Players · …" readout is a **standalone-only** affordance
+> (W-STANDALONE-01), never part of the competition surface.
+
+### Zone 3 — Settings (the required spine)
+The three rows that gate *Enable scoring*:
+- **Matches** (§6.1)
+- **Points** (§6.2)
+- **Course / Tee** (§6.3)
+
+### Zone 4 — Options (optional, tagged "· optional")
+- **Handicaps** (§6.4)
+- **Modifiers** (§6.5) — *hidden entirely when the format supports none*
+- **Rules of the Day** — plain textarea ("formats, gimmes, mulligans, tiebreakers…")
+
+### Exit actions
+- **Enable scoring** — readiness-gated (see §7).
+- **Save & exit** — always enabled; flushes the Rules textarea (the textarea has no collapse
+  event, so it's genuinely unsaved until exit — "Save" is honest here).
+
+---
+
+## 6. The config rows
+
+Each row is a collapsed summary (LABEL + value + green check when resolved) that expands to an
+in-place accordion editor. Editors persist-on-collapse with optimistic acknowledgment (onMutate
+shows the check/value instantly, background save, rollback on failure).
+
+### 6.1 Matches
+- **Count is derived, never set.** No "number of matches" field. **The pre-create count stepper
+  ("Matches to add") is removed** (Phase 0 found it still present; W-GAMEPAGE-01a removes it).
+- **Start at ONE empty match** (not zero, not N). Gives an obvious first action without presuming
+  the count.
+- Per match: `MATCH N` header, remove (−), drag handle (⋮⋮), two player slots with "vs",
+  "+ Add player" for empty slots. Tap a slot to pick; drag to reorder. (All already shipped.)
+- "+ Add match" appends another empty row at the bottom.
+- **Any match with an empty player slot is invalid** (red-X). Not just the trailing match — a middle
+  match with one filled and one empty slot is equally invalid. This *is* the readiness rule:
+  Enable-scoring gates on **zero unfilled matches** (§7). No separate validity check.
+- **Fill-or-remove, not auto-drop.** This model **supersedes #460's collapse-on-incomplete** (which
+  dropped unfilled matches and teed off with fewer on a confirm). Build-as-you-go means matches are
+  never pre-seeded as empties, so an empty match is an *unfinished add*, not a deliberate blank —
+  the resolution is to fill it or remove it, enforced by the gate. (Removed in W-GAMEPAGE-01a as an
+  audit-before-delete on `CollapseConfirm`/`confirmCollapse`.)
+- Workflow rationale: pairings are built one matchup at a time (set match 1, then match 2, …),
+  *not* by assigning players to arbitrary match numbers. Pre-filling N empty matches presumes a
+  count that isn't universal (BBMI is always 8; other competitions vary).
+
+### 6.2 Points
+- **Competition Format:** a "How's it played?" picker. Sets the **label on the leaderboard.**
+  Running the format in-app comes later — until then results are entered by hand. (Copy must
+  carry this; don't imply auto-scoring.)
+- **Points per match:** −/+ stepper, **required** (red dot).
+- **Points follows Matches:** surface **Total Points Available = match count × per-match** so the
+  stakes are visible (the current app shows per-match only).
+
+### 6.3 Course / Tee
+- Resolved state: course + tee shown, "× Change course" button (Image 5).
+- Selection runs the **staged search flow** (§10).
+- Gates Handicaps (§6.4) — handicaps require a complete 18 with a stroke-index table.
+
+### 6.4 Handicaps  *(optional)*
+- Per match: `MATCH N · WHO GETS STROKES?` with a **three-segment selector**:
+  `{Player A} | Even | {Player B}`.
+- **Even → collapse to one row**, caption "Even match — no strokes given." **No stepper rendered.**
+- **A side picked → reveal the −/+ STROKES stepper** and the allocation caption
+  ("on holes 1, 2, 3" / "on holes 2, 4, 6, 13").
+- Each match inlines its own matchup (restates "Jeremy vs Ty"), so Handicaps is
+  self-referencing — you don't need Matches open alongside it (relevant to §9).
+- **Hard-gated on BOTH Matches AND Course** (a complete 18). Handicaps without a stroke-index
+  table isn't a valid configured state.
+
+> **✓ Resolved (pending #466 merge) — indexed-nine compose verified.** The "N strokes on holes
+> a, b, c" allocation consumes the **stroke-index table** from the composed course. The indexed-nine
+> compose (two real indexed 9-hole courses → interleaved 18 → correct handicap allocation — the real
+> September/BBMI path) is now **verified on real indexed data** through the actual
+> `applyCourse → setBackNine` path (#466): correct interleaved 1–18, allocation spread across both
+> nines, and swap-preserves-front-index. The verification **caught and fixed a shipped swap-path
+> bug** (#465's swap read the already-composed 18's interleaved front index, length 18 not 1–9, so
+> `composeTwoNines` silently dropped the index → index-off allocation on every back-nine swap; the
+> #465 eye-check missed it because its course had no index to lose). `games.9hole.test.ts` locks the
+> regression. **Flip this note to fully-closed once #466 merges.** Handicaps hole-allocation is safe
+> for the BBMI 3×9.
+
+### 6.5 Modifiers  *(optional — hidden when none apply)*
+- **Applicability is data-driven.** Read `compatible_modifiers` from the `game_type_templates`
+  table. **Do not** mirror the list in a code enum — the table is the single source; a duplicated
+  enum is exactly the DB-vs-code drift that bites later.
+- **What lives in code is a modifier registry**, not the applicability list:
+  `key → { label, description, controlType, jsonbWriter }`. Data answers *which modifiers apply*;
+  code answers *how each renders and stores*.
+- **Panel logic:** read the template's `compatible_modifiers` → look each key up in the registry →
+  render those cards. **List empty → hide the entire Modifiers row** (don't render a dead "no
+  modifiers" stub). Consequence: the Options group has variable membership; accepted.
+- **Config-only scope.** A toggled modifier writes to `games.modifiers` jsonb and does **nothing**
+  to scoring behavior. The execution engines (moving tees, carry-style scoring) stay deferred
+  (see `DEFERRED.md`). This is not a broken promise: in the hand-entered-scoring era a toggled
+  modifier is a **structured rule-of-the-day** — the app records "last 3 holes worth double" even
+  though it doesn't compute it.
+- **Copy guardrail:** the on-state must **not** imply auto-enforcement. Moving Tee Boxes especially
+  looks like it should be changing the scorecard. "Set, not yet auto-scored" has to carry in the
+  copy. (Replaces the current app's "coming soon" stub, which was holding that expectation.)
+
+**Modifier definitions (initial registry + jsonb shape):**
+
+| Key | Control | jsonb shape | Notes |
+|---|---|---|---|
+| `gloriousFinishingHoles` | checkbox + **hole-count** stepper | `{ enabled: bool, holes: N }` | Stepper is the **number of trailing holes** worth double. Doubling is **fixed/implied** — it is not a multiplier. **Default `holes: 3`** so the control opens matching the "last 3 holes" suggestion in its own copy. |
+| `movingTees` | checkbox | `{ enabled: bool }` | No parameter. |
+
+---
+
+## 7. Readiness gate (Enable scoring)
+
+`Enable scoring` is enabled when the **required spine** is satisfied:
+- **Matches:** zero unfilled matches — **any** match with an empty player slot blocks (not only the
+  trailing one — §6.1). This is a hard block that **replaces** #460's collapse-on-incomplete
+  auto-drop. The validity signal (`allFilled`) already exists today (it outlines the button); the
+  flip is making the button actually `disabled` when `!allFilled`.
+- **Points:** points-per-match set (required, red dot — §6.2).
+- **Course:** selected (a complete 18 — §6.3).
+
+Options (Handicaps, Modifiers, Rules) **never** gate. `Save & exit` is always enabled.
+
+---
+
+## 8. Standalone seam (W-STANDALONE-01)
+
+"Available Players" is removed from the **competition** surface entirely — it's team-derived and
+duplicated. The "16 Players · {teams}" readout and any direct player add/manage UI belong only to
+the **standalone-game** world, where players are *not* team-derived and genuinely need to be
+seen/managed. Framing: not "hidden for competitions" but "a standalone-only affordance that was
+never part of the competition surface." When standalone games are built, reintroduce a player
+panel conditionally there.
+
+---
+
+## 9. Accordion behavior
+
+- **One open panel at a time, GLOBAL across all zones.** No per-section scoping.
+- Rationale: the zones aren't spatial (§5) — it's still one scrolling mobile column, so the
+  original reason for single-open (two tall panels open = scroll swamp + lose your place) is
+  fully intact. Per-section scoping would let, e.g., Course and Handicaps both be open, buying
+  only cross-referencing — which Handicaps already solves by inlining its own matchups (§6.4) —
+  at the cost of "some rows close each other, some don't" inconsistency and split-state
+  complexity.
+- **No carve-out.** With the player readout gone for competitions (§8), the single-open slot is
+  unconditionally the five config rows (Matches, Points, Course, Handicaps, Modifiers — Modifiers
+  only when present). Reset and the Setup/Scoring toggle are not accordion rows.
+- **Flips this decision only if** a workflow genuinely needs a Setting and an Option open together.
+  None identified.
+
+---
+
+## 10. Staged course-search flow
+
+1. **Default:** recents + a search bar.
+2. **On type:** switch to local / BBMI courses, **live-filter** (no API call yet).
+3. **On enter:** **fire the API call.** Adds a `SEARCH RESULTS` section (deduped against local) —
+   and **only now** surface the "+ Add course manually" button (not before).
+4. **18-hole pick:** choose tee → Confirm 18-Hole Round.
+5. **9-hole pick:** Confirm 9-Hole Round **or** "+ Add Back 9" — the #465 W-9HOLE inline flow,
+   presented inline (not a separate screen).
+
+---
+
+## 11. Destructive-edit guard (point-of-action, not global)
+
+- Removing a player or match **that has scores** → warn + confirm
+  ("Match N has scores — removing clears them").
+- Fires **only** on removal-of-a-scored-unit. Everything else re-derives safely
+  (derive-don't-snapshot).
+- Partly already enforced: `applyCourse` freezes on scores.
+
+---
+
+## 12. Reuse (don't rebuild)
+
+- `GameDangerZone` (#457) — danger zone on surface 2.
+- Reset primitives (Phase A, migration 066) — Reset to Defaults on the setup face.
+- Resolved-state display (#462) — collapsed-row summaries.
+- W-9HOLE flow (#465) — the 9-hole / back-9 inline step in the course flow.
+- The `<Sheet>` primitive — if surface 2 lands as a sheet (see OPEN pins).
+
+---
+
+## 13. OPEN pins (settle at spec/build time)
+
+These are deliberately unresolved. Several cross PR boundaries (§14).
+
+1. **Surface 2 — full page vs `<Sheet>` overlay.** Lean `<Sheet>` (nav-consistent,
+   recede-and-return) — but then "switch to setup" = dismiss-sheet + mode-transition-replace on
+   the page underneath (a sheet with a nav side-effect). Full page is simpler for the stack.
+   Settle with the nav-consistency lens (W-BACKNAV-01).
+2. **Scoring→Setup re-render — clean in-place navigate vs reload.** Reload is a UX smell; prefer a
+   clean navigate if state remaps cleanly. Phase 0 / build call.
+3. **Back-nine tee — inherit the front's tee vs pick its own.** Lean inherit.
+4. **Add-manually timing — confirm that API-returns-nothing surfaces the manual button cleanly**
+   (it should appear with SEARCH RESULTS on enter, even when results are empty).
+
+---
+
+## 14. Spec phasing (this is big — DO NOT spec as one PR)
+
+Likely split (updated post-W-GAMEPAGE-01a Phase 0):
+
+- **(a) Structural core** — *scope corrected:* Zone grouping (Zone 1/3/4 only on `match/new`; **no
+  Zone 2** until d) + Matches hard-block model (remove pre-create count stepper, remove #460
+  collapse-on-incomplete, gate on any-empty-slot) + Total Points readout (pipe derived count into the
+  Points panel) + hide Available Players for competitions. The accordion (§9) and identity header
+  (§5 Zone 1) are **already shipped** (#462/#463) — confirm, don't build. **The toggle/lock moved
+  OUT of (a) → (d)** (the toggle isn't on the setup screen pre-enable).
+- **(b) Course-flow refinement** — staged search (§10) is ~shipped (#464); remnant is mostly OPEN pin
+  #4. Likely a punch-list, not a full phase.
+- **(c) Destructive-edit guard** (§11) — small, contained.
+- **(d) Surface-2 + back-stack nav + toggle/lock** (§2 surface 2, §3 toggle lock + directional
+  confirms, §4) — nav-adjacent; reuse `<Sheet>`; keep consistent with W-BACKNAV-01. **Also absorbs
+  `GameConfigurationView`** (the post-enable edit surface found in Phase 0) into the two-surface
+  model — reconcile it against setup-face / scoring-face / settings-summary rather than leaving two
+  divergent config surfaces. Carries OPEN pins #1, #2.
+- **Modifiers** (§6.5) — can ride with (a) or be its own small PR; config-only, no engine.
+
+Each PR follows the standard CC contract: Phase 0 diagnose-first report-and-STOP, DO-NOT lists,
+per-task commits, `tsc --noEmit` + `next lint` clean, verify-by-eye on real data, audit-before-delete.
+
+---
+
+## 15. Standing decisions ledger (this pass)
+
+| Decision | Resolution |
+|---|---|
+| Available Players (competitions) | Removed; team-derived. Standalone-only affordance (W-STANDALONE-01). Branch already exists; phase (a) stops rendering the competition branch. |
+| Game Management (competition) | Toggle + Reset + delegate. **Toggle/Reset live post-enable, not on setup screen → Zone 2 empty in (a), populates in (d).** |
+| Matches count | Derived, not set. Pre-create count stepper removed (W-GAMEPAGE-01a). |
+| Matches initial state | One empty row. |
+| Matches validity | **Any** match with an empty slot = invalid (not just trailing); hard-blocks Enable scoring. **Replaces #460 collapse-on-incomplete.** |
+| Points | Follows Matches; surface Total = valid-matches × per-match (count piped into Points panel). |
+| Competition Format | Sets leaderboard label only; in-app run deferred; hand-entry until then. |
+| Modifiers applicability | `compatible_modifiers` from `game_type_templates` (data, not enum). |
+| Modifiers render/store | Code registry: `key → {label, description, controlType, jsonbWriter}`. |
+| Modifiers empty | Hide the entire row. |
+| Modifiers scope | Config-only → `games.modifiers` jsonb; engine deferred. |
+| Glorious Finishing Holes | Hole-**count** stepper, doubling implied; `{enabled, holes}`; default `holes: 3`. |
+| Moving Tees | `{enabled}`; no parameter. |
+| Accordion | Single open, global; no carve-out. |
+| Handicaps gate | Hard-gated on Matches AND Course (complete 18). |
+| Handicaps trust | **Verified on real indexed data (#466)** — interleaved 1–18, allocation across both nines, swap-preserves-front. Compose caught + fixed a shipped swap-path index-drop bug. Safe for BBMI 3×9. *(Flip to fully-closed on #466 merge.)* |
+
+---
+
+## Cross-references
+- `CLAUDE.md` — enforced patterns (optimistic updates, migration naming, RLS split, middleware auth).
+- `STYLE_GUIDE.md` — `--color-bt-*` tokens; all surfaces/colors via tokens.
+- `PERMISSIONS.md` — owner/planner/member gating; competition setup is `canEdit`.
+- `DEFERRED.md` — modifier execution engines (moving tees, carry-style scoring) remain deferred.
+- Migrations — authoritative for `games.modifiers`, `game_type_templates`.
+- W-BACKNAV-01 (future nav session) — consumes §4 back-stack rules and OPEN pins #1–#2.
+- W-STANDALONE-01 (future) — reintroduces a player panel for standalone games (§8).

--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -125,6 +125,11 @@ async function driveToSetupWithHandicap(page: Page) {
   await expect(createBtn).toBeVisible({ timeout: 20_000 });
   await createBtn.click();
 
+  // T2 hard block (W-GAMEPAGE-01 §6.1): "Create game" seeds exactly ONE empty
+  // match (build-as-you-go), so Enable scoring is DISABLED until both slots fill.
+  // No silent collapse-to-filled-count — an empty slot keeps the gate shut.
+  await expect(page.getByRole("button", { name: "Enable scoring" })).toBeDisabled({ timeout: 20_000 });
+
   // Accordion toggle = the row's HEADER button (the first button in the row). When
   // a panel is expanded its body fills the row, so clicking the row CENTER would
   // land in the editor, not the header — target the header explicitly to collapse.
@@ -190,9 +195,9 @@ test("match-play spine — pair + relocated handicap → enable → enter a hole
   test.setTimeout(60_000);
   await driveToSetupWithHandicap(page);
 
-  // Enable scoring → the overview. Gate on the button being ENABLED — that's
-  // the signal both slots are filled (filledCount > 0), so the click can't race
-  // an incomplete pairing and trip the collapse confirm.
+  // Enable scoring → the overview. Gate on the button being ENABLED — under the
+  // T2 hard block that's the signal EVERY match is fully paired (the single match
+  // here), so the click can't race an incomplete pairing.
   const enableBtn = page.getByRole("button", { name: "Enable scoring" });
   await expect(enableBtn).toBeEnabled({ timeout: 10_000 });
   await enableBtn.click();

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -18,7 +18,6 @@ import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
-import { TeamsPanel } from "@/components/competition/TeamsPanel";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/GameRulesNote";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
@@ -936,7 +935,9 @@ export default function NewMatchGamePage() {
           setDoublesPairings.isPending || setDoublesHandicap.isPending;
         const tA = teamForSlot("a");
         const tB = teamForSlot("b");
-        const availableCount = (gameCompId && rosterIds.length > 0 ? rosterIds.length : (crew.data?.length ?? 0));
+        // Standalone-only readout now (T4 hides this row for competitions), so the
+        // count is just the trip crew — no roster branch.
+        const availableCount = crew.data?.length ?? 0;
         // Hard block (W-GAMEPAGE-01 §6.1): the row resolves only when EVERY match
         // is fully paired — an empty slot is an unfinished add, not a quiet drop.
         const matchesSummary = allFilled
@@ -972,20 +973,20 @@ export default function NewMatchGamePage() {
               <GameIdentityHeader tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} isOwner={isOwner} />
             )}
 
-            {/* Available Players — between Identity and Settings, not a labeled
-                zone. (T4 gates this to standalone-only.) */}
-            <ChecklistRow
-              label="Available players"
-              value={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
-              state="resolved"
-              expanded={openRow === "players"}
-              onToggle={() => toggleRow("players")}
-              testId="row-players"
-            >
-              <div data-testid="players-rosters">
-                {gameCompId ? (
-                  <TeamsPanel tripId={tripId} competitionId={gameCompId} canEdit={false} structureLocked embedded />
-                ) : (
+            {/* Available players (W-GAMEPAGE-01 §8) — STANDALONE games only. In a
+                competition the rosters live on the competition face (the leaderboard
+                + RostersOverlay own team membership), so this read-only echo is
+                redundant noise here; the row is hidden entirely. */}
+            {!gameCompId && (
+              <ChecklistRow
+                label="Available players"
+                value={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
+                state="resolved"
+                expanded={openRow === "players"}
+                onToggle={() => toggleRow("players")}
+                testId="row-players"
+              >
+                <div data-testid="players-rosters">
                   <div className="flex flex-col gap-1">
                     {(crew.data ?? []).map((c) => (
                       <span key={c.user_id} className="text-sm" style={{ color: "var(--color-bt-text)" }}>
@@ -993,9 +994,9 @@ export default function NewMatchGamePage() {
                       </span>
                     ))}
                   </div>
-                )}
-              </div>
-            </ChecklistRow>
+                </div>
+              </ChecklistRow>
+            )}
 
             {/* ── Zone 3 — SETTINGS (the required spine that gates Enable scoring):
                 Matches · Course · Format·Points (W-GAMEPAGE-01 §5). ── */}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -996,11 +996,8 @@ export default function NewMatchGamePage() {
               <GameIdentityHeader tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} isOwner={isOwner} />
             )}
 
-            {/* Available Players — expands to the canonical rosters view. For a
-                competition game this is the SAME TeamsPanel the Rosters overlay
-                uses, but READ-ONLY (canEdit=false): the pool is revealed, not
-                editable — team setup isn't reachable from a game's setup, not even
-                for the owner. Standalone (no teams) falls back to the flat crew. */}
+            {/* Available Players — between Identity and Settings, not a labeled
+                zone. (T4 gates this to standalone-only.) */}
             <ChecklistRow
               label="Available players"
               value={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
@@ -1023,6 +1020,10 @@ export default function NewMatchGamePage() {
                 )}
               </div>
             </ChecklistRow>
+
+            {/* ── Zone 3 — SETTINGS (the required spine that gates Enable scoring):
+                Matches · Course · Format·Points (W-GAMEPAGE-01 §5). ── */}
+            <ZoneHeader>Settings</ZoneHeader>
 
             {/* Matches — the pairing builder (the score-entry unit), in place. */}
             <ChecklistRow
@@ -1047,9 +1048,10 @@ export default function NewMatchGamePage() {
               />
             </ChecklistRow>
 
-            {/* Course — BEFORE Handicaps (W-9HOLE-01 reorder). Handicaps' per-hole
-                stroke allocation needs the course's stroke-index table, so Course
-                resolves first; the one-open chain reads Matches → Course → Handicaps. */}
+            {/* Course — Handicaps' per-hole stroke allocation needs the course's
+                stroke-index table, so Course resolves before Handicaps (W-9HOLE-01);
+                the one-open chain reads Matches → Course → Handicaps (Handicaps is
+                in Zone 4 below). */}
             {gameQ.data && (
               <GameSetupRows
                 slot="course"
@@ -1064,9 +1066,27 @@ export default function NewMatchGamePage() {
               />
             )}
 
+            {/* Format · Points — the last Settings row (the spine: matches × value). */}
+            {gameQ.data && (
+              <GameSetupRows
+                slot="config"
+                tripId={tripId}
+                competitionId={gameCompId}
+                game={gameQ.data as unknown as GameRow}
+                canEdit={canEdit}
+                configOpen={openRow === "config"}
+                onOpenConfig={() => changeOpenRow("config")}
+                onCloseEditor={() => changeOpenRow(null)}
+                onChanged={onSetupChanged}
+              />
+            )}
+
+            {/* ── Zone 4 — OPTIONS (never gate Enable): Handicaps · Modifiers ·
+                Rules of the Day (W-GAMEPAGE-01 §5). ── */}
+            <ZoneHeader>Options</ZoneHeader>
+
             {/* Handicaps — hard-gated on Matches AND Course (W-9HOLE-01): both must
-                resolve (a complete 18) before per-hole strokes can be allocated. The
-                one-open rule physically enforces the chain. */}
+                resolve (a complete 18) before per-hole strokes can be allocated. */}
             <ChecklistRow
               label="Handicaps"
               value={handicapsSummary}
@@ -1086,28 +1106,12 @@ export default function NewMatchGamePage() {
               />
             </ChecklistRow>
 
-            {/* Format · Points — AFTER Handicaps (the reorder). */}
-            {gameQ.data && (
-              <GameSetupRows
-                slot="config"
-                tripId={tripId}
-                competitionId={gameCompId}
-                game={gameQ.data as unknown as GameRow}
-                canEdit={canEdit}
-                configOpen={openRow === "config"}
-                onOpenConfig={() => changeOpenRow("config")}
-                onCloseEditor={() => changeOpenRow(null)}
-                onChanged={onSetupChanged}
-              />
-            )}
-
             {/* Modifiers — acknowledge-only: the toggle targets exist but no
                 modifier has a scoring effect yet, so the row is inert until then. */}
             <ChecklistRow label="Modifiers" value="None — coming soon" state="acknowledged-empty" />
 
-            {/* Zone 3 — RULES / notes (W-EDITMODAL-01): freeform, below the
-                checklist. Saves on blur; "Save & exit" flushes it via rulesRef.
-                Competition games only (re-homes the modal's rules field). */}
+            {/* Rules of the Day — freeform note (W-EDITMODAL-01). Saves on blur;
+                "Save & exit" flushes it via rulesRef. Competition games only. */}
             {gameCompId && gameQ.data && (
               <GameRulesNote ref={rulesRef} tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} />
             )}
@@ -1367,6 +1371,19 @@ function assignInDraft(
  * back arrow only (top-left), centered title (white) + subtitle, optional
  * top-right slot (the overview's Edit link).
  */
+/** A labeled zone divider on the setup face (W-GAMEPAGE-01 §5) — the groups are
+ *  labels, not panes (one scrolling column). Token-styled, quiet caption. */
+function ZoneHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 pt-2">
+      <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+        {children}
+      </span>
+      <span className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
+    </div>
+  );
+}
+
 function SetupHeader({
   title,
   subtitle,

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1050,6 +1050,7 @@ export default function NewMatchGamePage() {
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
                 canEdit={canEdit}
+                matchCount={filledDraft.length}
                 configOpen={openRow === "config"}
                 onOpenConfig={() => changeOpenRow("config")}
                 onCloseEditor={() => changeOpenRow(null)}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -26,6 +26,7 @@ import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
+import { filledMatches, allMatchesFilled } from "@/lib/matchDraft";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
 /** "07:40" → "7:40 AM". Empty/invalid → "". */
@@ -168,7 +169,7 @@ export default function NewMatchGamePage() {
   // game to these: the unfilled slots are discarded and points-in-play / the cup
   // clinch recompute from this count. "Defined" was builder-time intent only.
   const filledDraft = useMemo(
-    () => draft.filter((d) => d.a.length === playersPerSide && d.b.length === playersPerSide),
+    () => filledMatches(draft, playersPerSide),
     [draft, playersPerSide]
   );
 
@@ -927,7 +928,7 @@ export default function NewMatchGamePage() {
         // physically gates Handicaps behind Matches. Collapse = acknowledge +
         // persist (the draft editors commit on close). Course + Name·Format·Points
         // stay overlays this pass (tracked follow-ons) but ride the same one-open.
-        const allFilled = draft.length > 0 && filledDraft.length === draft.length;
+        const allFilled = allMatchesFilled(draft, playersPerSide);
         const anyHandicap = draft.some((d) => d.handicap !== 0);
         const matchesExist = filledDraft.length > 0;
         const savingSetup =

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -96,9 +96,6 @@ export default function NewMatchGamePage() {
   const [gameId, setGameId] = useState<string | null>(search.get("game"));
   const [manualScreen, setManualScreen] = useState<Screen | null>(null);
 
-  // New-game form. Dynamic match count: start at 1 (a single default match) and
-  // grow one at a time — never force the full suggested count up front.
-  const [matchCount, setMatchCount] = useState(1);
   const [teeTime, setTeeTime] = useState(""); // "HH:MM" 24h
   // Setup editing state
   const [draft, setDraft] = useState<DraftMatch[]>([]);
@@ -140,7 +137,6 @@ export default function NewMatchGamePage() {
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
   // Collapse-on-advance: when teeing off with some slots still unfilled, confirm
   // the consequence (the game drops to the filled count; cup clinch shifts).
-  const [confirmCollapse, setConfirmCollapse] = useState(false);
   // Course (Slice C): picked on the new-game screen, applied to the game once
   // it's created. id null until chosen.
   const [courseId, setCourseId] = useState<string | null>(null);
@@ -240,25 +236,14 @@ export default function NewMatchGamePage() {
   // undifferentiated, so any two of the crew pair up (Slice B). In a 2-team
   // competition the cap becomes min(teamA, teamB) since matches cross the team
   // line — generally min team size across teams — which is Slice D's concern.
-  const crewCount = crew.data?.length ?? 0;
-  // 1v1 needs 2 players per match, 2v2 needs 4 (two pairs).
-  const maxMatches = Math.max(1, Math.floor(crewCount / (sided ? 4 : 2)));
-
-  // Competition roster + the singles match cap = min(teamA, teamB). Used to seed
-  // a resumed competition game's pairings and to scope the player picker.
+  // Build-as-you-go (W-GAMEPAGE-01 §6.1): matches start at one and grow via
+  // "+ Add match" — no pre-seeded count, so the old crew/roster match caps that
+  // sized the initial draft are gone.
   const gameCompId = (gameQ.data?.competition_id as string | null) ?? null;
   const rosterIds = useMemo(
     () => [...new Set((assignQ.data ?? []).map((a) => a.user_id as string))],
     [assignQ.data]
   );
-  const compMatchCount = useMemo(() => {
-    const sizes = new Map<string, number>();
-    for (const a of assignQ.data ?? []) sizes.set(a.team_id as string, (sizes.get(a.team_id as string) ?? 0) + 1);
-    // A 2v2 match consumes 2 from each team, a 1v1 consumes 1 — so the cap is
-    // min over teams of floor(teamSize / playersPerSide).
-    const counts = [...sizes.values()].map((n) => Math.floor(n / playersPerSide));
-    return counts.length >= 2 ? Math.max(1, Math.min(...counts)) : 0;
-  }, [assignQ.data, playersPerSide]);
 
   const status = gameQ.data?.status as string | undefined;
   // Phase 2B.1: scoring enabled is the real "open for scoring" flag (publish no
@@ -459,12 +444,10 @@ export default function NewMatchGamePage() {
       return;
     }
     // Resume-into-empty: a competition game tapped from the leaderboard arrives
-    // with no game_matches, so the derived "setup" landing had an empty draft and
-    // a disabled CTA. Seed blank pairing cards from the roster's match cap (or the
-    // crew cap for a standalone game) so setup is fillable.
-    const n = compMatchCount || maxMatches;
-    if (n > 0) setDraft(Array.from({ length: n }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
-  }, [screen, draft.length, serverMatches, handicapOf, membersOfSide, sided, compMatchCount, maxMatches]);
+    // with no game_matches → seed ONE empty match (build-as-you-go; no pre-seeded
+    // count — W-GAMEPAGE-01 §6.1). "+ Add match" grows it from there.
+    setDraft([{ matchNumber: 1, a: [], b: [], handicap: 0 }]);
+  }, [screen, draft.length, serverMatches, handicapOf, membersOfSide, sided]);
 
   // After a +1/−1 (or initial create): re-pull the game's matches AND refresh
   // the competition board so "first to XX" / "X of Y" recompute ON SCREEN. The
@@ -498,22 +481,18 @@ export default function NewMatchGamePage() {
         // Non-fatal: the game still works on the template default par/index.
       }
     }
-    const count = Math.min(Math.max(1, matchCount), maxMatches);
-    // Persist the configured matches as rows NOW (empty) so the game has ≥1
-    // configured match from creation — the board's clinch goalpost (value ×
-    // count) is live immediately, not 0 until tee-off.
-    const emptyMatches = Array.from({ length: count }, (_, i) => ({ sideA: null, sideB: null, matchNumber: i + 1 }));
+    // Persist ONE empty match row so the game has a configured match from
+    // creation (build-as-you-go — W-GAMEPAGE-01 §6.1; "+ Add match" grows it).
+    const emptyMatches = [{ sideA: null, sideB: null, matchNumber: 1 }];
     if (sided) await setDoublesPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
     else await setPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
     await refreshAfterMatchCountChange();
     // The DERIVED screen flips to "setup" the instant setGameId ran (above), so the
     // checklist is already interactive — and the user may have started pairing while
-    // this create flow finished its awaits. Only seed the blank cards if they
-    // HAVEN'T (the seed effect already seeded them otherwise); never clobber a draft
-    // the user has touched. (Don't reset draftTouched here either — that would
-    // re-arm the seed effect to overwrite live edits.)
+    // this create flow finished its awaits. Only seed the blank card if they
+    // HAVEN'T (the seed effect already seeded otherwise); never clobber a touched draft.
     if (!draftTouched.current) {
-      setDraft(Array.from({ length: count }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
+      setDraft([{ matchNumber: 1, a: [], b: [], handicap: 0 }]);
     }
     go("setup");
   }
@@ -525,7 +504,7 @@ export default function NewMatchGamePage() {
     if (serverMatches.length > 0) {
       setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide, sided));
     } else if (draft.length === 0) {
-      setDraft(Array.from({ length: matchCount }, (_, i) => ({ matchNumber: i + 1, a: [], b: [], handicap: 0 })));
+      setDraft([{ matchNumber: 1, a: [], b: [], handicap: 0 }]);
     }
     go("setup");
   }
@@ -536,14 +515,13 @@ export default function NewMatchGamePage() {
   // count and the cup clinch shifts — a surfaced consequence, not a scold). With
   // nothing filled there's no match to play, so it's a no-op.
   function attemptReady() {
-    if (filledDraft.length === 0) return;
-    // Enable commits everything itself (commitReady → saveSetup) — collapse any
-    // open row WITHOUT re-firing persist-on-collapse (raw setter, not changeOpenRow).
+    // Hard block (W-GAMEPAGE-01 §6.1/§7): every match must be fully paired — the
+    // Enable button is disabled while any slot is empty, so this is a guard, not a
+    // gate. (No more collapse-on-incomplete: an empty match is an unfinished add,
+    // resolved by filling or removing it — not auto-dropped.)
+    if (draft.length === 0 || filledDraft.length !== draft.length) return;
+    // Collapse any open row WITHOUT re-firing persist-on-collapse (raw setter).
     setOpenRow(null);
-    if (filledDraft.length < draft.length) {
-      setConfirmCollapse(true);
-      return;
-    }
     void commitReady();
   }
 
@@ -609,7 +587,6 @@ export default function NewMatchGamePage() {
   // refetch (#459).
   async function commitReady() {
     if (!tripId || !gameId) return;
-    setConfirmCollapse(false);
     const ok = await saveSetup();
     if (!ok) return;
     await enableScoring.mutateAsync({ tripId, gameId });
@@ -921,11 +898,6 @@ export default function NewMatchGamePage() {
       <div className="w-full px-4 py-5">
       {screen === "new" && (
         <NewGame
-          sided={sided}
-          matchCount={matchCount}
-          setMatchCount={setMatchCount}
-          maxMatches={maxMatches}
-          crewCount={crewCount}
           teeTime={teeTime}
           setTeeTime={setTeeTime}
           courseName={courseName}
@@ -965,9 +937,13 @@ export default function NewMatchGamePage() {
         const tA = teamForSlot("a");
         const tB = teamForSlot("b");
         const availableCount = (gameCompId && rosterIds.length > 0 ? rosterIds.length : (crew.data?.length ?? 0));
-        const matchesSummary = matchesExist
+        // Hard block (W-GAMEPAGE-01 §6.1): the row resolves only when EVERY match
+        // is fully paired — an empty slot is an unfinished add, not a quiet drop.
+        const matchesSummary = allFilled
           ? `${filledDraft.length} match${filledDraft.length === 1 ? "" : "es"}${tA && tB ? ` · ${tA.name} vs ${tB.name}` : ""}`
-          : "Not set";
+          : draft.length === 0
+            ? "Not set"
+            : "Finish or remove the empty match";
         // Handicaps is hard-gated on Matches AND Course (W-9HOLE-01): the per-hole
         // stroke allocation needs the course's stroke-index table, so a complete
         // 18 must resolve first. "Course resolved" = a course applied AND an 18-hole
@@ -1029,7 +1005,7 @@ export default function NewMatchGamePage() {
             <ChecklistRow
               label="Matches"
               value={matchesSummary}
-              state={matchesExist ? "resolved" : "unresolved"}
+              state={allFilled ? "resolved" : "unresolved"}
               expanded={openRow === "matches"}
               onToggle={() => toggleRow("matches")}
               testId="row-matches"
@@ -1134,8 +1110,7 @@ export default function NewMatchGamePage() {
               <PrimaryButton
                 label={enableScoring.isPending ? "Enabling…" : "Enable scoring"}
                 onClick={attemptReady}
-                disabled={savingSetup || enableScoring.isPending || filledDraft.length === 0}
-                outlined={!allFilled}
+                disabled={savingSetup || enableScoring.isPending || !allFilled}
               />
               {gameCompId && (
                 <button
@@ -1221,85 +1196,6 @@ export default function NewMatchGamePage() {
           />
         );
       })()}
-
-      {/* Collapse-on-incomplete confirm — fires only when teeing off with some
-          slots unfilled. States the real drop (filled count · points) and that
-          the cup clinch recalculates; confirming discards the unfilled slots. */}
-      {confirmCollapse && (
-        <CollapseConfirm
-          filled={filledDraft.length}
-          total={draft.length}
-          perMatchValue={(gameQ.data?.points_distribution as { value?: number } | null)?.value ?? null}
-          inCompetition={!!gameCompId}
-          pending={setPairings.isPending || setDoublesPairings.isPending || enableScoring.isPending}
-          onConfirm={() => void commitReady()}
-          onCancel={() => setConfirmCollapse(false)}
-        />
-      )}
-    </div>
-  );
-}
-
-/**
- * Collapse confirm (advance with unfilled slots). A consequence notice, not a
- * scold: the unfilled matches aren't being created, so the game drops to the
- * filled count, its points-in-play drop with it, and — in a competition — the
- * cup's first-to-win total recalculates (the surprising part, so say it).
- * Recovery is adding matches later, not an undo.
- */
-function CollapseConfirm({
-  filled,
-  total,
-  perMatchValue,
-  inCompetition,
-  pending,
-  onConfirm,
-  onCancel,
-}: {
-  filled: number;
-  total: number;
-  perMatchValue: number | null;
-  inCompetition: boolean;
-  pending: boolean;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
-  const unfilled = total - filled;
-  const pts = perMatchValue != null ? filled * perMatchValue : null;
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-6" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onCancel}>
-      <div onClick={(e) => e.stopPropagation()} className="w-full" style={{ maxWidth: 360, background: "var(--color-bt-card-float)", borderRadius: 18, padding: 20, border: "1px solid var(--color-bt-border)" }}>
-        <div style={{ fontSize: 17, fontWeight: 700, color: "var(--color-bt-text)" }}>
-          {unfilled} {unfilled === 1 ? "match isn’t" : "matches aren’t"} set
-        </div>
-        <p style={{ fontSize: 14, lineHeight: 1.5, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
-          Enable scoring now and this game collapses to{" "}
-          <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
-            {filled} {filled === 1 ? "match" : "matches"}
-            {pts != null ? ` · ${pts} pts` : ""}
-          </span>
-          . The unfilled {unfilled === 1 ? "slot is" : "slots are"} discarded.
-          {inCompetition && " The cup’s first-to-win total recalculates from the lower total."}
-        </p>
-        <div className="mt-5 flex flex-col gap-2">
-          <button
-            onClick={onConfirm}
-            disabled={pending}
-            className="w-full disabled:opacity-40"
-            style={{ height: 48, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 15, fontWeight: 600 }}
-          >
-            {pending ? "Enabling…" : `Enable with ${filled}`}
-          </button>
-          <button
-            onClick={onCancel}
-            disabled={pending}
-            className="w-full disabled:opacity-40"
-            style={{ height: 46, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
-          >
-            Keep setting up
-          </button>
-        </div>
-      </div>
     </div>
   );
 }
@@ -1419,11 +1315,6 @@ function SetupHeader({
 }
 
 function NewGame({
-  sided,
-  matchCount,
-  setMatchCount,
-  maxMatches,
-  crewCount,
   teeTime,
   setTeeTime,
   courseName,
@@ -1432,11 +1323,6 @@ function NewGame({
   pending,
   canEdit,
 }: {
-  sided: boolean;
-  matchCount: number;
-  setMatchCount: (n: number) => void;
-  maxMatches: number;
-  crewCount: number;
   teeTime: string;
   setTeeTime: (t: string) => void;
   courseName: string | null;
@@ -1446,9 +1332,9 @@ function NewGame({
   canEdit: boolean;
 }) {
   if (!canEdit) return <MemberNotReady />;
-  // Clamp the displayed value to the crew-derived cap (state may still hold an
-  // old value while the crew query resolves).
-  const value = Math.min(Math.max(1, matchCount), maxMatches);
+  // Build-as-you-go (W-GAMEPAGE-01 §6.1): creating the game seeds exactly ONE
+  // empty match — no up-front count. Matches are added one at a time on the setup
+  // face, so there's no stepper here.
   return (
     <div>
       <div className="flex flex-col gap-3.5">
@@ -1469,23 +1355,6 @@ function NewGame({
           value={parseTime(teeTime)}
           onChange={(v) => setTeeTime(toTime24(v))}
         />
-
-        {/* Matches — count stepper. */}
-        <div>
-          <FieldLabel>Matches to add</FieldLabel>
-          <div className="flex w-full items-center justify-between rounded-xl border px-3 py-2.5" style={pillStyle}>
-            <span style={{ fontSize: 14, color: "var(--color-bt-text)" }}>
-              {value} {value === 1 ? "match" : "matches"}
-            </span>
-            <div className="flex items-center gap-2">
-              <Stepper dir="dec" disabled={value <= 1} onClick={() => setMatchCount(Math.max(1, value - 1))} />
-              <Stepper dir="inc" disabled={value >= maxMatches} onClick={() => setMatchCount(Math.min(maxMatches, value + 1))} />
-            </div>
-          </div>
-          <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 6, paddingLeft: 2 }}>
-            {crewCount} in the crew · up to {maxMatches} {sided ? "2v2" : "singles"} match{maxMatches === 1 ? "" : "es"}
-          </p>
-        </div>
       </div>
 
       <PrimaryButton label="Create game" onClick={onCreate} disabled={pending} />
@@ -2006,14 +1875,6 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
     >
       {children}
     </label>
-  );
-}
-
-function Stepper({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled: boolean; onClick: () => void }) {
-  return (
-    <button onClick={onClick} disabled={disabled} className="flex items-center justify-center disabled:opacity-30" style={{ width: 30, height: 30, borderRadius: 8, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}>
-      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
-    </button>
   );
 }
 

--- a/src/components/games/FormatPointsPanel.tsx
+++ b/src/components/games/FormatPointsPanel.tsx
@@ -26,11 +26,15 @@ import type { PointsDistribution } from "@/lib/pointsDistribution";
  * is what matters, and it's always written atomically. Optimistic via `setData`.
  */
 export function FormatPointsPanel({
-  tripId, game, canEdit,
+  tripId, game, canEdit, matchCount,
 }: {
   tripId: string;
   game: GameRow;
   canEdit: boolean;
+  /** Valid (fully-paired) match count — drives the "Total points available"
+   *  readout for match-format games (W-GAMEPAGE-01 §6.2). Derived, not snapshotted:
+   *  Total = matchCount × points-per-match, recomputing as matches are added. */
+  matchCount?: number;
 }) {
   const gameId = game.id;
   const utils = trpc.useUtils();
@@ -123,12 +127,34 @@ export function FormatPointsPanel({
 
       {/* Points */}
       {isMatchPlay ? (
-        <PointStepper
-          label="Points per match"
-          caption="POINTS PER MATCH"
-          value={perMatchValue}
-          onChange={readOnly ? () => {} : onPerMatch}
-        />
+        <>
+          <PointStepper
+            label="Points per match"
+            caption="POINTS PER MATCH"
+            value={perMatchValue}
+            onChange={readOnly ? () => {} : onPerMatch}
+          />
+          {/* Total points available (W-GAMEPAGE-01 §6.2) — derived live from the
+              valid match count × per-match value, so it tracks matches as they're
+              added (never snapshotted). Hidden until at least one match resolves. */}
+          {matchCount != null && matchCount > 0 && (
+            <div
+              className="flex items-center justify-between rounded-lg px-3 py-2.5"
+              style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+              data-testid="total-points-available"
+            >
+              <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                Total points available
+              </span>
+              <span className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
+                {matchCount * perMatchValue}
+                <span className="ml-1 text-[11px] font-normal" style={{ color: "var(--color-bt-text-dim)" }}>
+                  {matchCount} × {perMatchValue}
+                </span>
+              </span>
+            </div>
+          )}
+        </>
       ) : (
         <>
           <PointStepper

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -30,6 +30,7 @@ export function GameSetupRows({
   canEdit,
   onChanged,
   slot = "both",
+  matchCount,
   courseOpen: courseOpenProp,
   configOpen: configOpenProp,
   onOpenCourse,
@@ -47,6 +48,10 @@ export function GameSetupRows({
    *  match page place Course BEFORE Handicaps and Format·Points after. Default
    *  "both" — the other surfaces render them together as one block. */
   slot?: "course" | "config" | "both";
+  /** Valid (fully-paired) match count, for the per-match "Total points" readout
+   *  (W-GAMEPAGE-01 §6.2). Derived live by the page — omit on surfaces that don't
+   *  build matches (no Total shown). */
+  matchCount?: number;
   /** Page-owned one-open state (controlled). Omit → self-managed (uncontrolled). */
   courseOpen?: boolean;
   configOpen?: boolean;
@@ -112,7 +117,7 @@ export function GameSetupRows({
           onToggle={configOpen ? closeEditor : openConfig}
           testId="row-format-points"
         >
-          <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} />
+          <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} matchCount={matchCount} />
         </ChecklistRow>
       )}
     </>

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { isMatchFilled, filledMatches, allMatchesFilled, type MatchSides } from "./matchDraft";
+
+// W-GAMEPAGE-01 §6.1/§7 — the hard-block readiness gate. An empty or half-filled
+// match must keep "Enable scoring" disabled (no silent collapse to the filled
+// count). These guard the pure rule the setup face derives the gate from.
+
+const singles = (a: string[], b: string[]): MatchSides => ({ a, b });
+
+describe("isMatchFilled", () => {
+  it("singles (1 per side): filled only when both sides have a player", () => {
+    expect(isMatchFilled(singles(["x"], ["y"]), 1)).toBe(true);
+    expect(isMatchFilled(singles([], ["y"]), 1)).toBe(false);
+    expect(isMatchFilled(singles(["x"], []), 1)).toBe(false);
+    expect(isMatchFilled(singles([], []), 1)).toBe(false);
+  });
+
+  it("2v2 (2 per side): a half-filled side is not full strength", () => {
+    expect(isMatchFilled(singles(["a", "b"], ["c", "d"]), 2)).toBe(true);
+    expect(isMatchFilled(singles(["a"], ["c", "d"]), 2)).toBe(false);
+    expect(isMatchFilled(singles(["a", "b"], ["c"]), 2)).toBe(false);
+  });
+});
+
+describe("filledMatches", () => {
+  it("returns only the fully-paired matches, preserving order", () => {
+    const draft = [
+      singles(["a"], ["b"]),
+      singles(["c"], []),
+      singles(["d"], ["e"]),
+    ];
+    const out = filledMatches(draft, 1);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(draft[0]);
+    expect(out[1]).toBe(draft[2]);
+  });
+});
+
+describe("allMatchesFilled (the Enable-scoring gate)", () => {
+  it("is FALSE for an empty draft (nothing to score)", () => {
+    expect(allMatchesFilled([], 1)).toBe(false);
+  });
+
+  it("is TRUE when every match is fully paired", () => {
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles(["c"], ["d"])], 1)).toBe(true);
+  });
+
+  it("HARD-BLOCKS: a single unfilled slot anywhere disables the gate", () => {
+    // The just-added empty match (build-as-you-go) keeps the gate shut...
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles([], [])], 1)).toBe(false);
+    // ...as does a half-filled trailing match.
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles(["c"], [])], 1)).toBe(false);
+    // ...and an unfilled match in the MIDDLE (not just the trailing one).
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles([], ["x"]), singles(["c"], ["d"])], 1)).toBe(false);
+  });
+
+  it("2v2: every side must be at full strength", () => {
+    expect(allMatchesFilled([singles(["a", "b"], ["c", "d"])], 2)).toBe(true);
+    expect(allMatchesFilled([singles(["a", "b"], ["c"])], 2)).toBe(false);
+  });
+});

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure, client-safe predicates for the match-setup draft (W-GAMEPAGE-01 §6.1/§7).
+ *
+ * The setup face builds matches one at a time (build-as-you-go) and HARD-BLOCKS
+ * "Enable scoring" until every match is fully paired. The gate is derived, not
+ * snapshotted — it recomputes on every roster edit — so the rule lives here as a
+ * pure function the page and its tests share (no React/tRPC/DB deps).
+ *
+ * A "side" holds exactly `playersPerSide` member ids (1 for singles, 2 for 2v2).
+ * A match is FILLED when both sides are at full strength; an empty or half-filled
+ * slot is an unfinished add, not a quiet drop.
+ */
+
+/** A side-pairing — the only fields the readiness rule needs. */
+export interface MatchSides {
+  a: string[];
+  b: string[];
+}
+
+/** True when both sides carry exactly `playersPerSide` players. */
+export function isMatchFilled(match: MatchSides, playersPerSide: number): boolean {
+  return match.a.length === playersPerSide && match.b.length === playersPerSide;
+}
+
+/** The filled subset — the matches that would actually be created/scored. */
+export function filledMatches<M extends MatchSides>(draft: M[], playersPerSide: number): M[] {
+  return draft.filter((m) => isMatchFilled(m, playersPerSide));
+}
+
+/**
+ * The Enable-scoring gate: at least one match AND every match fully paired. An
+ * empty draft is NOT ready (nothing to score); a draft with any unfilled slot is
+ * NOT ready (the hard block — no silent collapse to the filled count).
+ */
+export function allMatchesFilled(draft: MatchSides[], playersPerSide: number): boolean {
+  return draft.length > 0 && draft.every((m) => isMatchFilled(m, playersPerSide));
+}


### PR DESCRIPTION
Phase (a) of the game-page lifecycle build (`CC_SPEC_W-GAMEPAGE-01a_structural_core.md`, committed in this PR). Restructures the competition match-setup face into labeled zones, replaces the soft collapse-on-incomplete with a hard readiness block, surfaces total points, and removes the redundant roster echo for competition games. Presentational + readiness logic only — **no migrations, no schema, no `games.modifiers`/templates touched**.

Phase 0 was resolved by the user before building (spec §2.5): **DECISION A** — zones are 1/3/4 only, no pre-enable Zone 2 (toggle/reset stay deferred to phase d); **DECISION B** — the hard-block replaces #460's collapse-on-incomplete and removes the pre-create count stepper.

## Per-task

**T1 — Zone grouping (§5)** `1195e5b1`
Re-parent the setup rows into labeled zones: Zone 1 Identity header (shipped) → **SETTINGS** (Matches · Course/Tee · Format·Points) → **OPTIONS** (Handicaps · Modifiers · Rules). New `ZoneHeader` (token-only, dim label + divider). Purely presentational; the global single-open accordion is unchanged.

**T2 — Matches hard-block (§6.1, DECISION B)** `82e97e8c`
- Create/seed/resume all seed exactly **one** empty match (build-as-you-go); removed the "Matches to add" stepper + `matchCount`/`maxMatches`/`crewCount`/`compMatchCount` derivations and the now-dead `Stepper`.
- Enable scoring is **disabled until every match is fully paired** (`allMatchesFilled`) — an empty slot anywhere (trailing, middle, or a just-added match) is an unfinished add, never a silent drop. Removed the `CollapseConfirm` overlay + `confirmCollapse` state + the collapse branch in `attemptReady`.
- Matches row state/summary are `allFilled`-aware ("Finish or remove the empty match" while invalid).

**T3 — Total points available (§6.2)** `85004fe4`
Pipe the valid (filledDraft) match count `page → GameSetupRows → FormatPointsPanel`; show `Total = matches × points-per-match` for match-format games. **Derived, not snapshotted** — tracks matches/per-match live (eye-verified: 10 = 5×2 → 15 = 5×3 → back). `matchCount` is optional, so other surfaces are unaffected.

**T4 — Hide Available players for competitions (§8)** `134f745f`
In a competition the rosters live on the competition face (leaderboard + RostersOverlay), so the read-only echo is redundant — render the row for **standalone games only**; dropped the `TeamsPanel` branch + its now-unused import. `TeamsPanel`/`RostersOverlay` untouched.

**T5 — Tests + verify (§8)** `7076eede`
Extracted the gate predicate into a client-safe pure module (`src/lib/matchDraft.ts`) the page + test share; 7 unit tests cover empty-not-ready / all-filled-ready / hard-block-on-any-unfilled-slot (singles + 2v2). Hardened `e2e/match-play.spec.ts` to assert Enable is **disabled** on the seeded empty match before filling, and refreshed the stale collapse-confirm comments.

## Phase 0 deltas found
None beyond the two pre-resolved flags (the spec captured both: Zone 2 controls aren't on the setup screen → deferred; the hard-block contradicted shipped #460 → replaced it). No spec-vs-code STOP surfaced during the build.

## Verification
- `npx tsc --noEmit` clean · `next lint` clean (no new warnings).
- Vitest: **725 passed** (incl. 7 new `matchDraft` tests).
- Playwright `match-play.spec.ts`: **green** (now also asserts the hard-block disabled state).
- Eye-verified on a real competition game (light + dark): zones render with correct row membership, no Available-players row, Total = 10 (5×2) and updates live, no console errors.

## Follow-up (not in this PR)
After merge, update the W-GAMEPAGE-01 doc's "already shipped vs remaining" delta (housekeeping, per spec §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)