### PR TITLE
W-GAMEPAGE row pattern Phase 3: handicap row revision (shared primitives + teal-fill)

### DIFF
--- a/W-GAMEPAGE-01_visual_vocabulary.md
+++ b/W-GAMEPAGE-01_visual_vocabulary.md
@@ -23,9 +23,15 @@ accent(teal)→`--color-bt-accent`, danger→`--color-bt-danger`.
    teal check overlay — it never swaps the icon out for a check. Rows stay identifiable in any state
    (critical in a mostly-collapsed accordion).
 2. **Teal means something, always.** Teal is reserved for: the check badge (done), the active-selection
-   outline (live choice), and live computed values (the points total). **Never** captions, helper text,
-   default icon color, or required markers. Teal earns meaning by being rare. *(This was corrected
-   repeatedly — over-teal is the default mistake.)*
+   outline (live choice), live computed values (the points total), and — the one scoped expansion (row
+   pattern Phase 3) — the **selection-state fill of a segmented selector** (see §8). **Never** captions,
+   helper text, default icon color, or required markers. Teal earns meaning by being rare. *(This was
+   corrected repeatedly — over-teal is the default mistake.)*
+   - **Scoped exception — teal-fill as a selection state.** A segmented selector (the §8 `[A│Even│B]`
+     handicap selector) marks its selected segment with a **faint teal wash** (`rgba(45,212,191,0.14)`)
+     **plus** the teal border. This is deliberate and bounded to segmented selectors — it is NOT a license
+     to fill arbitrary surfaces with teal. The general rule (teal = outline/accent, not fill) still holds
+     everywhere else; here the fill *is* the selection signal, distinct from a value or a badge.
 3. **Show the control when live; summarize when not.** No dead/greyed controls reserved "just in case"
    (e.g. no stepper under an Even match).
 4. **Reuse primitives — match, don't reinvent.** The stepper and avatars already exist; adopt their
@@ -129,14 +135,23 @@ Three densities, one component:
 - **Match number on the LEFT** (a small left gutter, like the matches design). The per-row
   `MATCH # · WHO GETS STROKES?` header is **removed** — the control answers it, repeating it five times
   wasted vertical space.
