### PR TITLE
W-GAMEPAGE-01 Modifiers: data-driven config-only special-rules panel

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -27,6 +27,9 @@ import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/ma
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { filledMatches, allMatchesFilled } from "@/lib/matchDraft";
+import { GAME_TYPES } from "@/lib/gameTypes";
+import { ModifierCards } from "@/components/games/ModifierCards";
+import { enabledCount, modifiersSummary, type ModifiersMap } from "@/lib/modifiers";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
 /** "07:40" → "7:40 AM". Empty/invalid → "". */
@@ -120,11 +123,16 @@ export default function NewMatchGamePage() {
   // one collapses any other; collapsing a draft editor (matches/handicaps) commits
   // it (persist-on-collapse). The one-open rule physically gates Handicaps: it
   // can't be open while Matches is, so you set matches → collapse → open handicaps.
-  const [openRow, setOpenRow] = useState<"matches" | "handicaps" | "players" | "course" | "config" | null>(null);
+  const [openRow, setOpenRow] = useState<"matches" | "handicaps" | "players" | "course" | "config" | "modifiers" | null>(null);
   // Surfaced when a persist-on-collapse save fails — the draft is kept (edits are
   // never discarded on a transient error), so this offers a retry rather than a
   // silent loss.
   const [collapseError, setCollapseError] = useState(false);
+  // Modifiers draft (golf "special rules" — config-only, W-GAMEPAGE-01 §6.5).
+  // Page-owned so the row persists on collapse like Matches/Handicaps. Seeded
+  // from the game's modifiers whenever the row is CLOSED (never mid-edit — see
+  // the seed effect below).
+  const [modifiersDraft, setModifiersDraft] = useState<ModifiersMap>({});
   // Zone-3 rules note (W-EDITMODAL-01) — "Save & exit" flushes any typed-but-
   // unsaved rules through this handle before navigating (the one field with no
   // collapse event of its own).
@@ -199,6 +207,9 @@ export default function NewMatchGamePage() {
   // both refresh the board after (see refreshAfterMatchCountChange).
   const addMatch = trpc.matches.addMatch.useMutation();
   const removeMatch = trpc.matches.removeMatch.useMutation();
+  // Modifiers (golf "special rules" — config-only, W-GAMEPAGE-01 §6.5). Persisted
+  // via games.update on accordion-collapse; presence-model jsonb (lib/modifiers).
+  const updateModifiers = trpc.games.update.useMutation();
   // Finishing retries (idempotent recompute); a failure stays on the overview
   // and surfaces via the global error toast — loud + retryable, not a silent
   // stall. Score writes go through useScoreSaver (above).
@@ -449,6 +460,15 @@ export default function NewMatchGamePage() {
     setDraft([{ matchNumber: 1, a: [], b: [], handicap: 0 }]);
   }, [screen, draft.length, serverMatches, handicapOf, membersOfSide, sided]);
 
+  // Seed the modifiers draft from the server — but ONLY while the row is closed,
+  // so an in-progress edit is never clobbered. On collapse the row persists +
+  // optimistically updates the game cache, so this re-syncs to the same value
+  // (and picks up any external change while closed). Mirrors the draft seed.
+  useEffect(() => {
+    if (openRow === "modifiers") return;
+    setModifiersDraft(((gameQ.data?.modifiers as ModifiersMap | null) ?? {}));
+  }, [gameQ.data?.modifiers, openRow]);
+
   // After a +1/−1 (or initial create): re-pull the game's matches AND refresh
   // the competition board so "first to XX" / "X of Y" recompute ON SCREEN. The
   // board has no realtime sub (only a 30s poll) and re-seeds competitions.
@@ -628,12 +648,34 @@ export default function NewMatchGamePage() {
     }
   }
 
