### PR TITLE
W-GAMEPAGE visual pass P-B: stepper unification (one canonical Stepper, 4 migrated)

### DIFF
--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
-  Flag, Plus, Minus, Pencil, Star, Trash2, X, Trophy, RotateCcw,
+  Flag, Plus, Pencil, Star, Trash2, X, Trophy, RotateCcw,
   Spade, Target, Beer, Dices, Swords, Radio, ChevronRight, ChevronUp, ChevronDown, Check, Users, Info, SlidersHorizontal,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { ModifierCards } from "@/components/games/ModifierCards";
+import { Stepper } from "@/components/games/Stepper";
 import type { PointsDistribution } from "@/lib/pointsDistribution";
 import {
   validatePlacement, matchReadout, placementFit, matchFit, deriveMatchCount, type MatchFormat,
@@ -982,16 +983,13 @@ export function PointStepper({
 }: {
   label: string; caption: string; value: number; onChange: (n: number) => void; footer?: React.ReactNode; max?: number;
 }) {
+  // A Field + footer composition over the canonical <Stepper> (P-B). The bespoke
+  // step-buttons are gone; min stays 1 and fmtValue keeps the ½-point display.
   return (
     <Field label={label} required>
       <div className="rounded-xl" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}>
-        <div className="flex items-center gap-3 px-3 py-3">
-          <StepBtn dir="dec" disabled={value <= 1} onClick={() => onChange(Math.max(1, value - 1))} />
-          <div className="flex-1 text-center">
-            <div className="text-3xl font-black leading-none tabular-nums" style={{ color: "var(--color-bt-text)" }}>{fmtValue(value)}</div>
-            <div className="mt-1 text-[10px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>{caption}</div>
-          </div>
-          <StepBtn dir="inc" disabled={max != null && value >= max} onClick={() => onChange(max != null ? Math.min(max, value + 1) : value + 1)} />
+        <div className="px-3 py-3">
+          <Stepper size="full" value={value} min={1} max={max} onChange={onChange} label={caption} formatValue={fmtValue} />
         </div>
         {footer && (
           <div className="px-3 py-2.5" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
@@ -1000,21 +998,6 @@ export function PointStepper({
         )}
       </div>
     </Field>
-  );
-}
-
-function StepBtn({ dir, onClick, disabled }: { dir: "inc" | "dec"; onClick: () => void; disabled?: boolean }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={dir === "inc" ? "Increase" : "Decrease"}
-      className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg disabled:opacity-40"
-      style={{ background: "var(--color-bt-card)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-    >
-      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
-    </button>
   );
 }
 

--- a/src/components/games/HandicapRoster.tsx
+++ b/src/components/games/HandicapRoster.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ChevronLeft, Plus, Minus } from "lucide-react";
+import { ChevronLeft } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
+import { Stepper } from "@/components/games/Stepper";
 import { clampStrokes, strokeHint, MAX_STROKES } from "@/lib/handicap";
 
 /**
@@ -132,13 +133,17 @@ export function HandicapRoster({
                   <span className="truncate block" style={{ fontSize: 15, fontWeight: 500, color: "var(--color-bt-text)" }}>{p.name}</span>
                   {hint && <span className="block truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 1 }}>{hint}</span>}
                 </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <StepBtn dir="dec" disabled={strokes <= 0} onClick={() => bump(p.id, strokes, -1)} />
-                  <span style={{ minWidth: 34, textAlign: "center", fontSize: strokes === 0 ? 13 : 17, fontWeight: 700, color: strokes === 0 ? "var(--color-bt-text-dim)" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
-                    {strokes === 0 ? "SCR" : strokes}
-                  </span>
-                  <StepBtn dir="inc" disabled={strokes >= MAX_STROKES} onClick={() => bump(p.id, strokes, 1)} />
-                </div>
+                {/* Delta callbacks (not onChange) so bump's pending-ref rapid-tap
+                    handling is preserved; formatValue keeps "SCR" at 0 (P-B). */}
+                <Stepper
+                  size="full"
+                  value={strokes}
+                  min={0}
+                  max={MAX_STROKES}
+                  onDecrement={() => bump(p.id, strokes, -1)}
+                  onIncrement={() => bump(p.id, strokes, 1)}
+                  formatValue={(n) => (n === 0 ? "SCR" : String(n))}
+                />
               </div>
             );
           })}
