### PR TITLE
W-GAMEPAGE-01 (b): course-flow punch-list — manual-entry timing, back-9 tee inherit, dedup

### DIFF
--- a/src/components/games/course/CourseRowContent.tsx
+++ b/src/components/games/course/CourseRowContent.tsx
@@ -44,6 +44,18 @@ export function CourseRowContent({
   const frontName = (frontQ.data?.name as string | undefined) ?? "Front nine";
   const backName = (backQ.data?.name as string | undefined) ?? "Back nine";
 
+  // Back-nine tee inheritance fallback (pin #3). The composed tee NAME is the
+  // front's (setBackNine), but the back-9 yardages come from a same-named tee on
+  // the back course — and when the back course has no tee by that name, its FIRST
+  // tee was used instead. Surface that so the inherited name isn't silently
+  // mismatched. Derived from the snapshot's tee name vs the back course's tees.
+  const appliedTeeName = ((game.scorecard_schema as { units?: { metadata?: { tee?: { name?: string } } } } | null)
+    ?.units?.metadata?.tee?.name ?? "").trim();
+  const backTees = ((backQ.data?.tee_sets as { name?: string }[] | undefined) ?? []);
+  const backTeeFallback =
+    !!backId && !!appliedTeeName && backTees.length > 0 &&
+    !backTees.some((t) => (t.name ?? "").trim() === appliedTeeName);
+
   // Swap/change sub-views (only meaningful in the resolved state).
   const [view, setView] = useState<"default" | "swapBack">("default");
 
@@ -94,6 +106,11 @@ export function CourseRowContent({
         <div className="flex flex-col gap-2">
           <NineSummary label="Front nine" name={frontName} />
           <NineSummary label="Back nine" name={backName} />
+          {backTeeFallback && (
+            <p className="px-1 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }} data-testid="back-tee-fallback">
+              {backName} has no {appliedTeeName} tee — its first tee’s yardages are used for the back nine.
+            </p>
+          )}
         </div>
       ) : (
         <NineSummary label="Course" name={frontName} />

--- a/src/components/games/course/CourseSearchPanel.tsx
+++ b/src/components/games/course/CourseSearchPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Search, AlertTriangle, PencilLine, ChevronRight } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { searchCourses, teeColor, type CourseSummary } from "@/lib/courseService";
+import { manualEntryVisible, dedupeApiCourses } from "@/lib/courseSearch";
 import type { RecentCourse } from "./CoursePicker";
 
 /**
@@ -87,6 +88,12 @@ export function CourseSearchPanel({
   const local = nine((localSearch.data as RecentCourse[]) ?? []);
   const recents = nine((recent.data as RecentCourse[]) ?? []);
   const showResults = query.trim().length >= 2;
+  // Dedup API results against the user's SAVED courses by name (§10 stage 3): a
+  // course already saved shows in the local list above, so don't double-list it.
+  const apiDeduped = useMemo(
+    () => dedupeApiCourses(apiResults, [...local, ...recents].map((c) => c.name)),
+    [apiResults, local, recents]
+  );
   const courseSub = useMemo(() => (c: RecentCourse) => {
     const par = (c.par ?? []).reduce<number>((a, p) => a + p, 0);
     return [c.location, par ? `Par ${par}` : "", `${c.hole_count} holes`].filter(Boolean).join(" · ");
@@ -162,12 +169,18 @@ export function CourseSearchPanel({
           {apiSearched && (
             <div className="flex flex-col gap-2">
               <p className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>From the course database</p>
-              {apiResults.length === 0 ? (
-                <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>No matches in the database.</p>
+              {apiDeduped.length === 0 ? (
+                // Empty (§10 / pin #4): no dead end — the manual-entry button
+                // surfaces directly below (gated on apiSearched). Distinguish a
+                // truly-empty return from "all matches already saved above". Copy
+                // is honest placeholder; final voice pending Zach.
+                <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+                  {apiResults.length === 0 ? "No courses found — add it manually below." : "Everything matching is already in your courses above."}
+                </p>
               ) : (
                 // Picking an API result NAVIGATES to the entry page (it needs a pull
                 // + review before it becomes a saved course).
-                apiResults.map((c) => <PickRow key={c.id} name={c.name} sub={c.location} onClick={() => router.push(entryHref(c.id))} />)
+                apiDeduped.map((c) => <PickRow key={c.id} name={c.name} sub={c.location} onClick={() => router.push(entryHref(c.id))} />)
               )}
             </div>
           )}
@@ -180,15 +193,22 @@ export function CourseSearchPanel({
         </div>
       )}
 
-      <button
-        onClick={() => router.push(entryHref())}
-        data-testid="course-add-manually"
-        className="flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3"
-        style={{ borderColor: "var(--color-bt-accent-border)", borderStyle: "dashed", color: "var(--color-bt-accent)", background: "transparent" }}
-      >
-        <PencilLine size={16} />
-        <span style={{ fontSize: 14, fontWeight: 600 }}>{back ? "Add a 9-hole course manually" : "Add course manually"}</span>
-      </button>
+      {/* Manual entry timing (§10 / pin #4): FRONT mode gates this behind the
+          full-database search — hidden on recents + while live-filtering, shown
+          only once the user has searched (incl. an EMPTY result, so a no-match
+          query still has a path forward). BACK mode has no API stage (a back nine
+          is a saved/manual 9-holer), so the button stays available throughout. */}
+      {manualEntryVisible({ back, apiSearched }) && (
+        <button
+          onClick={() => router.push(entryHref())}
+          data-testid="course-add-manually"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-3"
+          style={{ borderColor: "var(--color-bt-accent-border)", borderStyle: "dashed", color: "var(--color-bt-accent)", background: "transparent" }}
+        >
+          <PencilLine size={16} />
+          <span style={{ fontSize: 14, fontWeight: 600 }}>{back ? "Add a 9-hole course manually" : "Add course manually"}</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/games/course/CourseSearchPanel.tsx
+++ b/src/components/games/course/CourseSearchPanel.tsx
@@ -70,8 +70,11 @@ export function CourseSearchPanel({
     setApiSearching(false);
   }
 
-  // Select a SAVED course: one tee → apply; many → expand the tee chooser.
+  // Select a SAVED course. FRONT: one tee → apply; many → tee chooser. BACK: the
+  // back nine INHERITS the front's tee (pin #3), so never prompt — apply with no
+  // teeName and let setBackNine resolve it (match front's tee, fall back to first).
   function selectSaved(c: RecentCourse) {
+    if (back) { onApply({ id: c.id, name: c.name }); return; }
     const tees = c.tee_sets ?? [];
     if (tees.length <= 1) { onApply({ id: c.id, name: c.name, teeName: tees[0]?.name?.trim() || undefined }); return; }
     setTeePickFor(c);

--- a/src/lib/courseSearch.test.ts
+++ b/src/lib/courseSearch.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { manualEntryVisible, dedupeApiCourses, normalizeCourseName } from "./courseSearch";
+
+// W-GAMEPAGE-01 §10 — course-search flow. The manual-entry timing (pin #4) and
+// the API-vs-local dedup (stage 3) are the punch-list items this phase closes.
+
+describe("manualEntryVisible (pin #4 timing)", () => {
+  it("FRONT mode: hidden until the full-DB search has run", () => {
+    expect(manualEntryVisible({ back: false, apiSearched: false })).toBe(false); // recents / live-filter
+    expect(manualEntryVisible({ back: false, apiSearched: true })).toBe(true); // after enter (incl. empty)
+  });
+  it("BACK mode: always visible — no API stage to gate behind", () => {
+    expect(manualEntryVisible({ back: true, apiSearched: false })).toBe(true);
+    expect(manualEntryVisible({ back: true, apiSearched: true })).toBe(true);
+  });
+});
+
+describe("dedupeApiCourses (stage 3 — vs saved)", () => {
+  const api = [
+    { id: "p1", name: "Pebble Beach" },
+    { id: "p2", name: "Spyglass Hill" },
+    { id: "p3", name: "  pebble beach  " }, // dupe by normalized name, different casing/space
+  ];
+
+  it("drops API results whose name matches a saved course (case/space-insensitive)", () => {
+    const out = dedupeApiCourses(api, ["PEBBLE BEACH"]);
+    expect(out.map((c) => c.id)).toEqual(["p2"]); // both Pebble variants dropped
+  });
+  it("keeps everything when nothing is saved", () => {
+    expect(dedupeApiCourses(api, [])).toHaveLength(3);
+  });
+  it("empty API → empty out", () => {
+    expect(dedupeApiCourses([], ["Anything"])).toEqual([]);
+  });
+});
+
+describe("normalizeCourseName", () => {
+  it("trims + lowercases for cross-source (API id ≠ saved id) matching", () => {
+    expect(normalizeCourseName("  Augusta National  ")).toBe("augusta national");
+  });
+});

--- a/src/lib/courseSearch.ts
+++ b/src/lib/courseSearch.ts
@@ -1,0 +1,33 @@
+/**
+ * Course-search flow helpers (W-GAMEPAGE-01 §10) — pure, client-safe, so the
+ * picker and its tests share one definition. No React/tRPC/DB deps.
+ */
+
+/** Normalize a course name for cross-source matching (API id ≠ saved DB id, so
+ *  dedup/compare is name-keyed). */
+export function normalizeCourseName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/**
+ * Manual-entry button visibility (§10 / pin #4).
+ * - FRONT mode gates it behind the full-database search: hidden on recents +
+ *   while live-filtering, shown only once `apiSearched` (incl. an EMPTY result,
+ *   so a no-match query still has a path forward).
+ * - BACK mode has no API stage (a back nine is a saved/manual 9-holer), so the
+ *   button stays available throughout.
+ */
+export function manualEntryVisible(opts: { back: boolean; apiSearched: boolean }): boolean {
+  return opts.back || opts.apiSearched;
+}
+
+/**
+ * Dedup API search results against the user's SAVED courses by normalized name
+ * (§10 stage 3) — a saved course already shows in the local list, so it must not
+ * double-list under "From the course database".
+ */
+export function dedupeApiCourses<T extends { name: string }>(api: T[], savedNames: Iterable<string>): T[] {
+  const set = new Set<string>();
+  for (const n of savedNames) set.add(normalizeCourseName(n));
+  return api.filter((c) => !set.has(normalizeCourseName(c.name)));
+}

--- a/src/server/routers/games.9hole.test.ts
+++ b/src/server/routers/games.9hole.test.ts
@@ -122,4 +122,44 @@ describe("games.setBackNine — indexed two-nines compose (W-9HOLE-01)", () => {
       ctx.caller().games.setBackNine({ tripId, gameId: g.id, backCourseId: backId })
     ).rejects.toThrow();
   });
+
+  // W-GAMEPAGE-01 pin #3 — the back nine INHERITS the front's tee. The composed
+  // tee NAME is always the front's; the back-9 YARDAGE comes from the same-named
+  // tee on the back course, falling back to the back's first tee when absent.
+  it("back-nine tee inherits the front's tee name; falls back to the back's first tee when absent", async () => {
+    const teeYards = (g: { scorecard_schema: unknown }) =>
+      (g.scorecard_schema as { units: { metadata: { tee: { name: string; yards: number[] } } } }).units.metadata.tee;
+
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Tee inherit" });
+    const front = await ctx.caller().courses.create({
+      name: `TF ${Date.now()}`, holeCount: 9, par: par9, handicapIndex: fIdx, hasStrokeIndex: true,
+      teeSets: [{ name: "White", yards: Array(9).fill(350) }], source: "manual",
+    });
+    createdCourses.push(front.id as string);
+    await ctx.caller().games.applyCourse({ tripId, gameId: g.id, courseId: front.id }); // front tee = White
+
+    // INHERIT-MATCH: back course lists Blue FIRST, then White (distinct yards). With
+    // no explicit tee, the back-9 yards must come from White (inherit) — NOT Blue (first).
+    const backMatch = await ctx.caller().courses.create({
+      name: `TBM ${Date.now()}`, holeCount: 9, par: par9, handicapIndex: bIdx, hasStrokeIndex: true,
+      teeSets: [{ name: "Blue", yards: Array(9).fill(500) }, { name: "White", yards: Array(9).fill(300) }], source: "manual",
+    });
+    createdCourses.push(backMatch.id as string);
+    await ctx.caller().games.setBackNine({ tripId, gameId: g.id, backCourseId: backMatch.id });
+    let tee = teeYards(await ctx.caller().games.getById({ tripId, gameId: g.id }));
+    expect(tee.name).toBe("White"); // composed name = the front's
+    expect(tee.yards.slice(9)).toEqual(Array(9).fill(300)); // inherited White on the back, not Blue (first)
+
+    // FALLBACK: swap to a back with NO White (only Gold). Back-9 yards fall back to
+    // the first tee (Gold); the composed name still reads the front's White.
+    const backNoMatch = await ctx.caller().courses.create({
+      name: `TBN ${Date.now()}`, holeCount: 9, par: par9, handicapIndex: b2Idx, hasStrokeIndex: true,
+      teeSets: [{ name: "Gold", yards: Array(9).fill(411) }], source: "manual",
+    });
+    createdCourses.push(backNoMatch.id as string);
+    await ctx.caller().games.setBackNine({ tripId, gameId: g.id, backCourseId: backNoMatch.id });
+    tee = teeYards(await ctx.caller().games.getById({ tripId, gameId: g.id }));
+    expect(tee.name).toBe("White"); // still the front's name
+    expect(tee.yards.slice(9)).toEqual(Array(9).fill(411)); // fell back to Gold (the back's first tee)
+  });
 });

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -411,7 +411,17 @@ export const gamesRouter = router({
       }
 
       const backTees = (back.tee_sets as SnapshotTee[] | null) ?? [];
-      const backTee = (input.backTeeSetName ? backTees.find((t) => t.name === input.backTeeSetName) : undefined) ?? backTees[0] ?? null;
+      // Back-nine tee INHERITS the front's tee (W-GAMEPAGE-01 pin #3): match the
+      // front's applied tee NAME on the back course so the back-9 yardages come
+      // from the same-named tee; fall back to the back's first tee when that name
+      // is absent (the UI surfaces the fallback). An explicit backTeeSetName (a
+      // deliberate override) still wins. The composed tee NAME stays the front's
+      // (see composedTee below) regardless — this only picks the back-9 yards.
+      const frontTeeName = frontMeta.tee?.name?.trim();
+      const backTee =
+        (input.backTeeSetName ? backTees.find((t) => t.name === input.backTeeSetName) : undefined) ??
+        (frontTeeName ? backTees.find((t) => (t.name ?? "").trim() === frontTeeName) : undefined) ??
+        backTees[0] ?? null;
 
       // Recover the FRONT nine's ORIGINAL 1..9 data from the snapshot. On the
       // first compose the schema IS a 9-hole front (index already 1..9). On a


### PR DESCRIPTION
W-GAMEPAGE-01 phase (b) — the §10 course-flow remnant. Finishing touches on the shipped staged search (#464) + 9-hole compose (#465/#466); **the picker, API integration, and compose are untouched.** Closes the Settings spine (§6.3).

## Phase 0 delta (vs the "~90% / pin #4 only" estimate)
Close, but three real items, not one: **pin #4** (primary), a **missing API-vs-local dedup** (§10 stage 3), and **pin #3 genuinely unresolved** (the back nine used its *own* tee, not the front's). Per-stage walk reported in Phase 0; no #467 regression found.

## Per-task
**Pin #4 — manual-entry timing** `8ccee817`
"+ Add course manually" was rendered *unconditionally* (shown on recents + while typing). Now: **hidden** during recents + live-filter, **shown only after the full-database search runs — including an empty return** (so a no-match query still has a path forward). Front-mode gates on `apiSearched`; **back mode keeps it visible** (no API stage — a back nine is a saved/manual 9-holer). Empty-API copy points at the fallback.

**§10 stage 3 — dedup** `8ccee817`
API results are deduped against saved courses by normalized name (API id ≠ saved DB id), so a saved course no longer double-lists under "From the course database" ("…already in your courses above" when all matches are saved).

**Pin #3 → (b): back-nine inherits the front's tee** `2ebd5410`
The back nine now inherits the front's tee instead of prompting for its own. `setBackNine` matches the front's applied tee **name** on the back course for the back-9 yardages, **falling back to the back's first tee when that name is absent** — and the UI **surfaces that fallback** (a note, so the inherited name isn't a silent mismatch). The composed tee name stays the front's. The back-mode picker no longer prompts for a tee.

Pure helpers extracted to `src/lib/courseSearch.ts` (`manualEntryVisible`, `dedupeApiCourses`) — shared with the unit test (matchDraft/modifiers precedent).

## Verification
- `tsc --noEmit` clean · `next lint` clean.
- Vitest: 6 new `courseSearch` unit tests; `games.9hole.test.ts` extended (+1) — **inherit-match** uses the same-named back tee's yards, **no-match** falls back to first (name stays front's); all 7 pass. Critical-path `match-play.spec` green.
- **Eye-verified on real data (light + dark):** manual button absent on recents + while typing, present after an empty search ("No courses found — add it manually below."); pin #3 staged on **Split Test 9 (White) + Peninsula Cypress (no White)** → note renders "…has no White tee — its first tee's yardages are used for the back nine." Game restored to no-course after. No console errors.

## Copy
Empty-state + fallback copy are honest placeholders — **final voice pending Zach**.

**After this, the Settings spine (Matches · Points · Course) is complete.** Only (d) — surface-2 + back-stack + `GameConfigurationView` + #470 — remains (the W-BACKNAV-01 session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)