### PR TITLE
fix(gamepage): P-D handicap selector defects — team colors (by slot), strokes alignment, left-align chips

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1151,13 +1151,12 @@ export default function NewMatchGamePage() {
                 playersPerSide={playersPerSide}
                 nameOf={nameOf}
                 colorOf={colorOf}
-                // P-D defect 1: color by SLOT (side A = team[0], side B = team[1]) —
-                // the same `teamForSlot` binding the Matches panel uses (tA/tB) — so a
-                // player on a side reads that side's team color in this match, matching
-                // the Matches panel. tA/tB are undefined for a standalone game → the
-                // per-player palette fallback applies.
-                teamA={tA}
-                teamB={tB}
+                // P-D defect 1: resolve each player's TEAM color from their roster
+                // assignment (teamOfUser) — the same source the overview uses — so the
+                // assigned players read Rhinos red / Phoenix purple. An UNASSIGNED
+                // player (no team_assignments row) correctly gets undefined → the
+                // per-player palette fallback (not a bug). Undefined for standalone.
+                teamColorOf={(id) => (twoTeams ? teamById.get(teamOfUser.get(id) ?? "")?.color : undefined)}
                 avatarIconOf={avatarIconOf}
               />
             </ChecklistRow>
@@ -1682,8 +1681,7 @@ function HandicapsSection({
   playersPerSide,
   nameOf,
   colorOf,
-  teamA,
-  teamB,
+  teamColorOf,
   avatarIconOf,
 }: {
   draft: DraftMatch[];
@@ -1691,22 +1689,22 @@ function HandicapsSection({
   playersPerSide: number;
   nameOf: Map<string, string>;
   colorOf: Map<string, string>;
-  /** The teams bound to side A / side B (2-team competition). The handicap avatars
-   *  color by SLOT — side A = team[0], side B = team[1] — exactly like the Matches
-   *  panel (`teamForSlot`), so a player on side A reads that side's team color in
-   *  this match (NOT their individual roster row). Undefined for a standalone game
-   *  → falls back to the per-player palette. (P-D defect 1: colorOf alone is the
-   *  neutral palette and loses team identity.) */
-  teamA?: { color: string };
-  teamB?: { color: string };
+  /** A player's TEAM color from their roster assignment (`teamOfUser`), the same
+   *  source the overview uses (`sideColor`/`teamOfSide`) — so the handicap avatars
+   *  match every other team-avatar surface (Rhinos red / Phoenix purple). A player
+   *  with NO team assignment correctly returns undefined → the per-player palette
+   *  fallback (NOT a bug — an unassigned player has no team color). Undefined for a
+   *  standalone (non-2-team) game too. (P-D defect 1: colorOf alone was the neutral
+   *  palette and lost team identity for the assigned players.) */
+  teamColorOf: (userId: string) => string | undefined;
   avatarIconOf: Map<string, string | null>;
 }) {
-  const sidePart = (members: string[], teamColor: string | undefined): Participant | null => {
+  const sidePart = (members: string[]): Participant | null => {
     if (members.length === 0) return null;
     return {
       id: members.join("+"),
       name: members.map((u) => nameOf.get(u) ?? "Player").join(" & "),
-      color: teamColor ?? colorOf.get(members[0]) ?? PLAYER_COLORS[0],
+      color: teamColorOf(members[0]) ?? colorOf.get(members[0]) ?? PLAYER_COLORS[0],
       avatarIcon: avatarIconOf.get(members[0]) ?? null,
     };
   };
@@ -1728,8 +1726,8 @@ function HandicapsSection({
         // left gutter instead (passed below), shown only when there's >1 match.
         <RelHandicapControl
           key={i}
-          a={sidePart(d.a, teamA?.color)!}
-          b={sidePart(d.b, teamB?.color)!}
+          a={sidePart(d.a)!}
+          b={sidePart(d.b)!}
           value={d.handicap}
           matchNumber={draft.length > 1 ? i + 1 : undefined}
           onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1151,6 +1151,13 @@ export default function NewMatchGamePage() {
                 playersPerSide={playersPerSide}
                 nameOf={nameOf}
                 colorOf={colorOf}
+                // P-D defect 1: color by SLOT (side A = team[0], side B = team[1]) —
+                // the same `teamForSlot` binding the Matches panel uses (tA/tB) — so a
+                // player on a side reads that side's team color in this match, matching
+                // the Matches panel. tA/tB are undefined for a standalone game → the
+                // per-player palette fallback applies.
+                teamA={tA}
+                teamB={tB}
                 avatarIconOf={avatarIconOf}
               />
             </ChecklistRow>
@@ -1675,6 +1682,8 @@ function HandicapsSection({
   playersPerSide,
   nameOf,
   colorOf,
+  teamA,
+  teamB,
   avatarIconOf,
 }: {
   draft: DraftMatch[];
@@ -1682,14 +1691,22 @@ function HandicapsSection({
   playersPerSide: number;
   nameOf: Map<string, string>;
   colorOf: Map<string, string>;
+  /** The teams bound to side A / side B (2-team competition). The handicap avatars
+   *  color by SLOT — side A = team[0], side B = team[1] — exactly like the Matches
+   *  panel (`teamForSlot`), so a player on side A reads that side's team color in
+   *  this match (NOT their individual roster row). Undefined for a standalone game
+   *  → falls back to the per-player palette. (P-D defect 1: colorOf alone is the
+   *  neutral palette and loses team identity.) */
+  teamA?: { color: string };
+  teamB?: { color: string };
   avatarIconOf: Map<string, string | null>;
 }) {
-  const sidePart = (members: string[]): Participant | null => {
+  const sidePart = (members: string[], teamColor: string | undefined): Participant | null => {
     if (members.length === 0) return null;
     return {
       id: members.join("+"),
       name: members.map((u) => nameOf.get(u) ?? "Player").join(" & "),
-      color: colorOf.get(members[0]) ?? PLAYER_COLORS[0],
+      color: teamColor ?? colorOf.get(members[0]) ?? PLAYER_COLORS[0],
       avatarIcon: avatarIconOf.get(members[0]) ?? null,
     };
   };
@@ -1711,8 +1728,8 @@ function HandicapsSection({
         // left gutter instead (passed below), shown only when there's >1 match.
         <RelHandicapControl
           key={i}
-          a={sidePart(d.a)!}
-          b={sidePart(d.b)!}
+          a={sidePart(d.a, teamA?.color)!}
+          b={sidePart(d.b, teamB?.color)!}
           value={d.handicap}
           matchNumber={draft.length > 1 ? i + 1 : undefined}
           onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -84,22 +84,23 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
   };
 
   return (
-    <div>
-      {/* Match-number left gutter + the segmented selector (§8 — the header is gone;
-          the control itself answers "who gets strokes"). */}
-      <div className="flex items-center" style={{ gap: 10 }}>
-        {matchNumber != null && (
-          <span
-            className="flex-shrink-0 text-center"
-            style={{ width: 16, fontSize: 13, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}
-          >
-            {matchNumber}
-          </span>
-        )}
-        <div
-          className="flex flex-1"
-          style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card)" }}
+    // The match-number gutter sits LEFT of the match CONTENT column (§8 — no header).
+    // The reveal (stepper + caption) lives INSIDE that content column, so it aligns
+    // under the player columns / matchup — not centered on the whole panel (defect 2).
+    <div className="flex items-start" style={{ gap: 10 }}>
+      {matchNumber != null && (
+        <span
+          className="flex flex-shrink-0 items-center justify-center"
+          // height matches the segmented track (44 segment + 2×4 padding) so the
+          // number centers with the segments row, not the whole content column.
+          style={{ width: 16, height: 52, fontSize: 13, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}
         >
+          {matchNumber}
+        </span>
+      )}
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* Segmented selector */}
+        <div className="flex" style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card)" }}>
           <Segment selected={side === "a"} onClick={() => pickSide("a")}>
             <Avatar name={a.name} teamColor={a.color} sizePx={22} />
             <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{a.name}</span>
@@ -112,35 +113,35 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
             <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{b.name}</span>
           </Segment>
         </div>
-      </div>
 
-      {/* Reveal (§8): Even → one muted caption, no stepper. Side selected → the
-          centered canonical <Stepper full> (P-B) + a muted recipient caption (NOT
-          teal — teal is reserved for the selected segment's outline). Both the
-          stepper-gate and the caption come from the pure `relHandicapView`. */}
-      {showStepper ? (
-        <>
-          <div style={{ marginTop: 12 }}>
-            <Stepper
-              size="full"
-              value={n}
-              min={1}
-              max={MAX}
-              onDecrement={() => step(-1)}
-              onIncrement={() => step(1)}
-              formatValue={() => String(n)}
-              label={n === 1 ? "STROKE" : "STROKES"}
-            />
-          </div>
-          <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 12 }}>
+        {/* Reveal (§8) — under the matchup (defect 2): Even → one muted caption, no
+            stepper. Side selected → the centered <Stepper full> (P-B) + a muted
+            recipient caption (NOT teal — teal is the selected outline only). The
+            stepper centers within THIS content column, i.e. under the player columns. */}
+        {showStepper ? (
+          <>
+            <div style={{ marginTop: 12 }}>
+              <Stepper
+                size="full"
+                value={n}
+                min={1}
+                max={MAX}
+                onDecrement={() => step(-1)}
+                onIncrement={() => step(1)}
+                formatValue={() => String(n)}
+                label={n === 1 ? "STROKE" : "STROKES"}
+              />
+            </div>
+            <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 12 }}>
+              {caption}
+            </div>
+          </>
+        ) : (
+          <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
             {caption}
           </div>
-        </>
-      ) : (
-        <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
-          {caption}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
@@ -149,7 +150,9 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
  * One segment. Selected = teal OUTLINE on a lifted (card-raised) chip with white
  * text — never a solid fill (§8; a fill muddies the team avatars). Unselected =
  * transparent on the recessed track, muted text, a transparent border so selection
- * never shifts layout. `narrow` is the Even segment (no avatar, hugs its label).
+ * never shifts layout. `narrow` is the Even segment (no avatar, hugs its centered
+ * label). Player chips are LEFT-aligned (avatar then name) — table-like, the
+ * direction the Matches redesign is heading (defect 3).
  */
 function Segment({
   selected, onClick, children, narrow = false,
@@ -163,12 +166,13 @@ function Segment({
     <button
       type="button"
       onClick={onClick}
-      className="flex min-w-0 items-center justify-center gap-1.5"
+      className="flex min-w-0 items-center gap-1.5"
       style={{
         flex: narrow ? "0 0 auto" : "1 1 0",
+        justifyContent: narrow ? "center" : "flex-start",
         height: 44,
         borderRadius: 9,
-        padding: narrow ? "0 14px" : "0 8px",
+        padding: narrow ? "0 14px" : "0 10px",
         background: selected ? "var(--color-bt-card-raised)" : "transparent",
         border: selected ? "1.5px solid var(--color-bt-accent)" : "1.5px solid transparent",
         color: selected ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",


### PR DESCRIPTION
Visual/layout-only follow-up to P-D (#487) — three eye-review defects. **No behavior change** (`relHandicapView` untouched). The Even/selected outline is deliberately **not** touched (deferred to the shared-row-pattern session).

## Defect 1 — avatars now read TEAM colors (the real bug)
`HandicapsSection` colored side avatars from `colorOf` (the neutral per-player palette), losing team identity. Now it resolves each player's **team color from their roster assignment** (`teamOfUser` → `teamById.color`), the same source the overview uses (`sideColor`/`teamOfSide`) — so assigned players read Rhinos red / Phoenix purple, matching every other team-avatar surface. Still the team-colored **initial** (no `avatarIcon` — §11, avoids #477).

A player with **no** team assignment correctly falls back to the per-player palette (an unassigned player has no team color — not a bug). (History: this PR briefly tried slot-based coloring to force a team color onto an unassigned account, then reverted — that account turned out to be genuinely unassigned, confirmed in the Rosters panel.)

## Defect 2 — strokes block under the matchup, not the panel
The revealed `[− N +]` stepper + the "{Player} gets strokes on holes …" caption now live **inside the match-content column** (beside the match-number gutter), so they align under the player columns / matchup instead of centering on the whole accordion panel.

## Defect 3 — left-align chip content
Player chips are **left-aligned** (avatar then name) — table-like, the direction the Matches redesign is heading. The narrow Even chip stays centered.

## Verification
- **793 unit tests pass.** tsc + lint clean. **Full Playwright project green** (stroke + match-play — one local \`Score 7\` flake on the stroke spec, green on re-run; unrelated to handicaps).
- **Eye-verified dark + light** on a 1v1 game in a 2-team competition: assigned players read their team color (Rhinos red / Phoenix purple); an unassigned account reads the neutral fallback; the stroked match's stepper + caption sit under the matchup; chips left-aligned; **Even/outline-select unchanged from #487**; selecting/stepping/persistence unchanged.

**Scope (DO-NOT honored):** Even/selected treatment untouched; no behavior/persistence change; no \`avatarIcon\`; nothing beyond the three defects; \`HandicapRoster\` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)