### PR TITLE
A2-core: mode-toggle access correctness (the data layer)

### DIFF
--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -3,37 +3,9 @@ import { rollUp, placementDetail, awardedForGame, type LiveGame } from "@/lib/co
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
 import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
 import { isManualGameType } from "@/lib/gameTypes";
-import { matchPlayReady } from "@/lib/matchDraft";
-
-const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
-// Roster-gated golf formats: a stroke field / rack auto-grouping is "configured"
-// once it has participants (match play instead needs pairing rows — see below).
-const ROSTER_TYPES = new Set(["gtt_stroke_play", "gtt_rack_n_stack"]);
-
-/**
- * Is the game configured enough to be Ready (vs still Setting up)? "Ready must
- * be earned, not assumed" — exists-and-not-live ≠ Ready. The format's REQUIRED
- * roster is the gate; course + handicaps are optional and NEVER gate readiness:
- *  - match play → ALL pairings assigned (`matchPlayReady`: paired === total, ≥1) —
- *    the SAME threshold the setup-page Enable gate uses, so list-ready ⟺
- *    setup-can-enable (readiness rework P1b). A partly-paired game (3/5) is NOT
- *    configured → it reads "setting up" on the list, matching its setup page.
- *  - stroke / rack → participants assigned (game_participants rows)
- *  - manual / side events → points configured (no roster to assign)
- * One signal: lifecycle AND the row's `N PTS`/`—` both read it, so they can't
- * disagree (the Ready-but-`—` divergence class).
- */
-function isConfigured(
-  typeId: string | null,
-  matchPaired: number,
-  matchTotal: number,
-  participantCount: number,
-  hasPoints: boolean
-): boolean {
-  if (typeId && MATCH_PLAY_TYPES.has(typeId)) return matchPlayReady(matchPaired, matchTotal);
-  if (typeId && ROSTER_TYPES.has(typeId)) return participantCount > 0;
-  return hasPoints;
-}
+// isConfigured (+ the type sets) moved to gameReadiness.ts (A2-core) so the same
+// "is it configured?" signal backs both this display AND the server enable guard.
+import { isConfigured, MATCH_PLAY_TYPES } from "@/server/lib/gameReadiness";
 
 /** Singles vs doubles head-to-head sizing for the team-size-derived formats
  *  (rack-n-stack). Match play itself counts its configured rows instead. */

--- a/src/server/lib/gameReadiness.ts
+++ b/src/server/lib/gameReadiness.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { TRPCError } from "@trpc/server";
+import { matchPlayReady } from "@/lib/matchDraft";
+
+/**
+ * Game readiness — the ONE "is this game configured enough to score?" signal,
+ * shared (A2-core) by the competition leaderboard's Setting-up↔Ready display AND
+ * the server-side enable guard (`assertGameReady`). Lifted out of
+ * competitionLeaderboard.ts so the mode toggle's Setup→Scoring flip is refused
+ * server-side for an under-configured game, for ALL three formats — not just the
+ * client gate match play had. The format's REQUIRED roster is the bar; course +
+ * handicaps are optional and NEVER gate readiness.
+ */
+
+export const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
+// Roster-gated golf formats: a stroke field / rack auto-grouping is "configured"
+// once it has participants (match play instead needs pairing rows — see below).
+export const ROSTER_TYPES = new Set(["gtt_stroke_play", "gtt_rack_n_stack"]);
+
+/**
+ * Is the game configured enough to be Ready (vs still Setting up)?
+ *  - match play → ALL pairings assigned (`matchPlayReady`: paired === total, ≥1) —
+ *    the SAME threshold the setup-page Enable gate uses, so list-ready ⟺
+ *    setup-can-enable (readiness rework P1b).
+ *  - stroke / rack → participants assigned (game_participants rows)
+ *  - manual / side events → points configured (no roster to assign)
+ */
+export function isConfigured(
+  typeId: string | null,
+  matchPaired: number,
+  matchTotal: number,
+  participantCount: number,
+  hasPoints: boolean
+): boolean {
+  if (typeId && MATCH_PLAY_TYPES.has(typeId)) return matchPlayReady(matchPaired, matchTotal);
+  if (typeId && ROSTER_TYPES.has(typeId)) return participantCount > 0;
+  return hasPoints;
+}
+
+/**
+ * Server-side enable guard (A2-core, decision 4). Throws PRECONDITION_FAILED if the
+ * game isn't configured enough to switch to scoring. The client toggle is gated too
+ * (UX), but THIS is the enforcement — and it covers stroke/rack/manual, which had no
+ * client gate at all. Reads the same inputs the leaderboard derives `configured` from.
+ */
+export async function assertGameReady(supabase: SupabaseClient, gameId: string): Promise<void> {
+  const { data: game } = await supabase
+    .from("games")
+    .select("game_type_id, points_distribution, points_total")
+    .eq("id", gameId)
+    .maybeSingle();
+  if (!game) throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+
+  const typeId = (game.game_type_id as string | null) ?? null;
+  const hasPoints = game.points_distribution != null || game.points_total != null;
+  let matchPaired = 0;
+  let matchTotal = 0;
+  let participantCount = 0;
+
+  if (typeId && MATCH_PLAY_TYPES.has(typeId)) {
+    const { data: rows } = await supabase
+      .from("game_matches")
+      .select("side_a, side_b")
+      .eq("game_id", gameId);
+    const matches = (rows ?? []) as { side_a: { id?: string } | null; side_b: { id?: string } | null }[];
+    matchTotal = matches.length;
+    matchPaired = matches.filter((m) => m.side_a?.id && m.side_b?.id).length;
+  } else if (typeId && ROSTER_TYPES.has(typeId)) {
+    const { count } = await supabase
+      .from("game_participants")
+      .select("user_id", { count: "exact", head: true })
+      .eq("game_id", gameId);
+    participantCount = count ?? 0;
+  }
+
+  if (!isConfigured(typeId, matchPaired, matchTotal, participantCount, hasPoints)) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Finish setting up this game before switching it to scoring.",
+    });
+  }
+}

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -233,6 +233,47 @@ export function requireTeamIdentityEdit() {
   });
 }
 
