### PR TITLE
feat(gamepage): P-D — handicaps selector restyle (outline-select + avatars + altitude-aware reveal)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1690,19 +1690,16 @@ function HandicapsSection({
   return (
     <div className="flex flex-col gap-3" data-testid="handicaps-section">
       {filled.map(({ d, i }) => (
-        <div key={i}>
-          {draft.length > 1 && (
-            <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-              Match {i + 1}
-            </span>
-          )}
-          <RelHandicapControl
-            a={sidePart(d.a)!}
-            b={sidePart(d.b)!}
-            value={d.handicap}
-            onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}
-          />
-        </div>
+        // §8: the per-row "Match N" header is gone — the number rides the control's
+        // left gutter instead (passed below), shown only when there's >1 match.
+        <RelHandicapControl
+          key={i}
+          a={sidePart(d.a)!}
+          b={sidePart(d.b)!}
+          value={d.handicap}
+          matchNumber={draft.length > 1 ? i + 1 : undefined}
+          onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}
+        />
       ))}
     </div>
   );

--- a/src/components/games/RelHandicapControl.test.ts
+++ b/src/components/games/RelHandicapControl.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { relHandicapView } from "./RelHandicapControl";
+
+// W-GAMEPAGE visual pass P-D §8 — the altitude-aware reveal. Pure view-model so the
+// "Even = one line (no stepper)" vs "side = stepper + recipient caption" logic is
+// testable apart from render. (The segment outline + avatars are CSS — eye-verified.)
+describe("relHandicapView (the §8 reveal view-model)", () => {
+  it("Even (value 0): no stepper, no recipient, the muted Even caption", () => {
+    const v = relHandicapView(0, "Ann", "Bob");
+    expect(v.side).toBe("even");
+    expect(v.even).toBe(true);
+    expect(v.showStepper).toBe(false); // Even is ONE line — no stepper rendered
+    expect(v.recipient).toBeNull();
+    expect(v.holes).toEqual([]);
+    expect(v.caption).toBe("Even match — no strokes given");
+  });
+
+  it("left side (value < 0): side a gets strokes; stepper shows; recipient caption", () => {
+    const v = relHandicapView(-3, "Ann", "Bob");
+    expect(v.side).toBe("a");
+    expect(v.n).toBe(3);
+    expect(v.showStepper).toBe(true); // a side reveals the centered stepper
+    expect(v.recipient).toBe("Ann");
+    expect(v.holes).toHaveLength(3);
+    expect(v.caption).toBe(`Ann gets strokes on holes ${v.holes.join(", ")}`); // plural
+  });
+
+  it("right side (value > 0): side b; singular 'hole' at n=1", () => {
+    const v = relHandicapView(1, "Ann", "Bob");
+    expect(v.side).toBe("b");
+    expect(v.n).toBe(1);
+    expect(v.recipient).toBe("Bob");
+    expect(v.caption).toMatch(/^Bob gets strokes on hole \d+$/); // singular, no trailing 's'
+  });
+
+  it("clamps magnitude to ±18 and rounds, preserving side", () => {
+    expect(relHandicapView(25, "Ann", "Bob").n).toBe(18);
+    expect(relHandicapView(25, "Ann", "Bob").side).toBe("b");
+    expect(relHandicapView(-25, "Ann", "Bob").n).toBe(18);
+    expect(relHandicapView(-25, "Ann", "Bob").side).toBe("a");
+    expect(relHandicapView(2.4, "Ann", "Bob").n).toBe(2); // rounds
+  });
+});

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -2,15 +2,24 @@
 
 import { strokeHoles } from "@/lib/matchPlay";
 import { Stepper } from "@/components/games/Stepper";
