### PR TITLE
A2-precursor: mode-controls slot on the shared game-setup header

### DIFF
--- a/src/components/games/GameIdentityHeader.tsx
+++ b/src/components/games/GameIdentityHeader.tsx
@@ -17,9 +17,16 @@ import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
  *    the owner fills the checklist; filled → it's that delegate's assignment. The
  *    delegate grant is owner-only (`addOrganizer`/`removeOrganizer`), so non-owners
  *    see it read-only. A delegate landing here reads "… · Assigned to: you".
+ *
+ * This is the ONE shared setup-face header — match renders it directly, stroke/rack
+ * via `EnableScoringGate`'s `identityHeader` slot. The optional **`children`** below
+ * the assigned-to frame is the **mode-controls slot** (A2-precursor): the single home
+ * where A2-ux mounts the Game Management panel + Setup/Scoring toggle, so the toggle
+ * lands in one place across all three formats rather than three insertions. Empty by
+ * default → no visual change.
  */
 export function GameIdentityHeader({
-  tripId, game, canEdit, isOwner,
+  tripId, game, canEdit, isOwner, children,
 }: {
   tripId: string;
   game: GameRow;
@@ -27,6 +34,9 @@ export function GameIdentityHeader({
   canEdit: boolean;
   /** Can change the ASSIGNMENT (owner-only — matches the server gate). */
   isOwner: boolean;
+  /** Mode-controls slot (A2-precursor) — the Game Management panel/toggle mounts
+   *  here in A2-ux. Rendered below the assigned-to frame; omitted → nothing renders. */
+  children?: React.ReactNode;
 }) {
   const gameId = game.id;
   const me = useCurrentUser();
@@ -144,6 +154,10 @@ export function GameIdentityHeader({
           </button>
         )}
       </div>
+
+      {/* Mode-controls slot (A2-precursor) — the Game Management panel/toggle mounts
+          here in A2-ux. Empty today, so this is a no-op render. */}
+      {children && <div className="mt-3">{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## A2-precursor — one home for the toggle

First of the three sequenced A2 PRs (precursor → core → ux). It gives the upcoming Game Management toggle **one mounting home** across the match/stroke/rack setup faces.

### The finding that shapes this
Phase 0's premise was "three divergent headers." In fact the header is **already shared**: `GameIdentityHeader` (game name tap-to-edit + "Assigned to" delegate frame) is rendered by **all three** setup faces — match directly ([match/new:1079](src/app/trips/[tripId]/games/match/new/page.tsx)), stroke + rack via `EnableScoringGate`'s `identityHeader` slot. The divergence is in the setup *hull* (match has an inline checklist; stroke/rack use `EnableScoringGate`), not the header. Consolidating the hull would be a redesign the spec forbids ("consolidate, don't redesign; no visual change").

### So the precursor is minimal and correct
Add an optional **`children`** (the mode-controls slot) to `GameIdentityHeader`, rendered below the assigned-to frame. **Empty by default → zero visual change today.** A2-ux mounts the Game Management panel + Setup/Scoring toggle there. Because stroke/rack pass `GameIdentityHeader` through `EnableScoringGate.identityHeader`, A2-ux renders `<GameIdentityHeader>{panel}</GameIdentityHeader>` on all three with **no further wiring** — the slot is reachable from every format.

### Verification
- No call site passes `children` yet, so all three setup faces render byte-identical (verified the match header in-browser: name + assigned-to unchanged).
- `tsc` + `next lint` clean. Full Vitest **812 passed**. Whole Playwright project green (3/3).

### Next
- **A2-core** (`feat/game-mode-access-core`, off this branch) — the data-layer correctness: `canEditGame`, tRPC gating + faceBootstrap redaction, RLS hardening, server readiness guard, status-owning enable/disable.
- **A2-ux** (off core) — the toggle + status×role split + themed placeholder + stroke member-wait + settings-both-modes + Drop row + partial Edit retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)