### PR TITLE
feat(row-pattern): Phase 1 — extract Matches/Handicaps shared row primitives

### DIFF
--- a/src/components/games/PlayerChip.tsx
+++ b/src/components/games/PlayerChip.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Avatar } from "@/components/Avatar";
+
+/**
+ * PlayerChip — the shared player chip (Matches/Handicaps row pattern, Phase 1): the
+ * team-colored `Avatar` (§11 — the team-colored INITIAL, never `avatarIcon`) at the
+ * reconciled size **30** + the name, **left-aligned** (avatar then name, flush left).
+ *
+ * Presentational ONLY — owns no tap/selection state. Wrappers add interaction:
+ * Matches' `Slot` makes it tap-to-pick, the handicap segment makes it select-a-side.
+ * (That's what lets ONE chip serve both.) Pass `onClick`/`style`/`className` through
+ * to make it interactive or restyle the surface (e.g. the handicap segment's selected
+ * outline). It must look identical wherever wrapped — that consistency is the point.
+ */
+export function PlayerChip({
+  name,
+  teamColor,
+  className = "",
+  style,
+  ...rest
+}: {
+  name: string;
+  /** Drives the team-colored initial. Omit/null → Avatar's neutral fallback. */
+  teamColor?: string | null;
+} & React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`flex min-w-0 items-center gap-2 ${className}`}
+      style={{
+        width: "100%",
+        height: 44,
+        padding: "0 10px",
+        borderRadius: 10,
+        background: "var(--color-bt-card-raised)",
+        border: "1px solid var(--color-bt-border)",
+        ...style,
+      }}
+      {...rest}
+    >
+      {/* §11 team-colored initial — no avatarIcon. */}
+      <Avatar name={name} teamColor={teamColor} sizePx={30} />
+      <span
+        className="min-w-0 truncate"
+        style={{ fontSize: 15, fontWeight: 500, color: "var(--color-bt-text)" }}
+      >
+        {name}
+      </span>
+    </div>
+  );
+}