-- **Segmented control:** `[avatar + Player A] │ [Even] │ [avatar + Player B]`. Even segment is narrow,
-  no avatar; player segments carry the team avatar (§11).
-- **Selected = outline, not fill.** Active segment gets a teal border; **no solid teal fill** (solid
-  fill fights the avatar colors and muddies them).
-- **Even selected →** no stepper rendered, just a muted caption "Even match — no strokes given".
-- **Side selected →** the centered full stepper reveals, with a **muted** caption naming the recipient:
-  "{Player} gets strokes on holes 1, 2, 3" (names the recipient so the centered stepper isn't
-  ambiguous; **not teal**).
+- **Shared skeleton (row pattern Phase 3).** The row now uses the same primitives as the Matches setup
+  grid: the **`RowNumber`** gutter (number only — handicaps don't reorder, so no `DragHandle`) + the
+  shared **`PlayerChip`** (avatar **30**, left-aligned, team-colored §11) + a **separator** hairline
+  between matches. Matches and Handicaps are genuine siblings sharing real primitives.
+- **Segmented control:** `[PlayerChip A] │ [Even] │ [PlayerChip B]`. Even segment is narrow, no avatar;
+  player segments carry the shared chip.
+- **Selected = TEAL FILL + teal border** (revised in Phase 3 — was outline-only). The selected segment
+  (player OR Even) gets the faint teal wash (`rgba(45,212,191,0.14)`) **plus** the teal border;
+  unselected segments are the recessed card-raised chip with a transparent border. This is the one scoped
+  expansion of the teal discipline — teal-fill as a *selection state* in segmented selectors (see §1).
+- **Even selected →** **just the row** — no stepper, **no caption**. The "Even match — no strokes given"
+  line was **dropped** (the selected Even segment already says it).
+- **Side selected →** the full stepper reveals, with a **muted** caption naming the recipient:
+  "{Player} gets strokes on holes 1, 2, 3" (**not teal**). The stepper is positioned **geometrically**:
+  centered under the **middle** column by default (mobile-first), snapping under the **selected player's
+  column** when that column is wide enough to contain the stepper (`playerColumnWidth ≥ stepperWidth`) —
+  a measured rule, not a pixel breakpoint.
 - **Even matches = one line; stroked matches = two lines.** Massive vertical savings vs. the current
   match-play handicaps screen.
 

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1759,18 +1759,28 @@ function HandicapsSection({
     );
   }
   return (
-    <div className="flex flex-col gap-3" data-testid="handicaps-section">
-      {filled.map(({ d, i }) => (
+    // Separator hairline between matches (row pattern Phase 3) — the same delimiter
+    // Matches uses, replacing the old gap-3 spacing so the two surfaces read alike.
+    <div className="flex flex-col" data-testid="handicaps-section">
+      {filled.map(({ d, i }, idx) => (
         // §8: the per-row "Match N" header is gone — the number rides the control's
         // left gutter instead (passed below), shown only when there's >1 match.
-        <RelHandicapControl
+        <div
           key={i}
-          a={sidePart(d.a)!}
-          b={sidePart(d.b)!}
-          value={d.handicap}
-          matchNumber={draft.length > 1 ? i + 1 : undefined}
-          onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}
-        />
+          style={{
+            borderTop: idx > 0 ? "1px solid var(--color-bt-border)" : undefined,
+            paddingTop: idx > 0 ? 14 : 0,
+            paddingBottom: 14,
+          }}
+        >
+          <RelHandicapControl
+            a={sidePart(d.a)!}
+            b={sidePart(d.b)!}
+            value={d.handicap}
+            matchNumber={draft.length > 1 ? i + 1 : undefined}
+            onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}
+          />
+        </div>
       ))}
     </div>
   );

--- a/src/components/games/RelHandicapControl.test.ts
+++ b/src/components/games/RelHandicapControl.test.ts
@@ -1,18 +1,21 @@
 import { describe, it, expect } from "vitest";
 import { relHandicapView } from "./RelHandicapControl";
 
-// W-GAMEPAGE visual pass P-D §8 — the altitude-aware reveal. Pure view-model so the
-// "Even = one line (no stepper)" vs "side = stepper + recipient caption" logic is
-// testable apart from render. (The segment outline + avatars are CSS — eye-verified.)
+// W-GAMEPAGE visual pass P-D §8, revised by row-pattern Phase 3 — the altitude-aware
+// reveal. Pure view-model so the "Even = just the row (no stepper, no caption)" vs
+// "side = stepper + recipient caption" logic is testable apart from render. (The
+// teal-fill selection + the shared chip/gutter are CSS — eye-verified.)
 describe("relHandicapView (the §8 reveal view-model)", () => {
-  it("Even (value 0): no stepper, no recipient, the muted Even caption", () => {
+  it("Even (value 0): no stepper, no recipient, NO caption (P3b dropped it)", () => {
     const v = relHandicapView(0, "Ann", "Bob");
     expect(v.side).toBe("even");
     expect(v.even).toBe(true);
-    expect(v.showStepper).toBe(false); // Even is ONE line — no stepper rendered
+    expect(v.showStepper).toBe(false); // Even is JUST the row — no stepper rendered
     expect(v.recipient).toBeNull();
     expect(v.holes).toEqual([]);
-    expect(v.caption).toBe("Even match — no strokes given");
+    // The "Even match — no strokes given" caption was dropped — the selected Even
+    // segment already says it, so an Even match is one line with no caption beneath.
+    expect(v.caption).toBe("");
   });
 
   it("left side (value < 0): side a gets strokes; stepper shows; recipient caption", () => {

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -2,7 +2,8 @@
 
 import { strokeHoles } from "@/lib/matchPlay";
 import { Stepper } from "@/components/games/Stepper";
-import { Avatar } from "@/components/Avatar";
+import { RowNumber } from "@/components/games/RowNumber";
+import { PlayerChip } from "@/components/games/PlayerChip";
 import type { Participant } from "./types";
 
 /**
@@ -89,28 +90,26 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
     // under the player columns / matchup — not centered on the whole panel (defect 2).
     <div className="flex items-start" style={{ gap: 10 }}>
       {matchNumber != null && (
-        <span
-          className="flex flex-shrink-0 items-center justify-center"
-          // height matches the segmented track (44 segment + 2×4 padding) so the
-          // number centers with the segments row, not the whole content column.
-          style={{ width: 16, height: 52, fontSize: 13, fontWeight: 700, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}
-        >
-          {matchNumber}
-        </span>
+        // The shared RowNumber cell (row pattern Phase 1b) — same recessed treatment
+        // as the Matches number column (no DragHandle; handicaps don't reorder). Height
+        // matches the segmented track (44 segment + 2×4 padding) so the number centers
+        // with the segments row, not the whole content column.
+        <RowNumber number={matchNumber} className="flex-shrink-0" style={{ width: 22, height: 52 }} />
       )}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* Segmented selector */}
         <div className="flex" style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card)" }}>
           <Segment selected={side === "a"} onClick={() => pickSide("a")}>
-            <Avatar name={a.name} teamColor={a.color} sizePx={22} />
-            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{a.name}</span>
+            {/* The SHARED PlayerChip (avatar 30, left-aligned) — identical to the
+                Matches chip. The segment wrapper owns the selection surface, so the
+                chip's own surface is stripped to transparent and shows it through. */}
+            <PlayerChip name={a.name} teamColor={a.color} style={{ background: "transparent", border: "none", height: "100%" }} />
           </Segment>
           <Segment selected={even} onClick={() => onChange(0)} narrow>
             Even
           </Segment>
           <Segment selected={side === "b"} onClick={() => pickSide("b")}>
-            <Avatar name={b.name} teamColor={b.color} sizePx={22} />
-            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{b.name}</span>
+            <PlayerChip name={b.name} teamColor={b.color} style={{ background: "transparent", border: "none", height: "100%" }} />
           </Segment>
         </div>
 
@@ -166,13 +165,16 @@ function Segment({
     <button
       type="button"
       onClick={onClick}
-      className="flex min-w-0 items-center gap-1.5"
+      className="flex min-w-0 items-center"
       style={{
         flex: narrow ? "0 0 auto" : "1 1 0",
-        justifyContent: narrow ? "center" : "flex-start",
+        justifyContent: "center",
+        // Player segments carry the shared PlayerChip (which owns its own avatar
+        // inset), so the segment adds no padding; the narrow Even segment hugs its
+        // centered label with its own padding.
         height: 44,
-        borderRadius: 9,
-        padding: narrow ? "0 14px" : "0 10px",
+        borderRadius: 10,
+        padding: narrow ? "0 14px" : 0,
         background: selected ? "var(--color-bt-card-raised)" : "transparent",
         border: selected ? "1.5px solid var(--color-bt-accent)" : "1.5px solid transparent",
         color: selected ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { strokeHoles } from "@/lib/matchPlay";
 import { Stepper } from "@/components/games/Stepper";
 import { RowNumber } from "@/components/games/RowNumber";
@@ -90,6 +91,41 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
     onChange(side === "a" ? -mag : mag);
   };
 
+  // Geometric stepper alignment (§8 — measured, NOT a pixel breakpoint). The reveal
+  // is centered under the MIDDLE (Even) column by default (mobile-first: the stepper
+  // is wider than a narrow player column). As a progressive enhancement, when the
+  // selected player's column is wide enough to CONTAIN the stepper
+  // (`playerColumnWidth ≥ stepperWidth`), it snaps to center under that name instead.
+  // The default is centered (textAlign on the wrapper), so `offset` only ever shifts
+  // it sideways under the name — no flash, and the narrow case never moves.
+  const contentRef = useRef<HTMLDivElement>(null);
+  const stepperRef = useRef<HTMLDivElement>(null);
+  const segARef = useRef<HTMLButtonElement>(null);
+  const segBRef = useRef<HTMLButtonElement>(null);
+  const [offset, setOffset] = useState(0);
+  useEffect(() => {
+    if (!showStepper) return;
+    const measure = () => {
+      const content = contentRef.current;
+      const stepper = stepperRef.current;
+      const seg = side === "a" ? segARef.current : segBRef.current;
+      if (!content || !stepper || !seg) return;
+      const cRect = content.getBoundingClientRect();
+      const sRect = seg.getBoundingClientRect();
+      const W = cRect.width;
+      const S = stepper.offsetWidth; // the stepper's intrinsic width (inline-block)
+      const colW = sRect.width;
+      const colCenter = sRect.left + sRect.width / 2 - cRect.left;
+      // Snap under the name only when the column can hold the stepper; else stay
+      // centered (offset 0 = under the middle, the default).
+      setOffset(colW >= S ? colCenter - W / 2 : 0);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (contentRef.current) ro.observe(contentRef.current);
+    return () => ro.disconnect();
+  }, [showStepper, side]);
+
   return (
     // The match-number gutter sits LEFT of the match CONTENT column (§8 — no header).
     // The reveal (stepper + caption) lives INSIDE that content column, so it aligns
@@ -102,10 +138,10 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
         // with the segments row, not the whole content column.
         <RowNumber number={matchNumber} className="flex-shrink-0" style={{ width: 22, height: 52 }} />
       )}
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div ref={contentRef} className="flex min-w-0 flex-1 flex-col">
         {/* Segmented selector */}
         <div className="flex" style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card)" }}>
-          <Segment selected={side === "a"} onClick={() => pickSide("a")}>
+          <Segment selected={side === "a"} onClick={() => pickSide("a")} innerRef={segARef}>
             {/* The SHARED PlayerChip (avatar 30, left-aligned) — identical to the
                 Matches chip. The segment wrapper owns the selection surface, so the
                 chip's own surface is stripped to transparent and shows it through. */}
@@ -114,7 +150,7 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
           <Segment selected={even} onClick={() => onChange(0)} narrow>
             Even
           </Segment>
-          <Segment selected={side === "b"} onClick={() => pickSide("b")}>
+          <Segment selected={side === "b"} onClick={() => pickSide("b")} innerRef={segBRef}>
             <PlayerChip name={b.name} teamColor={b.color} style={{ background: "transparent", border: "none", height: "100%" }} />
           </Segment>
         </div>
@@ -126,17 +162,23 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
             within THIS content column, i.e. under the player columns. */}
         {showStepper && (
           <>
-            <div style={{ marginTop: 12 }}>
-              <Stepper
-                size="full"
-                value={n}
-                min={1}
-                max={MAX}
-                onDecrement={() => step(-1)}
-                onIncrement={() => step(1)}
-                formatValue={() => String(n)}
-                label={n === 1 ? "STROKE" : "STROKES"}
-              />
+            {/* Centered by default (textAlign → under the middle column); the measured
+                `offset` only shifts it under the selected name when that column can
+                hold it (geometric, P3c). inline-block so offsetWidth = the stepper's
+                intrinsic width (the `S` the effect compares against the column). */}
+            <div style={{ marginTop: 12, textAlign: "center" }}>
+              <div ref={stepperRef} style={{ display: "inline-block", transform: `translateX(${offset}px)` }}>
+                <Stepper
+                  size="full"
+                  value={n}
+                  min={1}
+                  max={MAX}
+                  onDecrement={() => step(-1)}
+                  onIncrement={() => step(1)}
+                  formatValue={() => String(n)}
+                  label={n === 1 ? "STROKE" : "STROKES"}
+                />
+              </div>
             </div>
             <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 12 }}>
               {caption}
@@ -156,15 +198,18 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
  * never shifts layout. `narrow` is the Even segment (no chip, hugs its centered label).
  */
 function Segment({
-  selected, onClick, children, narrow = false,
+  selected, onClick, children, narrow = false, innerRef,
 }: {
   selected: boolean;
   onClick: () => void;
   children: React.ReactNode;
   narrow?: boolean;
+  /** The selected player segment is measured against the stepper width (P3c). */
+  innerRef?: React.Ref<HTMLButtonElement>;
 }) {
   return (
     <button
+      ref={innerRef}
       type="button"
       onClick={onClick}
       className="flex min-w-0 items-center"

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -13,11 +13,14 @@ import type { Participant } from "./types";
  * undraggable one-thumbed in the sun; the number matters most in the big-mismatch
  * case, exactly where a bare slider fails).
  *
- * §8 look: the selected segment is an OUTLINE (teal border), never a solid fill —
- * a fill fights the team avatars the player segments now carry. The per-row
- * "WHO GETS STROKES?" header is gone; the match number sits in a small left gutter.
- * Reveal is altitude-aware: Even shows one muted caption (no stepper); a side
- * selected reveals the centered <Stepper full> + a muted recipient caption.
+ * Look (§8, as revised by the row-pattern Phase 3): the row shares the Matches
+ * skeleton — a RowNumber gutter + the shared PlayerChip (avatar 30, left-aligned) —
+ * with a `[A│Even│B]` segmented selector. The selected segment is a TEAL FILL (faint
+ * wash + teal border), the scoped selection-state treatment for segmented selectors
+ * (vocabulary §1/§8); unselected segments are the recessed card-raised chip. The
+ * per-row "WHO GETS STROKES?" header is gone; the match number rides the gutter.
+ * Reveal is altitude-aware: Even is just the row (no stepper, no caption); a side
+ * selected reveals the <Stepper full> + a muted recipient caption.
  *
  * Same data model (NO behavior change — P-D is appearance + layout only): one
  * signed value, strokes to exactly ONE side, never split.
@@ -41,9 +44,11 @@ export interface RelHandicapView {
   even: boolean;
   recipient: string | null;
   holes: number[];
-  /** The muted reveal caption: "Even match …" or "{recipient} gets strokes on holes …". */
+  /** The muted recipient caption ("{recipient} gets strokes on holes …"), shown only
+   *  for a stroked side. EMPTY for Even — the selected Even segment already says it,
+   *  so an Even match is just the row (P3b dropped "Even match — no strokes given"). */
   caption: string;
-  /** Even → no stepper (one line); a side → the centered <Stepper full> reveals. */
+  /** Even → no stepper (one line, no caption); a side → the centered <Stepper full> reveals. */
   showStepper: boolean;
 }
 export function relHandicapView(value: number, aName: string, bName: string): RelHandicapView {
@@ -53,8 +58,9 @@ export function relHandicapView(value: number, aName: string, bName: string): Re
   const even = side === "even";
   const recipient = even ? null : side === "a" ? aName : bName;
   const holes = [...strokeHoles(n)].sort((x, y) => x - y);
+  // Even → no caption (the segment says it); a side → who gets the strokes.
   const caption = even
-    ? "Even match — no strokes given"
+    ? ""
     : `${recipient} gets strokes on hole${n === 1 ? "" : "s"} ${holes.join(", ")}`;
   return { side, n, even, recipient, holes, caption, showStepper: !even };
 }
@@ -113,11 +119,12 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
           </Segment>
         </div>
 
-        {/* Reveal (§8) — under the matchup (defect 2): Even → one muted caption, no
-            stepper. Side selected → the centered <Stepper full> (P-B) + a muted
-            recipient caption (NOT teal — teal is the selected outline only). The
-            stepper centers within THIS content column, i.e. under the player columns. */}
-        {showStepper ? (
+        {/* Reveal (§8) — under the matchup (defect 2): Even is JUST the row (no
+            stepper, no caption — the selected Even segment already says it, P3b).
+            Side selected → the centered <Stepper full> (P-B) + a muted recipient
+            caption (NOT teal — teal is the selection fill only). The stepper centers
+            within THIS content column, i.e. under the player columns. */}
+        {showStepper && (
           <>
             <div style={{ marginTop: 12 }}>
               <Stepper
@@ -135,10 +142,6 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
               {caption}
             </div>
           </>
-        ) : (
-          <div className="text-center" style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginTop: 10 }}>
-            {caption}
-          </div>
         )}
       </div>
     </div>
@@ -146,12 +149,11 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
 }
 
 /**
- * One segment. Selected = teal OUTLINE on a lifted (card-raised) chip with white
- * text — never a solid fill (§8; a fill muddies the team avatars). Unselected =
- * transparent on the recessed track, muted text, a transparent border so selection
- * never shifts layout. `narrow` is the Even segment (no avatar, hugs its centered
- * label). Player chips are LEFT-aligned (avatar then name) — table-like, the
- * direction the Matches redesign is heading (defect 3).
+ * One segment — the selection wrapper around the shared PlayerChip (player segments)
+ * or the centered "Even" label (narrow). Selected = TEAL FILL (faint teal wash + teal
+ * border) — the scoped selection-state treatment for segmented selectors (§1/§8).
+ * Unselected = the recessed card-raised chip with a transparent border, so selection
+ * never shifts layout. `narrow` is the Even segment (no chip, hugs its centered label).
  */
 function Segment({
   selected, onClick, children, narrow = false,
@@ -175,7 +177,12 @@ function Segment({
         height: 44,
         borderRadius: 10,
         padding: narrow ? "0 14px" : 0,
-        background: selected ? "var(--color-bt-card-raised)" : "transparent",
+        // Selection treatment = TEAL FILL (the scoped expansion of the teal
+        // discipline — teal-fill is permitted as a SELECTION state in segmented
+        // selectors; see W-GAMEPAGE-01_visual_vocabulary §1/§8). Selected = faint
+        // teal wash + teal border; unselected = the recessed card-raised chip + a
+        // transparent border so selection never shifts layout.
+        background: selected ? "rgba(45,212,191,0.14)" : "var(--color-bt-card-raised)",
         border: selected ? "1.5px solid var(--color-bt-accent)" : "1.5px solid transparent",
         color: selected ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
         fontSize: 14,


### PR DESCRIPTION
## Matches/Handicaps shared row pattern — Phase 3

Brings the 1v1 handicap selector (`RelHandicapControl` + `HandicapsSection`) onto the finalized row pattern, so Matches and Handicaps are genuine siblings sharing real primitives. **Reopens #487 (P-D)** — expected, not a regression: P-D shipped first, but the pattern was derived from both rows. `HandicapRoster` (the stroke/rack full-screen) is untouched.

### Commits
- **P3a** — adopt the shared `RowNumber` gutter (number only, no `DragHandle`) + `PlayerChip` (avatar **30**, left-aligned). The segment wrapper owns the selection surface; the chip's own surface is stripped to transparent and shows it through, so the handicap chip is identical to the Matches chip. (avatar 22 → 30, left-align — the visible kinship.)
- **P3b** — selection treatment is now **teal fill** (`rgba(45,212,191,0.14)`) + teal border (was outline-only); unselected = card-raised. The **"Even match — no strokes given" caption is dropped** — Even is just the row. Separator hairline between matches (replacing `gap-3`).
- **P3c** — **geometric** stepper alignment: centered under the middle column by default (mobile-first), snapping under the selected player's column when it's wide enough to contain the stepper (`playerColumnWidth ≥ stepperWidth`). A measured layout (`useEffect` + `ResizeObserver`), not a pixel breakpoint.
- **P3d** — vocabulary note (`W-GAMEPAGE-01_visual_vocabulary.md` §1/§8: teal-fill = the scoped selection-state for segmented selectors; Even caption dropped; shared skeleton; geometric stepper) + `relHandicapView` test updated for the dropped caption.

### Teal discipline — the one scoped expansion
Teal-fill is now permitted as a **selection state in segmented selectors** (and only there) — documented in §1 as a bounded exception to the general teal = outline/accent rule. The fill *is* the selection signal; captions stay muted, never teal.

### Verification
- `tsc` + `next lint` clean. Full Vitest **808 passed**. Whole Playwright project green (3/3, incl. `match-play.spec.ts` which drives this surface — one stroke-path flake passed clean on re-run, unrelated to this match-play-only change).
- Eye-verified dark + light on a 1v1 game: same gutter + chip as Matches, teal-fill selection (player + Even), Even = one line (no caption), stroked = stepper revealed and centered under the middle at 375 / snapped under the selected name at 900, team colors carry through `PlayerChip`, separators between matches. Selector behavior + stroke logic + persistence unchanged.

### DO-NOT honored
No change to selector behavior / stroke assignment / persistence; `HandicapRoster` untouched; no `avatarIcon`; the stepper rule is geometric (not a pixel breakpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)