### PR TITLE
feat(gamepage): Phase C — Points row inline + Enable gate + Add Game teardown (default-0)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -972,12 +972,17 @@ export default function NewMatchGamePage() {
         // persist (the draft editors commit on close). Course + Name·Format·Points
         // stay overlays this pass (tracked follow-ons) but ride the same one-open.
         const allFilled = allMatchesFilled(draft, playersPerSide);
-        // C3: points > 0 joins the Enable gate (Phase C). Read the persisted
-        // per-match value — the SAME number the inline Points row shows — so the
-        // row's resolved state and the gate agree (one truth). pointsReady is the
-        // family's client-gate extension (matchDraft.ts).
+        // C3: points > 0 joins the Enable gate (Phase C) — but ONLY for a
+        // COMPETITION game. Points-per-match is a cup concept: the inline Points row
+        // exists only when `gameCompId` is set (GameSetupRows gates it on
+        // competitionId), and a STANDALONE match game has no points at all (created
+        // with points_distribution null). So the points term is conditional —
+        // otherwise a standalone game (no Points UI, always 0) could NEVER enable.
+        // The per-match value read here is the SAME number the inline Points row
+        // shows, so the row's resolved state and the gate agree (one truth);
+        // pointsReady is the family's client-gate extension (matchDraft.ts).
         const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
-        const enableReady = allFilled && pointsReady(pointsPerMatch);
+        const enableReady = allFilled && (!gameCompId || pointsReady(pointsPerMatch));
         const anyHandicap = draft.some((d) => d.handicap !== 0);
         // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points,
         // Handicaps, and Modifiers stay LOCKED until a match exists (they mean nothing

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -27,7 +27,7 @@ import { buildDecided, matchState, strokeHoles, matchHasScores, type HoleResult 
 import { DangerConfirmModal } from "@/components/DangerZone";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import { filledMatches, allMatchesFilled, hasValidMatch } from "@/lib/matchDraft";
+import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady } from "@/lib/matchDraft";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
@@ -972,6 +972,12 @@ export default function NewMatchGamePage() {
         // persist (the draft editors commit on close). Course + Name·Format·Points
         // stay overlays this pass (tracked follow-ons) but ride the same one-open.
         const allFilled = allMatchesFilled(draft, playersPerSide);
+        // C3: points > 0 joins the Enable gate (Phase C). Read the persisted
+        // per-match value — the SAME number the inline Points row shows — so the
+        // row's resolved state and the gate agree (one truth). pointsReady is the
+        // family's client-gate extension (matchDraft.ts).
+        const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
+        const enableReady = allFilled && pointsReady(pointsPerMatch);
         const anyHandicap = draft.some((d) => d.handicap !== 0);
         // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points,
         // Handicaps, and Modifiers stay LOCKED until a match exists (they mean nothing
@@ -1188,10 +1194,16 @@ export default function NewMatchGamePage() {
                 commit-to-play) + Save & exit (secondary, always enabled — the
                 leave-and-resume door; flushes the rules note then navigates). */}
             <div className="flex flex-col gap-2 pt-2">
+              {/* Enable spine = all matches paired AND points > 0 (C3). Course is
+                  DELIBERATELY NOT in this gate — ever. A game must be able to start
+                  with no course: an off-API course, dead cell signal, or network
+                  outage are all real, and you only lose course metrics + handicaps,
+                  never the ability to play. Do not "complete the spine" by adding
+                  courseResolved here. */}
               <PrimaryButton
                 label={enableScoring.isPending ? "Enabling…" : "Enable scoring"}
                 onClick={attemptReady}
-                disabled={savingSetup || enableScoring.isPending || !allFilled}
+                disabled={savingSetup || enableScoring.isPending || !enableReady}
               />
               {gameCompId && (
                 <button

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -12,7 +12,7 @@ import { ModifierCards } from "@/components/games/ModifierCards";
 import { Stepper } from "@/components/games/Stepper";
 import type { PointsDistribution } from "@/lib/pointsDistribution";
 import {
-  validatePlacement, matchReadout, placementFit, matchFit, deriveMatchCount, type MatchFormat,
+  validatePlacement, matchReadout, placementFit, matchFit, type MatchFormat,
 } from "@/lib/gameConfig";
 // Format definitions live in code (W-PERF-01) — the catalog + its type come from
 // here, read synchronously, never fetched. Re-exported below so existing
@@ -21,11 +21,6 @@ import {
 import { GAME_TYPES, gameTypesForScoringModel, type GameType, type ScoringModel } from "@/lib/gameTypes";
 
 export type { GameType };
-
-// Mirrors the builder cap (matches router / match-new page). The page-one match
-// count seeds the builder's initial slot count up to here.
-const MAX_MATCHES = 24;
-const MATCH_PLAY_DOUBLES = "gtt_match_play_doubles";
 
 /**
  * CompetitionGamesPanel — the Slice D contest list + the two-tab add/edit page
@@ -403,10 +398,6 @@ export function GameSheet({
     const d = game?.points_distribution;
     return d?.type === "per_match" ? d.value : 1;
   });
-  // Page-one match count (1v1/2v2 only): SEEDS the builder's initial slot count
-  // on create — it is NOT a stored target. null = "follow the team-size default"
-  // (updates as teams get sized); a number = the owner set it explicitly.
-  const [matchCountOverride, setMatchCountOverride] = useState<number | null>(null);
   // Placement split. 1st place initializes EMPTY (never 0) so "untouched" stays
   // distinct from "entered 0".
   const [placeInputs, setPlaceInputs] = useState<string[]>(() => {
@@ -442,7 +433,6 @@ export function GameSheet({
   // Paired match play (1v1 / 2v2) — the ONLY formats that get a page-one match
   // count. Rack (rack_n_stack) auto-groups by team size, stroke has no matches.
   const isPairedMatch = selectedType?.resultStrategy === "match_play";
-  const isDoubles = effectiveTypeId === MATCH_PLAY_DOUBLES;
   const isGolf = category === "golf";
 
   // Members (for the delegate picker + name resolution) and the existing grant.
@@ -461,13 +451,6 @@ export function GameSheet({
   const teamSizes = useMemo(() => Object.values((teamCounts as Record<string, number>) ?? {}), [teamCounts]);
   const numTeams = teamSizes.length;
 
-  // The team-size estimate the builder would otherwise seed with — the default
-  // the page-one field pre-fills (clamped ≥1, ≤ cap). The owner can override it.
-  const derivedMatchCount = Math.max(
-    1,
-    Math.min(MAX_MATCHES, deriveMatchCount(teamSizes, matchFormatFor(effectiveTypeId)) ?? 1)
-  );
-  const matchCount = matchCountOverride ?? derivedMatchCount;
   // On edit, "how many matches" is DERIVED from the live rows (display only —
   // the count is changed in the builder, not re-typed here).
   const existingMatchesQ = trpc.matches.listByGame.useQuery(
@@ -486,10 +469,6 @@ export function GameSheet({
   const removeOrg = trpc.games.removeOrganizer.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
   const clearCourse = trpc.games.clearCourse.useMutation();
-  // Seed the builder's slots on create — empty (unpaired) rows, which count 0
-  // until paired (#394), so the game stays Setting-up · — until the builder.
-  const setPairings = trpc.matches.setPairings.useMutation();
-  const setDoublesPairings = trpc.matches.setDoublesPairings.useMutation();
 
   // Resolve the applied course's NAME for the field label (a pre-set course
   // has an id but no just-picked name). Skipped when nothing's applied.
@@ -578,9 +557,16 @@ export function GameSheet({
         }
         await setDist.mutateAsync({ tripId, gameId, distribution });
       } else {
+        // C1 default-0: a NEW match game is created at 0 points-per-match — its
+        // value is set on the setup page's inline Points row (C2), and 0 keeps the
+        // Enable gate shut (C3) until it's set. Placement games keep the Add
+        // stepper, so their distribution comes from `buildDistribution()`.
+        const createDistribution: PointsDistribution | null = isMatchPlay
+          ? { type: "per_match", value: 0 }
+          : distribution;
         const created = (await create.mutateAsync({
           tripId, gameTypeId: effectiveTypeId, name: title.trim(), competitionId,
-          pointsDistribution: distribution, pointsTotal: isMatchPlay ? null : total,
+          pointsDistribution: createDistribution, pointsTotal: isMatchPlay ? null : total,
         })) as { id: string };
         gameId = created.id;
         if (compFormat || rules.trim() || Object.keys(modifiers).length > 0) {
@@ -594,19 +580,10 @@ export function GameSheet({
             // Non-fatal: the game still saves on the template default par/index.
           }
         }
-        // Seed the builder's slots (1v1/2v2 only): persist `matchCount` EMPTY
-        // match rows. They're the slots the builder opens with — not a stored
-        // target; under #394 they count 0 until paired, so the game still reads
-        // Setting-up · — on the board. Non-fatal (the builder can seed itself).
-        if (isPairedMatch) {
-          const empty = Array.from({ length: matchCount }, (_, i) => ({ sideA: null, sideB: null, matchNumber: i + 1 }));
-          try {
-            if (isDoubles) await setDoublesPairings.mutateAsync({ tripId, gameId, matches: empty });
-            else await setPairings.mutateAsync({ tripId, gameId, matches: empty });
-          } catch {
-            // Non-fatal: the builder seeds from the team-size estimate if absent.
-          }
-        }
+        // C1: Add no longer seeds match rows. Matches are build-as-you-go in the
+        // configurer — the setup page seeds ONE empty match when it lands with zero
+        // rows (match/new/page.tsx) and "+ Add match" grows it. (The old count
+        // stepper + its seeding here were redundant with that.)
       }
       if (canEdit) {
         await reconcileDelegate(gameId);
@@ -706,8 +683,6 @@ export function GameSheet({
                 onClearCourse={handleClearCourse}
                 isMatchPlay={isMatchPlay}
                 isPairedMatch={isPairedMatch}
-                matchCount={matchCount}
-                setMatchCount={setMatchCountOverride}
                 existingMatchCount={existingMatchCount}
                 total={total}
                 setTotal={setTotal}
@@ -820,7 +795,7 @@ export function GameSheet({
 function GameTab({
   isEdit, canEdit, categoriesPresent, category, setCategory, categoryTypes, effectiveTypeId,
   setGameTypeId, selectedType, title, setTitle, isGolf, courseId, courseName, onPickCourse, onClearCourse, isMatchPlay,
-  isPairedMatch, matchCount, setMatchCount, existingMatchCount,
+  isPairedMatch, existingMatchCount,
   total, setTotal, perMatchValue, setPerMatchValue, readout,
 }: {
   isEdit: boolean; canEdit: boolean; categoriesPresent: readonly string[]; category: string;
@@ -828,7 +803,7 @@ function GameTab({
   setGameTypeId: (id: string) => void; selectedType: GameType | undefined; title: string;
   setTitle: (s: string) => void; isGolf: boolean; courseId: string | null; courseName: string | null;
   onPickCourse: () => void; onClearCourse: () => void; isMatchPlay: boolean;
-  isPairedMatch: boolean; matchCount: number; setMatchCount: (n: number) => void; existingMatchCount: number | null;
+  isPairedMatch: boolean; existingMatchCount: number | null;
   total: number; setTotal: (n: number) => void; perMatchValue: number; setPerMatchValue: (n: number) => void;
   readout: ReturnType<typeof matchReadout>;
 }) {
@@ -920,14 +895,22 @@ function GameTab({
         </Field>
       )}
 
+      {/* W-GAMEPAGE Phase-C teardown: Add Game no longer sets match-play points.
+          A new match game is created at 0 points (build-as-you-go) and its
+          points-per-match is set on the setup page's inline Points row (C2). So
+          the match-play stepper shows on EDIT only; placement (stroke/non-golf)
+          keeps its Add stepper — placement games have no inline setup-page Points
+          row, so the modal stays their points home. */}
       {isMatchPlay ? (
-        <PointStepper
-          label="Points per match"
-          caption="POINTS PER MATCH"
-          value={perMatchValue}
-          onChange={readOnly ? () => {} : setPerMatchValue}
-          footer={<MatchReadoutLine readout={readout} />}
-        />
+        isEdit ? (
+          <PointStepper
+            label="Points per match"
+            caption="POINTS PER MATCH"
+            value={perMatchValue}
+            onChange={readOnly ? () => {} : setPerMatchValue}
+            footer={<MatchReadoutLine readout={readout} />}
+          />
+        ) : null
       ) : (
         <PointStepper
           label="Point value"
@@ -945,33 +928,18 @@ function GameTab({
         />
       )}
 
-      {/* Number of matches (1v1/2v2 only) — SEEDS the builder's slot count on
-          create; you still assign players in the builder. On edit it's derived
-          from the live rows (display only — change it in the builder). */}
-      {isPairedMatch && (
-        isEdit ? (
-          <Field label="Matches">
-            <div className="rounded-lg px-3 py-2.5 text-sm" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}>
-              <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
-                {existingMatchCount ?? "—"} {existingMatchCount === 1 ? "match" : "matches"}
-              </span>{" "}
-              · add or remove in Set Pairings
-            </div>
-          </Field>
-        ) : (
-          <PointStepper
-            label="Number of matches"
-            caption="MATCHES"
-            value={matchCount}
-            onChange={readOnly ? () => {} : setMatchCount}
-            max={MAX_MATCHES}
-            footer={
-              <span className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-                Opens the builder with {matchCount} {matchCount === 1 ? "slot" : "slots"} · assign players there
-              </span>
-            }
-          />
-        )
+      {/* Matches (1v1/2v2 only): EDIT shows the derived live count (changed in the
+          builder). Add no longer seeds a count — build-as-you-go owns it: the setup
+          page seeds one empty match on landing and "+ Add match" grows it (C1). */}
+      {isPairedMatch && isEdit && (
+        <Field label="Matches">
+          <div className="rounded-lg px-3 py-2.5 text-sm" style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}>
+            <span style={{ color: "var(--color-bt-text)", fontWeight: 600 }}>
+              {existingMatchCount ?? "—"} {existingMatchCount === 1 ? "match" : "matches"}
+            </span>{" "}
+            · add or remove in Set Pairings
+          </div>
+        </Field>
       )}
     </>
   );

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -74,6 +74,7 @@ export function ChecklistRow({
   expanded,
   onToggle,
   children,
+  control,
   disabled,
   testId,
 }: {
@@ -93,11 +94,18 @@ export function ChecklistRow({
   onToggle?: () => void;
   /** Accordion: the dropped-down editor content (rendered beneath when expanded). */
   children?: React.ReactNode;
+  /** Inline trailing control (e.g. a `<Stepper inline>`) that the row carries in
+   *  place of a chevron — the row does NOT open and is **exempt from the single-open
+   *  accordion** (W-GAMEPAGE Phase C: the Points row). Mutually exclusive with
+   *  accordion/overlay; the control owns its own taps. */
+  control?: React.ReactNode;
   disabled?: boolean;
   testId?: string;
 }) {
   const accordion = !!onToggle && !disabled;
   const overlay = !!onClick && !disabled && !accordion;
+  // A control row carries an inline control and never toggles (no accordion/overlay).
+  const controlRow = !!control && !accordion && !overlay;
   const isOpen = accordion && !!expanded;
 
   // State → treatment (§4/§12), via the shared pure mapping.
@@ -153,7 +161,10 @@ export function ChecklistRow({
     </div>
   );
 
-  const trailing = (
+  const trailing = controlRow ? (
+    // The inline control sits where the chevron would — it owns its own taps.
+    <span className="flex shrink-0 items-center">{control}</span>
+  ) : (
     <span className="flex shrink-0 items-center">
       {accordion ? (
         <ChevronDown size={16} style={{ color: "var(--color-bt-text-dim)", transform: isOpen ? "rotate(180deg)" : undefined, transition: "transform 120ms" }} />

--- a/src/components/games/FormatPointsPanel.tsx
+++ b/src/components/games/FormatPointsPanel.tsx
@@ -5,20 +5,20 @@ import { trpc } from "@/lib/trpc-client";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { validatePlacement } from "@/lib/gameConfig";
 import {
-  Field, PointStepper, PlacementEditor, FormatSheet, formatLabel,
+  PointStepper, PlacementEditor,
   type GameRow,
 } from "@/components/competition/CompetitionGamesPanel";
-import { ChevronRight } from "lucide-react";
 import type { PointsDistribution } from "@/lib/pointsDistribution";
 
 /**
- * Zone 2 "Format · Points" accordion body (W-EDITMODAL-01) — the focused points +
- * competition-format editor that replaces the old Edit-Game modal for this row.
- * Name moved to the Zone-1 header; Course/Matches/Modifiers/Rules/Delegate live in
- * their own rows/zones — so this panel is JUST format + points.
+ * Points accordion body for **placement** (stroke/non-golf) games — the point value
+ * + the placement split. Phase C narrowed this: the competition-format picker is
+ * removed (not re-homed — the Add/Edit modal still sets `competition_format`), and
+ * match-format games (1v1/2v2/rack) no longer use this panel at all — they carry an
+ * INLINE per-match stepper in the row (`GameSetupRows` → `PointsPerMatchControl`).
+ * So this is now JUST the placement points editor.
  *
- * Persistence: format saves on pick (independent `update{competitionFormat}`);
- * points save as the **total + distribution PAIR** (`setPointsTotal` +
+ * Persistence: points save as the **total + distribution PAIR** (`setPointsTotal` +
  * `setPointsDistribution` together — never one without the other). Saved on-change
  * rather than on-collapse: every intermediate points value is VALID (unlike the
  * draft editors' half-filled matches), so there's no invalid-intermediate to hide,
@@ -48,10 +48,7 @@ export function FormatPointsPanel({
   const [placeInputs, setPlaceInputs] = useState<string[]>(
     dist0?.type === "placement" && dist0.values.length > 0 ? dist0.values.map(String) : [""]
   );
-  const [compFormat, setCompFormat] = useState<string | null>(game.competition_format ?? null);
-  const [formatSheetOpen, setFormatSheetOpen] = useState(false);
 
-  const update = trpc.games.update.useMutation();
   const setTotalM = trpc.games.setPointsTotal.useMutation();
   const setDistM = trpc.games.setPointsDistribution.useMutation();
 
@@ -98,34 +95,12 @@ export function FormatPointsPanel({
     if (!startedNext) void savePoints(null, total);
     else if (p.saveable) void savePoints({ type: "placement", values: vals }, total);
   }
-  function onFormat(key: string | null) {
-    setCompFormat(key);
-    setFormatSheetOpen(false);
-    optimisticGame({ competition_format: key } as Partial<GameRow>);
-    update.mutate({ tripId, gameId, competitionFormat: (key as never) ?? null }, { onSuccess: refresh });
-  }
 
   const readOnly = !canEdit;
   return (
     <div className="flex flex-col gap-4" data-testid="format-points-panel">
-      {/* Competition format */}
-      <Field label="Competition format">
-        <button
-          type="button"
-          onClick={() => { if (!readOnly) setFormatSheetOpen(true); }}
-          disabled={readOnly}
-          className="flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-sm"
-          style={{ background: "var(--color-bt-card-raised)", color: compFormat ? "var(--color-bt-text)" : "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
-        >
-          <span>{formatLabel(compFormat) ?? "How's it played?"}</span>
-          <ChevronRight size={15} style={{ color: "var(--color-bt-text-dim)" }} />
-        </button>
-        <p className="mt-1 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          Sets the label on the leaderboard. Running it up in-app comes later — until then you enter results by hand.
-        </p>
-      </Field>
-
-      {/* Points */}
+      {/* Points (Phase C: the competition-format picker is gone — removed, not
+          re-homed; the Add/Edit modal still sets competition_format). */}
       {isMatchPlay ? (
         <>
           <PointStepper
@@ -165,10 +140,6 @@ export function FormatPointsPanel({
           />
           <PlacementEditor total={total} placeInputs={placeInputs} setPlaceInputs={readOnly ? () => {} : onPlaceInputs} placement={placement} />
         </>
-      )}
-
-      {formatSheetOpen && (
-        <FormatSheet current={compFormat} onPick={(k) => onFormat(k)} onClose={() => setFormatSheetOpen(false)} />
       )}
     </div>
   );

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -5,6 +5,7 @@ import { Flag, Hash } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { Stepper } from "@/components/games/Stepper";
+import { pointsReady } from "@/lib/matchDraft";
 import { CourseRowContent } from "@/components/games/course/CourseRowContent";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { type GameRow } from "@/components/competition/CompetitionGamesPanel";
@@ -135,10 +136,12 @@ export function GameSetupRows({
             subtitle={
               <>
                 Total Points Available:{" "}
-                <span style={{ color: perMatch > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)", fontWeight: 600 }}>{pointsTotal}</span>
+                <span style={{ color: pointsReady(perMatch) ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)", fontWeight: 600 }}>{pointsTotal}</span>
               </>
             }
-            state={perMatch > 0 ? "resolved" : "empty"}
+            // Same `pointsReady` truth as the C3 Enable gate — row-resolved ⟺ gate's
+            // points term satisfied (they can't disagree).
+            state={pointsReady(perMatch) ? "resolved" : "empty"}
             disabled={!canEdit}
             testId="row-format-points"
             control={

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Flag, Hash } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { GAME_TYPES } from "@/lib/gameTypes";
+import { Stepper } from "@/components/games/Stepper";
 import { CourseRowContent } from "@/components/games/course/CourseRowContent";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { type GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
+import type { PointsDistribution } from "@/lib/pointsDistribution";
 
 /**
  * §B setup-shell drill-down rows: the **course pre-step** then **Format · Points**.
@@ -90,6 +94,11 @@ export function GameSetupRows({
   // derived from per-match × the valid match count. Per-match drives resolved/empty.
   const perMatch = game.points_distribution?.type === "per_match" ? game.points_distribution.value : 0;
   const pointsTotal = (matchCount ?? 0) * perMatch;
+  // Match-format games (1v1/2v2/rack) carry the points INLINE (Phase C §7 — a
+  // right-justified stepper, no expansion). Placement (stroke/non-golf) keeps the
+  // expandable editor (its split needs a body).
+  const ptype = GAME_TYPES.find((t) => t.id === game.game_type_id)?.resultStrategy;
+  const isMatchPlay = ptype === "match_play" || ptype === "rack_n_stack";
 
   return (
     <>
@@ -113,27 +122,113 @@ export function GameSetupRows({
         </ChecklistRow>
       )}
       {slot !== "course" && competitionId && (
-        <ChecklistRow
-          icon={Hash}
-          title="Points Per Match"
-          subtitle={
-            <>
-              Total Points Available:{" "}
-              <span style={{ color: "var(--color-bt-accent)", fontWeight: 600 }}>{pointsTotal}</span>
-            </>
-          }
-          state={perMatch > 0 ? "resolved" : "empty"}
-          disabled={!canEdit}
-          expanded={configOpen}
-          // P3: locked until a match exists → omit onToggle (read-only, no chevron),
-          // matching the gated Handicaps row. (The Enable gate / Points>0 stay P-C.)
-          onToggle={configLocked ? undefined : configOpen ? closeEditor : openConfig}
-          testId="row-format-points"
-        >
-          <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} matchCount={matchCount} />
-        </ChecklistRow>
+        isMatchPlay ? (
+          // Points row INLINE (Phase C §7): the row carries a right-justified
+          // <Stepper inline> and never opens — exempt from the single-open accordion.
+          // The competition-format picker is gone (removed, not re-homed — the Add/Edit
+          // modal still sets competition_format). Dashed/empty at 0 (reachable since
+          // C1's default-0); resolved + teal check + teal total at >0. The stepper
+          // stays live so `+` lifts it out of empty; `−` disabled at 0 (Stepper floor).
+          <ChecklistRow
+            icon={Hash}
+            title="Points Per Match"
+            subtitle={
+              <>
+                Total Points Available:{" "}
+                <span style={{ color: perMatch > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)", fontWeight: 600 }}>{pointsTotal}</span>
+              </>
+            }
+            state={perMatch > 0 ? "resolved" : "empty"}
+            disabled={!canEdit}
+            testId="row-format-points"
+            control={
+              <PointsPerMatchControl
+                tripId={tripId}
+                game={game}
+                perMatch={perMatch}
+                // P3: locked until ≥1 valid match exists (points mean nothing before
+                // a match). Locked → the stepper is disabled (read-only), matching the
+                // gated rows. Otherwise live.
+                disabled={configLocked || !canEdit}
+              />
+            }
+          />
+        ) : (
+          // Placement (stroke/non-golf): keep the expandable editor (the split needs
+          // a body). Format picker removed from FormatPointsPanel.
+          <ChecklistRow
+            icon={Hash}
+            title="Points"
+            subtitle={
+              <>
+                Total Points Available:{" "}
+                <span style={{ color: perMatch > 0 ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)", fontWeight: 600 }}>{pointsTotal}</span>
+              </>
+            }
+            state={perMatch > 0 ? "resolved" : "empty"}
+            disabled={!canEdit}
+            expanded={configOpen}
+            onToggle={configLocked ? undefined : configOpen ? closeEditor : openConfig}
+            testId="row-format-points"
+          >
+            <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} matchCount={matchCount} />
+          </ChecklistRow>
+        )
       )}
     </>
+  );
+}
+
+/**
+ * The inline per-match points control (Phase C §7) — a canonical `<Stepper inline>`
+ * that persists on each change. Floor is 0 (reachable since Add defaults new games
+ * to 0); `−` disable-styles at 0. Writes the total+distribution PAIR atomically
+ * (total null for match games — the total is derived = value × matchCount), optimistic
+ * on the `getById` cache so the row's subtitle/check/total land instantly, then marks
+ * the competition board stale (CLAUDE.md #10 — faceBootstrap refreshes the Live face).
+ */
+function PointsPerMatchControl({
+  tripId, game, perMatch, disabled,
+}: {
+  tripId: string;
+  game: GameRow;
+  perMatch: number;
+  disabled?: boolean;
+}) {
+  const gameId = game.id;
+  const utils = trpc.useUtils();
+  const setTotalM = trpc.games.setPointsTotal.useMutation();
+  const setDistM = trpc.games.setPointsDistribution.useMutation();
+  // Local value for snappy stepping; re-sync if the persisted value changes elsewhere.
+  const [value, setValue] = useState(perMatch);
+  useEffect(() => { setValue(perMatch); }, [perMatch]);
+
+  function onChange(v: number) {
+    setValue(v);
+    const next: PointsDistribution = { type: "per_match", value: v };
+    const cur = utils.games.getById.getData({ tripId, gameId });
+    if (cur) utils.games.getById.setData({ tripId, gameId }, { ...cur, points_total: null, points_distribution: next } as typeof cur);
+    void (async () => {
+      try {
+        await setTotalM.mutateAsync({ tripId, gameId, total: null });
+        await setDistM.mutateAsync({ tripId, gameId, distribution: next });
+        utils.games.listByTrip.invalidate({ tripId });
+        if (game.competition_id) utils.competitions.faceBootstrap.invalidate({ tripId });
+      } catch {
+        utils.games.getById.invalidate({ tripId, gameId });
+      }
+    })();
+  }
+
+  return (
+    <Stepper
+      size="inline"
+      value={value}
+      min={0}
+      onChange={disabled ? () => {} : onChange}
+      disabled={disabled}
+      testId="points-stepper"
+    />
   );
 }
 

--- a/src/components/games/Stepper.test.ts
+++ b/src/components/games/Stepper.test.ts
@@ -35,6 +35,13 @@ describe("stepperBounds", () => {
     expect(stepperBounds(0, 0, 18).atFloor).toBe(true); // HandicapRoster min=0 (SCR)
     expect(stepperBounds(1, 1, 9).atFloor).toBe(true); // ModifierCards glorious_holes min=1
   });
+
+  it("inline Points control (Phase C): min 0, no max — `−` disabled at 0, `+` always free", () => {
+    expect(stepperBounds(0, 0).atFloor).toBe(true); // can't go below 0 points
+    expect(stepperBounds(0, 0).decValue).toBe(0); // clamps at the floor
+    expect(stepperBounds(0, 0).atCeil).toBe(false); // no ceiling
+    expect(stepperBounds(0, 0).incValue).toBe(1); // `+` lifts it out of empty
+  });
 });
 
 describe("STEPPER_SIZES", () => {

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, type MatchSides } from "./matchDraft";
 
 // Readiness rework P1b — the ONE match-play readiness threshold, shared by the
 // setup-page Enable gate and the server `isConfigured` so they can't drift.
@@ -15,6 +15,32 @@ describe("hasValidMatch (the downstream gate)", () => {
     expect(hasValidMatch([s([], [])], 1)).toBe(false); // seeded empty only
     expect(hasValidMatch([s(["x"], [])], 1)).toBe(false); // half-paired only
     expect(hasValidMatch([], 1)).toBe(false);
+  });
+});
+
+// W-GAMEPAGE Phase C / P-C — points > 0 joins the Enable gate, and it's the SAME
+// truth the inline Points row reads for resolved/empty, so they can't disagree.
+describe("pointsReady (the points term of the Enable gate)", () => {
+  it("true only at points > 0", () => {
+    expect(pointsReady(1)).toBe(true);
+    expect(pointsReady(3)).toBe(true);
+    expect(pointsReady(0)).toBe(false); // the C1 default for a new match game
+    expect(pointsReady(-1)).toBe(false);
+  });
+});
+
+describe("the Enable gate = all matches paired AND points > 0 (C3)", () => {
+  const s = (a: string[], b: string[]): MatchSides => ({ a, b });
+  const enableReady = (draft: MatchSides[], pps: number, points: number) =>
+    allMatchesFilled(draft, pps) && pointsReady(points);
+  it("true only when every match is paired AND points > 0", () => {
+    expect(enableReady([s(["x"], ["y"])], 1, 3)).toBe(true); // paired + points
+  });
+  it("false at points 0 even with every match paired", () => {
+    expect(enableReady([s(["x"], ["y"])], 1, 0)).toBe(false);
+  });
+  it("false when a match is unpaired even with points > 0", () => {
+    expect(enableReady([s(["x"], ["y"]), s([], [])], 1, 3)).toBe(false);
   });
 });
 

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -66,3 +66,16 @@ export function matchPlayReady(pairedCount: number, totalCount: number): boolean
 export function allMatchesFilled(draft: MatchSides[], playersPerSide: number): boolean {
   return matchPlayReady(filledMatches(draft, playersPerSide).length, draft.length);
 }
+
+/**
+ * The POINTS term of the Enable gate (W-GAMEPAGE Phase C / P-C). A match game can't
+ * Enable scoring at 0 points-per-match — there's nothing to award — so points > 0
+ * joins all-matches-paired in the gate. This is the SAME truth the Points row reads
+ * for its resolved/empty state (`GameSetupRows`), so the row and the gate can't
+ * disagree: points > 0 ⟺ Points row resolved ⟺ this term satisfied. Kept separate
+ * from `matchPlayReady` (the server shares that for `isConfigured`) — this is a
+ * client-gate extension of the family, not a change to the shared pairing threshold.
+ */
+export function pointsReady(pointsPerMatch: number): boolean {
+  return pointsPerMatch > 0;
+}


### PR DESCRIPTION
W-GAMEPAGE visual pass, Phase C. Three commits (C1→C2→C3, atomic — the teardown's default-0 is what makes the inline UI and the gate meaningful) + tests.

## C1 — Add Game teardown + default-0 ([049a5dca])
Add Game no longer sets match-play points or number-of-matches; new match games are created at **0 points** and build matches as-you-go.
- Match-play points-per-match stepper → **Edit-only** (existing games still editable). **Number-of-matches** stepper + its create-time match-row seeding → **removed** (redundant: the setup page seeds one empty match on landing). Placement keeps its Add stepper (no inline setup-page row exists for it — preserve-and-flag).
- New match games created with `{ per_match, value: 0 }`. Server already accepts 0 — **no migration**; existing games read their stored value.
- **Game-delete untouched** (Edit-only). Cleaned up the orphaned match-count machinery.

## C2 — Points row inline + drop the format picker ([23a387f5])
- `ChecklistRow`: new `control` slot — an inline trailing control; the row doesn't open and is **exempt from the single-open accordion**.
- `GameSetupRows`: the match-play Points row is now a right-justified `<Stepper size="inline">` (min 0, `−` disabled at 0) via `PointsPerMatchControl` (persists the total+distribution pair, optimistic + faceBootstrap invalidate). Dashed/empty at 0, resolved + teal check + teal total at >0. Placement keeps its expandable editor.
- `FormatPointsPanel`: the **competition-format picker is removed** (not re-homed — the Add/Edit modal still sets `competition_format`).

## C3 — points > 0 joins the Enable gate; course never gates ([3c52baf8])
- `matchDraft.ts`: new `pointsReady(pps)` — the family's client-gate extension (NOT a change to `matchPlayReady`, which the server shares). Enable gates on `allFilled && pointsReady(pps)`. The Points row reads the **same** predicate, so row-resolved ⟺ gate's points term (one truth).
- **Course is deliberately never in the gate** — commented rationale (off-API course / dead cell / network outage are real; you lose only course metrics + handicaps, never the ability to play).

## Verification
- **777 unit tests pass** (+5: `pointsReady`, the combined gate, the inline-stepper floor). tsc + lint clean. Critical-path E2E green.
- **Eye-verified dark + light:**
  - **Add Game** stripped to Type/Format/Title/Course — no points/match-count steppers. Created a game → arrived with `per_match: 0` (DB-confirmed) → setup page showed **Points dashed-0** + one auto-seeded empty match.
  - **Edit Game** (Poker) still works — **"Delete game permanently" present**, point-value stepper intact (open→close, no mutation).
  - **Points row inline** — `− 3 +`, no chevron, doesn't expand; dashed at 0 (muted icon, no check), resolved + teal check + teal total at >0, `−` disabled at 0.
  - **Enable gate** — blocked at points 0 even with all matches paired; unblocks at >0. **A game with no course still Enables** (010b8be8 has no course — verified bright/enabled at points 3).
- Test data restored: throwaway game deleted; 010b8be8 back at points 3.

**Follow-on (not here):** game-delete → setup-page danger zone gated on scoring-enabled. Delete stays in Edit Game for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