+import { Avatar } from "@/components/Avatar";
 import type { Participant } from "./types";
 
 /**
  * RelHandicapControl — the relative-handicap control for 1v1 (Slice B §6, as
- * amended by Spec Addendum B-1). A direction TOGGLE + a STEPPER — no draggable
- * slider (a ±18 span is undraggable one-thumbed in the sun; the number matters
- * most in the big-mismatch case, exactly where a bare slider fails).
+ * amended by Spec Addendum B-1; restyled in W-GAMEPAGE visual pass P-D §8). A
+ * segmented direction selector + a STEPPER — no draggable slider (a ±18 span is
+ * undraggable one-thumbed in the sun; the number matters most in the big-mismatch
+ * case, exactly where a bare slider fails).
  *
- * Same data model: one signed value, strokes to exactly ONE side, never split.
+ * §8 look: the selected segment is an OUTLINE (teal border), never a solid fill —
+ * a fill fights the team avatars the player segments now carry. The per-row
+ * "WHO GETS STROKES?" header is gone; the match number sits in a small left gutter.
+ * Reveal is altitude-aware: Even shows one muted caption (no stepper); a side
+ * selected reveals the centered <Stepper full> + a muted recipient caption.
+ *
+ * Same data model (NO behavior change — P-D is appearance + layout only): one
+ * signed value, strokes to exactly ONE side, never split.
  *   value < 0 → left (a) gets |value|;  value > 0 → right (b) gets value;  0 = even.
  * The parent persists it as the two per-user `game_participants.handicap_strokes`
  * counts (recipient = n, other = 0) — NOT `games.modifiers.buddy_rules` (Slice F).
@@ -22,18 +31,44 @@ import type { Participant } from "./types";
 // otherwise strokes 19+ silently produce no extra pips. See Spec Addendum B-1.
 const MAX = 18;
 
+/** The pure reveal view-model (§8) — pure so the altitude-aware reveal is unit-
+ *  testable apart from render: which side is selected, the recipient, the holes,
+ *  whether the stepper shows, and the muted caption. `recipient` is null when even. */
+export interface RelHandicapView {
+  side: "a" | "b" | "even";
+  n: number;
+  even: boolean;
+  recipient: string | null;
+  holes: number[];
+  /** The muted reveal caption: "Even match …" or "{recipient} gets strokes on holes …". */
+  caption: string;
+  /** Even → no stepper (one line); a side → the centered <Stepper full> reveals. */
+  showStepper: boolean;
+}
+export function relHandicapView(value: number, aName: string, bName: string): RelHandicapView {
+  const clamped = Math.max(-MAX, Math.min(MAX, Math.round(value)));
+  const side: "a" | "b" | "even" = clamped < 0 ? "a" : clamped > 0 ? "b" : "even";
+  const n = Math.abs(clamped);
+  const even = side === "even";
+  const recipient = even ? null : side === "a" ? aName : bName;
+  const holes = [...strokeHoles(n)].sort((x, y) => x - y);
+  const caption = even
+    ? "Even match — no strokes given"
+    : `${recipient} gets strokes on hole${n === 1 ? "" : "s"} ${holes.join(", ")}`;
+  return { side, n, even, recipient, holes, caption, showStepper: !even };
+}
+
 interface RelHandicapControlProps {
   a: Participant;
   b: Participant;
   value: number; // signed, ∈ [−MAX, MAX]
   onChange: (value: number) => void;
+  /** Small left-gutter match number (§8). Omit for a lone match (no number shown). */
+  matchNumber?: number;
 }
 
