### PR TITLE
Readiness P1: one shared match-play-ready threshold + honest ready-not-armed copy

### DIFF
--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -166,8 +166,10 @@ export function GameRow({
 
   // Subtitle / running state (§A3), all keyed off the one derived lifecycle:
   //  - live   → running state (the real "Blue 2 up · thru 13" is deferred).
-  //  - ready  → SPLIT by the arm tell: armed = good to go; not-armed = the
-  //             remaining pre-live step (so the muted icon has a matching nudge).
+  //  - ready  → SPLIT by the arm tell: armed = good to go; not-armed = the one
+  //             remaining step is ENABLING scoring (the roster IS assigned — that's
+  //             what `configured` means — and handicaps are optional/never gate, so
+  //             the old "Assign players + handicaps" was wrong; readiness rework P1a).
   //  - setting-up → a tap-to-continue CTA, but only when the row is tappable;
   //             an inert crew row leans on the dashed outline alone (§A3).
   //  - final  → none; the recessed tile + outer result speak for it.
@@ -177,7 +179,7 @@ export function GameRow({
       : lifecycle === "ready"
       ? armed
         ? "Ready to play"
-        : "Assign players + handicaps"
+        : "Ready — enable scoring"
       : lifecycle === "setting-up"
       ? tappable
         ? "Tap to keep setting up"

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, type MatchSides } from "./matchDraft";
+
+// Readiness rework P1b — the ONE match-play readiness threshold, shared by the
+// setup-page Enable gate and the server `isConfigured` so they can't drift.
+describe("matchPlayReady (the shared threshold)", () => {
+  it("ready only when there is ≥1 match AND every match is paired (paired === total)", () => {
+    expect(matchPlayReady(5, 5)).toBe(true); // all paired
+    expect(matchPlayReady(3, 5)).toBe(false); // partial — was wrongly "ready" on the list before
+    expect(matchPlayReady(0, 1)).toBe(false); // a seeded-but-empty match is not ready
+    expect(matchPlayReady(0, 0)).toBe(false); // nothing to score
+    expect(matchPlayReady(1, 1)).toBe(true);
+  });
+});
 
 // W-GAMEPAGE-01 §6.1/§7 — the hard-block readiness gate. An empty or half-filled
 // match must keep "Enable scoring" disabled (no silent collapse to the filled

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -28,10 +28,24 @@ export function filledMatches<M extends MatchSides>(draft: M[], playersPerSide: 
 }
 
 /**
+ * The ONE match-play readiness threshold (readiness rework P1b). A match game is
+ * ready ⟺ it has ≥1 match AND **every** match is paired — `paired === total`, no
+ * empty slots. Both surfaces consume THIS so they can't drift: the setup-page
+ * Enable gate (via `allMatchesFilled`, over the client draft) and the server
+ * `isConfigured` (over `game_matches` rows). Before this, setup demanded all-paired
+ * while the list called ≥1-paired "ready" — a 3/5 game read "ready" on the list but
+ * "can't enable" on setup. Now list-ready ⟺ setup-can-enable.
+ */
+export function matchPlayReady(pairedCount: number, totalCount: number): boolean {
+  return totalCount > 0 && pairedCount === totalCount;
+}
+
+/**
  * The Enable-scoring gate: at least one match AND every match fully paired. An
  * empty draft is NOT ready (nothing to score); a draft with any unfilled slot is
- * NOT ready (the hard block — no silent collapse to the filled count).
+ * NOT ready (the hard block — no silent collapse to the filled count). Delegates
+ * to `matchPlayReady` so the threshold is shared with the server, not duplicated.
  */
 export function allMatchesFilled(draft: MatchSides[], playersPerSide: number): boolean {
-  return draft.length > 0 && draft.every((m) => isMatchFilled(m, playersPerSide));
+  return matchPlayReady(filledMatches(draft, playersPerSide).length, draft.length);
 }

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -3,6 +3,7 @@ import { rollUp, placementDetail, awardedForGame, type LiveGame } from "@/lib/co
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
 import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
 import { isManualGameType } from "@/lib/gameTypes";
+import { matchPlayReady } from "@/lib/matchDraft";
 
 const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
 // Roster-gated golf formats: a stroke field / rack auto-grouping is "configured"
@@ -13,7 +14,10 @@ const ROSTER_TYPES = new Set(["gtt_stroke_play", "gtt_rack_n_stack"]);
  * Is the game configured enough to be Ready (vs still Setting up)? "Ready must
  * be earned, not assumed" — exists-and-not-live ≠ Ready. The format's REQUIRED
  * roster is the gate; course + handicaps are optional and NEVER gate readiness:
- *  - match play → pairings assigned (game_matches rows)
+ *  - match play → ALL pairings assigned (`matchPlayReady`: paired === total, ≥1) —
+ *    the SAME threshold the setup-page Enable gate uses, so list-ready ⟺
+ *    setup-can-enable (readiness rework P1b). A partly-paired game (3/5) is NOT
+ *    configured → it reads "setting up" on the list, matching its setup page.
  *  - stroke / rack → participants assigned (game_participants rows)
  *  - manual / side events → points configured (no roster to assign)
  * One signal: lifecycle AND the row's `N PTS`/`—` both read it, so they can't
@@ -21,11 +25,12 @@ const ROSTER_TYPES = new Set(["gtt_stroke_play", "gtt_rack_n_stack"]);
  */
 function isConfigured(
   typeId: string | null,
-  matchCount: number,
+  matchPaired: number,
+  matchTotal: number,
   participantCount: number,
   hasPoints: boolean
 ): boolean {
-  if (typeId && MATCH_PLAY_TYPES.has(typeId)) return matchCount > 0;
+  if (typeId && MATCH_PLAY_TYPES.has(typeId)) return matchPlayReady(matchPaired, matchTotal);
   if (typeId && ROSTER_TYPES.has(typeId)) return participantCount > 0;
   return hasPoints;
 }
@@ -138,7 +143,13 @@ export async function computeCompetitionLeaderboard(
   // "configured rows incl. empty, ≥1 from creation" goalpost — pairing now moves
   // the live clinch target, by design.)
   const matchCountByGame = new Map<string, number>();
+  // Total match ROWS (paired + the seeded/unpaired) per game — already in the
+  // fetched data, no extra query. Feeds the readiness threshold: a match game is
+  // configured only when EVERY row is paired (`paired === total`), the SAME bar
+  // the setup-page Enable gate uses (`matchPlayReady`) — readiness rework P1b.
+  const totalMatchRowsByGame = new Map<string, number>();
   for (const r of (matchRowsRes.data ?? []) as { game_id: string; side_a: unknown; side_b: unknown }[]) {
+    totalMatchRowsByGame.set(r.game_id, (totalMatchRowsByGame.get(r.game_id) ?? 0) + 1);
     if (r.side_a == null || r.side_b == null) continue;
     matchCountByGame.set(r.game_id, (matchCountByGame.get(r.game_id) ?? 0) + 1);
   }
@@ -278,6 +289,7 @@ export async function computeCompetitionLeaderboard(
         configured: isConfigured(
           typeId,
           matchCountByGame.get(gid) ?? 0,
+          totalMatchRowsByGame.get(gid) ?? 0,
           participantCountByGame.get(gid) ?? 0,
           hasPoints
         ),

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -375,6 +375,42 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     expect(game.pointsTotal).toBe(2); // value 2 × 1 assigned match
   });
 
+  it("a MULTI-match game is NOT configured until EVERY match is paired (readiness rework P1b)", async () => {
+    // The threshold fix: the list called a match game ready at ≥1 paired, while the
+    // setup page only enables when ALL are paired. A 1-of-2 game must now read
+    // Setting up (not Ready), so the two surfaces agree.
+    const comp = await ctx.createCompetition(tripId, "D2 Partial Pairing Comp");
+    await ctx.createTeam(comp, "A", { shortName: "A" });
+    await ctx.createTeam(comp, "B", { shortName: "B" });
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: "gtt_match_play_singles", name: "Partial", competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 2 },
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    // Two rows: one fully paired, one with an empty side → PARTIAL (1 of 2).
+    await ctx.admin.from("game_matches").delete().eq("game_id", g.id);
+    await ctx.admin.from("game_matches").insert([
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 1, display_order: 0,
+        side_a: { type: "user", id: ctx.getUser("owner").id },
+        side_b: { type: "user", id: ctx.getUser("member").id }, status: "pending" },
+      { id: crypto.randomUUID(), game_id: g.id, match_number: 2, display_order: 1,
+        side_a: { type: "user", id: ctx.getUser("planner").id },
+        side_b: null, status: "pending" },
+    ]);
+    let lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    let game = lb.games.find((x: { id: string }) => x.id === g.id) as { configured: boolean };
+    expect(game.configured).toBe(false); // 1 of 2 paired → still Setting up (was wrongly Ready before)
+
+    // Pair the second match → 2 of 2 → configured.
+    await ctx.admin.from("game_matches")
+      .update({ side_b: { type: "user", id: ctx.getUser("outsider").id } })
+      .eq("game_id", g.id).eq("match_number", 2);
+    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    game = lb.games.find((x: { id: string }) => x.id === g.id) as { configured: boolean };
+    expect(game.configured).toBe(true); // all paired → Ready
+  });
+
   it("pointsTotal (§A5 outer column) reads the distribution sum when no owner total is set", async () => {
     // The board row's `N PTS` must match what rollUp counts as available, even
     // for a distribution-only placement game (no explicit points_total). 9+6=15.


### PR DESCRIPTION
Implements P1a + P1b from the readiness Phase-0 report. Two surfaces computed "ready" with **different thresholds** and the not-yet-enabled subtitle was wrong; this fixes both at the source.

## The bug
- **Threshold drift (P1b):** the setup page enables only when **all** matches are paired (`allMatchesFilled`), but the server `isConfigured` called a match game ready at **≥1** paired (`matchCount > 0`). A 3/5 game read **"ready"** on the BBMI Cup list while its own setup page showed it **can't-enable**.
- **Wrong copy (P1a):** a configured-but-not-enabled game showed **"Assign players + handicaps"** — but a `configured` game already has its roster, and handicaps are optional/never gate. The one remaining step is **enabling scoring**.

**Decision (Zach): all-paired is the truth.** A partly-paired game reads "setting up" on the list, matching its setup page.

## P1b — one shared threshold
- `matchDraft.ts`: extracted pure **`matchPlayReady(paired, total) = total > 0 && paired === total`**; `allMatchesFilled` now delegates to it (one rule, not two).
- `competitionLeaderboard.ts`: `isConfigured`'s match-play branch consumes the **same** `matchPlayReady` (`paired === total`), using the total match-row count — **already in the fetched `game_matches` data, no new query**. Non-match-play branches + the course/handicaps exclusion untouched.
- Result: **list-ready ⟺ setup-can-enable.** A partly-paired game reads "setting up" on both.

## P1a — honest subtitle
`GameRow.tsx`: ready-not-armed → **"Ready — enable scoring"** (was "Assign players + handicaps"). *(Flag for Zach if a different voice is preferred — the meaning, enable-not-assign, is the fix.)*

## Scope
Per the report: **no flicker/collapse-boundary work (P2), no Points/Modifiers gating (P3)** — separate specs.

## Verification
- `tsc` + `next lint` clean.
- Tests: `matchPlayReady` unit; **new server test** — a multi-match game with 1 of 2 paired is **not** configured (was wrongly Ready under the old bar), configured once all paired. `competitions.d2`/`d1followon` green (32). Critical-path E2E green.
- **Eye-verified on the real BBMI Cup list (dark + light):** "Assign players + handicaps" **gone everywhere**; configured-not-armed games (1v1, Rack-n-Stack, SP Course, test) read **"Ready — enable scoring"**; armed games "Ready to play"; the 0-paired "test match 2v2" reads "Tap to keep setting up" (configured false — consistent with its setup page). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)