### PR TITLE
fix(team-identity): roster-removal lock once scoring starts

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -154,6 +154,18 @@ who's in, what they're called, what role they hold — is the Owner's.
 | Delegate / revoke a game organizer | ✓ | ✓ | — | `games.addOrganizer` / `removeOrganizer` *(trip staff only — a delegate can't sub-delegate)* |
 | View who runs a game | ✓ | ✓ | ✓ | `games.listOrganizers` |
 
+> **Roster-removal lock once scoring starts (team-identity).** Once a competition
+> has **any entered score** (`score_entries` exists for any of its games), its team
+> rosters are **locked for REMOVALS** — `teamAssignments.remove`, a *move/trade*
+> (`teamAssignments.assign` to a **different** team), and `teams.delete` all throw
+> (`PRECONDITION_FAILED`). **Adding** a player to a team (`assign` with no prior
+> membership) stays allowed — an add can't orphan anyone in an existing match.
+> Before the first score, full roster editing per the role gates above. Enforced
+> server-side (`assertRosterUnlocked`); the Rosters sheet disables the removal
+> controls with an explanation (the add path stays live). Leaderboard standings are
+> never gated — they stay visible to all roles. Mid-competition trades are parked in
+> DEFERRED (durable per-score attribution); this lock is the BBMI-safe stance.
+
 > **Per-game organizer delegation (Slice D1 §8).** Game edit/configure/enter-results
 > resolves to **`canEdit || isGameOrganizer(gameId)`** — trip Owner/Organizer, OR a
 > user granted organizer of *that specific game* (`game_organizers` row). It is

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -267,6 +267,13 @@ export function TeamsPanel({
     { tripId, competitionId },
     { enabled: !!competitionId }
   );
+  // Roster-removal lock: once any game has a score, removals/trades/team-deletes are
+  // server-blocked (C1). Disable those controls here so the block isn't a surprise;
+  // ADDS stay enabled. (Distinct from `structureLocked`/go-live.)
+  const { data: removalsLocked = false } = trpc.teamAssignments.rosterLocked.useQuery(
+    { tripId, competitionId },
+    { enabled: !!competitionId }
+  );
   const { data: members = [] } = trpc.tripMembers.list.useQuery({ tripId });
   // The viewer — to resolve "is the captain of THIS team" for identity editing
   // (PR b2). canEdit is the owner (structure); identity opens to owner OR captain.
@@ -366,6 +373,17 @@ export function TeamsPanel({
         className={`space-y-4 px-4 pb-4 ${embedded ? "" : "pt-3"}`}
         style={embedded ? undefined : { borderTop: "1px solid var(--color-bt-border)" }}
       >
+        {canEdit && removalsLocked && (
+          // Quiet explanation, not an alarm — the controls below are disabled, this
+          // says why. Adds stay live.
+          <p
+            className="rounded-lg px-3 py-2 text-[11px]"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
+            data-testid="rosters-locked-note"
+          >
+            Scoring has started — rosters are locked for removals. You can still add players.
+          </p>
+        )}
         {!teamsExist && (
           <NoTeamsEmptyState
             canEdit={canEdit && !structureLocked}
@@ -423,6 +441,7 @@ export function TeamsPanel({
                   canEdit={canEdit}
                   canEditIdentity={canEditIdentity(team.id)}
                   structureLocked={structureLocked}
+                  removalsLocked={removalsLocked}
                   onEdit={() => setEditingTeam(team)}
                   onDelete={() => setDeletingTeam(team)}
                   tripId={tripId}
@@ -527,6 +546,7 @@ function TeamCard({
   canEdit,
   canEditIdentity,
   structureLocked,
+  removalsLocked,
   onEdit,
   onDelete,
   tripId,
@@ -541,6 +561,9 @@ function TeamCard({
    *  color (PR b2). A captain edits ONLY their own team's identity. */
   canEditIdentity: boolean;
   structureLocked: boolean;
+  /** Scoring has started → removals/trades/team-delete are blocked (C1). Disables
+   *  the per-player ×, the move-drag, and the team-delete trash; adds stay live. */
+  removalsLocked: boolean;
   onEdit: () => void;
   onDelete: () => void;
   tripId: string;
@@ -640,9 +663,10 @@ function TeamCard({
         <span className="flex-shrink-0 text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
           {teamMembers.length}
         </span>
-        {canEdit && !structureLocked && (
-          // Delete-team lives at the list level (W-TEAMDEL-01). Hidden once live —
-          // removing a team is a structure change (§9).
+        {canEdit && !structureLocked && !removalsLocked && (
+          // Delete-team lives at the list level (W-TEAMDEL-01). Hidden once live OR
+          // once scoring starts — deleting a team is a mass removal (the locked note
+          // above explains it).
           <button
             type="button"
             onClick={onDelete}
@@ -681,10 +705,11 @@ function TeamCard({
               name={m.displayName}
               avatarIcon={m.user?.avatar_icon ?? null}
               teamColor={team.color}
-              draggable={canEdit}
+              // Dragging an assigned player = a MOVE/trade → disabled once removals lock.
+              draggable={canEdit && !removalsLocked}
               isCaptain={isCaptain}
               onDragStart={
-                canEdit
+                canEdit && !removalsLocked
                   ? (e) => {
                       e.dataTransfer.setData(DND_USER_KEY, id);
                       e.dataTransfer.effectAllowed = "move";
@@ -692,6 +717,7 @@ function TeamCard({
                   : undefined
               }
               onRemove={canEdit ? () => remove.mutate({ tripId, competitionId, userId: id }) : undefined}
+              removeLocked={removalsLocked}
               removeAriaLabel={`Remove ${m.displayName} from ${team.name}`}
               // Owner sets captain (PR b); members see the filled ★ read-only.
               onToggleCaptain={
@@ -720,6 +746,7 @@ function PlayerRow({
   isCaptain,
   onDragStart,
   onRemove,
+  removeLocked = false,
   removeAriaLabel,
   onToggleCaptain,
   captainAriaLabel,
@@ -731,6 +758,8 @@ function PlayerRow({
   isCaptain: boolean;
   onDragStart?: (e: React.DragEvent) => void;
   onRemove?: () => void;
+  /** Scoring started → the × is shown DISABLED (with a why-tooltip), not hidden. */
+  removeLocked?: boolean;
   removeAriaLabel: string;
   /** Owner-only: tap the ★ to mark/unmark captain. Absent for members. */
   onToggleCaptain?: () => void;
@@ -782,9 +811,11 @@ function PlayerRow({
       {onRemove && (
         <button
           type="button"
-          onClick={onRemove}
+          onClick={removeLocked ? undefined : onRemove}
+          disabled={removeLocked}
           aria-label={removeAriaLabel}
-          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+          title={removeLocked ? "Locked — scoring has started. You can still add players." : undefined}
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg disabled:cursor-not-allowed disabled:opacity-40"
           style={{ color: "var(--color-bt-text-dim)" }}
         >
           <X size={14} />

--- a/src/server/lib/rosterLock.ts
+++ b/src/server/lib/rosterLock.ts
@@ -1,0 +1,49 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Roster-removal lock (team-identity integrity). Once the first score is entered
+ * in ANY game of a competition, that competition's rosters freeze for REMOVALS —
+ * removing a player, trading/moving them, or deleting a team. ADDS stay allowed
+ * (an add can't orphan anyone in an existing match). Prevention replaces the
+ * earlier flip-to-setup recovery: a removal can't invalidate a live game if the
+ * removal is blocked once scoring starts.
+ *
+ * The "scored" signal is `score_entries` existence — the SAME boundary
+ * `applyCourse` freezes the course snapshot on, not a parallel invention.
+ */
+
+/** Has ANY game in this competition recorded a score yet? (first-score signal) */
+export async function competitionHasScore(
+  supabase: SupabaseClient,
+  competitionId: string,
+): Promise<boolean> {
+  const { data: games } = await supabase
+    .from("games")
+    .select("id")
+    .eq("competition_id", competitionId);
+  const ids = (games ?? []).map((g) => g.id as string);
+  if (ids.length === 0) return false;
+  const { count } = await supabase
+    .from("score_entries")
+    .select("id", { count: "exact", head: true })
+    .in("game_id", ids);
+  return (count ?? 0) > 0;
+}
+
+export const ROSTER_LOCKED_MESSAGE =
+  "Scoring has started — team rosters are locked. You can still add players, but can't remove or move them.";
+
+/**
+ * Throw if the competition is roster-locked (any score entered). Call BEFORE a
+ * removal/trade/team-delete write; never call it on a pure add (adds are always
+ * allowed).
+ */
+export async function assertRosterUnlocked(
+  supabase: SupabaseClient,
+  competitionId: string,
+): Promise<void> {
+  if (await competitionHasScore(supabase, competitionId)) {
+    throw new TRPCError({ code: "PRECONDITION_FAILED", message: ROSTER_LOCKED_MESSAGE });
+  }
+}

--- a/src/server/routers/rosterLock.test.ts
+++ b/src/server/routers/rosterLock.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext, genId } from "../../__tests__/helpers/test-setup";
+
+// Team-identity: roster-removal lock once scoring starts. Asymmetric — removals
+// (remove / trade-move / team-delete) freeze at first score; ADDS always pass.
+let ctx: TestContext;
+let tripId: string;
+let competitionId: string;
+let teamA: string;
+let teamB: string;
+let ownerId: string;
+let memberId: string;
+let plannerId: string;
+
+describe("roster-removal lock", () => {
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    tripId = await ctx.createTrip("Roster Lock Test");
+    await ctx.addTripMember(tripId, "member", "Member");
+    await ctx.addTripMember(tripId, "planner", "Member"); // the post-lock "pure add"
+    competitionId = await ctx.createCompetition(tripId, "Roster Lock Cup");
+    teamA = await ctx.createTeam(competitionId, "Team A");
+    teamB = await ctx.createTeam(competitionId, "Team B");
+    ownerId = ctx.user.id;
+    memberId = ctx.getUser("member").id;
+    plannerId = ctx.getUser("planner").id;
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  describe("before the first score — full roster editing", () => {
+    it("assign (add), move/trade, remove, and team-delete all succeed", async () => {
+      const caller = ctx.caller();
+      await caller.teamAssignments.assign({ tripId, competitionId, userId: memberId, teamId: teamA }); // add
+      await caller.teamAssignments.assign({ tripId, competitionId, userId: memberId, teamId: teamB }); // move
+      const removed = await caller.teamAssignments.remove({ tripId, competitionId, userId: memberId });
+      expect(removed).toEqual({ success: true });
+      const tmp = await ctx.createTeam(competitionId, "Temp Team");
+      const del = await caller.teams.delete({ tripId, teamId: tmp });
+      expect(del).toEqual({ success: true });
+    });
+  });
+
+  describe("after the first score — removals locked, adds allowed", () => {
+    beforeAll(async () => {
+      // Assign the players we'll test WHILE still unlocked, then lock the comp by
+      // inserting a game with a score (the first-score signal).
+      await ctx.caller().teamAssignments.assign({ tripId, competitionId, userId: memberId, teamId: teamA });
+      await ctx.caller().teamAssignments.assign({ tripId, competitionId, userId: ownerId, teamId: teamB });
+      const gameId = genId("rl-game");
+      await ctx.admin.from("games").insert({
+        id: gameId, trip_id: tripId, competition_id: competitionId,
+        game_type_id: "gtt_match_play_singles", name: "Locker", status: "active",
+        points_distribution: { type: "per_match", value: 2 },
+      });
+      const { error } = await ctx.admin.from("score_entries").insert({
+        id: genId("se"), game_id: gameId, participant_id: ownerId,
+        participant_type: "user", unit_label: "1", value: 4,
+      });
+      if (error) throw new Error(`score_entries insert failed: ${error.message}`);
+    });
+
+    it("a pure ADD (player with no prior team) still succeeds", async () => {
+      const added = await ctx.caller().teamAssignments.assign({ tripId, competitionId, userId: plannerId, teamId: teamA });
+      expect(added.team_id).toBe(teamA);
+    });
+
+    it("remove is blocked", async () => {
+      await expect(
+        ctx.caller().teamAssignments.remove({ tripId, competitionId, userId: memberId })
+      ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    });
+
+    it("a move/trade (assign to a DIFFERENT team) is blocked", async () => {
+      await expect(
+        ctx.caller().teamAssignments.assign({ tripId, competitionId, userId: memberId, teamId: teamB })
+      ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    });
+
+    it("team-delete (mass removal) is blocked", async () => {
+      await expect(
+        ctx.caller().teams.delete({ tripId, teamId: teamB })
+      ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    });
+
+    it("rosterLocked query reports true", async () => {
+      const locked = await ctx.caller().teamAssignments.rosterLocked({ tripId, competitionId });
+      expect(locked).toBe(true);
+    });
+  });
+});

--- a/src/server/routers/teamAssignments.ts
+++ b/src/server/routers/teamAssignments.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
-import { assertRosterUnlocked } from "../lib/rosterLock";
+import { assertRosterUnlocked, competitionHasScore } from "../lib/rosterLock";
 
 /**
  * team_assignments — composite PK (competition_id, user_id) means a user
@@ -38,6 +38,14 @@ export const teamAssignmentsRouter = router({
     .input(z.object({ tripId: z.string(), competitionId: z.string() }))
     .use(requireTripMember)
     .query(({ ctx, input }) => listTeamAssignments(ctx, input.competitionId)),
+
+  // rosterLocked — has scoring started (any score entered)? Drives the Rosters
+  // sheet's disabled remove/delete controls (C1 is the enforcement; this is so the
+  // block isn't a surprising error). Adds stay enabled regardless.
+  rosterLocked: authedProcedure
+    .input(z.object({ tripId: z.string(), competitionId: z.string() }))
+    .use(requireTripMember)
+    .query(({ ctx, input }) => competitionHasScore(ctx.supabase, input.competitionId)),
 
   // -----------------------------------------------------------------------
   // assign — set a user's team (canEdit). Upsert behaviour relies on the

--- a/src/server/routers/teamAssignments.ts
+++ b/src/server/routers/teamAssignments.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireTripRole } from "../middleware";
+import { assertRosterUnlocked } from "../lib/rosterLock";
 
 /**
  * team_assignments — composite PK (competition_id, user_id) means a user
@@ -53,6 +54,19 @@ export const teamAssignmentsRouter = router({
     )
     .use(requireTripRole("Organizer"))
     .mutation(async ({ ctx, input }) => {
+      // Roster-removal lock — asymmetric: a pure ADD (no prior assignment) always
+      // passes. A MOVE/TRADE (already on a DIFFERENT team) removes them from that
+      // team, so it's blocked once scoring has started. (Re-assigning to the same
+      // team is a no-op, not a removal — passes.)
+      const { data: existing } = await ctx.supabase
+        .from("team_assignments")
+        .select("team_id")
+        .eq("competition_id", input.competitionId)
+        .eq("user_id", input.userId)
+        .maybeSingle();
+      const isMove = !!existing && (existing.team_id as string) !== input.teamId;
+      if (isMove) await assertRosterUnlocked(ctx.supabase, input.competitionId);
+
       const { data: inserted, error } = await ctx.supabase
         .from("team_assignments")
         .upsert(
@@ -89,6 +103,10 @@ export const teamAssignmentsRouter = router({
     )
     .use(requireTripRole("Owner"))
     .mutation(async ({ ctx, input }) => {
+      // Roster-removal lock: a removal is blocked once any game in the competition
+      // has a score (it could orphan the player in a configured match).
+      await assertRosterUnlocked(ctx.supabase, input.competitionId);
+
       const { error } = await ctx.supabase
         .from("team_assignments")
         .delete()

--- a/src/server/routers/teams.ts
+++ b/src/server/routers/teams.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireCompetitionRole, requireTeamIdentityEdit } from "../middleware";
+import { assertRosterUnlocked } from "../lib/rosterLock";
 
 /**
  * teams — competition-scoped teams.
@@ -138,6 +139,17 @@ export const teamsRouter = router({
     .input(z.object({ tripId: z.string(), teamId: z.string() }))
     .use(requireCompetitionRole("co_admin"))
     .mutation(async ({ ctx, input }) => {
+      // Roster-removal lock: deleting a team is a MASS removal (cascades to clear
+      // its assignments), so it's blocked once the competition has any score.
+      const { data: team } = await ctx.supabase
+        .from("teams")
+        .select("competition_id")
+        .eq("id", input.teamId)
+        .maybeSingle();
+      if (team?.competition_id) {
+        await assertRosterUnlocked(ctx.supabase, team.competition_id as string);
+      }
+
       const { error } = await ctx.supabase
         .from("teams")
         .delete()


### PR DESCRIPTION
The remaining team-identity piece (the flip-to-setup spec was cut — **prevention replaces recovery**). Once a competition has any entered score, its rosters freeze for **removals**; **adds stay allowed**. A removal can't invalidate a live game if the removal is blocked.

## C1 — server lock ([new lib])
`src/server/lib/rosterLock.ts`: `competitionHasScore` (first-score signal — reuses `score_entries` existence, the same boundary `applyCourse` freezes on) + `assertRosterUnlocked` (throws `PRECONDITION_FAILED`). Wired into:
- `teamAssignments.remove` — always a removal → guarded.
- `teamAssignments.assign` — guarded **only on a move/trade** (existing assignment → a *different* team). A pure **add** (no prior membership) and a same-team no-op pass.
- `teams.delete` — guarded (mass removal; fetches the team's `competition_id`).
- Before first score, everything passes unchanged.

## C2 — Rosters sheet reflects it
New `teamAssignments.rosterLocked` query → the client `removalsLocked` signal (distinct from `structureLocked`/go-live). When locked: a quiet note ("Scoring has started — rosters are locked for removals. You can still add players."), the per-player `×` shown **disabled** with a why-tooltip, move-drag disabled, the team-delete trash hidden. The add path (CrewRoster) is untouched. Server is enforcement; this only explains it.

## C3 — PERMISSIONS + tests
- `PERMISSIONS.md`: the rule (removals blocked once scored; adds allowed; **standings never gated**; trade model parked in DEFERRED).
- `rosterLock.test.ts` (6 tests, real test DB): pre-score assign/move/remove/team-delete all succeed; post-score remove + move + `teams.delete` all throw while a **pure add succeeds**; `rosterLocked` reports true. The asymmetry, explicit.

## Verification
- **804 unit tests pass** (+6). tsc + lint clean. **Full Playwright project green** (stroke + match-play).
- **Eye-verified dark + light** on the scored BBMI cup: locked note, all 16 player-removes disabled (tooltip), team-trash hidden, captain ★ unaffected; standings stay visible to all.

**Scope (DO-NOT honored):** adds never blocked; no flip-to-setup machinery; no per-match check (simple full freeze on removals); no lock before first score; durable-attribution model parked in DEFERRED; server is the enforcement, UI only explains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