-export function RelHandicapControl({ a, b, value, onChange }: RelHandicapControlProps) {
-  const clamped = Math.max(-MAX, Math.min(MAX, Math.round(value)));
-  const side: "a" | "b" | "even" = clamped < 0 ? "a" : clamped > 0 ? "b" : "even";
-  const n = Math.abs(clamped);
-  const holes = [...strokeHoles(n)].sort((x, y) => x - y);
+export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHandicapControlProps) {
+  const { side, n, even, caption, showStepper } = relHandicapView(value, a.name, b.name);
 
   // Selecting a player keeps the current magnitude (min 1) and points it that way.
   // Switching sides preserves |value| (sign flip).
@@ -43,84 +78,105 @@ export function RelHandicapControl({ a, b, value, onChange }: RelHandicapControl
   };
   // Step magnitude; never crosses into Even (Even is toggle-only). Inert when even.
   const step = (delta: number) => {
-    if (side === "even") return;
+    if (even) return;
     const mag = Math.max(1, Math.min(MAX, n + delta));
     onChange(side === "a" ? -mag : mag);
   };
 
-  const even = side === "even";
-
   return (
-    <div style={{ padding: "2px 2px 0" }}>
-      <div
-        style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)", marginBottom: 6 }}
-      >
-        Who gets strokes?
-      </div>
-      {/* Row 1 · Direction (segmented control) */}
-      <div
-        className="flex"
-        style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card-raised)" }}
-      >
-        <Segment selected={side === "a"} onClick={() => pickSide("a")}>
-          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{a.name}</span>
-        </Segment>
-        <Segment selected={even} onClick={() => onChange(0)}>
-          Even
-        </Segment>
-        <Segment selected={side === "b"} onClick={() => pickSide("b")}>
-          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{b.name}</span>
-        </Segment>
-      </div>
-
-      {/* Row 2 · Magnitude — the canonical full Stepper (P-B). Delta callbacks keep
-          `step`'s sign-aware, never-crosses-Even behavior; formatValue shows "—"
-          when even; the wrapper dims/locks the whole control in the Even state. */}
-      <div style={{ marginTop: 12, opacity: even ? 0.35 : 1, pointerEvents: even ? "none" : "auto" }}>
-        <Stepper
-          size="full"
-          value={n}
-          min={1}
-          max={MAX}
-          disabled={even}
-          onDecrement={() => step(-1)}
-          onIncrement={() => step(1)}
-          formatValue={() => (even ? "—" : String(n))}
-          label={n === 1 ? "STROKE" : "STROKES"}
-        />
-      </div>
-
-      {/* Resolved line */}
-      <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 12 }}>
-        {even ? (
-          "Even match — no strokes given"
-        ) : (
-          <span>
-            on hole{n === 1 ? "" : "s"} {holes.join(", ")}
+    <div>
+      {/* Match-number left gutter + the segmented selector (§8 — the header is gone;
+          the control itself answers "who gets strokes"). */}
+      <div className="flex items-center" style={{ gap: 10 }}>
+        {matchNumber != null && (
+          <span
+            className="flex-shrink-0 text-center"
+            style={{ width: 16, fontSize: 13, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}
+          >
+            {matchNumber}
           </span>
         )}
+        <div
+          className="flex flex-1"
+          style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card)" }}
+        >
+          <Segment selected={side === "a"} onClick={() => pickSide("a")}>
+            <Avatar name={a.name} teamColor={a.color} sizePx={22} />
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{a.name}</span>
+          </Segment>
+          <Segment selected={even} onClick={() => onChange(0)} narrow>
+            Even
+          </Segment>
+          <Segment selected={side === "b"} onClick={() => pickSide("b")}>
+            <Avatar name={b.name} teamColor={b.color} sizePx={22} />
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{b.name}</span>
+          </Segment>
+        </div>
       </div>
+
+      {/* Reveal (§8): Even → one muted caption, no stepper. Side selected → the
+          centered canonical <Stepper full> (P-B) + a muted recipient caption (NOT
+          teal — teal is reserved for the selected segment's outline). Both the
+          stepper-gate and the caption come from the pure `relHandicapView`. */}
+      {showStepper ? (
+        <>
+          <div style={{ marginTop: 12 }}>
+            <Stepper
+              size="full"
+              value={n}
+              min={1}
+              max={MAX}
+              onDecrement={() => step(-1)}
+              onIncrement={() => step(1)}
+              formatValue={() => String(n)}
+              label={n === 1 ? "STROKE" : "STROKES"}
+            />
+          </div>
+          <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 12 }}>
+            {caption}
+          </div>
+        </>
+      ) : (
+        <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
+          {caption}
+        </div>
+      )}
     </div>
   );
 }
 
