### PR TITLE
Matches panel: × always present — remove a match, or clear the last one's players

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -635,7 +635,32 @@ export default function NewMatchGamePage() {
   // server return); this just syncs it. No-op until a real match exists. On
   // failure the draft is KEPT (never discard edits) and an inline retry surfaces.
   async function persistDraftOnCollapse() {
-    if (filledDraft.length === 0) return;
+    if (filledDraft.length === 0) {
+      // Clear-to-empty: the floor-of-one × emptied the last match's slots, so the
+      // draft has its row(s) but nothing filled. Persist them as EMPTY matches (null
+      // sides — the shape creation seeds) so the clear SURVIVES reload; otherwise
+      // saveSetup's filled-only write skips it and the server keeps the old players
+      // (the revert-on-reload bug). Scoped to a draft that is ALL-empty (every slot
+      // empty) — the deliberate post-clear state — so a transient half-filled slot is
+      // left unpersisted (existing behavior), never wiped. saveSetup itself stays
+      // filled-only: it's also the Enable gate's "ready" signal, which empty is not.
+      const allEmpty = draft.length > 0 && draft.every((m) => m.a.length === 0 && m.b.length === 0);
+      if (!allEmpty || !tripId || !gameId) return;
+      try {
+        const empty = draft.map((_, i) => ({ sideA: null, sideB: null, matchNumber: i + 1 }));
+        if (sided) await setDoublesPairings.mutateAsync({ tripId, gameId, matches: empty });
+        else await setPairings.mutateAsync({ tripId, gameId, matches: empty });
+        setCollapseError(false);
+        if (competitionId) {
+          utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+          utils.games.listByTrip.invalidate({ tripId });
+          utils.competitions.faceBootstrap.invalidate({ tripId });
+        }
+      } catch {
+        setCollapseError(true);
+      }
+      return;
+    }
     try {
       const ok = await saveSetup();
       if (ok) {
@@ -1671,21 +1696,28 @@ function MatchSetup({
                   red — draft removal is free (no persisted scores) and the open panel
                   must never read as an error. Far right. The runtime-overview remove
                   (a scored, destructive match) keeps its danger color; this one does
-                  not. Hidden at the floor of 1, but the column stays so rows align. */}
-              {draft.length > 1 ? (
-                <button
-                  type="button"
-                  onClick={() => setDraft((prev) => prev.filter((_, j) => j !== i))}
-                  title="Remove match"
-                  aria-label={`Remove match ${i + 1}`}
-                  className="flex items-center justify-center"
-                  style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)" }}
-                >
-                  <X size={16} />
-                </button>
-              ) : (
-                <span />
-              )}
+                  not. ALWAYS present, floor-aware: with >1 match it REMOVES the row;
+                  on the LAST match it CLEARS the slots (empties both sides back to the
+                  dashed "+ add player" state) rather than deleting it — the server
+                  enforces a floor of ≥1 match (setPairings .min(1) / removeMatch's
+                  throw), so the last match is cleared, never removed. One glyph, both
+                  meanings (no room for a label). */}
+              <button
+                type="button"
+                onClick={() =>
+                  setDraft((prev) =>
+                    prev.length > 1
+                      ? prev.filter((_, j) => j !== i)
+                      : prev.map((m, j) => (j === i ? { ...m, a: [], b: [], handicap: 0 } : m))
+                  )
+                }
+                title={draft.length > 1 ? "Remove match" : "Clear players"}
+                aria-label={draft.length > 1 ? `Remove match ${i + 1}` : `Clear match ${i + 1}`}
+                className="flex items-center justify-center"
+                style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)" }}
+              >
+                <X size={16} />
+              </button>
             </div>
           );
         })}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -30,7 +30,7 @@ import { buildDecided, matchState, strokeHoles, matchHasScores, type HoleResult 
 import { DangerConfirmModal } from "@/components/DangerZone";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady } from "@/lib/matchDraft";
+import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeOrClearMatch } from "@/lib/matchDraft";
 import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
@@ -1704,13 +1704,7 @@ function MatchSetup({
                   meanings (no room for a label). */}
               <button
                 type="button"
-                onClick={() =>
-                  setDraft((prev) =>
-                    prev.length > 1
-                      ? prev.filter((_, j) => j !== i)
-                      : prev.map((m, j) => (j === i ? { ...m, a: [], b: [], handicap: 0 } : m))
-                  )
-                }
+                onClick={() => setDraft((prev) => removeOrClearMatch(prev, i))}
                 title={draft.length > 1 ? "Remove match" : "Clear players"}
                 aria-label={draft.length > 1 ? `Remove match ${i + 1}` : `Clear match ${i + 1}`}
                 className="flex items-center justify-center"

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeOrClearMatch, type MatchSides } from "./matchDraft";
 
 // Readiness rework P1b — the ONE match-play readiness threshold, shared by the
 // setup-page Enable gate and the server `isConfigured` so they can't drift.
