### PR TITLE
W-GAMEPAGE-01 (c): styled confirm before removing a scored match (A-only)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus, Trash2 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
@@ -23,7 +23,8 @@ import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/Game
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
-import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
+import { buildDecided, matchState, strokeHoles, matchHasScores, type HoleResult } from "@/lib/matchPlay";
+import { DangerConfirmModal } from "@/components/DangerZone";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { filledMatches, allMatchesFilled } from "@/lib/matchDraft";
@@ -1675,6 +1676,12 @@ function Overview({
   onRemoveMatch: (matchId: string) => void;
   mutatingCount: boolean;
 }) {
+  // Destructive-edit guard (W-GAMEPAGE-01 §11): removing a SCORED match clears its
+  // entered scores, so it confirms first via the shared DangerConfirmModal (the one
+  // in-app confirm vocabulary, #433 — replaces the old window.confirm). An UNSCORED
+  // match removes with no friction. Holds the pending match while the modal is open.
+  // (Declared before the early return below — hooks must run every render.)
+  const [pendingRemoval, setPendingRemoval] = useState<{ matchId: string; label: string } | null>(null);
   if (!published) return <MemberNotReady gameName={gameName} />;
   const decideds = groups.map(decidedFor);
   const allOver = groups.length > 0 && decideds.every((d) => matchState(d, holeCount).over);
@@ -1712,15 +1719,15 @@ function Overview({
                 onClick={() => onOpenMatch(g.matchId)}
               />
             </div>
-            {/* −1: remove this match (live count). Warn first if it has scores —
-                never silently drop entry. Down to the minimum of 1. */}
+            {/* −1: remove this match (live count). A SCORED match confirms first
+                (the modal below) — never silently drop entry; an unscored one goes
+                straight through. Down to the minimum of 1. */}
             {canEdit && !complete && groups.length > 1 && (
               <button
                 type="button"
                 onClick={() => {
-                  const scored = decideds[i].length > 0;
-                  if (scored && !window.confirm(`Match ${i + 1} has scores entered. Remove it and discard them?`)) return;
-                  onRemoveMatch(g.matchId);
+                  if (matchHasScores(decideds[i])) setPendingRemoval({ matchId: g.matchId, label: `Match ${i + 1}` });
+                  else onRemoveMatch(g.matchId);
                 }}
                 disabled={mutatingCount}
                 title="Remove match"
@@ -1776,6 +1783,27 @@ function Overview({
         <button onClick={onFinish} disabled={finishing} className="mt-5 w-full disabled:opacity-40" style={{ height: 50, borderRadius: 12, background: "var(--color-bt-warning)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
           {finishing ? "Re-locking…" : "Re-lock result"}
         </button>
+      )}
+
+      {/* Scored-match removal confirm (W-GAMEPAGE-01 §11). Cancel preserves the
+          scores; confirm fires removeMatch, which clears the orphaned entries
+          server-side. Copy is honest placeholder — final voice pending Zach. */}
+      {pendingRemoval && (
+        <DangerConfirmModal
+          tone="danger"
+          icon={<Trash2 size={18} />}
+          title={`Remove ${pendingRemoval.label}?`}
+          body={`${pendingRemoval.label} has scores entered — removing it discards them. This can't be undone.`}
+          confirmLabel="Remove & discard"
+          pendingLabel="Removing…"
+          isPending={mutatingCount}
+          testId="confirm-remove-scored-match"
+          onCancel={() => setPendingRemoval(null)}
+          onConfirm={() => {
+            onRemoveMatch(pendingRemoval.matchId);
+            setPendingRemoval(null);
+          }}
+        />
       )}
     </div>
   );

--- a/src/lib/matchPlay.test.ts
+++ b/src/lib/matchPlay.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { strokeHoles, buildDecided, matchState, type HoleResult } from "./matchPlay";
+import { strokeHoles, buildDecided, matchState, matchHasScores, type HoleResult } from "./matchPlay";
+
+// W-GAMEPAGE-01 §11 — the destructive-edit guard's "scores exist" signal. A hole
+// is decided only when both sides' grosses are in, so a non-empty decided list IS
+// "this match has entered scores" (removing it must confirm first).
+describe("matchHasScores", () => {
+  it("is false for a match with no decided holes (nothing to lose → no confirm)", () => {
+    expect(matchHasScores([])).toBe(false);
+  });
+  it("is true once any hole is decided (scores entered → confirm before removal)", () => {
+    expect(matchHasScores(["W"])).toBe(true);
+    expect(matchHasScores(["H", "L", "W"])).toBe(true);
+  });
+});
 
 describe("strokeHoles", () => {
   it("returns nothing for n <= 0", () => {

--- a/src/lib/matchPlay.ts
+++ b/src/lib/matchPlay.ts
@@ -9,6 +9,17 @@
 
 export type HoleResult = "W" | "L" | "H"; // A vs B on NET; decided holes only, play order
 
+/**
+ * Has this match had any scores entered? (W-GAMEPAGE-01 §11.) A hole is decided
+ * only when both sides' grosses are in (see `buildDecided`), so a non-empty
+ * `decided` list IS the "scores exist" signal the destructive-edit guard keys on
+ * — removing a scored match clears entered scores, so it must confirm first.
+ * Pure + named so the guard and its test share one definition.
+ */
+export function matchHasScores(decided: HoleResult[]): boolean {
+  return decided.length > 0;
+}
+
 export interface MatchState {
   thru: number; // decided holes counted toward the official result
   diff: number; // + = A up, − = B up (frozen at close-out)


### PR DESCRIPTION
W-GAMEPAGE-01 phase (c), scope **(A)-only** per the Phase 0 decision. Point-of-action protection against score loss when removing a **scored match**.

## Phase 0 reshaped the build (reported + decided before coding)
The spec assumed a guard needed building. Reality on `main`:
- **`games.modifiers`-style guard already existed** — the overview `−1` (remove-match) control was *already* guarded, but by a native `window.confirm` (a standing violation of the #433 "no `window.confirm` anywhere" rule).
- **`removeMatch` already clears scores** server-side (`score_entries` + `game_results` for the removed sides). So (c) **gates an existing clear**, it doesn't add one. No server change.
- **`score_entries` has no `match_id`** — "match has scores" is derived from the match's decided holes (client) / side-keyed rows (server).
- The **player-removal** scored-orphan path (`assignPlayer`/`setPairings` don't clear scores) is only reachable through the **un-built (d) settings-lock gap** → filed as [#470](https://github.com/zgrether/buddytrip/issues/470) for (d), not built here (decision: **(A)-only, file (B)**).

The intended asymmetry (deliberate): course change **freezes** on scores (`applyCourse`, hard block — unchanged); match removal **warns-and-clears** (soft — dropping a player mid-event is a real need). Same goal, two correct strengths.

## Per-task
**Task 1** `feat(scores): canonical matchHasScores predicate` — pure `matchHasScores(decided)` in `matchPlay.ts` (a match-play hole is decided only when both grosses are in → non-empty decided list = "has scores"). +2 unit tests. (Did **not** force-merge with `applyCourse`'s game-scope server count — different scope/side.)

**Task 2** `feat(game-edit): styled confirm before removing a scored match` — replace the `window.confirm` on the overview `−1` with the shared `DangerConfirmModal` (danger tone). Scored match → confirm; unscored → frictionless. On confirm the unchanged `removeMatch` runs (clears orphaned scores). Copy is honest placeholder — **final voice pending Zach**.

## Verification
- `tsc --noEmit` clean · `next lint` clean.
- Vitest: `matchPlay`/`matchDraft` green (+2). Critical-path `match-play.spec.ts` green (no regression).
- **Eye-verified on a real scored 3-match game** (light + dark): the `−1` on a scored match opens the danger modal with correct copy; **Cancel preserves the scores (DB-confirmed: 36 entries, 3 matches untouched)**; tokens resolve in both themes; no console errors.

## Testing-scope note (transparent)
No bespoke multi-match E2E was added: (A) is a client-gate restyle on an already-reachable, already-guarded path whose clear (`removeMatch`) is unchanged and the gate predicate is unit-tested + the modal eye-verified. A dedicated spec needs a 2+-match scored game (the critical-path spec is single-match) — disproportionate scaffolding for a confirm-restyle, the kind of per-screen coverage CLAUDE.md defers "as regressions warrant." Happy to add it if you'd prefer it merge-gated.

## Flagged for (d)
[#470](https://github.com/zgrether/buddytrip/issues/470) — silent score-orphan on `assignPlayer`/`setPairings` (player path), coupled to (d)'s settings-lock model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)