+  // Modifiers persist-on-collapse: write the draft to games.modifiers, optimistic
+  // on the game cache so the row's resolved/summary lands instantly, then mark the
+  // competition board stale (CLAUDE.md #10 — faceBootstrap is the one that refreshes
+  // the Live face). All-config-valid, so no draft-keep-on-error dance like Matches.
+  async function persistModifiersOnCollapse() {
+    if (!tripId || !gameId) return;
+    const cur = utils.games.getById.getData({ tripId, gameId });
+    if (cur) utils.games.getById.setData({ tripId, gameId }, { ...cur, modifiers: modifiersDraft } as typeof cur);
+    try {
+      await updateModifiers.mutateAsync({ tripId, gameId, modifiers: modifiersDraft });
+      if (competitionId) {
+        utils.games.listByTrip.invalidate({ tripId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+      }
+    } catch {
+      // Re-sync from the server cache on failure (the optimistic write is rolled
+      // back by the next gameQ read; the row stays usable).
+      void gameQ.refetch();
+    }
+  }
+
   // The single entry point for changing which row is open. Leaving a draft editor
   // commits it (covers BOTH collapse paths: tapping the row to close it AND
   // opening another row, since one-at-a-time collapses the current one first).
   function changeOpenRow(next: typeof openRow) {
     if (next === openRow) return;
     if (openRow === "matches" || openRow === "handicaps") void persistDraftOnCollapse();
+    if (openRow === "modifiers") void persistModifiersOnCollapse();
     setOpenRow(next);
   }
   // Accordion header tap: toggle this row (collapsing whatever else was open).
@@ -956,6 +998,14 @@ export default function NewMatchGamePage() {
         const handicapsReady = matchesExist && courseResolved;
         const handicapsState: ChecklistRowState = !handicapsReady ? "unresolved" : anyHandicap ? "resolved" : "acknowledged-empty";
         const handicapsSummary = !matchesExist ? "Set matches first" : !courseResolved ? "Set the course first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
+        // Modifiers (W-GAMEPAGE-01 §6.5) — applicability is data-driven from the
+        // format's gameTypes.ts compatibleModifiers (NOT the deprecated DB column).
+        // Empty → the row is hidden entirely. Check semantics: ≥1 enabled =
+        // resolved (check); applicable-but-none = unresolved (NO check — an optional
+        // row isn't "set" just by being offered).
+        const availableModifiers = GAME_TYPES.find((t) => t.id === gameQ.data?.game_type_id)?.compatibleModifiers ?? [];
+        const modifiersOn = enabledCount(modifiersDraft, availableModifiers);
+        const modifiersState: ChecklistRowState = modifiersOn > 0 ? "resolved" : "unresolved";
         const onSetupChanged = () => {
           void gameQ.refetch();
           if (competitionId) {
@@ -1085,9 +1135,27 @@ export default function NewMatchGamePage() {
               />
             </ChecklistRow>
 
-            {/* Modifiers — acknowledge-only: the toggle targets exist but no
-                modifier has a scoring effect yet, so the row is inert until then. */}
-            <ChecklistRow label="Modifiers" value="None — coming soon" state="acknowledged-empty" />
+            {/* Modifiers (W-GAMEPAGE-01 §6.5) — config-only "special rules" driven
+                by the format's compatibleModifiers (gameTypes.ts). Hidden entirely
+                when the format offers none; otherwise an accordion of toggle cards
+                (+ a hole-count stepper for glorious_holes), persist-on-collapse. */}
+            {availableModifiers.length > 0 && (
+              <ChecklistRow
+                label="Modifiers"
+                value={modifiersSummary(modifiersDraft, availableModifiers)}
+                state={modifiersState}
+                expanded={openRow === "modifiers"}
+                onToggle={() => toggleRow("modifiers")}
+                testId="row-modifiers"
+              >
+                <ModifierCards
+                  available={availableModifiers}
+                  modifiers={modifiersDraft}
+                  onChange={setModifiersDraft}
+                  readOnly={!canEdit}
+                />
+              </ChecklistRow>
+            )}
 
             {/* Rules of the Day — freeform note (W-EDITMODAL-01). Saves on blur;
                 "Save & exit" flushes it via rulesRef. Competition games only. */}

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -8,6 +8,7 @@ import {
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
+import { ModifierCards } from "@/components/games/ModifierCards";
 import type { PointsDistribution } from "@/lib/pointsDistribution";
 import {
   validatePlacement, matchReadout, placementFit, matchFit, deriveMatchCount, type MatchFormat,
@@ -106,14 +107,6 @@ const COMP_FORMATS = [
 export function formatLabel(key: string | null): string | null {
   return COMP_FORMATS.find((f) => f.key === key)?.label ?? null;
 }
-
-/** Display metadata for the golf special-rule keys. Which rules are AVAILABLE
- *  comes from the game type's model (compatibleModifiers); this is just the copy.
- *  Per-rule configurability is deferred — each is on/off for now. */
-const SPECIAL_RULES: Record<string, { label: string; desc: string }> = {
-  moving_tees: { label: "Moving tees", desc: "The trailing team picks the tee box on the next hole." },
-  glorious_holes: { label: "Glorious finishing holes", desc: "The closing holes carry extra weight." },
-};
 
 /** Singles vs doubles for the match readout. Only singles exists today. */
 function matchFormatFor(gameTypeId: string | null): MatchFormat {
@@ -1088,7 +1081,9 @@ function ConfigTab({
       </Field>
 
       {isGolf && availableModifiers.length > 0 && (
-        <SpecialRules available={availableModifiers} modifiers={modifiers} setModifiers={setModifiers} />
+        <Field label="Special rules">
+          <ModifierCards available={availableModifiers} modifiers={modifiers} onChange={setModifiers} readOnly={!canEdit} />
+        </Field>
       )}
 
       <Field label="Competition format">
@@ -1222,72 +1217,6 @@ function DelegationBlock({
         Hand this game&rsquo;s setup and running to one person — they get their own Configuration tab.
       </p>
     </Field>
-  );
-}
-
-/**
- * SPECIAL RULES — golf-only, model-driven optional rules (e.g. moving tees,
- * glorious finishing holes). Which rules appear comes from the game type's
- * `compatibleModifiers`; enabled ones are stored in `games.modifiers` keyed by
- * rule, value = per-rule config (deferred — on/off for now).
- */
-function SpecialRules({
-  available, modifiers, setModifiers,
-}: {
-  available: string[];
-  modifiers: Record<string, Record<string, unknown>>;
-  setModifiers: (m: Record<string, Record<string, unknown>>) => void;
-}) {
-  const toggle = (key: string) => {
-    const next = { ...modifiers };
-    if (next[key]) delete next[key];
-    else next[key] = {};
-    setModifiers(next);
-  };
-  return (
-    <Field label="Special rules">
-      <div className="space-y-1.5">
-        {available.map((key) => {
-          const meta = SPECIAL_RULES[key] ?? { label: key, desc: "" };
-          const on = !!modifiers[key];
-          return (
-            <div
-              key={key}
-              className="flex items-center justify-between gap-3 rounded-lg px-3 py-2.5"
-              style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
-            >
-              <div className="min-w-0">
-                <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>{meta.label}</p>
-                {meta.desc && <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>{meta.desc}</p>}
-              </div>
-              <Switch on={on} onClick={() => toggle(key)} label={meta.label} />
-            </div>
-          );
-        })}
-      </div>
-      <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-        Optional. Fine-tuning each rule comes later — flip it on now to flag it for the day.
-      </p>
-    </Field>
-  );
-}
-
-function Switch({ on, onClick, label }: { on: boolean; onClick: () => void; label: string }) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={on}
-      aria-label={label}
-      onClick={onClick}
-      className="relative h-6 w-10 flex-shrink-0 rounded-full transition-colors"
-      style={{ background: on ? "var(--color-bt-accent)" : "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-    >
-      <span
-        className="absolute top-0.5 h-4 w-4 rounded-full transition-all"
-        style={{ left: on ? "20px" : "2px", background: on ? "var(--color-bt-base)" : "var(--color-bt-text-dim)" }}
-      />
-    </button>
   );
 }
 

--- a/src/components/games/ModifierCards.tsx
+++ b/src/components/games/ModifierCards.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Minus, Plus } from "lucide-react";
+import {
+  modifierDef,
+  isModifierEnabled,
+  gloriousHolesCount,
+  setModifierEnabled,
+  setGloriousHoles,
+  GLORIOUS_HOLES_MIN,
+  GLORIOUS_HOLES_MAX,
+  type ModifiersMap,
+} from "@/lib/modifiers";
+
+/**
+ * ModifierCards — the config-only "special rules" card list (W-GAMEPAGE-01 §6.5).
+ *
+ * Generic over the modifier registry: one card per APPLICABLE key (`available`
+ * comes from the format's `gameTypes.ts` compatibleModifiers — NOT the DB).
+ * Presence-model writes via the pure `lib/modifiers` helpers; **no scoring
+ * effect** — a toggled modifier is recorded, not computed.
+ *
+ * Shared by both setup surfaces (the `match/new` setup row + the post-enable
+ * `GameConfigurationView`). The caller wraps/labels it; this renders just the
+ * cards + the honest "recorded, not auto-scored" caption. Empty `available` →
+ * renders nothing (callers also hide their row entirely).
+ */
+export function ModifierCards({
+  available,
+  modifiers,
+  onChange,
+  readOnly = false,
+}: {
+  available: string[];
+  modifiers: ModifiersMap;
+  onChange: (next: ModifiersMap) => void;
+  readOnly?: boolean;
+}) {
+  if (available.length === 0) return null;
+  return (
+    <div className="space-y-1.5" data-testid="modifier-cards">
+      {available.map((key) => {
+        const def = modifierDef(key);
+        const on = isModifierEnabled(modifiers, key);
+        return (
+          <div
+            key={key}
+            className="rounded-lg px-3 py-2.5"
+            style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+            data-testid={`modifier-card-${key}`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>{def.label}</p>
+                {def.description && (
+                  <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>{def.description}</p>
+                )}
+              </div>
+              <Switch
+                on={on}
+                disabled={readOnly}
+                onClick={() => onChange(setModifierEnabled(modifiers, key, !on))}
+                label={def.label}
+              />
+            </div>
+            {/* Stepper only for checkbox+stepper modifiers, and only once enabled. */}
+            {def.controlType === "checkbox+stepper" && on && (
+              <HoleStepper
+                value={gloriousHolesCount(modifiers)}
+                disabled={readOnly}
+                onChange={(n) => onChange(setGloriousHoles(modifiers, n))}
+              />
+            )}
+          </div>
+        );
+      })}
+      <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        Optional. These are recorded as rules of the day — the app doesn’t auto-score them yet.
+      </p>
+    </div>
+  );
+}
+
+/** Trailing-hole count for glorious finishing holes (the only stepper modifier). */
+function HoleStepper({ value, onChange, disabled }: { value: number; onChange: (n: number) => void; disabled?: boolean }) {
+  return (
+    <div
+      className="mt-2.5 flex items-center justify-between rounded-lg px-3 py-2"
+      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      data-testid="glorious-holes-stepper"
+    >
+      <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        Last <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>{value}</span> hole{value === 1 ? "" : "s"} worth double
+      </span>
+      <div className="flex items-center gap-2">
+        <StepBtn dir="dec" disabled={disabled || value <= GLORIOUS_HOLES_MIN} onClick={() => onChange(value - 1)} />
+        <StepBtn dir="inc" disabled={disabled || value >= GLORIOUS_HOLES_MAX} onClick={() => onChange(value + 1)} />
+      </div>
+    </div>
+  );
+}
+
+function StepBtn({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={dir === "inc" ? "Increase" : "Decrease"}
+      className="flex items-center justify-center disabled:opacity-30"
+      style={{ width: 30, height: 30, borderRadius: 8, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
+    >
+      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
+    </button>
+  );
+}
+
+/** The on/off toggle — the existing checked-state pattern (preserved from the
+ *  shipped SpecialRules panel so both surfaces read identically). */
+function Switch({ on, onClick, label, disabled }: { on: boolean; onClick: () => void; label: string; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      className="relative h-6 w-10 flex-shrink-0 rounded-full transition-colors disabled:opacity-40"
+      style={{ background: on ? "var(--color-bt-accent)" : "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+    >
+      <span
+        className="absolute top-0.5 h-4 w-4 rounded-full transition-all"
+        style={{ left: on ? "20px" : "2px", background: on ? "var(--color-bt-base)" : "var(--color-bt-text-dim)" }}
+      />
+    </button>
+  );
+}

--- a/src/lib/gameTypes.ts
+++ b/src/lib/gameTypes.ts
@@ -155,7 +155,12 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "user_holes",
     resultStrategy: "stroke_total",
     scorecardSchema: strokeSchema,
-    compatibleModifiers: ["glorious_holes"],
+    // ⚠ TESTABILITY VALUES, NOT real-world applicability. Crossed deliberately so each
+    // golf format exercises one Modifiers render branch (hide / checkbox / stepper / both).
+    // Real applicability is different (e.g. glorious_holes doubles a hole's MATCH value, so it
+    // does NOT apply to stroke play). Reconcile to real applicability when modifier scoring
+    // logic is built — see W-GAMEPAGE-01 §6.5. Tracked in DEFERRED.md.
+    compatibleModifiers: ["moving_tees", "glorious_holes"], // BOTH cards branch
     supportsFreeForAll: true,
     supportsSides: false,
     requiresSides: false,
@@ -172,7 +177,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "user_holes",
     resultStrategy: "match_play",
     scorecardSchema: singlesSchema,
-    compatibleModifiers: ["moving_tees", "glorious_holes"],
+    compatibleModifiers: ["moving_tees"], // ⚠ test-matrix value (CHECKBOX-only branch) — see note on gtt_stroke_play
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,
@@ -189,7 +194,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "group_holes",
     resultStrategy: "match_play",
     scorecardSchema: doublesSchema,
-    compatibleModifiers: ["moving_tees", "glorious_holes"],
+    compatibleModifiers: ["glorious_holes"], // ⚠ test-matrix value (STEPPER-only branch) — see note on gtt_stroke_play
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,
@@ -206,7 +211,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "user_holes",
     resultStrategy: "rack_n_stack",
     scorecardSchema: rackSchema,
-    compatibleModifiers: ["moving_tees", "glorious_holes"],
+    compatibleModifiers: [], // ⚠ test-matrix value (HIDE-the-row branch: a golf format with none) — see note on gtt_stroke_play
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,

--- a/src/lib/modifiers.test.ts
+++ b/src/lib/modifiers.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  MODIFIER_REGISTRY,
+  modifierDef,
+  isModifierEnabled,
+  setModifierEnabled,
+  gloriousHolesCount,
+  setGloriousHoles,
+  clampGloriousHoles,
+  enabledCount,
+  modifiersSummary,
+  GLORIOUS_HOLES_DEFAULT,
+  GLORIOUS_HOLES_MIN,
+  GLORIOUS_HOLES_MAX,
+  type ModifiersMap,
+} from "./modifiers";
+import { GAME_TYPES } from "./gameTypes";
+
+// W-GAMEPAGE-01 §6.5 — config-only modifiers. Presence-model jsonb, snake_case
+// keys, applicability from gameTypes.ts (NOT the deprecated DB column). These
+// lock the registry + the crossed test-matrix (Task 0) + the legacy-tolerant
+// read so existing production rows don't break.
+
+describe("registry", () => {
+  it("keys are snake_case with the expected control types", () => {
+    expect(MODIFIER_REGISTRY.moving_tees.controlType).toBe("checkbox");
+    expect(MODIFIER_REGISTRY.glorious_holes.controlType).toBe("checkbox+stepper");
+  });
+  it("modifierDef soft-falls-back for an unknown key (fail soft, not crash)", () => {
+    expect(modifierDef("not_a_real_key")).toEqual({ key: "not_a_real_key", label: "not_a_real_key", description: "", controlType: "checkbox" });
+  });
+});
+
+// The four render branches the crossed test-matrix exercises (Task 0). Maps each
+// golf format's compatibleModifiers (from gameTypes.ts) through the registry to
+// the control types it would render — locking the matrix + registry together.
+describe("render-branch matrix (gameTypes.ts → registry)", () => {
+  const controlsFor = (id: string) =>
+    (GAME_TYPES.find((t) => t.id === id)?.compatibleModifiers ?? []).map((k) => modifierDef(k).controlType);
+
+  it("rack_n_stack → [] (HIDE branch — golf format with none)", () => {
+    expect(controlsFor("gtt_rack_n_stack")).toEqual([]);
+  });
+  it("match_play_singles → [checkbox] (CHECKBOX-only branch)", () => {
+    expect(controlsFor("gtt_match_play_singles")).toEqual(["checkbox"]);
+  });
+  it("match_play_doubles → [checkbox+stepper] (STEPPER-only branch)", () => {
+    expect(controlsFor("gtt_match_play_doubles")).toEqual(["checkbox+stepper"]);
+  });
+  it("stroke_play → [checkbox, checkbox+stepper] (BOTH branch)", () => {
+    expect(controlsFor("gtt_stroke_play")).toEqual(["checkbox", "checkbox+stepper"]);
+  });
+});
+
+describe("presence-model read/write", () => {
+  it("isModifierEnabled: presence = enabled", () => {
+    expect(isModifierEnabled({ moving_tees: {} }, "moving_tees")).toBe(true);
+    expect(isModifierEnabled({}, "moving_tees")).toBe(false);
+  });
+
+  it("setModifierEnabled round-trips, immutably, with correct default value", () => {
+    const base: ModifiersMap = {};
+    const onTees = setModifierEnabled(base, "moving_tees", true);
+    expect(onTees).toEqual({ moving_tees: {} });
+    expect(base).toEqual({}); // immutable
+
+    const onGlorious = setModifierEnabled(base, "glorious_holes", true);
+    expect(onGlorious).toEqual({ glorious_holes: { holes: GLORIOUS_HOLES_DEFAULT } });
+
+    const off = setModifierEnabled(onTees, "moving_tees", false);
+    expect(off).toEqual({}); // absence = disabled
+  });
+});
+
+describe("gloriousHolesCount — legacy-tolerant", () => {
+  it("legacy production shape glorious_holes:{} reads as the default 3", () => {
+    expect(gloriousHolesCount({ glorious_holes: {} })).toBe(GLORIOUS_HOLES_DEFAULT);
+  });
+  it("reads an explicit holes value", () => {
+    expect(gloriousHolesCount({ glorious_holes: { holes: 5 } })).toBe(5);
+  });
+  it("clamps an out-of-range stored value", () => {
+    expect(gloriousHolesCount({ glorious_holes: { holes: 99 } })).toBe(GLORIOUS_HOLES_MAX);
+    expect(gloriousHolesCount({ glorious_holes: { holes: 0 } })).toBe(GLORIOUS_HOLES_MIN);
+  });
+  it("defaults for a disabled key (the value the stepper opens at)", () => {
+    expect(gloriousHolesCount({})).toBe(GLORIOUS_HOLES_DEFAULT);
+  });
+});
+
+describe("setGloriousHoles", () => {
+  it("enables the key and sets a clamped holes value", () => {
+    expect(setGloriousHoles({}, 4)).toEqual({ glorious_holes: { holes: 4 } });
+    expect(setGloriousHoles({}, 99)).toEqual({ glorious_holes: { holes: GLORIOUS_HOLES_MAX } });
+  });
+  it("preserves other modifiers", () => {
+    expect(setGloriousHoles({ moving_tees: {} }, 2)).toEqual({ moving_tees: {}, glorious_holes: { holes: 2 } });
+  });
+});
+
+describe("clampGloriousHoles", () => {
+  it("rounds, bounds, and guards NaN", () => {
+    expect(clampGloriousHoles(3.4)).toBe(3);
+    expect(clampGloriousHoles(-5)).toBe(GLORIOUS_HOLES_MIN);
+    expect(clampGloriousHoles(1000)).toBe(GLORIOUS_HOLES_MAX);
+    expect(clampGloriousHoles(NaN)).toBe(GLORIOUS_HOLES_DEFAULT);
+  });
+});
+
+describe("summary + count (row resolved/unresolved drivers)", () => {
+  const available = ["moving_tees", "glorious_holes"];
+
+  it("none enabled → count 0, 'None added' (row stays unresolved — no false check)", () => {
+    expect(enabledCount({}, available)).toBe(0);
+    expect(modifiersSummary({}, available)).toBe("None added");
+  });
+  it("glorious_holes shows its trailing-hole count", () => {
+    expect(modifiersSummary({ glorious_holes: { holes: 4 } }, available)).toBe("Glorious finishing holes (last 4)");
+  });
+  it("legacy glorious_holes:{} summarizes with the default", () => {
+    expect(modifiersSummary({ glorious_holes: {} }, available)).toBe("Glorious finishing holes (last 3)");
+  });
+  it("multiple enabled join in the available order", () => {
+    expect(enabledCount({ moving_tees: {}, glorious_holes: { holes: 2 } }, available)).toBe(2);
+    expect(modifiersSummary({ moving_tees: {}, glorious_holes: { holes: 2 } }, available)).toBe(
+      "Moving tees · Glorious finishing holes (last 2)"
+    );
+  });
+  it("ignores enabled keys that are not in the applicable set", () => {
+    expect(enabledCount({ some_other: {} }, available)).toBe(0);
+  });
+});

--- a/src/lib/modifiers.ts
+++ b/src/lib/modifiers.ts
@@ -1,0 +1,119 @@
+/**
+ * Modifiers — the config-only "special rules" model (W-GAMEPAGE-01 §6.5).
+ *
+ * A modifier is a structured rule-of-the-day the app RECORDS but does not yet
+ * compute — there is no scoring engine (deferred, `DEFERRED.md`). It is NOT a
+ * broken promise: in the hand-entered-scoring era a toggled modifier flags
+ * "last 3 holes worth double" for the group even though nothing auto-scores it.
+ *
+ * **Presence-model:** a key present in `games.modifiers` = enabled; absence =
+ * disabled. The per-key VALUE holds config (`glorious_holes → { holes: N }`;
+ * `moving_tees → {}`). This module is the single place that knows how each
+ * modifier renders + serializes — but APPLICABILITY (which keys a format offers)
+ * comes from `gameTypes.ts` `compatibleModifiers`, NOT here and NOT the DB
+ * (`game_type_templates.compatible_modifiers` is deprecated — see the Modifiers
+ * Phase-0 resolution, Flag 2).
+ *
+ * **Keys are snake_case** (`moving_tees`, `glorious_holes`) — the values already
+ * stored in `games.modifiers`, `gameTypes.ts`, and live rows. Never camelCase.
+ *
+ * Client-safe (no server/DB deps) so both setup surfaces share it.
+ */
+
+/** The `games.modifiers` jsonb shape: key → per-rule config object. */
+export type ModifiersMap = Record<string, Record<string, unknown>>;
+
+export type ModifierControl = "checkbox" | "checkbox+stepper";
+
+export interface ModifierDef {
+  key: string;
+  label: string;
+  /** Honest, config-only copy — must not imply the app auto-enforces the rule. */
+  description: string;
+  controlType: ModifierControl;
+}
+
+export const GLORIOUS_HOLES_DEFAULT = 3;
+export const GLORIOUS_HOLES_MIN = 1;
+export const GLORIOUS_HOLES_MAX = 9;
+
+export const MODIFIER_REGISTRY: Record<string, ModifierDef> = {
+  moving_tees: {
+    key: "moving_tees",
+    label: "Moving tees",
+    description: "Trailing side picks the next tee box. Recorded as a rule of the day — not auto-scored yet.",
+    controlType: "checkbox",
+  },
+  glorious_holes: {
+    key: "glorious_holes",
+    label: "Glorious finishing holes",
+    description: "The closing holes carry double. Recorded as a rule of the day — not auto-scored yet.",
+    controlType: "checkbox+stepper",
+  },
+};
+
+/** Metadata for a key, with a soft fallback for an unknown key (fail soft). */
+export function modifierDef(key: string): ModifierDef {
+  return MODIFIER_REGISTRY[key] ?? { key, label: key, description: "", controlType: "checkbox" };
+}
+
+/** Clamp a trailing-hole count into the sane range (rounds, guards NaN → default). */
+export function clampGloriousHoles(n: number): number {
+  if (!Number.isFinite(n)) return GLORIOUS_HOLES_DEFAULT;
+  return Math.max(GLORIOUS_HOLES_MIN, Math.min(GLORIOUS_HOLES_MAX, Math.round(n)));
+}
+
+/** Presence = enabled. */
+export function isModifierEnabled(modifiers: ModifiersMap, key: string): boolean {
+  return !!modifiers[key];
+}
+
+/**
+ * Trailing-hole count for glorious_holes — **legacy-tolerant**: an enabled key
+ * with no `holes` (the production `glorious_holes: {}` shape) reads as the
+ * default 3, so existing rows don't break. Returns the default for a disabled
+ * key too (the value the stepper opens at on first enable).
+ */
+export function gloriousHolesCount(modifiers: ModifiersMap): number {
+  const v = modifiers["glorious_holes"];
+  const h = v && typeof (v as { holes?: unknown }).holes === "number" ? (v as { holes: number }).holes : NaN;
+  return Number.isFinite(h) ? clampGloriousHoles(h) : GLORIOUS_HOLES_DEFAULT;
+}
+
+/** The jsonb value to store under a key when enabling it (its default config). */
+function defaultValueFor(key: string): Record<string, unknown> {
+  return key === "glorious_holes" ? { holes: GLORIOUS_HOLES_DEFAULT } : {};
+}
+
+/** Enable/disable a key (presence-model), returning a NEW map. */
+export function setModifierEnabled(modifiers: ModifiersMap, key: string, on: boolean): ModifiersMap {
+  const next = { ...modifiers };
+  if (on) next[key] = defaultValueFor(key);
+  else delete next[key];
+  return next;
+}
+
+/** Set glorious_holes' trailing-hole count (clamped); enables the key if absent. */
+export function setGloriousHoles(modifiers: ModifiersMap, holes: number): ModifiersMap {
+  return { ...modifiers, glorious_holes: { holes: clampGloriousHoles(holes) } };
+}
+
+/** Count of enabled modifiers among the applicable set. */
+export function enabledCount(modifiers: ModifiersMap, available: string[]): number {
+  return available.filter((k) => isModifierEnabled(modifiers, k)).length;
+}
+
+/**
+ * Collapsed-row summary. None enabled → "None added" (the row is NOT resolved —
+ * an optional row isn't "set" just by being applicable). ≥1 → a short list,
+ * e.g. "Glorious finishing holes (last 3) · Moving tees".
+ */
+export function modifiersSummary(modifiers: ModifiersMap, available: string[]): string {
+  const on = available.filter((k) => isModifierEnabled(modifiers, k));
+  if (on.length === 0) return "None added";
+  return on
+    .map((k) =>
+      k === "glorious_holes" ? `${modifierDef(k).label} (last ${gloriousHolesCount(modifiers)})` : modifierDef(k).label
+    )
+    .join(" · ");
+}


### PR DESCRIPTION
The Modifiers slice of W-GAMEPAGE-01 (§6.5), per the Phase-0 amendment. **Config-only** — a toggled modifier is recorded as a structured rule of the day; there is **no scoring engine** (deferred). Phase 0 found most of this already exists, so this is largely an extraction + relocation, not a fresh build.

## Phase 0 resolutions applied (amendment)
- **No migration** — `games.modifiers` jsonb already exists (it's written in production).
- **snake_case keys** (`moving_tees` / `glorious_holes`) everywhere — the original spec's camelCase was invented and would lookup-miss the DB, `gameTypes.ts`, and live rows.
- **Applicability from `gameTypes.ts` (code), not the DB** — the deprecated `compatible_modifiers` column is not read/written/reverted (W-PERF-01 moved format defs into code to avoid the 20–30s blank-dialog stall).
- **Presence-model jsonb, legacy-tolerant** — key present = enabled; `glorious_holes → {holes:N}`, `moving_tees → {}`; a legacy `glorious_holes:{}` reads as enabled-with-default-3. No `games.update` change needed.

## Per-task
**Task 0** `4a36acad` — Crossed `compatibleModifiers` test-matrix so each golf format exercises one render branch (rack=hide / singles=checkbox / doubles=stepper / stroke=both), with a **loud ⚠ flag** that these are testability values, not real applicability (reconcile when scoring logic lands).

**Task 1 — DROPPED** — column already exists.

**Task 2** `9ea9a6f6` — Extracted the registry + panel out of `CompetitionGamesPanel` into shared, client-safe modules (the `matchDraft.ts` precedent): `src/lib/modifiers.ts` (snake_case registry + pure presence-model read/write, legacy-tolerant `gloriousHolesCount`, clamp, summary) and `src/components/games/ModifierCards.tsx` (checkbox per key + hole-count stepper for `glorious_holes`, honest config-only copy). `CompetitionGamesPanel` now consumes `<ModifierCards>`; deleted the local `SPECIAL_RULES`/`SpecialRules`/`Switch` (audit-before-delete — `Switch` had no other consumer).

**Tasks 3 & 4** `e39095db` — Replaced the inert "None — coming soon" stub on `match/new` with a real accordion row (persist-on-collapse + optimistic `games.update` + `faceBootstrap` invalidate). Applicability data-driven; **empty → row hidden**. Check semantics fixed: ≥1 enabled = resolved (check) + summary; applicable-but-none = unresolved (no false check); none applicable = hidden.

**Task 5** `2b8de428` — 20 matrix-driven unit fixtures (`src/lib/modifiers.test.ts`): registry control types, the four render branches mapped through the registry, presence-model round-trips, legacy `{}` tolerance + clamp, summary/count.

## Copy
On-state copy is honest and config-only ("recorded as a rule of the day — not auto-scored yet") — **final voice pending Zach** (§7 guardrail).

## Verification
- `tsc --noEmit` clean · `next lint` clean (no new warnings).
- Vitest **745 passed** (+20). Critical-path `match-play.spec.ts` green.
- Eye-verified on real competition games (light + dark): singles checkbox-only · doubles `glorious_holes` stepper (default 3) · enable + hole-count (set 5) persists across collapse/reopen **and reload** (`{glorious_holes:{holes:5}}` in `games.modifiers`) · disable removes the key · no console errors. (All test games restored to `{}`.)

## Doc reconciliation owed (next round, not this PR)
`W-GAMEPAGE-01_game_page_lifecycle.md` §6.5/§15 still carry the old camelCase keys + `{enabled,holes}` shape — patch to snake_case + presence-model. Log the real-vs-testability applicability reconciliation (and the moving-tees moving-scale generalization) in `DEFERRED.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
