### PR TITLE
chore: file avatar bug issue + add 2v2 handicaps to DEFERRED

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -114,6 +114,13 @@ The heart of the event.
   helpers rather than special-casing each. (Spec note: "moving-tees moving-scale
   generalization.")
 
+### 2v2 per-individual handicaps
+
+The per-match handicap **side selector** (1v1 match play) assigns strokes to a *side*. In 2v2 best ball
+you need to stroke a *specific person* (e.g. just Buddy so he's competitive vs Steve), which the side
+selector can't express. **Deferred — not built.** Offline workaround is fine for now (BBMI Saturday is
+1v1). Build when 2v2 scoring logic lands. (Visual vocabulary §9 / §14.)
+
 ### Desktop side-by-side tee display (someday nomination — not actionable now)
 
 *Captured 2026-06-20 (golfcourseapi build). NOTE: CLAUDE.md references a


### PR DESCRIPTION
Two record-keeping items surfaced during W-GAMEPAGE visual-pass Phase 0 (verified they actually landed this time).

1. **Avatar bug filed as a GitHub issue** → [#477](https://github.com/zgrether/buddytrip/issues/477) (`bug`, `post-launch`): profile `avatarIcon` overrides the team avatar in the competition/in-match path (`MatchEntryView.tsx:472` / `ScoreEntryView.tsx:316`). Fix = suppress `avatarIcon` there. (Issue, not DEFERRED — it's a bug to fix.)
2. **2v2 per-individual handicaps** added to `DEFERRED.md` (this PR) — the side selector can't stroke a single player in best ball; deferred until 2v2 scoring lands.

Doc-only — `DEFERRED.md` is the sole file changed. No app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)