@@ -110,5 +110,43 @@ describe("allMatchesFilled (the Enable-scoring gate)", () => {
   it("2v2: every side must be at full strength", () => {
     expect(allMatchesFilled([singles(["a", "b"], ["c", "d"])], 2)).toBe(true);
     expect(allMatchesFilled([singles(["a", "b"], ["c"])], 2)).toBe(false);
+  });
+});
+
+// The floor-aware "×" action: remove the match when there's more than one, CLEAR
+// the slots when it's the last (the server enforces ≥1 match — the last is cleared,
+// never deleted, so there's no zero-match state).
+describe("removeOrClearMatch (the floor-aware × action)", () => {
+  const m = (a: string[], b: string[], handicap = 0) => ({ a, b, handicap, matchNumber: 0 });
+
+  it("with >1 match, REMOVES the match at the index", () => {
+    const draft = [m(["a"], ["b"]), m(["c"], ["d"]), m(["e"], ["f"])];
+    const out = removeOrClearMatch(draft, 1);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(draft[0]); // untouched rows are the same refs
+    expect(out[1]).toBe(draft[2]);
+  });
+
+  it("with exactly 1 match, CLEARS its slots — keeps ONE empty match (never zero)", () => {
+    const draft = [m(["a", "b"], ["c", "d"], 3)];
+    const out = removeOrClearMatch(draft, 0);
+    expect(out).toHaveLength(1); // the floor — not deleted
+    expect(out[0].a).toEqual([]);
+    expect(out[0].b).toEqual([]);
+    expect(out[0].handicap).toBe(0); // strokes reset with the pairing
+    expect(out[0].matchNumber).toBe(0); // other fields preserved
+  });
+
+  it("a cleared last match reads as NOT ready (Enable blocked, downstream locked)", () => {
+    const cleared = removeOrClearMatch([m(["a"], ["b"])], 0);
+    expect(allMatchesFilled(cleared, 1)).toBe(false); // can't enable
+    expect(hasValidMatch(cleared, 1)).toBe(false); // Points/Handicaps/Modifiers stay locked
+  });
+
+  it("does not mutate the input draft", () => {
+    const draft = [m(["a"], ["b"])];
+    const snapshot = JSON.parse(JSON.stringify(draft));
+    removeOrClearMatch(draft, 0);
+    expect(draft).toEqual(snapshot);
   });
 });

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -17,6 +17,20 @@ export interface MatchSides {
   b: string[];
 }
 
+/**
+ * The floor-aware "×" action on the setup draft (Matches panel). With MORE than one
+ * match, REMOVE the match at `index`. With exactly ONE match, CLEAR its slots instead
+ * — empty both sides + reset the handicap — keeping one empty match rather than
+ * deleting it. The server enforces a floor of ≥1 match (`setPairings`/
+ * `setDoublesPairings` `.min(1)`, `removeMatch`'s throw), so the last match is
+ * cleared, never removed (no zero-match state). Pure — returns a new draft, never
+ * mutates; preserves any other fields on the match (e.g. `matchNumber`) via spread.
+ */
+export function removeOrClearMatch<M extends MatchSides & { handicap: number }>(draft: M[], index: number): M[] {
+  if (draft.length > 1) return draft.filter((_, j) => j !== index);
+  return draft.map((m, j) => (j === index ? { ...m, a: [], b: [], handicap: 0 } : m));
+}
+
 /** True when both sides carry exactly `playersPerSide` players. */
 export function isMatchFilled(match: MatchSides, playersPerSide: number): boolean {
   return match.a.length === playersPerSide && match.b.length === playersPerSide;


### PR DESCRIPTION
## The gap

Phase 2 (#494) shipped the six-column Matches grid with a remove **×** gated on `draft.length > 1`. That left the **last remaining match with no ×** — you could remove match 2 but not match 1, and (since the player picker only *swaps*, never un-assigns) a single match's slots could never be cleared. You asked for a way to clear the players in a single match.

## The fix (chosen over "allow 0 matches")

Allowing a true zero-match state collides with a **deliberately-enforced server invariant** — `setPairings`/`setDoublesPairings` require `.min(1)` matches and `removeMatch` throws below 1 ("a match game must keep at least one match"), with downstream scoring assuming ≥1. So instead of breaking that contract, the **× is always present** and floor-aware:

- **`draft.length > 1`** → × **removes** that match (existing behavior).
- **`draft.length === 1`** → × **clears** the slots (empties both sides back to the dashed "+ add player" state), keeping one empty match. The last match is cleared, never deleted — no server change, no zero-match state.

This solves clearing a single match's players directly. To re-assign different players: clear, then tap the empty slots.

### Persistence fix
`persistDraftOnCollapse` early-returned on an all-empty draft, so a cleared last match would have **reverted to the old players on reload**. Now an all-empty draft (the deliberate post-clear state) persists as null-sided matches via `setPairings` (the shape creation seeds), so the clear survives reload. Scoped to *all-empty* so a transient half-filled slot is left unpersisted (existing behavior), never wiped. `saveSetup` stays filled-only — it's the Enable gate's "ready" signal, which empty is not, so an empty game still can't enable.

## Commits
- **C1** — × always present, floor-aware (remove vs clear) + persist the clear. Dim × (non-destructive, per P2b); one glyph, both meanings. 1v1 + 2v2 (the 2v2 last match clears all four slots).
- **C2** — extract `removeOrClearMatch` into the pure `matchDraft.ts` (the readiness-predicate pattern) + unit tests; page consumes it.

## Verification
- `tsc` + `next lint` clean. Full Vitest **812 passed** (+4 new for `removeOrClearMatch`). Whole Playwright project green (3/3, incl. `match-play.spec.ts`).
- Eye-verified (2v2, dark): single match now shows the × → tapping clears all four slots to dashed, the match stays, Enable disabled, subtitle "0 matches assigned". Collapse + reload → **stays empty** (DB confirmed: 1 match, null sides, play_groups/participants cleaned up — floor-of-one intact). Test game restored to its original state afterward.

## Server contract: unchanged
No change to the `.min(1)` / `removeMatch` floor-of-one — the last match is cleared, not removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)