### PR TITLE
Readiness P2: collapse-boundary Matches validity (kill the red-X flicker)

### DIFF
--- a/src/components/games/ChecklistRow.test.ts
+++ b/src/components/games/ChecklistRow.test.ts
@@ -38,6 +38,22 @@ describe("checklistRowVisuals", () => {
     expect(checklistRowVisuals("empty", true).border).toBe("1px solid var(--color-bt-border)");
   });
 
+  // Readiness rework P2 — the collapse-boundary verdict: while OPEN, an invalid row
+  // reads fully NEUTRAL (no red border / danger icon / X badge); the red verdict
+  // only appears once COLLAPSED. Kills the mid-build red↔teal flicker.
+  it("invalid is NEUTRAL while open, red only when collapsed", () => {
+    const open = checklistRowVisuals("invalid", true);
+    expect(open.border).not.toContain("danger"); // no red border while editing
+    expect(open.iconColor).not.toContain("danger"); // no danger icon while editing
+    expect(open.iconColor).toBe("var(--color-bt-text)"); // active/white, the editing look
+    expect(open.badge).toBeNull();
+
+    const collapsed = checklistRowVisuals("invalid", false);
+    expect(collapsed.border).toContain("var(--color-bt-danger)"); // verdict resolves on collapse
+    expect(collapsed.iconColor).toBe("var(--color-bt-danger)");
+    expect(collapsed.badge).toBe("x");
+  });
+
   it("the icon container is raised only when active (resolved/open), transparent when empty", () => {
     expect(checklistRowVisuals("empty", false).iconBg).toBe("transparent");
     expect(checklistRowVisuals("resolved", false).iconBg).toBe("var(--color-bt-card-raised)");

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -43,7 +43,14 @@ export interface RowVisuals {
 }
 export function checklistRowVisuals(state: ChecklistRowState, isOpen: boolean): RowVisuals {
   const resolved = state === "resolved";
-  const invalid = state === "invalid";
+  // Collapse-boundary validity (readiness rework P2): while the row is OPEN (the
+  // user is editing), an `invalid` row reads NEUTRAL — no red verdict. The
+  // invalid/resolved verdict resolves on COLLAPSE, so the red border + danger icon
+  // + red-X badge only apply when collapsed. (The badge already gated on `!isOpen`
+  // since P-A; folding `!isOpen` into `invalid` extends the same rule to the border
+  // + icon, killing the mid-build red↔teal flicker. The underlying `allFilled` truth
+  // is unchanged and still drives the Enable gate — this is presentation timing only.)
+  const invalid = state === "invalid" && !isOpen;
   const active = resolved || isOpen;
   return {
     surface: isOpen ? "var(--color-bt-card-raised)" : resolved ? "var(--color-bt-card)" : "transparent",


### PR DESCRIPTION
Implements P2 from the readiness Phase-0 report. The Matches row's invalid (red) state was **live-derived**, so the red border + danger icon flipped red↔resolved on **every slot edit** mid-build — flagging a half-built match as an error on each keystroke.

## The fix (one place)
**Decided model (Zach):** validity resolves at the **collapse boundary**, not live. While the Matches row is **open/editing**, it reads **neutral** (no red verdict); the invalid/resolved verdict appears **on collapse**.

Phase 0 Q2 confirmed: open+invalid *did* show red today — `checklistRowVisuals` gated the **badge** on `!isOpen` (since P-A) but **not** the border or icon color. So the fix is to fold `!isOpen` into the `invalid` branch:

```ts
const invalid = state === "invalid" && !isOpen;
```

Now an invalid row reads fully neutral while open (raised surface, solid border, white icon, no badge) and shows the full red verdict (border + danger icon + X badge) only when collapsed — extending the badge's existing rule to the border + icon, in **one function**, for any invalid row. **No call-site change**, no new state, no persisted data.

## Scope
Per the report: **no threshold/predicate change** (P1 shipped that), **no Enable-button change** (still gated on `!allFilled` + `attemptReady`), **no downstream gating** (P3), **no `GameRow` change**.

## Verification
- `tsc` + `next lint` clean · `ChecklistRow` unit tests pass (added: invalid-neutral-while-open vs red-when-collapsed) · critical-path E2E green.
- **Eye-verified on the 2v2 game (dark + light):** the Matches row reads **red when collapsed** (`rgb(248,113,113)` border) and flips to **neutral when opened** (`rgba(148,163,184,.18)` border, white icon) — **the mid-build flicker is gone**; re-collapsing restores the red verdict; **Enable stays blocked** when collapsed-invalid (gate unchanged). No console errors; the game was not mutated (no slots assigned).

The screenshots show the open row neutral (was red) while the pairing builder is being filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)