### PR TITLE
Readiness P3: Matches gates Points + Modifiers (lock until a valid match)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -27,7 +27,7 @@ import { buildDecided, matchState, strokeHoles, matchHasScores, type HoleResult 
 import { DangerConfirmModal } from "@/components/DangerZone";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import { filledMatches, allMatchesFilled } from "@/lib/matchDraft";
+import { filledMatches, allMatchesFilled, hasValidMatch } from "@/lib/matchDraft";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
@@ -973,7 +973,10 @@ export default function NewMatchGamePage() {
         // stay overlays this pass (tracked follow-ons) but ride the same one-open.
         const allFilled = allMatchesFilled(draft, playersPerSide);
         const anyHandicap = draft.some((d) => d.handicap !== 0);
-        const matchesExist = filledDraft.length > 0;
+        // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points,
+        // Handicaps, and Modifiers stay LOCKED until a match exists (they mean nothing
+        // before there's a match to apply them to). One named predicate, shared.
+        const matchesExist = hasValidMatch(draft, playersPerSide);
         const savingSetup =
           setPairings.isPending || setHandicap.isPending ||
           setDoublesPairings.isPending || setDoublesHandicap.isPending;
@@ -1108,6 +1111,7 @@ export default function NewMatchGamePage() {
                 game={gameQ.data as unknown as GameRow}
                 canEdit={canEdit}
                 matchCount={filledDraft.length}
+                configLocked={!matchesExist}
                 configOpen={openRow === "config"}
                 onOpenConfig={() => changeOpenRow("config")}
                 onCloseEditor={() => changeOpenRow(null)}
@@ -1151,7 +1155,7 @@ export default function NewMatchGamePage() {
                 subtitle={modifiersSubtitle}
                 state={modifiersState}
                 expanded={openRow === "modifiers"}
-                onToggle={() => toggleRow("modifiers")}
+                onToggle={matchesExist ? () => toggleRow("modifiers") : undefined}
                 testId="row-modifiers"
               >
                 <ModifierCards

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -31,6 +31,7 @@ export function GameSetupRows({
   onChanged,
   slot = "both",
   matchCount,
+  configLocked = false,
   courseOpen: courseOpenProp,
   configOpen: configOpenProp,
   onOpenCourse,
@@ -52,6 +53,10 @@ export function GameSetupRows({
    *  (W-GAMEPAGE-01 §6.2). Derived live by the page — omit on surfaces that don't
    *  build matches (no Total shown). */
   matchCount?: number;
+  /** Lock the Points (config) row until ≥1 valid match exists (readiness rework P3
+   *  — points mean nothing before a match). Locked = read-only, no chevron, same as
+   *  a gated Handicaps row. Default false (unlocked). */
+  configLocked?: boolean;
   /** Page-owned one-open state (controlled). Omit → self-managed (uncontrolled). */
   courseOpen?: boolean;
   configOpen?: boolean;
@@ -120,7 +125,9 @@ export function GameSetupRows({
           state={perMatch > 0 ? "resolved" : "empty"}
           disabled={!canEdit}
           expanded={configOpen}
-          onToggle={configOpen ? closeEditor : openConfig}
+          // P3: locked until a match exists → omit onToggle (read-only, no chevron),
+          // matching the gated Handicaps row. (The Enable gate / Points>0 stay P-C.)
+          onToggle={configLocked ? undefined : configOpen ? closeEditor : openConfig}
           testId="row-format-points"
         >
           <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} matchCount={matchCount} />

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, type MatchSides } from "./matchDraft";
 
 // Readiness rework P1b — the ONE match-play readiness threshold, shared by the
 // setup-page Enable gate and the server `isConfigured` so they can't drift.
+// Readiness rework P3 — the downstream gate (Points/Handicaps/Modifiers locked
+// until a valid match exists).
+describe("hasValidMatch (the downstream gate)", () => {
+  const s = (a: string[], b: string[]): MatchSides => ({ a, b });
+  it("true only when ≥1 match is fully paired", () => {
+    expect(hasValidMatch([s(["x"], ["y"])], 1)).toBe(true); // 1 paired
+    expect(hasValidMatch([s(["x"], ["y"]), s([], [])], 1)).toBe(true); // ≥1 paired (the other empty)
+  });
+  it("false at zero paired — incl. a seeded-but-empty match", () => {
+    expect(hasValidMatch([s([], [])], 1)).toBe(false); // seeded empty only
+    expect(hasValidMatch([s(["x"], [])], 1)).toBe(false); // half-paired only
+    expect(hasValidMatch([], 1)).toBe(false);
+  });
+});
+
 describe("matchPlayReady (the shared threshold)", () => {
   it("ready only when there is ≥1 match AND every match is paired (paired === total)", () => {
     expect(matchPlayReady(5, 5)).toBe(true); // all paired

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -28,6 +28,23 @@ export function filledMatches<M extends MatchSides>(draft: M[], playersPerSide: 
 }
 
 /**
+ * Does ≥1 valid (fully-paired) match exist? (Readiness rework P3 — the downstream
+ * gate.) Points / Handicaps / Modifiers mean nothing before there's a match to
+ * apply them to, so they stay LOCKED until this is true. This is the ONE "a match
+ * exists" definition the setup rows share — distinct from `matchPlayReady` (which
+ * needs ALL matches paired, the stricter Enable bar). A seeded-but-empty match
+ * does NOT count.
+ *
+ * ⚠ P-C seam: P-C adds "Points > 0 joins the Enable gate." That's a *separate*
+ * predicate on the Points value — it does NOT change THIS match-existence gate.
+ * Keep them apart: P3 = "can the row be edited at all"; P-C = "does the Enable
+ * button light up."
+ */
+export function hasValidMatch(draft: MatchSides[], playersPerSide: number): boolean {
+  return filledMatches(draft, playersPerSide).length > 0;
+}
+
+/**
  * The ONE match-play readiness threshold (readiness rework P1b). A match game is
  * ready ⟺ it has ≥1 match AND **every** match is paired — `paired === total`, no
  * empty slots. Both surfaces consume THIS so they can't drift: the setup-page


### PR DESCRIPTION
Implements P3 from the readiness Phase-0 report. The downstream rows shouldn't be configurable before there's a match to apply them to. Phase 0 found this **half-built** — Handicaps was already gated, but **Points and Modifiers weren't.** This extends the same pattern.

## Pre-flight
Confirmed `matchesExist = filledDraft.length > 0` is already **≥1 paired match** (filledDraft = paired) — so Handicaps gates correctly (not a hair early), and P3 reuses this exact notion. The Handicaps locked presentation = **omit `onToggle`** → ChecklistRow read-only (no chevron, no dim). Matched it; nothing invented.

## T1 — one named predicate
`hasValidMatch(draft, pps) = filledMatches(...).length > 0` in `matchDraft.ts` — the single "a valid match exists" definition all three rows share. Distinct from `matchPlayReady` (P1, needs **all** paired). Comments the **P-C seam** (Points>0-in-the-Enable-gate is a *separate* predicate, not this gate). `matchesExist` now calls it.

## T2 — gate Points
`GameSetupRows` gains `configLocked`; the page passes `!matchesExist`. The config row omits `onToggle` when locked → read-only, no chevron (the Handicaps pattern).

## T3 — gate Modifiers
`onToggle={matchesExist ? … : undefined}` — same lock. **hide-row-when-none (#469) untouched**: a no-compatible-modifier game still hides the row regardless of the gate (the gate is inside the `availableModifiers.length > 0` wrapper).

## Scope (per the report + P-C coordination)
No threshold change (P1), no flicker work (P2), and **no P-C work** — the stepper stays expand-based, the format picker stays, and Points>0 is **not** added to the Enable gate. P3 only gates *whether the rows are interactive*, keyed on match existence.

## Verification
- `tsc` + `next lint` clean · `matchDraft` tests 10 pass (+1 `hasValidMatch`) · critical-path E2E green.
- **Eye-verified on real games (dark + light):**
  - **No valid match** (0-paired 2v2): Points, Handicaps, **Modifiers** all read-only (no chevron) — locked; Matches + Course stay tappable.
  - **≥1 valid match** (5/5 singles): Points, Handicaps, Modifiers all **unlock**.
  - No-compatible-modifier game still **hides** the Modifiers row (gate doesn't override hide-when-none).
  - No console errors.

## Note on stacking
Branched off main (independent of P2/#483, which only touches `ChecklistRow.tsx` — no overlap). The readiness rework's final item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)