-function Segment({ selected, onClick, children }: { selected: boolean; onClick: () => void; children: React.ReactNode }) {
+/**
+ * One segment. Selected = teal OUTLINE on a lifted (card-raised) chip with white
+ * text — never a solid fill (§8; a fill muddies the team avatars). Unselected =
+ * transparent on the recessed track, muted text, a transparent border so selection
+ * never shifts layout. `narrow` is the Even segment (no avatar, hugs its label).
+ */
+function Segment({
+  selected, onClick, children, narrow = false,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  narrow?: boolean;
+}) {
   return (
     <button
+      type="button"
       onClick={onClick}
-      className="flex min-w-0 flex-1 items-center justify-center gap-1.5"
+      className="flex min-w-0 items-center justify-center gap-1.5"
       style={{
-        height: 40,
+        flex: narrow ? "0 0 auto" : "1 1 0",
+        height: 44,
         borderRadius: 9,
-        padding: "0 6px",
-        background: selected ? "var(--color-bt-accent)" : "transparent",
-        color: selected ? "#0d1f1a" : "var(--color-bt-text-dim)",
+        padding: narrow ? "0 14px" : "0 8px",
+        background: selected ? "var(--color-bt-card-raised)" : "transparent",
+        border: selected ? "1.5px solid var(--color-bt-accent)" : "1.5px solid transparent",
+        color: selected ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
         fontSize: 14,
-        fontWeight: selected ? 700 : 500,
+        fontWeight: selected ? 600 : 500,
       }}
     >
       {children}
     </button>
   );
 }
-


### PR DESCRIPTION
W-GAMEPAGE visual pass, Phase D §8. Restyle-in-place of `RelHandicapControl` (the **1v1 match-play** handicap selector). **No behavior change** — same signed-value model, same `onChange`, same persistence; appearance + layout only. `HandicapRoster` (the stroke/rack full-screen list, §9 model 1) is untouched.

## T1 — segment + layout
- **Selected = teal outline** (`--color-bt-accent` border) on a lifted card-raised chip with white text — the **solid teal fill is gone** (it fought the avatars; also removes the hardcoded `#0d1f1a`). Unselected = transparent on a recessed `card` track, muted text.
- Player segments carry the team **`Avatar`** (§11) — team-colored initial via `teamColor`, **not** `avatarIcon` (renders team initials, sidesteps #477 here). The **Even** segment is narrow, no avatar.
- The per-row **"WHO GETS STROKES?" header is removed**; the match number rides a small **left gutter** instead (shown only when >1 match).

## T2 — altitude-aware reveal
- **Even** → ONE line: muted "Even match — no strokes given", **no stepper** (no reserved/greyed stepper).
- **A side** → TWO lines: the centered canonical `<Stepper full>` (P-B) + a **muted** recipient caption "{Player} gets strokes on holes …" (not teal).
- **Teal discipline:** teal appears **only** on the selected segment's outline; every caption is muted.
- The reveal logic is extracted to a pure **`relHandicapView(value, aName, bName)`** so it's unit-testable apart from render; the component consumes it (one source of truth).

## Verification
- **776 unit tests pass** (+4 `relHandicapView`: Even = no stepper + null recipient + muted caption; a side = stepper + recipient caption with singular/plural "hole(s)"; ±18 clamp + rounding preserve the side). tsc + lint clean (tokens only, no hex). Critical-path E2E green.
- **Eye-verified dark + light** on a 1v1 game with 5 matches: each match `[avatar A │ Even │ avatar B]` with the number in the left gutter, no header; **selected = teal outline, no fill**; avatars keep their team color; **Even = one line** (muted caption, no stepper); **stroked = two lines** (segment + centered `− 3 +` + "Rob gets strokes on holes 1, 2, 3" muted). onChange round-trips through the new render (Even→Ty→Even); the persisted match-3 value loaded + rendered correctly. Screenshot showed an Even and a stroked match in the same view.

Branched off `main` (independent of Phase C #486 — different files, no overlap).

**Not in scope (per DO-NOT):** the 2v2 per-individual model (§9 model 3, deferred); `HandicapRoster`; any behavior/persistence change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
