### PR TITLE
fix(team-identity): PR 1 — keystone predicate + roster-based setup display + config verdict

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -401,3 +401,40 @@ already fixed). Summary:
 - 2 conditional title colors → `var(--color-bt-text)`
 
 Fix incrementally; line-by-line locations in STYLE_GUIDE.md Section 7.
+
+---
+
+## Team trades / mid-competition roster moves (durable scoring attribution)
+
+**Parked — not BBMI scope. Captured because it shapes the score-record schema the engine spec depends on.**
+
+Moving a player between teams, or a player leaving mid-competition, must preserve scoring history
+correctly. The core rule:
+
+**A score carries two durable references — the person who earned it, and the team it counted for at the
+moment it was earned.** Team totals roll up from the **recorded** team on each score, NOT from the
+player's *current* team membership re-derived at calculation time.
+
+Why both references, and why durable:
+- **Person reference** — a score is a person's contribution; it stays attached to that person across any
+  roster change. (A traded player's earned points are theirs; a slot's new occupant does not inherit
+  them.)
+- **Team reference (at time of scoring)** — scores still belong to a team for rollup; the competition is
+  team-vs-team. But the team must be **recorded on the score when entered**, not looked up live. If team
+  is re-derived from current membership at calc time (today's model), then:
+  - trading a player **retroactively moves their historical points** to the new team (wrong), and
+  - swapping a new person into a slot **hands them the departed player's history** (wrong).
+
+So the schema-shaping decision for the engine: **score records must carry both `person` and the
+`team` the score counted toward, captured at entry time** (a recorded attribution, not a live derivation).
+Team rollup sums by the recorded team; per-person views read by person. This is what makes trades, swaps,
+and departures behave correctly without rewriting history.
+
+**Current state leans this way already** — `game_matches` store person/play_group refs (no team_id), and
+scoring currently attributes by roster *at read time*. The change is to **capture** the team attribution at
+score-entry (or first-score lock) so it stops being a live derivation that roster edits can retroactively
+alter. The lock-on-first-score guard (team-identity PR 2) is the near-term protection; durable per-score
+team attribution is the full long-term model this entry captures.
+
+**Not built for BBMI** — teams are set and stay set for September, and the lock guard prevents the broken
+state. This is the post-launch model for competitions where rosters genuinely change mid-event.

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -28,6 +28,7 @@ import { DangerConfirmModal } from "@/components/DangerZone";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady } from "@/lib/matchDraft";
+import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
@@ -977,6 +978,13 @@ export default function NewMatchGamePage() {
         // persist (the draft editors commit on close). Course + Name·Format·Points
         // stay overlays this pass (tracked follow-ons) but ride the same one-open.
         const allFilled = allMatchesFilled(draft, playersPerSide);
+        // Roster integrity (team-identity PR 1, the D-gap catch): a paired side whose
+        // player has LOST their team is invalid even though its SLOTS are full
+        // (dropped-after-paired). The keystone predicate (teamRoster.ts) — distinct
+        // from the slot-filled `allFilled` above. Only meaningful in a 2-team
+        // competition (standalone match play has no teams → always roster-valid).
+        const teamedUserIds = new Set(teamOfUser.keys());
+        const allRosterValid = !twoTeams || draft.every((d) => matchRosterValid(d.a, d.b, playersPerSide, teamedUserIds));
         // C3: points > 0 joins the Enable gate (Phase C) — but ONLY for a
         // COMPETITION game. Points-per-match is a cup concept: the inline Points row
         // exists only when `gameCompId` is set (GameSetupRows gates it on
@@ -987,7 +995,7 @@ export default function NewMatchGamePage() {
         // shows, so the row's resolved state and the gate agree (one truth);
         // pointsReady is the family's client-gate extension (matchDraft.ts).
         const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
-        const enableReady = allFilled && (!gameCompId || pointsReady(pointsPerMatch));
+        const enableReady = allFilled && allRosterValid && (!gameCompId || pointsReady(pointsPerMatch));
         const anyHandicap = draft.some((d) => d.handicap !== 0);
         // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points,
         // Handicaps, and Modifiers stay LOCKED until a match exists (they mean nothing
@@ -1008,7 +1016,11 @@ export default function NewMatchGamePage() {
         const matchesSubtitle = filledDraft.length === 0
           ? "0 matches assigned"
           : `${filledDraft.length} of ${draft.length} matches assigned`;
-        const matchesState: ChecklistRowState = allFilled ? "resolved" : "invalid";
+        // Resolved only when slots are filled AND every paired side is rostered;
+        // a dropped-after-paired side flips it to the invalid (red) verdict, surfaced
+        // the same way as the slot-filled hard-block (P2/P2b collapse-boundary timing
+        // unchanged — this only adds a reason a match is invalid).
+        const matchesState: ChecklistRowState = allFilled && allRosterValid ? "resolved" : "invalid";
         // Handicaps is hard-gated on Matches AND Course (W-9HOLE-01): the per-hole
         // stroke allocation needs the course's stroke-index table, so a complete
         // 18 must resolve first. "Course resolved" = a course applied AND an 18-hole

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -334,6 +334,11 @@ export default function NewMatchGamePage() {
   // A side's display color: its TEAM color in a 2-team competition, else the
   // per-player palette (standalone / non-team game) — unchanged for those.
   const sideColor = (sideId: string) => (twoTeams ? teamOfSide(sideId)?.color : undefined) ?? colorOf.get(sideId);
+  // THE canonical roster-based team-color resolver (team identity = the person's
+  // roster, never the slot). A user's team color in a 2-team competition; undefined
+  // when teamless or standalone → the consumer falls back to the neutral palette.
+  // Shared by the Matches panel (MatchSetup) and the handicap selector.
+  const teamColorOf = (userId: string) => (twoTeams ? teamById.get(teamOfUser.get(userId) ?? "")?.color : undefined);
   // The roster of one team — the constrained pool for that side's picker, so a
   // cross-team pair is impossible to assemble (Step 3: invalid unrepresentable).
   const rosterOfTeam = (teamId: string) =>
@@ -991,8 +996,6 @@ export default function NewMatchGamePage() {
         const savingSetup =
           setPairings.isPending || setHandicap.isPending ||
           setDoublesPairings.isPending || setDoublesHandicap.isPending;
-        const tA = teamForSlot("a");
-        const tB = teamForSlot("b");
         // Standalone-only readout now (T4 hides this row for competitions), so the
         // count is just the trip crew — no roster branch.
         const availableCount = crew.data?.length ?? 0;
@@ -1086,10 +1089,9 @@ export default function NewMatchGamePage() {
                 draft={draft}
                 setDraft={editDraft}
                 playersPerSide={playersPerSide}
-                teamA={tA}
-                teamB={tB}
                 nameOf={nameOf}
                 colorOf={colorOf}
+                teamColorOf={teamColorOf}
                 avatarIconOf={avatarIconOf}
                 openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
               />
@@ -1151,12 +1153,10 @@ export default function NewMatchGamePage() {
                 playersPerSide={playersPerSide}
                 nameOf={nameOf}
                 colorOf={colorOf}
-                // P-D defect 1: resolve each player's TEAM color from their roster
-                // assignment (teamOfUser) — the same source the overview uses — so the
-                // assigned players read Rhinos red / Phoenix purple. An UNASSIGNED
-                // player (no team_assignments row) correctly gets undefined → the
-                // per-player palette fallback (not a bug). Undefined for standalone.
-                teamColorOf={(id) => (twoTeams ? teamById.get(teamOfUser.get(id) ?? "")?.color : undefined)}
+                // Roster team color (the shared canonical resolver) — assigned
+                // players read their team color; an unassigned player gets undefined →
+                // the neutral palette (honest). Same source the Matches panel + overview use.
+                teamColorOf={teamColorOf}
                 avatarIconOf={avatarIconOf}
               />
             </ChecklistRow>
@@ -1291,7 +1291,6 @@ export default function NewMatchGamePage() {
             draft={draft}
             crew={selectorCrew}
             nameOf={nameOf}
-            avatarIconOf={avatarIconOf}
             onPick={(userId) => {
               editDraft((prev) => assignInDraft(prev, selector.matchIdx, selector.slot, selector.memberIdx, userId, playersPerSide));
               setSelector(null);
@@ -1470,10 +1469,9 @@ function MatchSetup({
   draft,
   setDraft,
   playersPerSide,
-  teamA,
-  teamB,
   nameOf,
   colorOf,
+  teamColorOf,
   avatarIconOf,
   openSelector,
 }: {
@@ -1481,12 +1479,13 @@ function MatchSetup({
   draft: DraftMatch[];
   setDraft: (fn: (prev: DraftMatch[]) => DraftMatch[]) => void;
   playersPerSide: number;
-  /** The teams bound to side A / side B (2-team competition). Undefined → no
-   *  team binding (standalone), and the per-side team header is hidden. */
-  teamA?: { name: string; color: string };
-  teamB?: { name: string; color: string };
   nameOf: Map<string, string>;
   colorOf: Map<string, string>;
+  /** A player's TEAM color from their ROSTER assignment (`teamOfUser`) — team
+   *  identity is the person, never the slot. A player dropped from their team
+   *  resolves to undefined → the neutral per-player palette (the honest "no team"
+   *  state), exactly like the handicap selector. Undefined for standalone games. */
+  teamColorOf: (userId: string) => string | undefined;
   avatarIconOf: Map<string, string | null>;
   openSelector: (matchIdx: number, slot: "a" | "b", memberIdx: number) => void;
 }) {
@@ -1525,22 +1524,20 @@ function MatchSetup({
     return {
       id: userId,
       name,
-      color: colorOf.get(userId) ?? PLAYER_COLORS[0],
+      // Roster team color (neutral if the player is teamless) — NOT the slot's.
+      color: teamColorOf(userId) ?? colorOf.get(userId) ?? PLAYER_COLORS[0],
       avatarIcon: avatarIconOf.get(userId) ?? null,
     };
   }
   // The member slots for one side — 1 for singles, 2 stacked for doubles. Each
-  // sub-slot picks a single player into that member position. A team header
-  // (Blue / Red) names the side's team so the constraint is legible.
-  // A side's slots — FLAT (config-checklist flatten): no bordered per-team panel /
-  // team-name header; team identity rides as the slot's color marker (dot/ring).
-  // Visual weight = conceptual weight: a side is just its player slot(s).
+  // sub-slot picks a single player into that member position. Team identity rides
+  // on the player avatar's ROSTER color (memberPart → teamColorOf), never the slot —
+  // so a dropped-from-team player reads neutral here, honestly (not the slot's color).
   const sideSlots = (members: string[], matchIdx: number, slot: "a" | "b") => {
-    const team = slot === "a" ? teamA : teamB;
     return (
       <div className="flex flex-col gap-1.5">
         {Array.from({ length: playersPerSide }).map((_, k) => (
-          <Slot key={k} player={memberPart(members[k])} teamColor={team?.color} onTap={() => openSelector(matchIdx, slot, k)} />
+          <Slot key={k} player={memberPart(members[k])} onTap={() => openSelector(matchIdx, slot, k)} />
         ))}
       </div>
     );
@@ -1932,7 +1929,6 @@ function PlayerSelector({
   draft,
   crew,
   nameOf,
-  avatarIconOf,
   onPick,
   onClose,
 }: {
@@ -1947,7 +1943,6 @@ function PlayerSelector({
   draft: DraftMatch[];
   crew: string[];
   nameOf: Map<string, string>;
-  avatarIconOf: Map<string, string | null>;
   onPick: (userId: string) => void;
   onClose: () => void;
 }) {
@@ -1981,7 +1976,7 @@ function PlayerSelector({
         <div className="mt-2 flex flex-col gap-1.5">
           {available.length === 0 && <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>Everyone&apos;s assigned.</span>}
           {available.map((id) => (
-            <SelectorRow key={id} name={nameOf.get(id) ?? "Player"} avatarIcon={avatarIconOf.get(id) ?? null} teamColor={teamColor} onClick={() => onPick(id)} />
+            <SelectorRow key={id} name={nameOf.get(id) ?? "Player"} teamColor={teamColor} onClick={() => onPick(id)} />
           ))}
         </div>
         {taken.length > 0 && (
@@ -1989,7 +1984,7 @@ function PlayerSelector({
             <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--color-bt-text-dim)", marginTop: 16 }}>Already in a match</div>
             <div className="mt-2 flex flex-col gap-1.5">
               {taken.map((id) => (
-                <SelectorRow key={id} name={nameOf.get(id) ?? "Player"} avatarIcon={avatarIconOf.get(id) ?? null} teamColor={teamColor} sub={`Match ${(inMatch.get(id) ?? 0) + 1}`} dim onClick={() => onPick(id)} />
+                <SelectorRow key={id} name={nameOf.get(id) ?? "Player"} teamColor={teamColor} sub={`Match ${(inMatch.get(id) ?? 0) + 1}`} dim onClick={() => onPick(id)} />
               ))}
             </div>
             <p style={{ fontSize: 12, color: "var(--color-bt-text-dim)", marginTop: 12 }}>
@@ -2022,7 +2017,7 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   );
 }
 
-function Slot({ player, onTap, teamColor }: { player: Participant | null; onTap: () => void; teamColor?: string | null }) {
+function Slot({ player, onTap }: { player: Participant | null; onTap: () => void }) {
   if (!player) {
     // The plus + label live together inside one dashed pill (card-raised so it
     // reads as a fillable block). Always "+ Add player".
@@ -2045,17 +2040,21 @@ function Slot({ player, onTap, teamColor }: { player: Participant | null; onTap:
       className="flex items-center gap-2"
       style={{ width: "100%", minWidth: 0, height: 44, padding: "0 10px", borderRadius: 10, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
     >
-      <Avatar name={player.name} avatarIcon={player.avatarIcon} teamColor={teamColor ?? player.color} sizePx={30} />
+      {/* Roster team color (neutral if teamless) — §11 team initial; no avatarIcon
+          (closes #477 in the setup panel). player.color is roster-resolved upstream. */}
+      <Avatar name={player.name} teamColor={player.color} sizePx={30} />
       <span style={{ minWidth: 0, fontSize: 15, fontWeight: 500, color: "var(--color-bt-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{player.name}</span>
     </button>
   );
 }
 
-function SelectorRow({ name, avatarIcon, teamColor, sub, dim, onClick }: { name: string; avatarIcon?: string | null; teamColor?: string | null; sub?: string; dim?: boolean; onClick: () => void }) {
+function SelectorRow({ name, teamColor, sub, dim, onClick }: { name: string; teamColor?: string | null; sub?: string; dim?: boolean; onClick: () => void }) {
   return (
     <button onClick={onClick} className="flex w-full items-center justify-between gap-2 text-left" style={{ padding: "9px 12px", borderRadius: 10, background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: dim ? 0.55 : 1 }}>
       <span className="flex min-w-0 items-center gap-2.5">
-        <Avatar name={name} avatarIcon={avatarIcon} teamColor={teamColor} sizePx={30} />
+        {/* §11 team initial, no avatarIcon (closes #477). teamColor is the slot's
+            team — correct here: the picker list is constrained to that team. */}
+        <Avatar name={name} teamColor={teamColor} sizePx={30} />
         <span style={{ fontSize: 15, color: "var(--color-bt-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{name}</span>
       </span>
       {sub && <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", flexShrink: 0 }}>{sub}</span>}

--- a/src/lib/teamRoster.test.ts
+++ b/src/lib/teamRoster.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { teamedUserIdSet, sideHasTeam, matchRosterValid } from "./teamRoster";
+
+// Team-identity PR 1 — the keystone roster-integrity predicate. Distinct from the
+// slot-filled readiness predicates (matchDraft): "are the filled slots' players
+// still on teams?", NOT "are the slots filled?".
+describe("teamedUserIdSet", () => {
+  it("collects the assigned user ids", () => {
+    const set = teamedUserIdSet([{ user_id: "a" }, { user_id: "b" }]);
+    expect(set.has("a")).toBe(true);
+    expect(set.has("b")).toBe(true);
+    expect(set.has("c")).toBe(false);
+  });
+});
+
+describe("sideHasTeam", () => {
+  const teamed = new Set(["a", "b", "c"]);
+  it("true only when every player on the side is teamed", () => {
+    expect(sideHasTeam(["a"], teamed)).toBe(true); // singles, teamed
+    expect(sideHasTeam(["a", "b"], teamed)).toBe(true); // 2v2, both teamed
+    expect(sideHasTeam(["a", "x"], teamed)).toBe(false); // one teamless
+    expect(sideHasTeam(["x"], teamed)).toBe(false); // teamless
+  });
+});
+
+describe("matchRosterValid", () => {
+  const teamed = new Set(["a", "b", "c", "d"]);
+  it("filled + both sides teamed → valid", () => {
+    expect(matchRosterValid(["a"], ["b"], 1, teamed)).toBe(true);
+    expect(matchRosterValid(["a", "b"], ["c", "d"], 2, teamed)).toBe(true);
+  });
+  it("filled but a side has a teamless player → INVALID (dropped-after-paired)", () => {
+    expect(matchRosterValid(["a"], ["x"], 1, teamed)).toBe(false); // side b teamless
+    expect(matchRosterValid(["x"], ["b"], 1, teamed)).toBe(false); // side a teamless
+    expect(matchRosterValid(["a", "x"], ["c", "d"], 2, teamed)).toBe(false); // one 2v2 member teamless
+  });
+  it("UNFILLED match → not applicable (true) — never conflate unfilled with teamless", () => {
+    expect(matchRosterValid([], [], 1, teamed)).toBe(true);
+    expect(matchRosterValid(["a"], [], 1, teamed)).toBe(true); // half-paired
+    expect(matchRosterValid(["a"], ["b"], 2, teamed)).toBe(true); // 2v2 but only 1 each
+  });
+});

--- a/src/lib/teamRoster.ts
+++ b/src/lib/teamRoster.ts
@@ -1,0 +1,47 @@
+/**
+ * Team-roster integrity predicates (team-identity Phase 0 → PR 1) — PURE, client-safe.
+ *
+ * The KEYSTONE both the config readiness verdict (this PR) and the leaderboard
+ * degraded-state detection (PR 3) derive from. Built once, in a shared home so the
+ * setup page AND the server leaderboard import the SAME rule.
+ *
+ * Distinct from the slot-filled readiness predicates in `matchDraft.ts`: those ask
+ * "are the slots FILLED?"; THESE ask "are the filled slots' players still on TEAMS?"
+ * — two different questions, never merged. The decided rule: in a (2-team)
+ * competition, match-play players are picked FROM teams, so a paired participant
+ * with no team is a roster-integrity break even though the match's SLOTS are full
+ * (the dropped-after-paired case). Standalone match play has no teams → N/A.
+ *
+ * Identity is the PERSON's roster (`team_assignments`), never the screen slot.
+ */
+
+/** The set of users who currently have a team (one entry per `team_assignments` row). */
+export function teamedUserIdSet(assignments: ReadonlyArray<{ user_id: string }>): Set<string> {
+  return new Set(assignments.map((a) => a.user_id));
+}
+
+/**
+ * Does every player on a side currently have a team? Intended for a FILLED side; an
+ * empty side is vacuously true, so gate on "filled" via `matchRosterValid` rather
+ * than reading this directly for an unfilled side.
+ */
+export function sideHasTeam(memberIds: ReadonlyArray<string>, teamed: ReadonlySet<string>): boolean {
+  return memberIds.every((id) => teamed.has(id));
+}
+
+/**
+ * Is a match roster-valid — both FILLED sides fully teamed? An UNFILLED match is
+ * "not applicable" → returns true, so this never double-flags the slot-filled gap
+ * (that's `matchDraft`'s job). It ONLY catches a fully-paired side whose player has
+ * since lost their team. `playersPerSide` = 1 (singles) / 2 (2v2).
+ */
+export function matchRosterValid(
+  a: ReadonlyArray<string>,
+  b: ReadonlyArray<string>,
+  playersPerSide: number,
+  teamed: ReadonlySet<string>,
+): boolean {
+  const filled = a.length === playersPerSide && b.length === playersPerSide;
+  if (!filled) return true; // unfilled is slot-filling's concern, not roster's
+  return sideHasTeam(a, teamed) && sideHasTeam(b, teamed);
+}


### PR DESCRIPTION
Team-identity integrity, PR 1 — the **config/setup-altitude** slice. Establishes the shared predicate PRs 2–3 depend on, makes the setup panel display the truth, and closes the config-altitude gaps. **A4 is clean (Phase 0): slot identity never reaches scoring — this PR is display correctness + the config verdict, not a scoring fix.** Decided rule: team identity = the player's **roster**, never the slot.

## C1 — keystone predicate ([new lib])
`src/lib/teamRoster.ts`: `matchRosterValid(a, b, playersPerSide, teamed)` — a **filled** match is roster-valid iff both sides are fully teamed; an **unfilled** match is "not applicable" (true). Distinct from the slot-filled readiness predicates (`matchDraft`) — never merged. Built in a shared home so the setup page (this PR) and the server leaderboard (PR 3) import the same rule. + `sideHasTeam`, `teamedUserIdSet`. **5 unit tests.**

## C2 — roster-based setup display (slot → roster; closes #477 here)
- New single canonical **`teamColorOf(userId)`** resolver (one home); both `MatchSetup` **and** the handicap selector consume it (replacing the inline duplicate).
- The Matches setup panel's assigned-player avatar colors by the player's **roster** team, not the slot. A player **dropped from their team** renders **neutral** here (honest "no team"), exactly like the handicap selector — never the slot's borrowed color. Removed the slot-based `teamA`/`teamB`/`tA`/`tB`.
- **#477:** `Slot` + `SelectorRow` stop passing `avatarIcon` → team-colored initial (§11).
- The picker **constraint** is unchanged (`teamForSlot` still scopes the pick list — correct: match-play picks from a team); only the avatar color resolution changed.

## C3 — config verdict catches dropped-after-paired (the D gap)
The readiness predicates test slot-filled only, so a previously-paired match whose player **later lost their team** still read "ready/valid". Now the Matches verdict is `resolved` only when `allFilled && allRosterValid`; a paired-but-teamless side flips it to the **invalid (red)** verdict — surfaced like the slot-filled hard-block (P2/P2b timing unchanged). The Enable gate is extended too (a roster-broken game can't enable — it would silently drop the teamless side's points). Reuses the C1 predicate over `teamOfUser`, no new fetch.

## C4 — DEFERRED + verification
- `DEFERRED.md`: durable per-score team attribution (parked engine-schema shaping — scores carry person + recorded team; PR 2's lock guard is the BBMI protection).
- **Verified:** 798 unit tests (+5). tsc + lint clean. **Full Playwright project green** (stroke + match-play). **Eye-verified dark + light** on a 2-team comp: setup avatars show roster colors (Rhinos red / Phoenix purple, left-aligned, team initials, #477 closed); **dropping a player from their team → setup avatar NEUTRAL + Matches row INVALID (red, "5 of 5 matches assigned") + Enable disabled**; re-adding resolves. Test data restored.

**Scope (DO-NOT honored):** no slot-based color anywhere (teamless → neutral); picker *constraint* untouched; predicate kept separate from the slot-filled ones; no `avatarIcon`; no scoring change; no guard (PR 2) or leaderboard surface/gate (PR 3) — config/setup altitude only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
