### PR TITLE
feat(gamepage): Phase F0 — course provenance read layer + back-tee capture + §5a title

### DIFF
--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -6,6 +6,7 @@ import { trpc } from "@/lib/trpc-client";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { Stepper } from "@/components/games/Stepper";
 import { pointsReady } from "@/lib/matchDraft";
+import { composedCourseTitle } from "@/lib/courseProvenance";
 import { CourseRowContent } from "@/components/games/course/CourseRowContent";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { type GameRow } from "@/components/competition/CompetitionGamesPanel";
@@ -85,12 +86,26 @@ export function GameSetupRows({
   // Course resolved = a complete 18 (W-9HOLE-01): a real 18-hole course, or a
   // 9-hole front with a back nine composed in. A lone 9-hole front (schema count
   // 9) is NOT resolved — it "needs a back nine", which keeps Handicaps gated.
-  // §5 Course subtitle reports the handicaps GATE, not the course name (the name
-  // lives in the expanded CourseRowContent), so we no longer fetch front/back names
-  // here — only whether the course resolves to a complete 18.
   const frontId = game.course_id ?? null;
+  const backId = (game.back_course_id as string | null) ?? null;
   const count = ((game.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0;
   const courseResolved = !!frontId && count === 18;
+  // §5a (P-F0c): the RESOLVED Course title is the course NAME (the subtitle stays the
+  // handicaps gate). Lift the two-ID name fetch (front + back) to the collapsed row —
+  // CourseRowContent fetches the same names in its expanded body. Gated on
+  // slot/resolved so the config-slot instance and no-course games don't fetch.
+  // `composedCourseTitle` derives the shared leading base (or the §5a fallback).
+  const wantNames = slot !== "config" && courseResolved;
+  const frontNameQ = trpc.courses.getById.useQuery({ courseId: frontId ?? "" }, { enabled: wantNames && !!frontId });
+  const backNameQ = trpc.courses.getById.useQuery({ courseId: backId ?? "" }, { enabled: wantNames && !!backId });
+  const frontName = frontNameQ.data?.name as string | undefined;
+  const backName = backNameQ.data?.name as string | undefined;
+  const namesReady = !!frontName && (!backId || !!backName);
+  const courseTitle = !courseResolved
+    ? "No Golf Course"
+    : namesReady
+      ? composedCourseTitle(backId ? [frontName, backName] : [frontName])
+      : "Golf Course Selected"; // pre-load: keep the old title until names arrive
   // Points (§5): the row subtitle is the live "Total Points Available: N" (N teal),
   // derived from per-match × the valid match count. Per-match drives resolved/empty.
   const perMatch = game.points_distribution?.type === "per_match" ? game.points_distribution.value : 0;
@@ -106,10 +121,10 @@ export function GameSetupRows({
       {slot !== "config" && (
         <ChecklistRow
           icon={Flag}
-          // §5 Course: the title flips on confirm; the subtitle reports the
-          // HANDICAPS GATE (course gates handicaps), not the course name — the name
-          // lives in the expanded editor (CourseRowContent).
-          title={courseResolved ? "Golf Course Selected" : "No Golf Course"}
+          // §5a Course: the resolved title is the course NAME (single) / shared base
+          // (composed) / tap-nudge fallback. The subtitle stays the HANDICAPS GATE —
+          // never the course name.
+          title={courseTitle}
           subtitle={courseResolved ? "Handicaps enabled" : "Handicaps disabled"}
           state={courseResolved ? "resolved" : "empty"}
           disabled={!canEdit}

--- a/src/lib/courseIndex.ts
+++ b/src/lib/courseIndex.ts
@@ -99,6 +99,13 @@ export interface ScorecardUnits {
     par?: number[];
     handicap_index?: number[];
     tee?: SnapshotTee;
+    /** The BACK nine's chosen tee NAME on a composed two-nines 18 (W-GAMEPAGE P-F0a).
+     *  The composed `tee.name` is the FRONT's; this records which tee the back nine
+     *  actually used (name-match-else-first), so the §16 split-band header can label
+     *  the back band honestly. ABSENT on single courses and on every game composed
+     *  before P-F0 — readers MUST treat absent as "fall back to the composed/front
+     *  tee name" (no migration backfills it). */
+    backTeeName?: string;
     [k: string]: unknown;
   };
 }
@@ -155,7 +162,11 @@ export function buildScorecardSchema(
   par: number[],
   handicapIndex: number[] | null | undefined,
   holeCount: number,
-  tee?: SnapshotTee | null
+  tee?: SnapshotTee | null,
+  /** The back nine's chosen tee NAME (composed two-nines 18 only; P-F0a). Provided
+   *  by `setBackNine`; omitted by `applyCourse` (a fresh front clears any stale
+   *  back-tee name, same as it resets back_course_id). */
+  backTeeName?: string | null
 ): ScorecardSchema {
   const next = JSON.parse(JSON.stringify(template)) as ScorecardSchema;
   const labels = range(1, holeCount);
@@ -170,6 +181,10 @@ export function buildScorecardSchema(
   // display + provenance. Omitted when no course/tee is applied.
   if (tee) metadata.tee = { ...tee, yards: tee.yards.slice(0, holeCount) };
   else delete metadata.tee;
+  // The back nine's chosen tee name (P-F0a) — capture-only; absent on single
+  // courses and pre-P-F0 composes (readers fall back to the composed tee name).
+  if (backTeeName && backTeeName.trim()) metadata.backTeeName = backTeeName.trim();
+  else delete metadata.backTeeName;
 
   next.units = { ...next.units, count: holeCount, labels, metadata };
 

--- a/src/lib/courseProvenance.test.ts
+++ b/src/lib/courseProvenance.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  composedCourseTitle, composeProvenance, TITLE_FALLBACK,
+  type ProvenanceCourse,
+} from "./courseProvenance";
+import type { TeeSetRecord } from "./courseService";
+
+// W-GAMEPAGE P-F0c — the §5a collapsed-Course-row title. Separator-delimited shared
+// WHOLE leading segment; the Pebble guard must NOT raw-substring-merge.
+describe("composedCourseTitle (§5a)", () => {
+  it("single name → that name", () => {
+    expect(composedCourseTitle(["Pebble Creek"])).toBe("Pebble Creek");
+  });
+
+  it("shared leading segment → the common base", () => {
+    expect(composedCourseTitle(["Peninsula — Cypress", "Peninsula — Lakes"])).toBe("Peninsula");
+    expect(composedCourseTitle(["Pinehurst · No. 2", "Pinehurst · No. 4"])).toBe("Pinehurst");
+    // The exact live-data case (spaced single hyphen " - " from the provider).
+    expect(
+      composedCourseTitle([
+        "Peninsula Golf & Racquet Club - Lakes",
+        "Peninsula Golf & Racquet Club - Cypress",
+      ]),
+    ).toBe("Peninsula Golf & Racquet Club");
+  });
+
+  it("Pebble guard: similar first WORDS but different first SEGMENT do NOT merge", () => {
+    // "Pebble Beach" / "Pebble Creek" are each ONE segment (no spaced separator) →
+    // they differ → no shared leading segment → fallback (never "Pebble").
+    expect(composedCourseTitle(["Pebble Beach", "Pebble Creek"])).toBe(TITLE_FALLBACK);
+  });
+
+  it("hyphenated single word stays one segment (only SPACED separators split)", () => {
+    expect(composedCourseTitle(["Winged-Foot — East", "Winged-Foot — West"])).toBe("Winged-Foot");
+  });
+
+  it("no overlap at all → fallback", () => {
+    expect(composedCourseTitle(["Augusta National", "St Andrews"])).toBe(TITLE_FALLBACK);
+  });
+
+  it("trivially short / generic shared base → fallback (not 'The' or a lone char)", () => {
+    expect(composedCourseTitle(["The — North", "The — South"])).toBe(TITLE_FALLBACK);
+    expect(composedCourseTitle(["A — One", "A — Two"])).toBe(TITLE_FALLBACK);
+  });
+
+  it("identical names → that name (no 'X — X')", () => {
+    expect(composedCourseTitle(["Riverside", "Riverside"])).toBe("Riverside");
+  });
+
+  it("empty / all-blank → fallback, never undefined", () => {
+    expect(composedCourseTitle([])).toBe(TITLE_FALLBACK);
+    expect(composedCourseTitle([null, undefined, "  "])).toBe(TITLE_FALLBACK);
+  });
+});
+
+// W-GAMEPAGE P-F0b — read-side provenance recovery from the fetched course records.
+const tee = (name: string, yards: (number | null)[]): TeeSetRecord => ({
+  name, courseRating: null, slopeRating: null, bogeyRating: null, yards,
+});
+const f9 = [400, 410, 420, 380, 390, 350, 540, 160, 430];
+const b9 = [405, 415, 425, 385, 395, 355, 545, 165, 435];
+
+describe("composeProvenance (P-F0b)", () => {
+  it("single course → passthrough tees + name, no back", () => {
+    const front: ProvenanceCourse = {
+      name: "Pebble Creek",
+      teeSets: [tee("White", [...f9, ...b9]), tee("Blue", [...f9, ...b9])],
+    };
+    const p = composeProvenance({ teeName: "White", backTeeName: null }, front, null);
+    expect(p.composed).toBe(false);
+    expect(p.front).toEqual({ courseName: "Pebble Creek", teeName: "White" });
+    expect(p.back).toBeNull();
+    expect(p.chosenTeeName).toBe("White");
+    expect(p.tees.map((t) => t.name)).toEqual(["White", "Blue"]);
+    expect(p.tees[0].yards).toHaveLength(18);
+  });
+
+  it("composed 18 → per-nine names + all tees concatenated front9+back9", () => {
+    const front: ProvenanceCourse = { name: "Front Club", teeSets: [tee("White", f9), tee("Blue", f9)] };
+    const back: ProvenanceCourse = { name: "Back Club", teeSets: [tee("White", b9), tee("Blue", b9)] };
+    const p = composeProvenance({ teeName: "White", backTeeName: "White" }, front, back);
+    expect(p.composed).toBe(true);
+    expect(p.front).toEqual({ courseName: "Front Club", teeName: "White" });
+    expect(p.back).toEqual({ courseName: "Back Club", teeName: "White" });
+    expect(p.tees).toHaveLength(2);
+    expect(p.tees[0].yards).toEqual([...f9, ...b9]); // White composed
+  });
+
+  it("back-tee name FALLS BACK to the composed name when absent (pre-P-F0 game)", () => {
+    const front: ProvenanceCourse = { name: "Front Club", teeSets: [tee("White", f9)] };
+    const back: ProvenanceCourse = { name: "Back Club", teeSets: [tee("White", b9)] };
+    const p = composeProvenance({ teeName: "White", backTeeName: null }, front, back);
+    expect(p.back?.teeName).toBe("White"); // not null/undefined — the composed name
+  });
+
+  it("back has no same-named tee → pickBackTee uses the back's FIRST tee (mirrors setBackNine)", () => {
+    const front: ProvenanceCourse = { name: "Front Club", teeSets: [tee("White", f9)] };
+    const back: ProvenanceCourse = { name: "Back Club", teeSets: [tee("Gold", b9), tee("Red", b9)] };
+    const p = composeProvenance({ teeName: "White", backTeeName: "Gold" }, front, back);
+    expect(p.back?.teeName).toBe("Gold"); // the captured chosen back tee
+    expect(p.tees[0].yards).toEqual([...f9, ...b9]); // White ← front White + back Gold (first)
+  });
+});

--- a/src/lib/courseProvenance.ts
+++ b/src/lib/courseProvenance.ts
@@ -1,0 +1,150 @@
+/**
+ * Course provenance read layer (W-GAMEPAGE P-F0) — PURE, client-safe.
+ *
+ * The per-game snapshot (`scorecard_schema…metadata.tee`) is flattened to ONE tee,
+ * but the global `courses` table keeps everything (`name`, `tee_sets` = all tees
+ * with per-hole `yards[]`) and the game stores `course_id` + `back_course_id`. So
+ * the data P-F's split-band header + multi-tee rows need is RECOVERABLE by ID — these
+ * pure fns do the recovery/derivation, given the fetched course records as input (no
+ * DB deps → testable). NOTHING here is persisted back into the snapshot (P-F0 is a
+ * read-side derivation: derive-don't-snapshot).
+ *
+ * Back-compat is load-bearing: a game composed before P-F0a has NO `backTeeName` —
+ * the back tee name falls back to the composed/front tee name; never undefined/crash.
+ */
+
+import type { TeeSetRecord } from "@/lib/courseService";
+
+/** A course record as far as provenance needs it (subset of `courses.getById`). */
+export interface ProvenanceCourse {
+  name: string;
+  teeSets: TeeSetRecord[];
+}
+
+/** The snapshot bits provenance reads (subset of `scorecard_schema.units.metadata`). */
+export interface ProvenanceSnapshot {
+  /** The composed/chosen tee name (the FRONT's, on a two-nines 18). */
+  teeName: string | null;
+  /** The back nine's chosen tee name (P-F0a) — absent on pre-P-F0 composes. */
+  backTeeName: string | null;
+}
+
+export interface NineProvenance {
+  courseName: string;
+  /** Null only when no tee was ever snapshotted (index-/tee-less course). */
+  teeName: string | null;
+}
+
+/** A composed tee for the §16 multi-tee rows: one name, 18 (or N) per-hole yards. */
+export interface ComposedTee {
+  name: string;
+  yards: (number | null)[];
+}
+
+export interface CourseProvenance {
+  composed: boolean;
+  front: NineProvenance;
+  /** Null for a single course. */
+  back: NineProvenance | null;
+  /** The chosen tee name (snapshot) — drives the §16 chosen-tee-row highlight. */
+  chosenTeeName: string | null;
+  /** Every tee for this 18, composed across both nines (or the single course's
+   *  tees as-is). For P-F's multi-tee yardage rows. */
+  tees: ComposedTee[];
+}
+
+const norm = (s: string | null | undefined): string => (s ?? "").trim().toLowerCase();
+const first9 = <T>(a: T[] | null | undefined): T[] => (a ?? []).slice(0, 9);
+
+/**
+ * Recover full course provenance for a game from the fetched course record(s).
+ * `back` null ⇒ single course (its tee sets pass through as-is). Composed ⇒ each
+ * FRONT tee is paired with the same-named BACK tee (else the back's first tee, the
+ * same name-match-else-first rule `setBackNine` uses for the chosen tee) and their
+ * yards concatenated front-9 + back-9.
+ */
+export function composeProvenance(
+  snapshot: ProvenanceSnapshot,
+  front: ProvenanceCourse,
+  back: ProvenanceCourse | null,
+): CourseProvenance {
+  const chosenTeeName = snapshot.teeName ?? null;
+  const composed = !!back;
+
+  if (!composed) {
+    return {
+      composed: false,
+      front: { courseName: front.name, teeName: chosenTeeName },
+      back: null,
+      chosenTeeName,
+      tees: front.teeSets.map((t) => ({ name: t.name, yards: t.yards })),
+    };
+  }
+
+  const backCourse = back as ProvenanceCourse;
+  // Per-nine tee name: front's is the composed/chosen name; the back's is the
+  // captured P-F0a value, falling back to the composed name on pre-P-F0 games.
+  const backTeeName = (snapshot.backTeeName ?? "").trim() || chosenTeeName;
+
+  const pickBackTee = (frontTeeName: string): TeeSetRecord | null =>
+    backCourse.teeSets.find((t) => norm(t.name) === norm(frontTeeName)) ??
+    backCourse.teeSets[0] ??
+    null;
+
+  const tees: ComposedTee[] = front.teeSets.map((ft) => {
+    const bt = pickBackTee(ft.name);
+    return { name: ft.name, yards: [...first9(ft.yards), ...first9(bt?.yards ?? null)] };
+  });
+
+  return {
+    composed: true,
+    front: { courseName: front.name, teeName: chosenTeeName },
+    back: { courseName: backCourse.name, teeName: backTeeName },
+    chosenTeeName,
+    tees,
+  };
+}
+
+// ── §5a composed-name Course title (P-F0c) ──────────────────────────────────────
+
+/** The one tap-nudge title (§5a) — two unrelated names can't self-describe collapsed. */
+export const TITLE_FALLBACK = "Golf Course Selected — Tap to View";
+
+/** Split a course name into segments on a SPACED separator (em/en-dash, hyphen,
+ *  middle dot). Spaced-only so hyphenated words ("Winged-Foot") stay one segment —
+ *  the separator is a real delimiter, not a substring. */
+function splitSegments(name: string): string[] {
+  return name.split(/\s+[—–·-]\s+/).map((s) => s.trim()).filter(Boolean);
+}
+
+/** A base too short/generic to stand alone as a title (§5a): a lone char or "The". */
+function isTrivialBase(base: string): boolean {
+  const t = base.trim();
+  return t.length <= 1 || /^the$/i.test(t);
+}
+
+/**
+ * The §5a collapsed-Course-row title. ONE name → that name. TWO names → the shared
+ * WHOLE leading segment(s) (separator-delimited, compared segment-by-segment — NOT
+ * raw substring, so "Pebble Beach" + "Pebble Creek" do NOT false-merge to "Pebble").
+ * No shared base, or a trivially-short/generic one → the tap-nudge fallback.
+ */
+export function composedCourseTitle(names: (string | null | undefined)[]): string {
+  const clean = names.map((n) => (n ?? "").trim()).filter(Boolean);
+  if (clean.length === 0) return TITLE_FALLBACK;
+  if (clean.length === 1) return clean[0];
+  // Identical names (e.g. both nines from one club's single name) → that name.
+  if (new Set(clean.map((s) => s.toLowerCase())).size === 1) return clean[0];
+
+  const segLists = clean.map(splitSegments);
+  const minLen = Math.min(...segLists.map((s) => s.length));
+  const shared: string[] = [];
+  for (let i = 0; i < minLen; i++) {
+    const seg = segLists[0][i];
+    if (segLists.every((s) => norm(s[i]) === norm(seg))) shared.push(seg);
+    else break;
+  }
+  const base = shared.join(" — ").trim();
+  if (!base || isTrivialBase(base)) return TITLE_FALLBACK;
+  return base;
+}

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -444,7 +444,10 @@ export const gamesRouter = router({
 
       const baseSchema = getGameTypeDefinition(game.game_type_id as string)?.scorecardSchema ?? null;
       if (!baseSchema?.units) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Game type has no scorecard schema." });
-      const snapshot = buildScorecardSchema(baseSchema, composed.par, composed.index, 18, composedTee);
+      // P-F0a: record the back nine's CHOSEN tee name (the composed tee carries the
+      // FRONT's name) so the §16 split-band header can label the back band honestly.
+      // Capture-only — `backTee` selection / yardages above are unchanged.
+      const snapshot = buildScorecardSchema(baseSchema, composed.par, composed.index, 18, composedTee, backTee?.name ?? null);
 
       // Clear the BACK nine's scores (holes 10-18) — they were the old nine's. The
       // front (1-9) is left intact. (A no-op on the first compose.)


### PR DESCRIPTION
W-GAMEPAGE Phase F0 — the data layer P-F/P-G consume, the one write-side capture, and (cheaply) §5a. **No scorecard UI here** — that's P-F. Builds on the Phase 0 report (Section A: the snapshot is flattened to one tee, but everything else is recoverable read-side by ID — no migration).

## F0a — capture the back nine's chosen tee name ([a06812c7])
`setBackNine`'s composed tee carries the **front's** name; the back nine's actually-chosen tee name was discarded. Now captured at **`scorecard_schema.units.metadata.backTeeName`** (snapshot field — **no migration**; `applyCourse` clears it on a fresh front). **Capture-only** — chosen tee, merged yardages, and scoring unchanged. **Back-compat:** existing games have no `backTeeName`; readers fall back to the composed/front name — never backfilled.

## F0b/F0c lib — `courseProvenance.ts` (pure, tested) ([5c076c85])
- **`composeProvenance` (F0b)** — recovers per-nine `{courseName, teeName}`, **all tees composed** across both nines (same name-match-else-first + concat-front9+back9 rule as `setBackNine`), and the chosen tee name for the §16 highlight, from the fetched `courses` records by ID. Back tee name = F0a's value, falling back when absent. Single course → tees pass through.
- **`composedCourseTitle` (F0c)** — the §5a title: one name → that name; two → the shared **whole leading segment** via **spaced** separator split, so `"Pebble Beach"` + `"Pebble Creek"` do **not** false-merge to `"Pebble"` (segment compare, not substring); no/trivially-short base → the tap-nudge fallback.
- **12 unit tests** incl. the Pebble guard, the exact live-data case (`"Peninsula Golf & Racquet Club - Lakes/Cypress"` → `"Peninsula Golf & Racquet Club"`), trivially-short/no-overlap/identical/empty, and `composeProvenance` recovery + back-tee fallback + all-tees compose.

## F0c wiring — §5a title on the collapsed Course row ([450e3dfa])
The resolved Course title is now the course **name** (single) / shared **base** (composed) / **fallback**. Two-ID name fetch lifted to the collapsed row (gated so the config-slot instance + no-course games don't fetch; keeps the old title until names load). **Subtitle unchanged** — still the handicaps gate.

## Verification
- **789 unit tests pass** (+12). tsc + lint clean. **Full Playwright project green** (stroke + match-play — running the whole project now, per the #486 lesson).
- **Eye-verified dark + light:** single → "Shipyard Golf Club — Brigantine / Clipper"; **composed → "Peninsula Golf & Racquet Club"** (built a throwaway from the real 9-hole Peninsula courses, then deleted it). **F0a confirmed in the DB:** the new game captured `backTeeName "Tee #2"`; the existing composed game stays `null` and renders fine (back-compat). Subtitle stayed the handicaps gate throughout.

**Scope (DO-NOT honored):** no migration/backfill; no scoring/chosen-tee/yardage change (F0a capture-only); F0b is read-side derivation (not persisted back); **no scorecard UI** (P-F); spaced-separator-only matching; subtitle untouched; picker/prefetch untouched.

Branched off main (post-#486); independent of #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
