### PR TITLE
fix(modifiers): de-frame the glorious-holes stepper (no box-in-a-box)

### DIFF
--- a/src/components/games/ModifierCards.tsx
+++ b/src/components/games/ModifierCards.tsx
@@ -81,15 +81,12 @@ export function ModifierCards({
 }
 
 /** Trailing-hole count for glorious finishing holes (the only stepper modifier).
- *  The count lives in the canonical compact <Stepper> now (P-B); the label carries
- *  the meaning the old inline sentence did. */
+ *  The count lives in the canonical compact <Stepper> (P-B). De-framed (§10): no
+ *  border/surface of its own — it's part of the modifier card, not a box-in-a-box.
+ *  `pl-8` aligns its label under the title (past the leading checkbox + gap). */
 function HoleStepper({ value, onChange, disabled }: { value: number; onChange: (n: number) => void; disabled?: boolean }) {
   return (
-    <div
-      className="mt-2.5 flex items-center justify-between rounded-lg px-3 py-2"
-      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-      data-testid="glorious-holes-stepper"
-    >
+    <div className="mt-2 flex items-center justify-between pl-8" data-testid="glorious-holes-stepper">
       <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>Final holes worth double</span>
       <Stepper
         size="compact"


### PR DESCRIPTION
P-E polish (vocabulary §10). The compact hole-count stepper rendered inside its **own bordered/filled sub-box** nested in the already-bordered modifier card — a box-in-a-box. §10's card is one unit; the compact stepper carries no container border/fill of its own.

## Change (layout only, one wrapper)
`HoleStepper`'s wrapper loses its `border` + surface `background` + rounded-box padding. The stepper row now sits **within** the modifier card as part of the same unit, with `pl-8` aligning its "Final holes worth double" label under the title (past the leading checkbox + gap).

The canonical `<Stepper>` (P-B), the toggle/count handlers, the mock copy, and the registry/jsonb behavior (#469) are all **untouched**.

## Verification
- `tsc --noEmit` clean · `next lint` clean · modifier tests pass (no assertion changes — layout only).
- **Eye-verified dark + light:** the glorious-holes card reads as one unit — checkbox + title/desc + the de-framed `[− 3 +]` (computed `border-width: 0px`, transparent bg), no inner box; checkbox/title alignment clean; on/off both fine. `moving_tees` (checkbox-only) unchanged — still no stepper. No console errors. Test-game state restored.

(Built on main after #480 merged, per the precondition.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)