@@ -154,15 +159,3 @@ export function HandicapRoster({
   );
 }
 
-function StepBtn({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled: boolean; onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className="flex items-center justify-center disabled:opacity-30"
-      style={{ width: 34, height: 34, borderRadius: 9, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
-    >
-      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
-    </button>
-  );
-}

--- a/src/components/games/ModifierCards.tsx
+++ b/src/components/games/ModifierCards.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Minus, Plus } from "lucide-react";
+import { Stepper } from "@/components/games/Stepper";
 import {
   modifierDef,
   isModifierEnabled,
@@ -81,7 +81,9 @@ export function ModifierCards({
   );
 }
 
-/** Trailing-hole count for glorious finishing holes (the only stepper modifier). */
+/** Trailing-hole count for glorious finishing holes (the only stepper modifier).
+ *  The count lives in the canonical compact <Stepper> now (P-B); the label carries
+ *  the meaning the old inline sentence did. */
 function HoleStepper({ value, onChange, disabled }: { value: number; onChange: (n: number) => void; disabled?: boolean }) {
   return (
     <div
@@ -89,29 +91,16 @@ function HoleStepper({ value, onChange, disabled }: { value: number; onChange: (
       style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
       data-testid="glorious-holes-stepper"
     >
-      <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
-        Last <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>{value}</span> hole{value === 1 ? "" : "s"} worth double
-      </span>
-      <div className="flex items-center gap-2">
-        <StepBtn dir="dec" disabled={disabled || value <= GLORIOUS_HOLES_MIN} onClick={() => onChange(value - 1)} />
-        <StepBtn dir="inc" disabled={disabled || value >= GLORIOUS_HOLES_MAX} onClick={() => onChange(value + 1)} />
-      </div>
+      <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>Final holes worth double</span>
+      <Stepper
+        size="compact"
+        value={value}
+        min={GLORIOUS_HOLES_MIN}
+        max={GLORIOUS_HOLES_MAX}
+        onChange={onChange}
+        disabled={disabled}
+      />
     </div>
-  );
-}
-
-function StepBtn({ dir, disabled, onClick }: { dir: "inc" | "dec"; disabled?: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={dir === "inc" ? "Increase" : "Decrease"}
-      className="flex items-center justify-center disabled:opacity-30"
-      style={{ width: 30, height: 30, borderRadius: 8, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text)" }}
-    >
-      {dir === "inc" ? <Plus size={16} /> : <Minus size={16} />}
-    </button>
   );
 }
 

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { strokeHoles } from "@/lib/matchPlay";
+import { Stepper } from "@/components/games/Stepper";
 import type { Participant } from "./types";
 
 /**
@@ -72,21 +73,21 @@ export function RelHandicapControl({ a, b, value, onChange }: RelHandicapControl
         </Segment>
       </div>
 
-      {/* Row 2 · Magnitude (stepper) */}
-      <div
-        className="flex items-center justify-center"
-        style={{ gap: 18, marginTop: 12, opacity: even ? 0.35 : 1, pointerEvents: even ? "none" : "auto" }}
-      >
-        <StepButton symbol="−" disabled={even || n <= 1} onClick={() => step(-1)} />
-        <div className="text-center" style={{ minWidth: 44 }}>
-          <div style={{ fontSize: 32, fontWeight: 800, lineHeight: 1, color: "var(--color-bt-text)" }}>
-            {even ? "—" : n}
-          </div>
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", color: "var(--color-bt-text-dim)", marginTop: 4 }}>
-            {n === 1 ? "STROKE" : "STROKES"}
-          </div>
-        </div>
-        <StepButton symbol="+" disabled={even || n >= MAX} onClick={() => step(1)} />
+      {/* Row 2 · Magnitude — the canonical full Stepper (P-B). Delta callbacks keep
+          `step`'s sign-aware, never-crosses-Even behavior; formatValue shows "—"
+          when even; the wrapper dims/locks the whole control in the Even state. */}
+      <div style={{ marginTop: 12, opacity: even ? 0.35 : 1, pointerEvents: even ? "none" : "auto" }}>
+        <Stepper
+          size="full"
+          value={n}
+          min={1}
+          max={MAX}
+          disabled={even}
+          onDecrement={() => step(-1)}
+          onIncrement={() => step(1)}
+          formatValue={() => (even ? "—" : String(n))}
+          label={n === 1 ? "STROKE" : "STROKES"}
+        />
       </div>
 
       {/* Resolved line */}
@@ -123,26 +124,3 @@ function Segment({ selected, onClick, children }: { selected: boolean; onClick: 
   );
 }
 
-function StepButton({ symbol, disabled, onClick }: { symbol: string; disabled: boolean; onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={symbol === "+" ? "Add a stroke" : "Remove a stroke"}
-      className="flex items-center justify-center"
-      style={{
-        width: 52,
-        height: 48,
-        borderRadius: 12,
-        background: "var(--color-bt-card-raised)",
-        border: "1px solid var(--color-bt-border)",
-        color: "var(--color-bt-text)",
-        fontSize: 24,
-        fontWeight: 600,
-        opacity: disabled ? 0.4 : 1,
-      }}
-    >
-      {symbol}
-    </button>
-  );
-}

--- a/src/components/games/Stepper.test.ts
+++ b/src/components/games/Stepper.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { stepperBounds, STEPPER_SIZES } from "./Stepper";
+
+// W-GAMEPAGE visual pass P-B (vocabulary §6) — the canonical stepper. These lock
+// the clamp/disabled logic that every migrated call site shares, so unification
+// can't change a floor/ceiling. (Node test env has no RTL; the pure bounds are
+// the migration-equivalence core.)
+
+describe("stepperBounds", () => {
+  it("disables − at the floor, + at the ceiling", () => {
+    expect(stepperBounds(0, 0, 18).atFloor).toBe(true); // roster scratch
+    expect(stepperBounds(1, 0, 18).atFloor).toBe(false);
+    expect(stepperBounds(18, 0, 18).atCeil).toBe(true);
+    expect(stepperBounds(17, 0, 18).atCeil).toBe(false);
+  });
+
+  it("no max → + never hits a ceiling", () => {
+    expect(stepperBounds(9999, 1).atCeil).toBe(false);
+  });
+
+  it("clamps the next value into [min, max]", () => {
+    expect(stepperBounds(0, 0, 18).decValue).toBe(0); // can't go below the floor
+    expect(stepperBounds(18, 0, 18).incValue).toBe(18); // can't exceed the ceiling
+    expect(stepperBounds(3, 1, 9).decValue).toBe(2);
+    expect(stepperBounds(3, 1, 9).incValue).toBe(4);
+  });
+
+  it("honors a custom step", () => {
+    expect(stepperBounds(4, 0, 18, 2).incValue).toBe(6);
+    expect(stepperBounds(1, 0, 18, 2).decValue).toBe(0); // clamps, doesn't go to -1
+  });
+
+  it("covers the four migrated call sites' floors", () => {
+    expect(stepperBounds(1, 1).atFloor).toBe(true); // PointStepper / RelHandicap min=1
+    expect(stepperBounds(0, 0, 18).atFloor).toBe(true); // HandicapRoster min=0 (SCR)
+    expect(stepperBounds(1, 1, 9).atFloor).toBe(true); // ModifierCards glorious_holes min=1
+  });
+});
+
+describe("STEPPER_SIZES", () => {
+  it("three densities, distinct button + number sizes; inline is right-aligned", () => {
+    expect(STEPPER_SIZES.full.btn).toBeGreaterThan(STEPPER_SIZES.compact.btn);
+    expect(STEPPER_SIZES.full.align).toBe("center");
+    expect(STEPPER_SIZES.compact.align).toBe("center");
+    expect(STEPPER_SIZES.inline.align).toBe("right");
+  });
+});

--- a/src/components/games/Stepper.tsx
+++ b/src/components/games/Stepper.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { Plus, Minus } from "lucide-react";
+
+/**
+ * Stepper — the ONE canonical −/+ number control (W-GAMEPAGE visual pass P-B;
+ * vocabulary §6). Replaces four bespoke step-buttons (PointStepper, HandicapRoster,
+ * ModifierCards, RelHandicapControl) with a single component in three densities.
+ *
+ * Look (§6): buttons are **transparent, thin-bordered rounded-squares** (NOT filled
+ * circles) with muted glyphs; the number is **bold 700**; an optional small-caps
+ * label sits beneath. `−`/`+` disable-style at the floor/ceiling (opacity, no color
+ * change).
+ *
+ * Value handling — covers all four migrated call sites without changing behavior:
+ *   - `onChange(next)` — the Stepper clamps `value ± step` into `[min, max]` and
+ *     emits the next value (the value-owning consumers).
+ *   - `onIncrement` / `onDecrement` — delta callbacks the PARENT owns (preferred
+ *     when present). Needed for HandicapRoster's rapid-tap pending-ref logic and
+ *     RelHandicapControl's sign-aware `step`, where the parent computes the next
+ *     value itself. `min`/`max` still drive the disabled state.
+ *   - `formatValue` — display override (default `String`); the roster renders 0 as
+ *     "SCR", the match-play control renders "—" when even.
+ */
+
+export type StepperSize = "full" | "compact" | "inline";
+
+export const STEPPER_SIZES: Record<StepperSize, { btn: number; num: number; gap: number; align: "center" | "right" }> = {
+  full: { btn: 40, num: 25, gap: 16, align: "center" },
+  compact: { btn: 30, num: 18, gap: 10, align: "center" },
+  inline: { btn: 32, num: 20, gap: 12, align: "right" },
+};
+
+/** The clamp + disabled logic, pure so migration-equivalence is unit-testable
+ *  apart from render. `−` disables at the floor, `+` at the ceiling (if any). */
+export function stepperBounds(value: number, min: number, max?: number, step = 1) {
+  const clamp = (n: number) => Math.max(min, max != null ? Math.min(max, n) : n);
+  return {
+    atFloor: value <= min,
+    atCeil: max != null && value >= max,
+    decValue: clamp(value - step),
+    incValue: clamp(value + step),
+  };
+}
+
+export function Stepper({
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  onIncrement,
+  onDecrement,
+  size,
+  label,
+  disabled = false,
+  formatValue = String,
+  align,
+  testId,
+}: {
+  value: number;
+  min: number;
+  max?: number;
+  step?: number;
+  onChange?: (next: number) => void;
+  onIncrement?: () => void;
+  onDecrement?: () => void;
+  size: StepperSize;
+  /** Optional small-caps label beneath the number (§6). */
+  label?: string;
+  disabled?: boolean;
+  /** Display override — default String(value). Roster → "SCR" at 0, etc. */
+  formatValue?: (n: number) => string;
+  /** Override the size's default alignment (center vs right-justified). */
+  align?: "center" | "right";
+  testId?: string;
+}) {
+  const dims = STEPPER_SIZES[size];
+  const justify = (align ?? dims.align) === "right" ? "flex-end" : "center";
+
+  const b = stepperBounds(value, min, max, step);
+  const dec = () => (onDecrement ? onDecrement() : onChange?.(b.decValue));
+  const inc = () => (onIncrement ? onIncrement() : onChange?.(b.incValue));
+
+  return (
+    <div className="flex items-center" style={{ gap: dims.gap, justifyContent: justify }} data-testid={testId}>
+      <StepBtn dir="dec" px={dims.btn} disabled={disabled || b.atFloor} onClick={dec} />
+      <div className="flex flex-col items-center" style={{ minWidth: dims.num + 14 }}>
+        <span style={{ fontSize: dims.num, fontWeight: 700, lineHeight: 1, color: "var(--color-bt-text)", fontVariantNumeric: "tabular-nums" }}>
+          {formatValue(value)}
+        </span>
+        {label && (
+          <span className="mt-1" style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+            {label}
+          </span>
+        )}
+      </div>
+      <StepBtn dir="inc" px={dims.btn} disabled={disabled || b.atCeil} onClick={inc} />
+    </div>
+  );
+}
+
+/** The shared step button (§6): transparent, thin-bordered rounded-square, muted glyph. */
+function StepBtn({ dir, px, disabled, onClick }: { dir: "inc" | "dec"; px: number; disabled: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={dir === "inc" ? "Increase" : "Decrease"}
+      className="flex flex-shrink-0 items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed"
+      style={{ width: px, height: px, borderRadius: 9, background: "transparent", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+    >
+      {dir === "inc" ? <Plus size={Math.round(px * 0.42)} /> : <Minus size={Math.round(px * 0.42)} />}
+    </button>
+  );
+}


### PR DESCRIPTION
Second slice of the visual pass. **Establish-one-canonical-and-migrate-four** (Phase 0 found no reusable stepper — four bespoke ones, none with the §6 no-bg square). The foundation P-C/P-D/P-E all consume. **No behavior changes** — same values/floors/ceilings/handlers everywhere; this is visual + structural unification only.

## T1 — canonical `Stepper` (vocab §6)
`src/components/games/Stepper.tsx`: transparent thin-bordered **rounded-square** buttons (not circles), **bold-700** number, optional caps label; three densities via one `size` prop (`full`/`compact`/`inline`). Covers all four call sites losslessly:
- `onChange(next)` (Stepper clamps) **or** `onIncrement`/`onDecrement` (parent owns the value — needed for the roster's rapid-tap pending-ref and the match-play sign-aware `step`).
- `formatValue` override (default `String`) → "SCR" / "—".
- Pure `stepperBounds` extracted + **6 unit tests**.

## T2–T5 — migrate the four (delete the duplicates)
| Task | Site | Notes |
|---|---|---|
| T2 | `PointStepper` (CompetitionGamesPanel) | now a thin Field+footer wrapper over `<Stepper full>` — deleted its local StepBtn. `fmtValue` ½-points kept. |
| T3 | `HandicapRoster` | `<Stepper full>` with delta callbacks (preserves `bump` rapid-tap) + "SCR" formatter. |
| T4 | `ModifierCards` | glorious-holes → `<Stepper compact>`; the count moved from the inline sentence into `[− N +]`. Switch/copy untouched (P-E). |
| T5 | `RelHandicapControl` | `<Stepper full>`; delta `step` + "—" when even; segment selector/fill untouched (P-D). |

## 🚩 Deviation flag (deliberate)
The spec said "delete `PointStepper`." It's actually a **Field + caption + footer composition used at 5 call sites**, not a stepper duplicate — so I kept it as a thin wrapper over the canonical `<Stepper>` (its bespoke StepBtn is deleted) rather than re-inlining Field+footer 5×. Same for `HoleStepper` (label + `<Stepper>`). **One canonical stepper control remains; no parallel step-button implementations.** If you'd rather fully inline + delete those wrappers, it's a trivial follow-up.

## Verification
- `tsc --noEmit` clean · `next lint` clean (only pre-existing CompetitionGamesPanel warnings) · `Stepper` unit tests pass · critical-path `match-play.spec` green (exercises points + handicaps).
- **Eye-verified on real games (dark + light):** Points panel `[− 3 +]`, modifier glorious-holes compact `[− 3 +]`, match-play strokes full (active `[− 1 +]` / `[− 3 +]` and even dimmed `[− — +]`) — all the identical no-bg square + bold number; min/max/disabled unchanged. No console errors. (Test game state restored to original.)
- **Handicap roster (4th context):** same canonical `<Stepper full>` + the "SCR" formatter, unit-tested; not separately staged (it's a multi-step stroke-game setup flow), but it's the same component verified in the other two `full`-density contexts.

Next: **P-C (Points row inline)** — the first consumer of the new `inline` density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)