+// canEditGame — the NON-throwing core of requireGameEdit (A2-core). True when the
+// user is a competition owner/co-admin (container-granted) OR a delegate of THIS
+// game (game_delegates row). The throwing middlewares below wrap it; READS that
+// must stay callable by members (e.g. the game scoreboard page, which a member
+// loads but sees redacted for a pending game) call it directly and branch on the
+// boolean instead of catching a throw. One home for "can this user edit / see the
+// setup of this game". Mirrors the DB rule `is_game_delegate` (migration 061).
+export async function canEditGame(
+  ctx: {
+    supabase: { from: (t: string) => unknown };
+    user: { id: string } | null;
+    membershipCache: Map<string, TripRole>;
+  },
+  tripId: string,
+  gameId: string
+): Promise<boolean> {
+  // Competition role first (owner/co-admin edit any game). resolveCompetitionRole
+  // returns "member" for a plain member (it only throws for a non-member, which a
+  // requireTripMember-gated read has already excluded) — so this is safe on reads.
+  const compRole = await resolveCompetitionRole(ctx, tripId);
+  if (COMP_ROLE_LEVEL[compRole] >= COMP_ROLE_LEVEL.co_admin) return true;
+  if (!ctx.user) return false;
+  // …otherwise a delegated organizer of THIS game (game-isolated).
+  const { data } = await (
+    ctx.supabase.from("game_delegates") as unknown as {
+      select: (s: string) => {
+        eq: (c: string, v: string) => {
+          eq: (c: string, v: string) => {
+            maybeSingle: () => Promise<{ data: { game_id: string } | null }>;
+          };
+        };
+      };
+    }
+  )
+    .select("game_id")
+    .eq("game_id", gameId)
+    .eq("user_id", ctx.user.id)
+    .maybeSingle();
+  return !!data;
+}
+
 export function requireGameEdit() {
   return middleware(async ({ ctx, getRawInput, next }) => {
     const raw = await getRawInput();
@@ -242,32 +283,7 @@ export function requireGameEdit() {
     }
     const { tripId, gameId } = parsed.data;
 
-    // Competition role first (owner/co-admin edit any game) — the container
-    // grants it; this gate never checks the trip role itself.
-    const compRole = await resolveCompetitionRole(ctx, tripId); // throws if not a member
-    let allowed = COMP_ROLE_LEVEL[compRole] >= COMP_ROLE_LEVEL.co_admin;
-
-    if (!allowed) {
-      // …otherwise a delegated organizer of THIS game (game-isolated).
-      const { data } = await (
-        ctx.supabase.from("game_delegates") as unknown as {
-          select: (s: string) => {
-            eq: (c: string, v: string) => {
-              eq: (c: string, v: string) => {
-                maybeSingle: () => Promise<{ data: { game_id: string } | null }>;
-              };
-            };
-          };
-        }
-      )
-        .select("game_id")
-        .eq("game_id", gameId)
-        .eq("user_id", ctx.user!.id)
-        .maybeSingle();
-      allowed = !!data;
-    }
-
-    if (!allowed) {
+    if (!(await canEditGame(ctx, tripId, gameId))) {
       throw new TRPCError({
         code: "FORBIDDEN",
         message: "Requires competition co-admin access or a game-organizer grant for this game",
@@ -298,29 +314,7 @@ export function requireGameRunAction() {
     }
     const { tripId, gameId } = parsed.data;
 
-    const compRole = await resolveCompetitionRole(ctx, tripId); // throws if not a member
-    let allowed = COMP_ROLE_LEVEL[compRole] >= COMP_ROLE_LEVEL.co_admin;
-
-    if (!allowed) {
-      const { data } = await (
-        ctx.supabase.from("game_delegates") as unknown as {
-          select: (s: string) => {
-            eq: (c: string, v: string) => {
-              eq: (c: string, v: string) => {
-                maybeSingle: () => Promise<{ data: { game_id: string } | null }>;
-              };
-            };
-          };
-        }
-      )
-        .select("game_id")
-        .eq("game_id", gameId)
-        .eq("user_id", ctx.user!.id)
-        .maybeSingle();
-      allowed = !!data;
-    }
-
-    if (!allowed) {
+    if (!(await canEditGame(ctx, tripId, gameId))) {
       throw new TRPCError({
         code: "FORBIDDEN",
         message: "Posting and score corrections are limited to a competition owner/co-admin or this game's delegate.",

--- a/src/server/routers/delegateSetupGate.test.ts
+++ b/src/server/routers/delegateSetupGate.test.ts
@@ -60,20 +60,24 @@ describe("matches setup gate admits the game delegate (§10)", () => {
     await ctx.caller().games.addOrganizer({ tripId, gameId: mine, userId: memberId });
 
     const member = ctx.callerAs("member");
-    const pairings = [{ sideA: null, sideB: null, matchNumber: 1 }];
+    const ownerId = ctx.getUser("owner").id;
 
-    // Delegate runs their game's setup…
+    // Delegate runs their game's setup — fully paired so the A2-core readiness
+    // guard passes (this test exercises the delegate GATE, not readiness).
     await expect(
-      member.matches.setPairings({ tripId, gameId: mine, matches: pairings })
+      member.matches.setPairings({
+        tripId, gameId: mine,
+        matches: [{ sideA: { type: "user", id: ownerId }, sideB: { type: "user", id: memberId }, matchNumber: 1 }],
+      })
     ).resolves.toBeTruthy();
-    // …enableScoring too.
+    // …enableScoring too (the gate admits the delegate; the game is ready).
     await expect(
       member.matches.enableScoring({ tripId, gameId: mine })
     ).resolves.toBeTruthy();
 
     // …but NOT another game (game-isolated).
     await expect(
-      member.matches.setPairings({ tripId, gameId: other, matches: pairings })
+      member.matches.setPairings({ tripId, gameId: other, matches: [{ sideA: null, sideB: null, matchNumber: 1 }] })
     ).rejects.toThrow(/Organizer|game-organizer/i);
   });
 

--- a/src/server/routers/games.test.ts
+++ b/src/server/routers/games.test.ts
@@ -69,10 +69,15 @@ describe("games router (Slice A — stroke play)", () => {
     ).rejects.toThrow();
   });
 
-  it("getById — any member sees the game + participants", async () => {
-    const game = await ctx.callerAs("member").games.getById({ tripId, gameId });
-    expect(game.id).toBe(gameId);
-    expect(game.participants).toHaveLength(2);
+  it("getById — a member gets the existence shell for a pending game; the owner sees the roster", async () => {
+    // A2-core: a SETUP-mode (pending) game is members-walled — the existence shell
+    // (the game row: name/type/status) stays so the placeholder renders, but the
+    // ROSTER is withheld from a plain member. The owner (editor) sees it in full.
+    const asMember = await ctx.callerAs("member").games.getById({ tripId, gameId });
+    expect(asMember.id).toBe(gameId);
+    expect(asMember.participants).toHaveLength(0);
+    const asOwner = await ctx.caller().games.getById({ tripId, gameId });
+    expect(asOwner.participants).toHaveLength(2);
   });
 
   it("listByTrip — any member sees the trip's games", async () => {

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireTripRole, requireGameEdit, requireGameRunAction } from "../middleware";
+import { requireTripMember, requireTripRole, requireGameEdit, requireGameRunAction, canEditGame } from "../middleware";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { computeStrokePlayResults } from "../lib/strokePlay";
 import { computeMatchPlayResults } from "../lib/matchPlay";
@@ -165,13 +165,25 @@ export const gamesRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
       }
 
-      const { data: participants } = await ctx.supabase
-        .from("game_participants")
-        .select("*")
-        .eq("game_id", input.gameId)
-        .order("created_at", { ascending: true });
+      // A2-core access gate: a SETUP-mode (pending) game is members-walled — the
+      // game row stays readable (the existence shell the placeholder needs: name /
+      // type / status), but the ROSTER (a child) is withheld unless the caller can
+      // edit the game (owner / organizer / this game's delegate). Scores, matches,
+      // and foursomes are the other children, gated in their own reads + by RLS.
+      const hideSetup =
+        (game.status as string) === "pending" && !(await canEditGame(ctx, ctx.tripId, input.gameId));
 
-      return { ...game, participants: participants ?? [] };
+      const participants = hideSetup
+        ? []
+        : (
+            await ctx.supabase
+              .from("game_participants")
+              .select("*")
+              .eq("game_id", input.gameId)
+              .order("created_at", { ascending: true })
+          ).data ?? [];
+
+      return { ...game, participants };
     }),
 
   // addParticipants — Owner/Organizer. 2–4 users, individual (no side/team).

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -12,6 +12,7 @@ import type { StrokeStanding } from "@/lib/strokePlay";
 import { buildScorecardSchema, composeTwoNines, validateStrokeIndex, type SnapshotTee, type ScorecardSchema } from "@/lib/courseIndex";
 import { validatePlacement } from "@/lib/gameConfig";
 import { GAME_TYPES, getGameTypeDefinition } from "@/lib/gameTypes";
+import { assertGameReady } from "../lib/gameReadiness";
 
 /**
  * games — the competition-engine spine (Slice A: individual stroke play).
@@ -614,9 +615,13 @@ export const gamesRouter = router({
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
     .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
+      // A2-core: the mode toggle OWNS status — Setup→Scoring sets status:'active'
+      // (no longer "first score owns Live"). Server readiness guard refuses an
+      // under-configured flip (all formats), and publishes pairings.
+      await assertGameReady(ctx.supabase, input.gameId);
       const { error } = await ctx.supabase
         .from("games")
-        .update({ scoring_enabled: true, pairings_published_at: new Date().toISOString() })
+        .update({ scoring_enabled: true, status: "active", pairings_published_at: new Date().toISOString() })
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to enable scoring: ${error.message}` });
@@ -641,6 +646,16 @@ export const gamesRouter = router({
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to disable scoring: ${error.message}` });
+      // A2-core round-trip fix: enable flipped match rows pending→active; revert the
+      // active ones back to pending so Scoring→Setup→Scoring is a clean round-trip.
+      // (`complete`/frozen match rows are left alone; scores are never touched.)
+      if (next === "pending") {
+        await ctx.supabase
+          .from("game_matches")
+          .update({ status: "pending" })
+          .eq("game_id", input.gameId)
+          .eq("status", "active");
+      }
       return { success: true };
     }),
 

--- a/src/server/routers/matches.test.ts
+++ b/src/server/routers/matches.test.ts
@@ -95,16 +95,32 @@ describe("matches router (Slice B — setup + visibility)", () => {
     expect(res.matches).toHaveLength(2);
   });
 
-  it("enableScoring — publishes pairings; the Member can now see them", async () => {
-    await ctx.callerAs("planner").matches.enableScoring({ tripId, gameId });
-    const res = await ctx.callerAs("member").matches.listByGame({ tripId, gameId });
+  it("enableScoring — readiness-gated; publishes + goes active; the Member can now see them", async () => {
+    // A2-core: enable now (a) is refused until every match is paired (the server
+    // readiness guard) and (b) the toggle OWNS status — Setup→Scoring sets
+    // status:'active' (no longer "first score owns Live"). The shared fixture has an
+    // empty slot, so use a dedicated game here to exercise both halves.
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Enable Test" });
+    // under-configured (one empty slot) → enable REFUSED
+    await ctx.callerAs("planner").matches.setPairings({
+      tripId, gameId: g.id,
+      matches: [{ sideA: { type: "user", id: owner }, sideB: null, matchNumber: 1 }],
+    });
+    await expect(
+      ctx.callerAs("planner").matches.enableScoring({ tripId, gameId: g.id })
+    ).rejects.toThrow(/finish setting up/i);
+    // fully paired → enable succeeds: publishes, member can see, status goes active
+    await ctx.callerAs("planner").matches.setPairings({
+      tripId, gameId: g.id,
+      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+    });
+    await ctx.callerAs("planner").matches.enableScoring({ tripId, gameId: g.id });
+    const res = await ctx.callerAs("member").matches.listByGame({ tripId, gameId: g.id });
     expect(res.published).toBe(true);
-    expect(res.matches).toHaveLength(2);
-    // Phase 2B.1: activate is match play's Enable — it publishes + enables, but
-    // no longer goes Live (status stays pending until the first score, #396).
-    const { data: game } = await ctx.admin.from("games").select("status, scoring_enabled").eq("id", gameId).single();
-    expect((game as { status: string; scoring_enabled: boolean }).scoring_enabled).toBe(true);
-    expect((game as { status: string }).status).toBe("pending");
+    expect(res.matches).toHaveLength(1);
+    const { data: game } = await ctx.admin.from("games").select("status, scoring_enabled").eq("id", g.id).single();
+    expect((game as { scoring_enabled: boolean }).scoring_enabled).toBe(true);
+    expect((game as { status: string }).status).toBe("active"); // A2-core: toggle owns status
   });
 
   it("assignPlayer — moving a player clears the vacated match's handicap", async () => {

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireGameEdit } from "../middleware";
+import { requireTripMember, requireGameEdit, canEditGame } from "../middleware";
 import { assertGameReady } from "../lib/gameReadiness";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 
@@ -642,7 +642,7 @@ export const matchesRouter = router({
     .query(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
-        .select("id, pairings_published_at")
+        .select("id, status, pairings_published_at")
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId)
         .maybeSingle();
@@ -651,7 +651,12 @@ export const matchesRouter = router({
       }
       const published = !!game.pairings_published_at;
 
-      if (ctx.tripRole === "Member" && !published) {
+      // A2-core access gate: keyed on STATUS (the canonical setup/scoring signal),
+      // not pairings_published_at. A SETUP-mode (pending) game's matches are hidden
+      // from everyone EXCEPT the owner/organizer/this-game's-delegate (canEditGame —
+      // which, unlike the old `tripRole === "Member"` check, correctly lets a plain-
+      // member DELEGATE see the game they're setting up). RLS walls the raw layer too.
+      if ((game.status as string) === "pending" && !(await canEditGame(ctx, ctx.tripId, input.gameId))) {
         return { published: false, matches: [], participants: [], playGroups: [] };
       }
 

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, requireGameEdit } from "../middleware";
+import { assertGameReady } from "../lib/gameReadiness";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 
 /**
@@ -611,9 +612,12 @@ export const matchesRouter = router({
     .use(requireGameEdit())
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
+      // A2-core: the mode toggle OWNS status — Setup→Scoring sets status:'active'
+      // (no longer "first score owns Live"), gated by the server readiness guard.
+      await assertGameReady(ctx.supabase, input.gameId);
       const { error } = await ctx.supabase
         .from("games")
-        .update({ pairings_published_at: new Date().toISOString(), scoring_enabled: true })
+        .update({ pairings_published_at: new Date().toISOString(), scoring_enabled: true, status: "active" })
         .eq("id", input.gameId);
       if (error) {
         throw new TRPCError({

--- a/src/server/routers/playGroups.ts
+++ b/src/server/routers/playGroups.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireGameEdit } from "../middleware";
+import { requireTripMember, requireGameEdit, canEditGame } from "../middleware";
 import { clampStrokes } from "@/lib/handicap";
 import { computeMatchPlayResults } from "../lib/matchPlay";
 import { computeRackNStackResults } from "../lib/rackNStack";
@@ -121,10 +121,24 @@ export const playGroupsRouter = router({
     }),
 
   // listByGame — any trip member. Foursomes + each participant's group/handicap.
+  // A2-core access gate: a member can't read foursomes for a SETUP-mode (pending)
+  // game — only the owner/organizer/delegate setting it up can (RLS enforces the
+  // raw layer too).
   listByGame: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
     .use(requireTripMember)
-    .query(async ({ ctx, input }) => readGroups(ctx.supabase, input.gameId)),
+    .query(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("status")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (game && (game.status as string) === "pending" && !(await canEditGame(ctx, ctx.tripId, input.gameId))) {
+        return { groups: [], participants: [] };
+      }
+      return readGroups(ctx.supabase, input.gameId);
+    }),
 });
 
 async function readGroups(supabase: import("@supabase/supabase-js").SupabaseClient, gameId: string) {

--- a/src/server/routers/scores.test.ts
+++ b/src/server/routers/scores.test.ts
@@ -102,17 +102,21 @@ describe("scores router (Slice A — per-hole entry)", () => {
     expect(entry.value).toBe(4);
   });
 
-  it("Enable keeps the game pre-Live; the first score flips it to active", async () => {
+  it("Enable sets status:active (A2-core: the toggle owns status; first-score is a no-op fallback)", async () => {
     const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Goes Live" });
     await ctx.caller().games.addParticipants({ tripId, gameId: g.id, userIds: [ownerId, memberId] });
     await ctx.caller().games.enableScoring({ tripId, gameId: g.id });
     const before = await ctx.admin.from("games").select("status, scoring_enabled").eq("id", g.id).single();
     expect(before.data?.scoring_enabled).toBe(true);
-    expect(before.data?.status).toBe("pending"); // enabled but NOT yet Live — the §A "enabled" state
+    // A2-core: Setup→Scoring (enable) now SETS status:'active' directly — the mode
+    // toggle owns status (no longer "first score owns Live", #396 superseded).
+    expect(before.data?.status).toBe("active");
 
+    // The scores.ts first-score flip is now a documented no-op fallback: scoring
+    // still works and status stays active.
     await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 });
     const after = await ctx.admin.from("games").select("status").eq("id", g.id).single();
-    expect(after.data?.status).toBe("active"); // first score → Live (#396)
+    expect(after.data?.status).toBe("active");
   });
 
   it("Disable reverts active→pending and KEEPS scores; re-enable allows scoring again", async () => {

--- a/src/server/routers/scores.test.ts
+++ b/src/server/routers/scores.test.ts
@@ -133,6 +133,11 @@ describe("scores router (Slice A — per-hole entry)", () => {
     const kept = await ctx.admin.from("score_entries").select("value").eq("game_id", g.id).eq("participant_id", ownerId).eq("unit_label", "1").single();
     expect(kept.data?.value).toBe(4); // scores are NEVER deleted on Disable
 
+    // A2-core gate: reverted to setup (pending/disabled), a plain member can't read
+    // the kept scores via tRPC — only the owner/editor can (RLS walls the raw layer).
+    expect(await ctx.callerAs("member").scores.listByGame({ tripId, gameId: g.id })).toHaveLength(0);
+    expect((await ctx.caller().scores.listByGame({ tripId, gameId: g.id })).length).toBeGreaterThan(0);
+
     // While disabled, entries are refused again; re-enabling re-opens it.
     await expect(
       ctx.caller().scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "2", value: 5 })

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -97,6 +97,11 @@ export const scoresRouter = router({
       // admits owner/organizer — so a member's own client can't flip the status.
       // Use the service-role client (same pattern as server-authored system
       // messages) for this automatic, non-privileged side effect.
+      //
+      // A2-core: status is NORMALLY set by the mode toggle (enableScoring now sets
+      // status:'active'), so on the happy path this is a no-op (a member can't reach
+      // a pending game to score it once the gate lands). It's kept as the FALLBACK
+      // for any enable path that bypasses the toggle.
       if (game.status === "pending") {
         await createAdminClient()
           .from("games")

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember } from "../middleware";
+import { requireTripMember, canEditGame } from "../middleware";
 import { createAdminClient } from "@/lib/supabase-admin";
 
 /**
@@ -164,12 +164,18 @@ export const scoresRouter = router({
     .query(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
-        .select("id")
+        .select("id, status")
         .eq("id", input.gameId)
         .eq("trip_id", ctx.tripId)
         .maybeSingle();
       if (!game) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+      // A2-core access gate: a member can't read scores for a SETUP-mode (pending)
+      // game — only the owner/organizer/delegate setting it up can. (RLS enforces
+      // this at the raw layer too.)
+      if ((game.status as string) === "pending" && !(await canEditGame(ctx, ctx.tripId, input.gameId))) {
+        return [];
       }
       // Both scoring units: 'user' (1v1/stroke) and 'play_group' (2v2 sides).
       // Singles games have only 'user' rows, so this is unchanged for them.

--- a/supabase/migrations/20260628120000_068_game_setup_mode_rls.sql
+++ b/supabase/migrations/20260628120000_068_game_setup_mode_rls.sql
@@ -1,0 +1,102 @@
+-- A2-core: Setup/Scoring mode — scoring-enabled-aware RLS on a game's child rows.
+--
+-- The mode toggle makes a SETUP-mode game members-walled: a plain trip member must
+-- not be able to read its scores / matches / pairings / foursomes / results / roster,
+-- even via raw PostgREST or Realtime. The tRPC layer already gates these reads
+-- (A2-core 3); this closes the raw-DB surface — the point of the keystone.
+--
+-- DB-VALUE layer (CLAUDE.md): these policies branch on an RLS-relevant column tsc
+-- cannot guard — so every touched policy is rebuilt explicitly here, idempotently
+-- (DROP IF EXISTS + CREATE).
+--
+-- SIGNAL = `games.scoring_enabled`, not `status`. A game is "open to the crew"
+-- exactly when scoring_enabled is true; setup mode is scoring_enabled = false. The
+-- A2-core toggle couples scoring_enabled ⟺ status:'active' (enable sets both; disable
+-- clears both), so this is equivalent to the status-based model — but keying RLS on
+-- scoring_enabled is **backward-compatible**: pre-A2-core code left an enabled game at
+-- scoring_enabled=true (status pending until the first score), so a status='pending'
+-- gate would have walled those legitimately-enabled games (and blocked the next score)
+-- during the window before the A2-core code ships. scoring_enabled has no such window
+-- and needs no data heal.
+--
+-- Decision A (confirmed): the games ROW stays membership-readable — it carries the
+-- existence shell (name/type/status) the "still being set up" placeholder needs, and
+-- it is NOT the scores/matches/pairings/foursomes the threat model targets. Only the
+-- 5 CHILD tables are tightened. (Row-level RLS can't column-subset a row anyway.)
+--
+-- Editors keep full access on a setup-mode game (they're setting it up): owner/
+-- organizer via the existing `_write` (FOR ALL, has_trip_role) policies and this
+-- game's delegate via the existing `_delegate` (FOR ALL, mig 061) policies — both
+-- PERMISSIVE, so OR'd with `_select`. score_entries is the exception: its `_write` is
+-- `is_trip_member` FOR ALL (engine decision #7 — any member scores), which would
+-- itself grant members SELECT, so score_entries' `_write` is tightened too (and the
+-- editor branch is spelled out in its policies, as it has no separate editor policy).
+--
+-- Shared member predicate: a member sees a child row only when the parent game is
+-- scoring-enabled, OR they are an editor (owner/organizer/this game's delegate).
+
+-- ── game_participants (roster) ───────────────────────────────────────────────
+DROP POLICY IF EXISTS game_participants_select ON public.game_participants;
+CREATE POLICY game_participants_select ON public.game_participants FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = game_participants.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))));
+
+-- ── game_results ─────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS game_results_select ON public.game_results;
+CREATE POLICY game_results_select ON public.game_results FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = game_results.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))));
+
+-- ── play_groups (foursomes / 2v2 sides) ──────────────────────────────────────
+DROP POLICY IF EXISTS play_groups_select ON public.play_groups;
+CREATE POLICY play_groups_select ON public.play_groups FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = play_groups.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))));
+
+-- ── game_matches (pairings) ──────────────────────────────────────────────────
+DROP POLICY IF EXISTS game_matches_select ON public.game_matches;
+CREATE POLICY game_matches_select ON public.game_matches FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = game_matches.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))));
+
+-- ── score_entries (the exception — _write is is_trip_member FOR ALL, so it grants
+--    SELECT too; tighten BOTH, and spell out the editor branch since there is no
+--    separate editor policy for this table) ─────────────────────────────────────
+DROP POLICY IF EXISTS score_entries_select ON public.score_entries;
+CREATE POLICY score_entries_select ON public.score_entries FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = score_entries.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))));
+DROP POLICY IF EXISTS score_entries_write ON public.score_entries;
+CREATE POLICY score_entries_write ON public.score_entries FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = score_entries.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.games g
+                 WHERE g.id = score_entries.game_id
+                   AND is_trip_member(g.trip_id)
+                   AND (g.scoring_enabled = true
+                        OR has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+                        OR is_game_delegate(g.id))));


### PR DESCRIPTION
## A2-core — the keystone's correctness core (data layer only; no UI)

Second of the three A2 PRs. **Stacked on `feat/game-setup-shared-header`** (A2-precursor) — retarget to `main` once that merges. Makes a SETUP-mode game's data genuinely members-walled and makes the mode toggle own game status. No toggle UI yet (that's A2-ux).

**The test that defines done:** a plain member gets NOTHING for a setup-mode game at EVERY layer — tRPC AND raw PostgREST/Realtime — while owner/organizer/this-game's-delegate get full access. ✅ Verified (below).

### Commits
1. **canEditGame** — extract the non-throwing owner/organizer/delegate predicate from `requireGameEdit` (which now calls it then throws). Reusable on reads that must stay callable.
2. **Toggle owns status + server readiness guard** — `enableScoring` (both `games.`+`matches.`) now sets `status:'active'` (Setup→Scoring; no longer "first score owns Live" — that flip stays as a documented no-op fallback). New `gameReadiness.ts` lifts `isConfigured` and adds `assertGameReady()` — both enable paths refuse an under-configured game (all 3 formats). `disableScoring` gains the `game_matches` round-trip reset. 
3. **tRPC read gate** — `getById` returns the existence shell (participants `[]`), `scores`/`playGroups`/`matches` return empty for a member on a setup-mode game; `matches.listByGame` re-keyed to status+`canEditGame` (also fixes the old `tripRole==='Member'` check that hid a plain-member delegate's own matches).
4. **RLS (migration 068)** — status-aware (`scoring_enabled`-keyed) `_select` on the 5 child tables + `score_entries._write`. Closes the raw-DB surface. **Signal = `scoring_enabled`** (not `status`) so it's backward-compatible (no breakage window vs main, no data heal). Editors keep access via the existing owner/org `_write` + delegate `_delegate` permissive policies.
5. **Tests** — member-gated-read coverage.

### Decisions encoded (from the OVERVIEW)
Access = tRPC + RLS now (dec 1); toggle owns status, first-score fallback kept (dec 2); server readiness guard (dec 4); `game_matches` round-trip fix (dec 5). **Option A** (confirmed): the `games` row stays member-readable (the existence shell the placeholder needs; row-level RLS can't column-subset) — only the 5 children are walled.

### Verification
- `tsc` + `next lint` clean. Full Vitest passes (3 `tripStatus` countdown failures are the known TZ-flake #453 — green in CI).
- **RLS proven by role simulation against the remote** (`SET request.jwt.claims` per user): member-non-delegate vs a pending game → participants/play_groups/scores all **0**, games row still readable (existence shell); owner vs pending → **full** (4 participants, 2 play_groups); member vs an **active** game → sees matches (member-score path intact); this-game's delegate → sees their pending game.
- Migration applied to remote via `execute_sql` (no history row) so CI's `db push` re-applies the committed file idempotently on merge.
- Whole Playwright: match-play + setup green; stroke critical-path is the intermittent #459 keypad flake (passes on retry).

### Next
- **A2-ux** (off this branch) — the toggle + Game Management panel, status×role content split, themed placeholder, stroke member-wait, settings-both-modes + Drop row, partial Edit retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)