### PR TITLE
fix(gamepage): open Matches panel reads neutral at 1/2 — neutralize draft remove button (readiness P2b)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1582,7 +1582,14 @@ function MatchSetup({
                 <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>Match {i + 1}</span>
                 <div className="flex items-center gap-1">
                   {/* Remove this match (down to the minimum of 1). Pre-tee-off
-                      draft has no persisted scores, so removal is free here. */}
+                      draft has no persisted scores, so removal is FREE here — and
+                      the panel is open/editing, where nothing must read as an error
+                      (readiness rework P2b: open → neutral always). So this is a
+                      DIM control (matching the grip handle below), not a danger-red
+                      one — the red `−` was the lone red left in the open panel and
+                      the thing that made "1 of 2" look invalid vs "1 of 1". The
+                      runtime-overview remove (a scored, destructive match) keeps
+                      its danger color; this draft one does not. */}
                   {draft.length > 1 && (
                     <button
                       type="button"
@@ -1590,7 +1597,7 @@ function MatchSetup({
                       title="Remove match"
                       aria-label={`Remove match ${i + 1}`}
                       className="flex items-center justify-center"
-                      style={{ width: 24, height: 24, color: "var(--color-bt-danger)" }}
+                      style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)" }}
                     >
                       <Minus size={16} />
                     </button>


### PR DESCRIPTION
Follow-up to #483 (readiness P2). Closes the "second red mechanism" Zach observed: an OPEN Matches panel still went red when a 2nd match was added.

## The bug
Three Matches states, dark mode:
1. Collapsed 1/1 → resolved teal check ✅
2. Open 1/1 → neutral ✅ (P2 working)
3. **Open 1/2 (a 2nd, empty match added) → red ❌**

P2 neutralized the row **header** (border / danger icon / red-X badge) while open. But state 3 still read red.

## Diagnosis (T1) — distinct from P2, not a regression of its guard
Verified live via DOM eval at open 1/2: the row **container border is neutral** (`rgba(148,163,184,0.18)`) and the icon **has no badge** — P2's header path is fully working. The only danger-colored descendants were the **two per-match draft remove (`−`) buttons** at [page.tsx:1593](../blob/fix/readiness-p2b-open-panel-neutral/src/app/trips/%5BtripId%5D/games/match/new/page.tsx#L1593): hardcoded `color: var(--color-bt-danger)`, rendered only when `draft.length > 1`. They're **absent at 1/1** (can't remove the last match) and **appear at 1/2** — which is exactly what made state 3 differ from state 2. The "panel went red" was these buttons appearing.

## Fix (T2)
The draft remove is a **free** action (filters the local array — no persisted scores) inside the open/editing panel, where nothing should read as an error. Made it a **dim control** (`var(--color-bt-text-dim)`, matching the adjacent grip handle) instead of danger-red.

The **runtime-overview** remove button (page.tsx:1813) — a genuinely destructive action on a scored, persisted match — **keeps** its danger color. Different surface, different gravity.

## Scope guardrails honored
- **No change to validity truth** — `allMatchesFilled` / `matchPlayReady` / `hasValidMatch` untouched; Enable gate unchanged.
- **Red verdict preserved** — collapsing at 1/2 still shows the red border + red-X badge (verified live). Open → neutral; collapsed-unpaired → red.
- **No new open/collapsed state** — reuses the existing draft-only render path.

## Verification (T3)
- `tsc --noEmit` clean; `next lint` clean
- **772 unit tests pass.** The fix is a single color token on a JSX button — no extractable pure logic, and the node test env has no RTL — so the existing `checklistRowVisuals` suite (which already covers `invalid` reading neutral while open) remains the unit guard for the header principle; this presentational change is eye-verified.
- Critical-path E2E green (one flaky `Score 7` timeout in the unrelated stroke path on first run, green on re-run)
- **Eye-verified dark + light**: open 1/2 → fully neutral (remove buttons dim, no red anywhere); collapsed 1/2 → red border + red-X badge preserved
- Test game `010b8be8` restored — draft edits never persisted (1 match, confirmed in DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