--- a/src/components/games/RowGutter.tsx
+++ b/src/components/games/RowGutter.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+
+/**
+ * RowGutter — the shared row "spine" (Matches/Handicaps row pattern, Phase 1). A
+ * recessed left gutter: an optional drag **handle** + the row **number**, de-emphasized
+ * as table STRUCTURE (dim, `tabular-nums`), not matchup content.
+ *
+ * Owns NO drag state — it only forwards the handle's mouse events; the parent arms
+ * its own draggable + owns reorder.
+ *
+ * Alignment: the handle's slot is **always reserved** (rendered empty when
+ * `showHandle` is false) so the number — and the content column after the gutter —
+ * line up whether or not the row reorders (Matches reorders, Handicaps doesn't).
+ * Aligned to the row's FIRST content line (`items-start`), so a taller 2v2 match
+ * (two stacked rows, Phase 2) keeps the number with its top row.
+ */
+
+// One content row's height — the handle/number center within this; `items-start`
+// keeps them on the first line of a taller (2v2) row.
+const LINE = 44;
+const HANDLE_W = 22;
+const NUMBER_W = 16;
+
+export function RowGutter({
+  number,
+  showHandle = true,
+  onHandleMouseDown,
+  onHandleMouseUp,
+}: {
+  number: number;
+  /** Reorderable rows show the grip; static rows (Handicaps) hide it — the slot is
+   *  still reserved so the number stays in the same column. */
+  showHandle?: boolean;
+  /** Forwarded to the handle — the parent arms its own draggable on mousedown. */
+  onHandleMouseDown?: () => void;
+  onHandleMouseUp?: () => void;
+}) {
+  return (
+    <div className="flex flex-shrink-0 items-start">
+      <span
+        onMouseDown={showHandle ? onHandleMouseDown : undefined}
+        onMouseUp={showHandle ? onHandleMouseUp : undefined}
+        aria-label={showHandle ? "Drag to reorder" : undefined}
+        title={showHandle ? "Drag to reorder" : undefined}
+        className={`flex items-center justify-center ${showHandle ? "cursor-grab active:cursor-grabbing" : ""}`}
+        style={{ width: HANDLE_W, height: LINE, color: "var(--color-bt-text-dim)", touchAction: "none" }}
+      >
+        {showHandle && <GripVertical size={16} />}
+      </span>
+      <span
+        className="flex items-center justify-center"
+        style={{ width: NUMBER_W, height: LINE, fontSize: 13, fontWeight: 500, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}
+      >
+        {number}
+      </span>
+    </div>
+  );
+}

--- a/src/components/games/rowPattern.test.tsx
+++ b/src/components/games/rowPattern.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { RowGutter } from "./RowGutter";
+import { PlayerChip } from "./PlayerChip";
+
+// Matches/Handicaps shared row pattern, Phase 1 — the primitives render in
+// isolation (no live screen consumes them yet; visual verification lands in Phases
+// 2/3 when wired in). Rendered via react-dom/server (the test env is node, no RTL).
+
+describe("RowGutter", () => {
+  it("renders the row number, with the drag handle by default", () => {
+    const html = renderToStaticMarkup(<RowGutter number={3} />);
+    expect(html).toContain(">3<"); // the number
+    expect(html).toContain("Drag to reorder"); // the handle (aria-label/title)
+  });
+
+  it("hides the handle when showHandle=false but RESERVES its slot (alignment) + keeps the number", () => {
+    const html = renderToStaticMarkup(<RowGutter number={1} showHandle={false} />);
+    expect(html).toContain(">1<");
+    expect(html).not.toContain("Drag to reorder"); // no handle
+    expect(html).toContain("width:22px"); // the handle slot is still reserved so the number aligns
+  });
+});
+
+describe("PlayerChip", () => {
+  it("renders the name + a size-30 team-colored Avatar on the card-raised surface", () => {
+    const html = renderToStaticMarkup(<PlayerChip name="Jeremy" teamColor="#ef4444" />);
+    expect(html).toContain("Jeremy"); // name
+    expect(html).toContain("#ef4444"); // team color → the avatar background (competition mode)
+    expect(html).toContain("width:30px"); // Avatar sizePx 30 (the reconciled size, not 22)
+    expect(html).toContain("var(--color-bt-card-raised)"); // the chip surface
+  });
+
+  it("renders the team INITIAL, never an avatarIcon", () => {
+    const html = renderToStaticMarkup(<PlayerChip name="Rob Smith" teamColor="#a855f7" />);
+    expect(html).toContain('aria-label="Rob Smith initials"'); // the initials path, not the icon path
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,6 +6,10 @@ import { config } from "dotenv";
 config({ path: path.resolve(__dirname, ".env.local") });
 
 export default defineConfig({
+  // Match the Next app's automatic JSX runtime so component .tsx files (which omit
+  // `import React`) render under react-dom/server in tests (the row-pattern
+  // primitives are the first such test).
+  esbuild: { jsx: "automatic" },
   test: {
     environment: "node",
     testTimeout: 30_000,


### PR DESCRIPTION
First of three (1: primitives → 2: Matches restyle ∥ 3: P-D revision). Extracts the two shared pieces both rows will consume, so the settled row pattern has **one home** instead of two look-alikes that drift. **No row is restyled here** — the primitives are drop-in-ready for Phases 2/3.

## P1a — `RowGutter` ([new])
The recessed left spine: an optional drag **handle** + the row **number**, de-emphasized as table structure (dim, `tabular-nums`). Owns **no drag state** — forwards the handle's mouse events; the parent arms its own draggable.
- **Alignment choice (reported):** the handle slot is **always reserved** (rendered empty when `showHandle=false`) so the number — and the content column after the gutter — align whether or not the row reorders (Matches reorders, Handicaps doesn't). True structural consistency across the two sibling rows.
- `items-start` keeps the number on the row's **first content line**, so a taller 2v2 match (two stacked rows, Phase 2) keeps its number with the top row.

## P1b — `PlayerChip` ([new])
The one chip both rows compose: the team-colored `Avatar` (§11 initial, **no `avatarIcon`**) at the reconciled size **30** + name, **left-aligned**, height 44, radius 10, card-raised, name ellipsis-truncates. Tokens only. **Presentational** — owns no tap/selection state; `className`/`style`/`onClick` pass through so wrappers (Matches' `Slot`, the handicap segment) add interaction or override the surface (e.g. the segment's selected outline).

## P1c — tests
The primitives have no extractable pure logic, so they're rendered in isolation via **`react-dom/server`** (the test env is node, no RTL — `renderToStaticMarkup` works without jsdom). Asserts: RowGutter renders the number always + handle only when `showHandle` (slot reserved at `width:22px`); PlayerChip renders the name + a size-30 team-colored Avatar (the **initial**, not an icon) on the card-raised surface. Live-screen verification lands in Phases 2/3 when consumed.
- `vitest.config`: `esbuild: { jsx: "automatic" }` so component `.tsx` files (which omit `import React`) render in tests — this is the first `.tsx` component test, so the change touches only it.

## Verification
**808 unit tests pass** (+4). tsc + lint clean. Full Playwright project green.

## Pre-flight (confirmed, nothing surprising)
`Avatar` is the shared avatar (team color + name → initial, no `avatarIcon`); the two replace-targets are Matches' `Slot` (Avatar 30) and P-D's `Segment` (Avatar 22, dropped for 30); `src/components/games/` is the shared home both the page and `RelHandicapControl` import from.

**Scope (DO-NOT honored):** no row restyled; no selection/tap/drag *state* in the primitives (handlers only); avatar size **30** (not 22); tokens only; no `avatarIcon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
