### PR TITLE
W-GAMEPAGE visual pass P-A: row restyle (icon + badge + 2 states + title/subtitle)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Flag, GripVertical, Plus, Minus, Trash2, Swords, SlidersHorizontal, Sparkles, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
@@ -30,7 +30,7 @@ import { effectiveStrokes } from "@/lib/handicap";
 import { filledMatches, allMatchesFilled } from "@/lib/matchDraft";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
-import { enabledCount, modifiersSummary, type ModifiersMap } from "@/lib/modifiers";
+import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
 import type { Participant, ScoreValues } from "@/components/games/types";
 
 /** "07:40" → "7:40 AM". Empty/invalid → "". */
@@ -982,13 +982,16 @@ export default function NewMatchGamePage() {
         // Standalone-only readout now (T4 hides this row for competitions), so the
         // count is just the trip crew — no roster branch.
         const availableCount = crew.data?.length ?? 0;
-        // Hard block (W-GAMEPAGE-01 §6.1): the row resolves only when EVERY match
-        // is fully paired — an empty slot is an unfinished add, not a quiet drop.
-        const matchesSummary = allFilled
-          ? `${filledDraft.length} match${filledDraft.length === 1 ? "" : "es"}${tA && tB ? ` · ${tA.name} vs ${tB.name}` : ""}`
-          : draft.length === 0
-            ? "Not set"
-            : "Finish or remove the empty match";
+        // §5 row copy (visual-pass P-A). Matches title is the format name; the
+        // subtitle is a status line ("x of y matches assigned"), not a value dump
+        // (team names live in the expanded editor). Matches uses the INVALID state
+        // while any slot is empty (§4/§6.1 hard-block) — never plain dashed-empty,
+        // since the seeded match always has a slot to fill until paired.
+        const matchesTitle = sided ? "2v2 Matches" : "1-on-1 Matches";
+        const matchesSubtitle = filledDraft.length === 0
+          ? "0 matches assigned"
+          : `${filledDraft.length} of ${draft.length} matches assigned`;
+        const matchesState: ChecklistRowState = allFilled ? "resolved" : "invalid";
         // Handicaps is hard-gated on Matches AND Course (W-9HOLE-01): the per-hole
         // stroke allocation needs the course's stroke-index table, so a complete
         // 18 must resolve first. "Course resolved" = a course applied AND an 18-hole
@@ -997,16 +1000,15 @@ export default function NewMatchGamePage() {
           !!gameQ.data?.course_id &&
           (((gameQ.data?.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0) === 18;
         const handicapsReady = matchesExist && courseResolved;
-        const handicapsState: ChecklistRowState = !handicapsReady ? "unresolved" : anyHandicap ? "resolved" : "acknowledged-empty";
-        const handicapsSummary = !matchesExist ? "Set matches first" : !courseResolved ? "Set the course first" : anyHandicap ? "Strokes assigned" : "Off — scratch";
+        const handicapsState: ChecklistRowState = anyHandicap ? "resolved" : "empty";
+        const handicapsSubtitle = anyHandicap ? "Handicaps assigned" : "No handicaps assigned";
         // Modifiers (W-GAMEPAGE-01 §6.5) — applicability is data-driven from the
         // format's gameTypes.ts compatibleModifiers (NOT the deprecated DB column).
-        // Empty → the row is hidden entirely. Check semantics: ≥1 enabled =
-        // resolved (check); applicable-but-none = unresolved (NO check — an optional
-        // row isn't "set" just by being offered).
+        // Empty → the row is hidden entirely.
         const availableModifiers = GAME_TYPES.find((t) => t.id === gameQ.data?.game_type_id)?.compatibleModifiers ?? [];
         const modifiersOn = enabledCount(modifiersDraft, availableModifiers);
-        const modifiersState: ChecklistRowState = modifiersOn > 0 ? "resolved" : "unresolved";
+        const modifiersState: ChecklistRowState = modifiersOn > 0 ? "resolved" : "empty";
+        const modifiersSubtitle = modifiersOn > 0 ? "Modifiers have been added" : "No modifiers added to your round yet";
         const onSetupChanged = () => {
           void gameQ.refetch();
           if (competitionId) {
@@ -1031,8 +1033,9 @@ export default function NewMatchGamePage() {
                 redundant noise here; the row is hidden entirely. */}
             {!gameCompId && (
               <ChecklistRow
-                label="Available players"
-                value={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
+                icon={Users}
+                title="Players"
+                subtitle={`${availableCount} player${availableCount === 1 ? "" : "s"}`}
                 state="resolved"
                 expanded={openRow === "players"}
                 onToggle={() => toggleRow("players")}
@@ -1056,9 +1059,10 @@ export default function NewMatchGamePage() {
 
             {/* Matches — the pairing builder (the score-entry unit), in place. */}
             <ChecklistRow
-              label="Matches"
-              value={matchesSummary}
-              state={allFilled ? "resolved" : "unresolved"}
+              icon={Swords}
+              title={matchesTitle}
+              subtitle={matchesSubtitle}
+              state={matchesState}
               expanded={openRow === "matches"}
               onToggle={() => toggleRow("matches")}
               testId="row-matches"
@@ -1118,10 +1122,10 @@ export default function NewMatchGamePage() {
             {/* Handicaps — hard-gated on Matches AND Course (W-9HOLE-01): both must
                 resolve (a complete 18) before per-hole strokes can be allocated. */}
             <ChecklistRow
-              label="Handicaps"
-              value={handicapsSummary}
+              icon={SlidersHorizontal}
+              title="Handicaps"
+              subtitle={handicapsSubtitle}
               state={handicapsState}
-              optional
               expanded={openRow === "handicaps"}
               onToggle={handicapsReady ? () => toggleRow("handicaps") : undefined}
               testId="row-handicaps"
@@ -1142,8 +1146,9 @@ export default function NewMatchGamePage() {
                 (+ a hole-count stepper for glorious_holes), persist-on-collapse. */}
             {availableModifiers.length > 0 && (
               <ChecklistRow
-                label="Modifiers"
-                value={modifiersSummary(modifiersDraft, availableModifiers)}
+                icon={Sparkles}
+                title="Game Modifiers"
+                subtitle={modifiersSubtitle}
                 state={modifiersState}
                 expanded={openRow === "modifiers"}
                 onToggle={() => toggleRow("modifiers")}

--- a/src/components/games/ChecklistRow.test.ts
+++ b/src/components/games/ChecklistRow.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { checklistRowVisuals } from "./ChecklistRow";
+
+// W-GAMEPAGE visual pass P-A (vocabulary §4) — the row state→treatment mapping.
+// Two states + one error; the type-icon always renders (the badge is an overlay,
+// never a swap), so these assert the chrome each state produces.
+
+describe("checklistRowVisuals", () => {
+  it("empty → dashed border, transparent surface, MUTED icon, NO badge", () => {
+    const v = checklistRowVisuals("empty", false);
+    expect(v.border).toContain("dashed");
+    expect(v.surface).toBe("transparent");
+    expect(v.iconColor).toBe("var(--color-bt-text-dim)");
+    expect(v.badge).toBeNull();
+  });
+
+  it("resolved → solid border, card surface, WHITE icon, teal CHECK badge", () => {
+    const v = checklistRowVisuals("resolved", false);
+    expect(v.border).toBe("1px solid var(--color-bt-border)");
+    expect(v.surface).toBe("var(--color-bt-card)");
+    expect(v.iconColor).toBe("var(--color-bt-text)");
+    expect(v.iconBg).toBe("var(--color-bt-card-raised)");
+    expect(v.badge).toBe("check");
+  });
+
+  it("invalid → danger border, danger icon, red-X badge (not a check)", () => {
+    const v = checklistRowVisuals("invalid", false);
+    expect(v.border).toContain("var(--color-bt-danger)");
+    expect(v.iconColor).toBe("var(--color-bt-danger)");
+    expect(v.badge).toBe("x");
+  });
+
+  it("open (editing) → raised surface, solid border, NO badge regardless of state", () => {
+    expect(checklistRowVisuals("resolved", true).badge).toBeNull();
+    expect(checklistRowVisuals("invalid", true).badge).toBeNull();
+    expect(checklistRowVisuals("empty", true).surface).toBe("var(--color-bt-card-raised)");
+    // An open empty row is no longer dashed (it's the active editor frame).
+    expect(checklistRowVisuals("empty", true).border).toBe("1px solid var(--color-bt-border)");
+  });
+
+  it("the icon container is raised only when active (resolved/open), transparent when empty", () => {
+    expect(checklistRowVisuals("empty", false).iconBg).toBe("transparent");
+    expect(checklistRowVisuals("resolved", false).iconBg).toBe("var(--color-bt-card-raised)");
+    expect(checklistRowVisuals("empty", true).iconBg).toBe("var(--color-bt-card-raised)");
+  });
+});

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -1,45 +1,68 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { ChevronRight, ChevronDown, Check } from "lucide-react";
+import { ChevronRight, ChevronDown, Check, X, type LucideIcon } from "lucide-react";
 
 /**
- * ChecklistRow — the ONE canonical config-checklist row (config-checklist model).
- * Every config aspect renders as this: uniform height + shape, `✓ LABEL · value ·
- * chevron`. It now behaves like an actual checklist item — **tap to expand the
- * editor IN PLACE** (a drop-down panel beneath the row, NOT a modal floating over
- * the page), edit live, **collapse = acknowledge** (the check appears; closing IS
- * accepting — no separate Accept button). The parent owns a single `openRowId` so
- * only one panel is open at a time (which also physically gates dependent rows).
+ * ChecklistRow — the ONE canonical config-checklist row (W-GAMEPAGE visual pass
+ * P-A; vocabulary §2–§5/§12). Every config aspect renders as this: a semantic
+ * **type-icon** (left) + **title / subtitle** + a trailing chevron / inline slot.
+ * Tap to expand the editor IN PLACE (a drop-down panel beneath the row, NOT a
+ * modal); **collapse = acknowledge**. The parent owns a single `openRowId` so only
+ * one panel is open at a time (which also physically gates dependent rows).
  *
- * Three presentations of a row:
+ * Three presentations:
  *   - **accordion** (`onToggle` + `children`) — tap toggles an in-place panel.
- *   - **overlay-tappable** (`onClick`, no children) — opens a separate editor
- *     (the Course picker / the Game-config Sheet, which stay overlays this pass);
+ *   - **overlay-tappable** (`onClick`, no children) — opens a separate editor; the
  *     trailing chevron points right.
- *   - **read-only** (neither) — a static summary row (Modifiers).
+ *   - **read-only** (neither) — a static summary row.
  *
- * Layout — **check LEADING (left), chevron TRAILING (right)** so the row reads as
- * a checklist and the check + chevron never fight (the #461 right-side conflict).
- *
- * Three STATES as distinct visuals (reusing GameRow's language + the net-new one):
- *   - unresolved          → skeleton: dashed border, NO fill, NO check, dim
- *     summary ("Not set"); needs attention.
- *   - acknowledged-empty  → solid border + `--color-bt-card-raised` fill + a
- *     leading check + dim "Off"/"None"; a valid done (you looked, chose nothing).
- *   - resolved            → ready: `--color-bt-card` fill + solid border + a
- *     leading check + the real summary announced LOUD (value is the prominent
- *     element, label the quiet caption — answers shout, questions whisper).
- * While EXPANDED the row shows its label as the active title (the loud-value
- * treatment is the collapsed-resolved state) and the trailing chevron points up.
+ * Two states + one error (vocabulary §4 — the old 3-state model collapsed to 2):
+ *   - **empty** → dashed border, transparent surface, MUTED icon, no badge. Both
+ *     "required-and-unsatisfied" and "optional-and-untouched" land here.
+ *   - **resolved** → solid border, `--color-bt-card` surface, WHITE icon, a small
+ *     teal **check badge** overlaid on the icon. **The icon never swaps for a check
+ *     (§3 keystone) — it persists; the badge is added.**
+ *   - **invalid** → the §6.1 hard-block (a match with an empty player slot): danger
+ *     border, danger icon + a red-X badge. A separate error treatment, not part of
+ *     the empty/resolved pair.
  */
-export type ChecklistRowState = "unresolved" | "acknowledged-empty" | "resolved";
+export type ChecklistRowState = "empty" | "resolved" | "invalid";
+
+/** The state→treatment mapping (vocabulary §4), pure so it's unit-testable apart
+ *  from render. Returns token-ready CSS values + which badge (if any) overlays the
+ *  persistent type-icon. `isOpen` (editing) suppresses the badge and raises the
+ *  surface. */
+export interface RowVisuals {
+  surface: string;
+  border: string;
+  iconColor: string;
+  iconBg: string;
+  /** Bottom-right overlay on the icon — never replaces it (§3 keystone). */
+  badge: "check" | "x" | null;
+}
+export function checklistRowVisuals(state: ChecklistRowState, isOpen: boolean): RowVisuals {
+  const resolved = state === "resolved";
+  const invalid = state === "invalid";
+  const active = resolved || isOpen;
+  return {
+    surface: isOpen ? "var(--color-bt-card-raised)" : resolved ? "var(--color-bt-card)" : "transparent",
+    border: invalid
+      ? "1.5px solid var(--color-bt-danger)"
+      : state === "empty" && !isOpen
+        ? "1.5px dashed var(--color-bt-border)"
+        : "1px solid var(--color-bt-border)",
+    iconColor: invalid ? "var(--color-bt-danger)" : active ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+    iconBg: active ? "var(--color-bt-card-raised)" : "transparent",
+    badge: (resolved || invalid) && !isOpen ? (invalid ? "x" : "check") : null,
+  };
+}
 
 export function ChecklistRow({
-  label,
-  value,
+  icon: Icon,
+  title,
+  subtitle,
   state,
-  optional,
   onClick,
   expanded,
   onToggle,
@@ -47,11 +70,14 @@ export function ChecklistRow({
   disabled,
   testId,
 }: {
-  label: string;
-  /** One-line summary (the resolved content, or "Not set" / "Off" / "None"). */
-  value: string;
+  /** The row's semantic type-icon (lucide). Persists in every state. */
+  icon: LucideIcon;
+  /** Large title (~16.5px) — the row/game-type name (varies by state for Course). */
+  title: string;
+  /** Small status line (~12.5px dim). ReactNode so a teal segment can be embedded
+   *  (the Points "…: N" live value). */
+  subtitle?: React.ReactNode;
   state: ChecklistRowState;
-  optional?: boolean;
   /** Overlay-tappable row (opens a separate editor). Omit for accordion/read-only. */
   onClick?: () => void;
   /** Accordion: whether this row's in-place panel is open (parent-owned). */
@@ -65,62 +91,60 @@ export function ChecklistRow({
 }) {
   const accordion = !!onToggle && !disabled;
   const overlay = !!onClick && !disabled && !accordion;
-  const acknowledged = state === "resolved" || state === "acknowledged-empty";
   const isOpen = accordion && !!expanded;
 
-  const fill =
-    isOpen ? "var(--color-bt-card-raised)"
-    : state === "resolved" ? "var(--color-bt-card)"
-    : state === "acknowledged-empty" ? "var(--color-bt-card-raised)"
-    : undefined; // unresolved: no fill
-  const border = state === "unresolved" && !isOpen ? "1.5px dashed var(--color-bt-border)" : "1px solid var(--color-bt-border)";
+  // State → treatment (§4/§12), via the shared pure mapping.
+  const { surface, border, iconColor, iconBg, badge } = checklistRowVisuals(state, isOpen);
+  // The badge's 2px ring matches the row surface so it reads as an overlay, not a
+  // floating dot. (Badge only shows collapsed, so the surface is card/transparent.)
+  const ringColor = state === "resolved" ? "var(--color-bt-card)" : "var(--color-bt-base)";
 
-  // Auto-scroll: when the panel opens, lift the row's top to the top of the
-  // screen so the dropped-down editor has full vertical room. The page scrolls in
-  // the window (the setup header is in-flow, not sticky), so block:"start" lands
-  // the row at the viewport top; a little scroll-margin keeps it off the edge.
+  // Auto-scroll: when the panel opens, lift the row's top to the top of the screen
+  // so the dropped-down editor has full vertical room.
   const rowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (isOpen) rowRef.current?.scrollIntoView({ block: "start" });
   }, [isOpen]);
 
-  // Leading: the check (acknowledged + collapsed). While expanded the row is
-  // "being decided" → no check yet (collapse re-acknowledges). Reserve the slot
-  // either way so labels align across all rows (one styling language).
-  const leading = (
-    <span className="flex w-5 shrink-0 items-center justify-center">
-      {acknowledged && !isOpen && <Check size={16} style={{ color: "var(--color-bt-accent)" }} />}
+  const iconBlock = (
+    <span
+      className="relative flex shrink-0 items-center justify-center"
+      style={{ width: 38, height: 38, borderRadius: 10, background: iconBg }}
+    >
+      <Icon size={18} style={{ color: iconColor }} strokeWidth={1.75} />
+      {badge && (
+        <span
+          className="absolute -bottom-1 -right-1 flex items-center justify-center rounded-full"
+          style={{
+            width: 16,
+            height: 16,
+            background: badge === "x" ? "var(--color-bt-danger)" : "var(--color-bt-accent)",
+            border: `2px solid ${ringColor}`,
+          }}
+          aria-hidden="true"
+        >
+          {badge === "x" ? (
+            <X size={9} strokeWidth={3} style={{ color: "var(--color-bt-text)" }} />
+          ) : (
+            <Check size={10} strokeWidth={3} style={{ color: "var(--color-bt-on-accent)" }} />
+          )}
+        </span>
+      )}
     </span>
   );
 
-  const labelCaption = (
-    <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-      {label}
-      {optional && <span style={{ fontWeight: 500, textTransform: "none", letterSpacing: 0 }}>· optional</span>}
-    </span>
+  const content = (
+    <div className="flex min-w-0 flex-1 flex-col">
+      <span className="truncate" style={{ fontSize: 16.5, fontWeight: 500, color: "var(--color-bt-text)", lineHeight: 1.25 }}>
+        {title}
+      </span>
+      {subtitle != null && (
+        <span className="truncate" style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", marginTop: 1 }}>
+          {subtitle}
+        </span>
+      )}
+    </div>
   );
-
-  // Content column — by state. Resolved + collapsed announces the VALUE loud
-  // (label demoted to a quiet caption). Expanded shows the label as the active
-  // title. Unresolved / acknowledged-empty keep the quiet caption + dim summary.
-  const content =
-    isOpen ? (
-      <div className="flex min-w-0 flex-1 flex-col">{labelCaption}</div>
-    ) : state === "resolved" ? (
-      <div className="flex min-w-0 flex-1 flex-col">
-        {labelCaption}
-        <span className="truncate text-[15px] font-semibold" style={{ color: "var(--color-bt-text)", marginTop: 1 }}>
-          {value}
-        </span>
-      </div>
-    ) : (
-      <div className="flex min-w-0 flex-1 flex-col">
-        {labelCaption}
-        <span className="truncate text-sm" style={{ color: "var(--color-bt-text-dim)", marginTop: 2 }}>
-          {value}
-        </span>
-      </div>
-    );
 
   const trailing = (
     <span className="flex shrink-0 items-center">
@@ -134,13 +158,13 @@ export function ChecklistRow({
 
   const headerInner = (
     <>
-      {leading}
+      {iconBlock}
       {content}
       {trailing}
     </>
   );
-  const headerClass = "flex w-full items-center gap-2.5 px-3.5 py-3 text-left disabled:opacity-60";
-  const containerStyle = { background: fill, border } as React.CSSProperties;
+  const headerClass = "flex w-full items-center gap-3 px-3.5 py-3 text-left disabled:opacity-60";
+  const containerStyle = { background: surface, border } as React.CSSProperties;
 
   // Accordion: a header button toggling an in-place panel below (same bordered
   // frame — the row IS the frame; the panel sheds all modal chrome).
@@ -159,7 +183,7 @@ export function ChecklistRow({
     );
   }
 
-  // Overlay-tappable (Course / Game-config) — opens a separate editor.
+  // Overlay-tappable — opens a separate editor.
   if (overlay) {
     return (
       <button type="button" onClick={onClick} disabled={disabled} className={`${headerClass} rounded-xl`} style={containerStyle} data-testid={testId}>

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { trpc } from "@/lib/trpc-client";
+import { Flag, Hash } from "lucide-react";
 import { CourseRowContent } from "@/components/games/course/CourseRowContent";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
-import { formatLabel, type GameRow } from "@/components/competition/CompetitionGamesPanel";
+import { type GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
 
 /**
@@ -75,28 +75,28 @@ export function GameSetupRows({
   // Course resolved = a complete 18 (W-9HOLE-01): a real 18-hole course, or a
   // 9-hole front with a back nine composed in. A lone 9-hole front (schema count
   // 9) is NOT resolved — it "needs a back nine", which keeps Handicaps gated.
+  // §5 Course subtitle reports the handicaps GATE, not the course name (the name
+  // lives in the expanded CourseRowContent), so we no longer fetch front/back names
+  // here — only whether the course resolves to a complete 18.
   const frontId = game.course_id ?? null;
-  const backId = (game.back_course_id as string | null) ?? null;
   const count = ((game.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0;
   const courseResolved = !!frontId && count === 18;
-  const frontQ = trpc.courses.getById.useQuery({ courseId: frontId ?? "" }, { enabled: !!frontId });
-  const backQ = trpc.courses.getById.useQuery({ courseId: backId ?? "" }, { enabled: !!backId });
-  const frontName = (frontQ.data?.name as string | undefined) ?? null;
-  const backName = (backQ.data?.name as string | undefined) ?? null;
-  const courseValue =
-    !frontId ? "Add a course"
-    : count === 9 ? `${frontName ?? "Front nine"} · needs a back nine`
-    : backId ? `${frontName ?? "Front"} + ${backName ?? "Back"}`
-    : (frontName ?? "Course");
+  // Points (§5): the row subtitle is the live "Total Points Available: N" (N teal),
+  // derived from per-match × the valid match count. Per-match drives resolved/empty.
+  const perMatch = game.points_distribution?.type === "per_match" ? game.points_distribution.value : 0;
+  const pointsTotal = (matchCount ?? 0) * perMatch;
 
   return (
     <>
       {slot !== "config" && (
         <ChecklistRow
-          label="Course / tee"
-          optional
-          value={courseValue}
-          state={courseResolved ? "resolved" : "unresolved"}
+          icon={Flag}
+          // §5 Course: the title flips on confirm; the subtitle reports the
+          // HANDICAPS GATE (course gates handicaps), not the course name — the name
+          // lives in the expanded editor (CourseRowContent).
+          title={courseResolved ? "Golf Course Selected" : "No Golf Course"}
+          subtitle={courseResolved ? "Handicaps enabled" : "Handicaps disabled"}
+          state={courseResolved ? "resolved" : "empty"}
           disabled={!canEdit}
           expanded={courseOpen}
           onToggle={courseOpen ? closeEditor : openCourse}
@@ -109,9 +109,15 @@ export function GameSetupRows({
       )}
       {slot !== "course" && competitionId && (
         <ChecklistRow
-          label="Format · Points"
-          value={formatPointsSummary(game)}
-          state="resolved"
+          icon={Hash}
+          title="Points Per Match"
+          subtitle={
+            <>
+              Total Points Available:{" "}
+              <span style={{ color: "var(--color-bt-accent)", fontWeight: 600 }}>{pointsTotal}</span>
+            </>
+          }
+          state={perMatch > 0 ? "resolved" : "empty"}
           disabled={!canEdit}
           expanded={configOpen}
           onToggle={configOpen ? closeEditor : openConfig}
@@ -122,23 +128,5 @@ export function GameSetupRows({
       )}
     </>
   );
-}
-
-/** "Head to head · 2/match" — the Format·Points row's loud summary. */
-function formatPointsSummary(game: GameRow): string {
-  const parts = [formatLabel(game.competition_format ?? null), pointsSummary(game)].filter(Boolean);
-  return parts.length > 0 ? parts.join(" · ") : "Set format & points";
-}
-
-/** A compact points summary for the config row: "2/match" · "8 pts". */
-function pointsSummary(game: GameRow): string | null {
-  const d = game.points_distribution;
-  if (d?.type === "per_match") return `${d.value}/match`;
-  if (d?.type === "placement") {
-    const total = game.points_total ?? d.values.reduce((a, b) => a + b, 0);
-    return `${total} pts`;
-  }
-  if (game.points_total != null) return `${game.points_total} pts`;
-  return null;
 }
 


### PR DESCRIPTION
First slice of the W-GAMEPAGE visual pass. Implements the visual vocabulary (#475 doc) for the **shared row only** — `ChecklistRow`. Row body / steppers / format-picker / handicaps controls / scorecard are untouched (P-B…P-G).

## Pre-flight (confirmed, no surprises)
`ChecklistRow` is the single shared row; **6 call sites** (4 in `match/new/page.tsx`, 2 in `GameSetupRows.tsx`). `acknowledged-empty` was produced **only** by the Handicaps "Off — scratch" case → mapped to **empty** per Zach. The Players row does render through `ChecklistRow` (placeholder copy flagged below).

## T1 — `ChecklistRow` (vocab §2–§5/§12)
- New required **`icon`** (lucide) in a ~38px raised container — **persists in every state**; resolution **overlays** a teal check badge (never swaps the icon — §3 keystone).
- **title / subtitle** anatomy replaces caps-eyebrow+value; subtitle is a ReactNode so Points can embed its teal `N`.
- **3 states → 2 (+invalid):** `unresolved`/`acknowledged-empty` collapse to **empty** (dashed, muted, no badge); **resolved** (solid, white icon, teal badge); **invalid** (danger border + red-X badge) kept for the §6.1 Matches hard-block.
- State→treatment extracted to a pure exported `checklistRowVisuals` (unit-tested).

## T2 — call sites (§5 verbatim copy)
Matches `Swords` (title = format name, e.g. "1-on-1 Matches" / "2v2 Matches"; **invalid** while any slot is empty) · Points `Hash` ("Total Points Available: N", **N teal**) · Course `Flag` (title flips; subtitle reports the **handicaps gate**, not the course name — vocab §5 note) · Handicaps `SlidersHorizontal` · Modifiers `Sparkles` · Players `Users`. Removed now-dead summary helpers. **No `points>0` gate change — that's P-C.**

## T3 — tests
5 unit tests over `checklistRowVisuals` (empty/resolved/invalid/open). (Node test env has no RTL, so the pure mapping is the testable core.)

## Verification
- `tsc --noEmit` clean · `next lint` clean · `ChecklistRow` tests pass · critical-path `match-play.spec` green.
- **Eye-verified on real competition games (dark + light):** resolved rows show type-icon + teal check badge + §5 copy ("Total Points Available: 10" with 10 teal); empty rows dashed + muted; **Matches red border + red-X badge** when a slot is empty. No console errors.

## 🚩 Flag for Zach (per spec)
- **Players row copy** — §5 has none; shipped placeholder `Players` / "{n} players". Final wording is yours.
- **Interim (expected):** the Points row shows the new chrome but **still expands** to its current body until **P-C**. Course/Modifiers/Handicaps subtitles now show the §5 status line (not the course name / modifier list / gating hint) — the specifics live in the expanded editors, per §2 ("a status line, not a value-eyebrow").

🤖 Generated with [Claude Code](https://claude.com/claude-code)