### PR TITLE
W-GAMEPAGE visual pass P-E: modifier card restyle (checkbox + mock copy)

### DIFF
--- a/src/components/games/ModifierCards.tsx
+++ b/src/components/games/ModifierCards.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Check } from "lucide-react";
 import { Stepper } from "@/components/games/Stepper";
 import {
   modifierDef,
@@ -49,19 +50,20 @@ export function ModifierCards({
             style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
             data-testid={`modifier-card-${key}`}
           >
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0">
-                <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>{def.label}</p>
-                {def.description && (
-                  <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>{def.description}</p>
-                )}
-              </div>
-              <Switch
+            <div className="flex items-start gap-3">
+              {/* Checkbox LEADING (§10): teal fill + dark check on, bordered off. */}
+              <Checkbox
                 on={on}
                 disabled={readOnly}
                 onClick={() => onChange(setModifierEnabled(modifiers, key, !on))}
                 label={def.label}
               />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>{def.label}</p>
+                {def.description && (
+                  <p className="mt-0.5 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>{def.description}</p>
+                )}
+              </div>
             </div>
             {/* Stepper only for checkbox+stepper modifiers, and only once enabled. */}
             {def.controlType === "checkbox+stepper" && on && (
@@ -104,24 +106,25 @@ function HoleStepper({ value, onChange, disabled }: { value: number; onChange: (
   );
 }
 
-/** The on/off toggle — the existing checked-state pattern (preserved from the
- *  shipped SpecialRules panel so both surfaces read identically). */
-function Switch({ on, onClick, label, disabled }: { on: boolean; onClick: () => void; label: string; disabled?: boolean }) {
+/** The on/off CHECKBOX (§10): teal fill + dark check glyph when on, transparent +
+ *  bordered when off. Toggles the modifier's presence in the jsonb exactly as the
+ *  old Switch did — appearance change only. */
+function Checkbox({ on, onClick, label, disabled }: { on: boolean; onClick: () => void; label: string; disabled?: boolean }) {
   return (
     <button
       type="button"
-      role="switch"
+      role="checkbox"
       aria-checked={on}
       aria-label={label}
       onClick={onClick}
       disabled={disabled}
-      className="relative h-6 w-10 flex-shrink-0 rounded-full transition-colors disabled:opacity-40"
-      style={{ background: on ? "var(--color-bt-accent)" : "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md transition-colors disabled:opacity-40"
+      style={{
+        background: on ? "var(--color-bt-accent)" : "transparent",
+        border: `1px solid ${on ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
+      }}
     >
-      <span
-        className="absolute top-0.5 h-4 w-4 rounded-full transition-all"
-        style={{ left: on ? "20px" : "2px", background: on ? "var(--color-bt-base)" : "var(--color-bt-text-dim)" }}
-      />
+      {on && <Check size={13} strokeWidth={3} style={{ color: "var(--color-bt-on-accent)" }} />}
     </button>
   );
 }

--- a/src/components/games/ModifierCards.tsx
+++ b/src/components/games/ModifierCards.tsx
@@ -76,9 +76,6 @@ export function ModifierCards({
           </div>
         );
       })}
-      <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-        Optional. These are recorded as rules of the day — the app doesn’t auto-score them yet.
-      </p>
     </div>
   );
 }

--- a/src/lib/modifiers.test.ts
+++ b/src/lib/modifiers.test.ts
@@ -123,7 +123,7 @@ describe("summary + count (row resolved/unresolved drivers)", () => {
   it("multiple enabled join in the available order", () => {
     expect(enabledCount({ moving_tees: {}, glorious_holes: { holes: 2 } }, available)).toBe(2);
     expect(modifiersSummary({ moving_tees: {}, glorious_holes: { holes: 2 } }, available)).toBe(
-      "Moving tees · Glorious finishing holes (last 2)"
+      "Moving tee boxes · Glorious finishing holes (last 2)"
     );
   });
   it("ignores enabled keys that are not in the applicable set", () => {

--- a/src/lib/modifiers.test.ts
+++ b/src/lib/modifiers.test.ts
@@ -29,6 +29,19 @@ describe("registry", () => {
   it("modifierDef soft-falls-back for an unknown key (fail soft, not crash)", () => {
     expect(modifierDef("not_a_real_key")).toEqual({ key: "not_a_real_key", label: "not_a_real_key", description: "", controlType: "checkbox" });
   });
+  // P-E (§10): titles are the card wording; descriptions are Zach's mock copy with
+  // NO "not-auto-scored" disclaimer (deliberate reversal of #469) — locked so it
+  // can't silently drift back.
+  it("labels match the card titles", () => {
+    expect(MODIFIER_REGISTRY.moving_tees.label).toBe("Moving tee boxes");
+    expect(MODIFIER_REGISTRY.glorious_holes.label).toBe("Glorious finishing holes");
+  });
+  it("descriptions carry NO auto-scored / config-only disclaimer", () => {
+    for (const def of Object.values(MODIFIER_REGISTRY)) {
+      expect(def.description.length).toBeGreaterThan(0);
+      expect(def.description.toLowerCase()).not.toMatch(/auto-scored|config-only|rule of the day/);
+    }
+  });
 });
 
 // The four render branches the crossed test-matrix exercises (Task 0). Maps each

--- a/src/lib/modifiers.ts
+++ b/src/lib/modifiers.ts
@@ -28,7 +28,9 @@ export type ModifierControl = "checkbox" | "checkbox+stepper";
 export interface ModifierDef {
   key: string;
   label: string;
-  /** Honest, config-only copy — must not imply the app auto-enforces the rule. */
+  /** The card description — Zach's exact mock wording (W-GAMEPAGE P-E). No
+   *  "config-only / not-auto-scored" disclaimer: a stale disclaimer left in when
+   *  scoring logic lands is worse than none (deliberate reversal of #469). */
   description: string;
   controlType: ModifierControl;
 }
@@ -40,14 +42,14 @@ export const GLORIOUS_HOLES_MAX = 9;
 export const MODIFIER_REGISTRY: Record<string, ModifierDef> = {
   moving_tees: {
     key: "moving_tees",
-    label: "Moving tees",
-    description: "Trailing side picks the next tee box. Recorded as a rule of the day — not auto-scored yet.",
+    label: "Moving tee boxes",
+    description: "Score well and everyone else will appreciate you moving back a tee. Score not so well, and move up a tee to get your mojo back. We'll help guide you so you don't forget.",
     controlType: "checkbox",
   },
   glorious_holes: {
     key: "glorious_holes",
     label: "Glorious finishing holes",
-    description: "The closing holes carry double. Recorded as a rule of the day — not auto-scored yet.",
+    description: "We suggest making the last 3 holes worth double for keeping things interesting up until the end, but you can choose your own adventure.",
     controlType: "checkbox+stepper",
   },
 };


### PR DESCRIPTION
Small, self-contained slice of the visual pass — chrome + copy for the modifier cards (`ModifierCards.tsx` / `lib/modifiers.ts`). **Data/registry behavior unchanged from #469** (snake_case keys, presence-model jsonb, `gameTypes.ts` applicability, hide-row-when-none). Consumes P-B's canonical `Stepper` (no local stepper re-introduced).

## Pre-flight (confirmed)
Switch toggle present; glorious-holes count already via the P-B compact `Stepper`; two snake_case modifiers. Located the exact current copy — the "…not auto-scored yet" disclaimer lived in **both** registry descriptions and the card's bottom caption.

## T1 — Switch → checkbox (§10)
Leading **checkbox** (left of title/description): teal fill + dark check (`on-accent`) when on, transparent/bordered when off. Same presence-model handler the Switch drove — appearance only. `glorious_holes` keeps the compact stepper below; `moving_tees` is checkbox-only.

## T2 — copy (§10), disclaimer dropped
- Both descriptions replaced with **Zach's exact mock wording** (verbatim — glorious: "We suggest making the last 3 holes worth double…"; moving: "Score well and everyone else will appreciate you moving back a tee…").
- `moving_tees` label "Moving tees" → **"Moving tee boxes"**.
- **Removed the disclaimer entirely** — both registry descriptions and the bottom caption (deliberate reversal of #469's guardrail: a stale disclaimer left in when scoring lands is worse than none). Updated the description-field comment + the summary test.

## T3 — tests
+2 registry tests lock the new labels and the **no-disclaimer rule** (descriptions must not match `/auto-scored|config-only|rule of the day/`) so it can't drift back. The toggle handler is the unchanged, already-tested `setModifierEnabled` presence-model round-trip.

## Verification
- `tsc --noEmit` clean · `next lint` clean · modifiers tests **22 pass** (+2) · critical-path `match-play.spec` green.
- **Eye-verified on real games (dark + light):** glorious_holes — leading teal checkbox + check, mock copy, compact `[− 3 +]` stepper; moving_tees — "Moving tee boxes", bordered off-checkbox, mock copy, **no stepper**; **no disclaimer** anywhere. Hide-row-when-none is untouched from #469 (the `availableModifiers.length > 0` gate is unchanged). No console errors. Test-game state restored.

Remaining visual-pass phases: **P-C** (Points inline), **P-D** (handicaps selector), **P-F** (scorecard), **P-G** (course chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)