### PR TITLE
W-NONGOLF lifecycle (Parts 1+2): non-golf scoreboard page + lean settings page

### DIFF
--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, Settings } from "lucide-react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
+import { NonGolfConfigurationView } from "@/components/games/NonGolfConfigurationView";
+import { NonGolfScoreboard } from "@/components/games/NonGolfScoreboard";
+import { useTripRole } from "@/hooks/useTripRole";
+import { GAME_TYPES, type ScoringModel } from "@/lib/gameTypes";
+import type { GameRow, LBTeamLite } from "@/components/competition/CompetitionGamesPanel";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function Spinner() {
+  return (
+    <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--color-bt-base)" }}>
+      <div className="h-8 w-8 animate-spin rounded-full border-2" style={{ borderColor: "var(--color-bt-accent)", borderTopColor: "transparent" }} />
+    </div>
+  );
+}
+
+/**
+ * The non-golf (manual) game scoreboard page (W-NONGOLF lifecycle surface) — the
+ * non-golf twin of golf's per-format game pages. A game tap on the leaderboard
+ * lands here (the old post-results modal is promoted to this page). Same
+ * mode-driven structure as golf:
+ *  - **Setup mode** (pending): member → `SetupPlaceholder`; owner/delegate →
+ *    pass-through (placeholder + "Set up this game" + corner gear → settings).
+ *  - **Scoring mode** (active/complete): the scoreboard (`NonGolfScoreboard`).
+ *
+ * The interim header is deliberately simple/functional — the consistent
+ * projected-points header (a logged follow-on) replaces it across all game types.
+ */
+export default function ManualGamePage() {
+  const { tripId: param } = useParams<{ tripId: string }>();
+  const router = useRouter();
+  const search = useSearchParams();
+  const urlGameId = search.get("game");
+
+  const isId = UUID_RE.test(param);
+  const resolved = trpc.trips.resolveSlug.useQuery(
+    { slugOrId: param },
+    { ...STRUCTURE_QUERY, enabled: !isId, retry: false }
+  );
+  const tripId = isId ? param : resolved.data?.id;
+  const utils = trpc.useUtils();
+  const { canEdit, isOwner } = useTripRole(tripId);
+
+  const gameQ = trpc.games.getById.useQuery(
+    { tripId: tripId!, gameId: urlGameId! },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!urlGameId }
+  );
+  const compQ = trpc.competitions.getByTrip.useQuery(
+    { tripId: tripId! },
+    { ...STRUCTURE_QUERY, enabled: !!tripId }
+  );
+
+  const game = gameQ.data as unknown as GameRow | undefined;
+  const competitionId = game?.competition_id ?? (compQ.data?.id as string | undefined) ?? null;
+  const scoringModel = ((compQ.data?.scoring_model as ScoringModel | undefined) ?? "match_play") as ScoringModel;
+
+  const lbQ = trpc.competitions.leaderboard.useQuery(
+    { tripId: tripId!, competitionId: competitionId! },
+    { enabled: !!tripId && !!competitionId }
+  );
+  const teams = useMemo(() => ((lbQ.data?.teams ?? []) as LBTeamLite[]), [lbQ.data]);
+  const initialOrder = useMemo(() => {
+    const cells = ((lbQ.data?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
+      .filter((c) => c.gameId === urlGameId)
+      .sort((a, b) => a.place - b.place);
+    return cells.length ? cells.map((c) => c.teamId) : teams.map((t) => t.id);
+  }, [lbQ.data, urlGameId, teams]);
+
+  const scoringEnabled = (game as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+  // Non-golf is "ready" to score once points are configured (mirrors the server
+  // `assertGameReady` manual branch: a distribution shape or an owner-set total).
+  const ready = !!game && (game.points_total != null || game.points_distribution != null);
+  const typeDef = GAME_TYPES.find((t) => t.id === game?.game_type_id);
+  const typeName = typeDef?.name ?? "Game";
+  const category = typeDef?.category ?? "other";
+
+  const enableScoring = trpc.games.enableScoring.useMutation();
+  const disableScoring = trpc.games.disableScoring.useMutation();
+
+  // Settings is a browser-history-aware overlay (same pattern as the golf pages):
+  // opening it pushes a history entry so the in-page back arrow and the OS/mouse
+  // back are the SAME action and both return to this page.
+  const [showConfig, setShowConfig] = useState(false);
+  function openConfig() {
+    if (typeof window !== "undefined") window.history.pushState({ btCfg: true }, "");
+    setShowConfig(true);
+  }
+  function closeConfig() {
+    if (typeof window !== "undefined" && (window.history.state as { btCfg?: boolean } | null)?.btCfg) {
+      window.history.back();
+    } else {
+      setShowConfig(false);
+    }
+  }
+  useEffect(() => {
+    const onPop = () => setShowConfig(false);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  async function refreshGame() {
+    await gameQ.refetch();
+    if (competitionId) {
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+      utils.games.listByTrip.invalidate({ tripId });
+    }
+  }
+  async function handleEnable() {
+    if (!tripId || !urlGameId) return;
+    try {
+      await enableScoring.mutateAsync({ tripId, gameId: urlGameId });
+      await refreshGame();
+      closeConfig(); // leave settings for the live board (consumes the history entry)
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+  async function handleDisable() {
+    if (!tripId || !urlGameId) return;
+    try {
+      await disableScoring.mutateAsync({ tripId, gameId: urlGameId });
+      await refreshGame();
+    } catch {
+      // surfaced via the global error toast
+    }
+  }
+
+  if (!tripId || !urlGameId) return <Spinner />;
+  if (gameQ.isLoading || !game) return <Spinner />;
+
+  const header = (title: string) => (
+    <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+      <button onClick={() => router.back()} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+        <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+      </button>
+      <div className="min-w-0 text-center">
+        <div className="truncate" style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
+        <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{typeName}</div>
+      </div>
+      {canEdit ? (
+        <button onClick={openConfig} aria-label="Settings" className="flex h-9 w-9 items-center justify-center" data-testid="game-settings-gear">
+          <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+        </button>
+      ) : <div className="h-9 w-9" />}
+    </header>
+  );
+
+  // ── The ONE settings page — reached via the corner gear in BOTH modes. ──
+  if (showConfig && canEdit && competitionId) {
+    return (
+      <div className="fixed inset-0 z-50">
+        <NonGolfConfigurationView
+          subtitle={typeName}
+          onBack={closeConfig}
+          tripId={tripId}
+          competitionId={competitionId}
+          game={game}
+          scoringModel={scoringModel}
+          canEdit={canEdit}
+          isOwner={isOwner}
+          onChanged={() => void refreshGame()}
+          onDeleted={() => router.push(`/trips/${tripId}/leaderboard`)}
+          scoringEnabled={scoringEnabled}
+          ready={ready}
+          onEnable={handleEnable}
+          onDisable={handleDisable}
+          busy={enableScoring.isPending || disableScoring.isPending}
+        />
+      </div>
+    );
+  }
+
+  const gameName = game.name?.trim() || typeName;
+
+  // ── Setup mode (pending) — member placeholder / owner pass-through. ──
+  if (!scoringEnabled) {
+    return (
+      <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
+        {header(gameName)}
+        <div className="flex-1">
+          <SetupPlaceholder
+            gameName={game.name}
+            category={category}
+            message={canEdit
+              ? "Set the format, points, and rules on the settings page — the crew can’t see the game until you switch it to scoring."
+              : undefined}
+          >
+            {canEdit && (
+              <button
+                type="button"
+                onClick={openConfig}
+                data-testid="setup-go-to-settings"
+                className="mx-auto flex items-center justify-center gap-2"
+                style={{ height: 48, padding: "0 22px", borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 15, fontWeight: 600 }}
+              >
+                <Settings size={17} /> Set up this game
+              </button>
+            )}
+          </SetupPlaceholder>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Scoring mode (active/complete) — the scoreboard. ──
+  return (
+    <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
+      {header(gameName)}
+      {competitionId && (
+        <NonGolfScoreboard
+          tripId={tripId}
+          competitionId={competitionId}
+          game={game}
+          teams={teams}
+          scoringModel={scoringModel}
+          initialOrder={initialOrder}
+          canEdit={canEdit}
+          onPosted={() => router.back()}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -67,12 +67,22 @@ export default function ManualGamePage() {
     { enabled: !!tripId && !!competitionId }
   );
   const teams = useMemo(() => ((lbQ.data?.teams ?? []) as LBTeamLite[]), [lbQ.data]);
-  const initialOrder = useMemo(() => {
-    const cells = ((lbQ.data?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
+  const gameCells = useMemo(
+    () => ((lbQ.data?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
       .filter((c) => c.gameId === urlGameId)
-      .sort((a, b) => a.place - b.place);
-    return cells.length ? cells.map((c) => c.teamId) : teams.map((t) => t.id);
-  }, [lbQ.data, urlGameId, teams]);
+      .sort((a, b) => a.place - b.place),
+    [lbQ.data, urlGameId]
+  );
+  const initialOrder = useMemo(
+    () => (gameCells.length ? gameCells.map((c) => c.teamId) : teams.map((t) => t.id)),
+    [gameCells, teams]
+  );
+  // Seed the match control's declared outcome from the posted cells — a draw is
+  // both sides at place 1 (the win/lose/tie post writes both → position 1).
+  const initialResult = useMemo(() => {
+    if (gameCells.length === 2 && gameCells.every((c) => c.place === 1)) return "tie";
+    return gameCells[0]?.teamId;
+  }, [gameCells]);
 
   const scoringEnabled = (game as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
   // Non-golf is "ready" to score once points are configured (mirrors the server
@@ -223,6 +233,7 @@ export default function ManualGamePage() {
           teams={teams}
           scoringModel={scoringModel}
           initialOrder={initialOrder}
+          initialResult={initialResult}
           canEdit={canEdit}
           onPosted={() => router.back()}
         />

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { ChevronLeft, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
@@ -9,7 +9,7 @@ import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
 import { RostersOverlay } from "./RostersOverlay";
 import { TeamSheet, type Team } from "./TeamsPanel";
-import { GameSheet, RunSheet, type GameRow, type LBTeamLite } from "./CompetitionGamesPanel";
+import { GameSheet } from "./CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 
 interface Competition {
@@ -88,20 +88,11 @@ export function CompetitionFace({
   // present the instant it opens, even on the bad signal organizers hit on-site.
   const gameTypes = GAME_TYPES;
 
-  // ── Non-golf (manual) game scoring + config-reopen, routed from the board ───
-  // Golf games open via their per-format route (the GameRow links). Non-golf
-  // games have no route, so an editor taps the row → the manual run sheet (the
-  // orphaned RunSheet, re-attached here), and its pencil reopens config in the
-  // GameSheet. This restores the entry points the retired CompetitionGamesPanel
-  // wired; the board only re-attaches them. Both queries are seeded by
-  // faceBootstrap (cache hit — no extra waterfall) and editor-only.
-  // STRUCTURE (games list) is kept (STRUCTURE_QUERY); the leaderboard is STATE —
-  // it keeps the default short staleTime + the board's own 30s poll.
-  const { data: allGames = [] } = trpc.games.listByTrip.useQuery({ tripId }, { ...STRUCTURE_QUERY, enabled: canEdit });
-  const { data: lb } = trpc.competitions.leaderboard.useQuery(
-    { tripId, competitionId: competition.id },
-    { enabled: canEdit }
-  );
+  // Non-golf (manual) games now have their own scoreboard PAGE (the W-NONGOLF
+  // lifecycle surface) — an editor taps the row and NAVIGATES there (the GameRow
+  // link), the same as golf. The old in-place RunSheet + its pencil → GameSheet
+  // edit-reopen are retired (the page's gear → settings page is the edit home now,
+  // like golf). So this board no longer scores/edits non-golf games inline.
 
   // Team-identity editing from a leaderboard name tap (PR b2): the standalone
   // editor needs full team rows; the captain check needs assignments + the viewer.
@@ -126,27 +117,6 @@ export function CompetitionFace({
       setRostersOpen(true);
     }
   };
-  const compGames = useMemo(
-    () => (allGames as GameRow[]).filter((g) => g.competition_id === competition.id),
-    [allGames, competition.id]
-  );
-  const [running, setRunning] = useState<GameRow | null>(null); // manual game being posted
-  const [editing, setEditing] = useState<GameRow | null>(null); // game whose config is reopened
-  // Seed the run sheet's finishing order from the posted leaderboard cells (when
-  // correcting), else the roster order — mirrors the retired panel.
-  const runningOrder = useMemo(() => {
-    if (!running) return [];
-    const teams = (lb?.teams ?? []) as LBTeamLite[];
-    const cells = ((lb?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
-      .filter((c) => c.gameId === running.id)
-      .sort((a, b) => a.place - b.place);
-    return cells.length ? cells.map((c) => c.teamId) : teams.map((t) => t.id);
-  }, [running, lb]);
-  const openManualGame = (gameId: string) => {
-    const g = compGames.find((x) => x.id === gameId);
-    if (g) setRunning(g);
-  };
-
   // ── Go live / back to setup (visibility switch, NOT a data lock) ───────────
   // Centralized here (not in the header) so going live can also flip the
   // default view to the board. Optimistic so the chrome-shrink + toggle update
@@ -272,48 +242,26 @@ export function CompetitionFace({
         // A hero team-name tap → STANDALONE identity editor (owner / captain of
         // that team); a non-permitted tap falls to the read-only overlay.
         onEditTeam={handleEditTeam}
-        onOpenGame={canEdit ? openManualGame : undefined}
       />
 
       {/* Add a game opens the GameSheet modal directly over the board (the
-          aggregate games panel was retired). It persists on its own Save and
-          invalidates the board's leaderboard; we also re-resolve faceBootstrap
-          so the board's GAMES list refreshes without a hard reload (#10). */}
-      {(addingGame || editing) && canEdit && (
+          aggregate games panel was retired). It's ADD-only now — editing an
+          existing game lives on the game's own settings page (the gear), for
+          golf AND non-golf alike. It persists on its own Save and invalidates
+          the board's leaderboard; we also re-resolve faceBootstrap so the
+          board's GAMES list refreshes without a hard reload (#10). */}
+      {addingGame && canEdit && (
         <GameSheet
           tripId={tripId}
           competitionId={competition.id}
-          game={editing}
+          game={null}
           types={gameTypes}
           canEdit={canEdit}
           scoringModel={competition.scoring_model ?? "match_play"}
           onClose={() => {
             setAddingGame(false);
-            setEditing(null);
             utils.competitions.faceBootstrap.invalidate({ tripId });
           }}
-        />
-      )}
-
-      {/* Manual (non-golf) scoring — the orphaned RunSheet re-attached to the
-          board. Tapping a non-golf row opens it (winner/loser/tie via the
-          finishing order → games.post → leaderboard); its pencil reopens config.
-          faceBootstrap is invalidated on close so the board reflects the posted
-          result without a hard reload (pattern #10 — the board seeds from it). */}
-      {running && canEdit && (
-        <RunSheet
-          tripId={tripId}
-          competitionId={competition.id}
-          game={running}
-          teams={(lb?.teams ?? []) as LBTeamLite[]}
-          initialOrder={runningOrder}
-          isEngine={!!gameTypes.find((t) => t.id === running.game_type_id)?.isEngine}
-          matchPlay={(competition.scoring_model ?? "match_play") === "match_play"}
-          onClose={() => {
-            setRunning(null);
-            utils.competitions.faceBootstrap.invalidate({ tripId });
-          }}
-          onEditConfig={() => { setEditing(running); setRunning(null); }}
         />
       )}
 

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1293,7 +1293,7 @@ export function RunSheet({
 
 /** Manual placement entry — order the teams 1st→last; PAYS shows the configured
  *  distribution (the poster sets ORDER, never points). */
-function ManualPlacementEditor({
+export function ManualPlacementEditor({
   order, teams, dist, teamById, move,
 }: {
   order: string[]; teams: LBTeamLite[]; dist: number[];
@@ -1339,7 +1339,7 @@ function ManualPlacementEditor({
  *  alone carries the meaning — no per-row "wins" label, no two rows both saying
  *  win. Posts winner→pos 1, loser→pos 2, tie→both pos 1; the leaderboard awards
  *  [total,0] (averaged for a tie). */
-function WinLoseTieEditor({
+export function WinLoseTieEditor({
   teams, result, onPick,
 }: {
   teams: LBTeamLite[]; result: string; onPick: (r: string) => void;

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -1339,7 +1339,7 @@ export function ManualPlacementEditor({
  *  alone carries the meaning — no per-row "wins" label, no two rows both saying
  *  win. Posts winner→pos 1, loser→pos 2, tie→both pos 1; the leaderboard awards
  *  [total,0] (averaged for a tie). */
-export function WinLoseTieEditor({
+function WinLoseTieEditor({
   teams, result, onPick,
 }: {
   teams: LBTeamLite[]; result: string; onPick: (r: string) => void;

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -77,12 +77,9 @@ interface Props {
   /** Tap a team name on the hero/list → opens Rosters focused on that team's
    *  identity editor (captain-scoped; routed by the face). Member-visible. */
   onEditTeam?: (teamId: string) => void;
-  /** Tap a non-golf game row (no route) → open its manual run sheet (routed by
-   *  the face). Editors only; omitted for crew. */
-  onOpenGame?: (gameId: string) => void;
 }
 
-export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam, onOpenGame }: Props) {
+export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam }: Props) {
   const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
@@ -207,7 +204,6 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
         onPrefetch={prefetchGame}
         canEdit={canEdit}
         onAddGame={onAddGame}
-        onOpenGame={onOpenGame}
       />
     );
   }
@@ -289,7 +285,6 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
         onPrefetch={prefetchGame}
         canEdit={canEdit}
         onAddGame={onAddGame}
-        onOpenGame={onOpenGame}
       />
     </div>
   );
@@ -300,7 +295,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
 // entry). Empty → the bones prompt + "Add a game"; populated → the session
 // breakdown + "Add a game". Editor-gated; the crew sees the list only.
 function GamesSection({
-  games, teams, cellsByGame, sessionsDone, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame, onOpenGame,
+  games, teams, cellsByGame, sessionsDone, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
@@ -312,7 +307,6 @@ function GamesSection({
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
   onAddGame?: () => void;
-  onOpenGame?: (gameId: string) => void;
 }) {
   const addBtn = canEdit && onAddGame && (
     <button
@@ -358,7 +352,6 @@ function GamesSection({
         mineSet={mineSet}
         viewer={viewer}
         onPrefetch={onPrefetch}
-        onOpenGame={onOpenGame}
       />
       {addBtn}
     </div>
@@ -613,7 +606,6 @@ function SessionBreakdown({
   mineSet,
   viewer,
   onPrefetch,
-  onOpenGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
@@ -623,7 +615,6 @@ function SessionBreakdown({
   mineSet: Set<string>;
   viewer: LBViewer;
   onPrefetch: (gameId: string) => void;
-  onOpenGame?: (gameId: string) => void;
 }) {
   return (
     <div>
@@ -649,7 +640,6 @@ function SessionBreakdown({
             viewerAvatarIcon={viewer.avatarIcon}
             viewerTeamColor={viewer.teamColor}
             onPrefetch={onPrefetch}
-            onOpenGame={onOpenGame}
           />
         ))}
       </div>
@@ -669,7 +659,6 @@ function EarlyState({
   onPrefetch,
   canEdit,
   onAddGame,
-  onOpenGame,
 }: {
   teams: LBTeam[];
   liveGames: LBGame[];
@@ -680,7 +669,6 @@ function EarlyState({
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
   onAddGame?: () => void;
-  onOpenGame?: (gameId: string) => void;
 }) {
   return (
     <div className="space-y-3" data-testid="competition-leaderboard">
@@ -750,7 +738,6 @@ function EarlyState({
                 viewerAvatarIcon={viewer.avatarIcon}
                 viewerTeamColor={viewer.teamColor}
                 onPrefetch={onPrefetch}
-                onOpenGame={onOpenGame}
               />
             ))}
           </div>

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -99,7 +99,6 @@ export function GameRow({
   viewerAvatarIcon,
   viewerTeamColor,
   onPrefetch,
-  onOpenGame,
 }: {
   game: LBGame;
   teams: LBTeam[];
@@ -113,10 +112,6 @@ export function GameRow({
   viewerAvatarIcon?: string | null;
   viewerTeamColor?: string | null;
   onPrefetch: (gameId: string) => void;
-  /** Non-golf games have no game-board route; when the viewer can act on them
-   *  (editors only), the row opens the manual run sheet in place instead of
-   *  navigating. Omitted → the row stays inert (crew, or no manual path). */
-  onOpenGame?: (gameId: string) => void;
 }) {
   const href = gameHref(tripId, game.gameTypeId, game.id);
   const hasScores = cells && cells.size > 0;
@@ -132,9 +127,9 @@ export function GameRow({
   const showScorecard = isGolfFormat(game.gameTypeId) && !isFinal;
   const scorecardOpens = showScorecard && game.hasCourse === true && !!href;
   const showDelegate = mine && !isFinal;
-  // A row is tappable when it has a golf route OR a non-golf editor handler —
-  // gates the setting-up CTA subtitle (an inert crew row gets no "tap to…").
-  const tappable = !!href || !!onOpenGame;
+  // A row is tappable when it has a route (golf OR the non-golf manual page) —
+  // gates the setting-up CTA subtitle (an inert, routeless row gets no "tap to…").
+  const tappable = !!href;
 
   // §A3 arm tell: the format icon goes full-color once scoring is enabled
   // (armed). The same signal splits the Ready subtitle (see below); Final quiets
@@ -289,22 +284,9 @@ export function GameRow({
       </Link>
     );
   }
-  // Non-golf game (no route): an editor taps to open the manual run sheet in
-  // place — the same tap feel as a golf row, no navigation. Without onOpenGame
-  // (crew) the row stays a plain, inert tile.
-  if (onOpenGame) {
-    return (
-      <button
-        type="button"
-        onClick={() => onOpenGame(game.id)}
-        className="block w-full text-left rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
-        style={panelStyle}
-        data-testid={`game-open-${game.id}`}
-      >
-        {inner}
-      </button>
-    );
-  }
+  // No route → an inert tile. (Non-golf games now HAVE a route — the manual
+  // scoreboard page — so they take the <Link> branch above like golf; the old
+  // tap-to-open-modal-in-place path was retired with the post-results modal.)
   return <div className="rounded-xl overflow-hidden" style={panelStyle}>{inner}</div>;
 }
 

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -5,7 +5,10 @@ import Link from "next/link";
 import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
+import { gameHref, isGolfFormat } from "@/lib/gameRoutes";
 import type { LBGame, LBTeam, LBCell } from "./CompetitionLeaderboard";
+
+export { gameHref, isGolfFormat } from "@/lib/gameRoutes";
 
 // ── Row helpers (own the board-row primitives) ────────────────────────────────
 
@@ -15,24 +18,6 @@ export function fmtPts(n: number): string {
   const isHalf = Math.abs(n - whole - 0.5) < 0.001;
   if (!isHalf) return String(whole);
   return whole === 0 ? "½" : `${whole}½`;
-}
-
-/** Map known game type IDs to their game board route segment. */
-const GAME_ROUTES: Record<string, string> = {
-  gtt_stroke_play: "new",
-  gtt_match_play_singles: "match/new",
-  gtt_match_play_doubles: "match/new",
-  gtt_rack_n_stack: "rack/new",
-};
-
-export function gameHref(
-  tripId: string,
-  gameTypeId: string | null,
-  gameId: string
-): string | null {
-  if (!gameTypeId) return null;
-  const seg = GAME_ROUTES[gameTypeId];
-  return seg ? `/trips/${tripId}/games/${seg}?game=${gameId}` : null;
 }
 
 /** §A1 format icon — the leading glyph that names the game's format, glanceable
@@ -47,13 +32,6 @@ const FORMAT_ICONS: Record<string, LucideIcon> = {
 };
 export function formatIcon(gameTypeId: string | null): LucideIcon {
   return (gameTypeId && FORMAT_ICONS[gameTypeId]) || Gamepad2;
-}
-
-/** Golf games carry a scorecard (§A3 scorecard column is golf-only). Today every
- *  built format is golf — proxy "golf" by "has a known game-board route"; a
- *  manual win/lose/halve side event (no route) is correctly excluded. */
-export function isGolfFormat(gameTypeId: string | null): boolean {
-  return !!gameTypeId && gameTypeId in GAME_ROUTES;
 }
 
 /**

--- a/src/components/games/NonGolfConfigurationView.tsx
+++ b/src/components/games/NonGolfConfigurationView.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { GameDangerZone } from "@/components/games/GameDangerZone";
+import { GameManagementPanel } from "@/components/games/GameManagementPanel";
+import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
+import { GameRulesNote } from "@/components/games/GameRulesNote";
+import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
+import {
+  PointStepper,
+  FormatSheet,
+  formatLabel,
+  fmtValue,
+  type GameRow,
+} from "@/components/competition/CompetitionGamesPanel";
+import type { ScoringModel } from "@/lib/gameTypes";
+
+/**
+ * NonGolfConfigurationView (W-NONGOLF lifecycle surface) — the non-golf twin of
+ * golf's `GameConfigurationView`: the ONE settings home, reached by the corner
+ * gear, carrying the mode toggle + Danger Zone. It mirrors golf's STRUCTURE
+ * (identity → settings → rules → toggle → danger zone) but ships a **LEAN
+ * payload** — only what non-golf needs, no golf cruft (no Matches / Course /
+ * Handicaps / Modifiers):
+ *
+ *  - **competition_format** (its real home now — drives future matchup/bracket dev),
+ *  - by the competition's `scoring_model`:
+ *      - **match_play** → a single game-value stepper (the points for the one
+ *        Team-A-vs-B match; win = N, draw = split). It feeds the EXISTING
+ *        win/lose/tie path via `games.points_total` — no second mechanism.
+ *      - **points** → the two points sections (value + placement split), reusing
+ *        `FormatPointsPanel` (its manual branch is exactly the placement editor),
+ *  - **Rules of the Day**, the **Setup/Scoring** toggle, the **Danger Zone**.
+ */
+export function NonGolfConfigurationView({
+  subtitle,
+  onBack,
+  tripId,
+  competitionId,
+  game,
+  scoringModel,
+  canEdit,
+  isOwner,
+  onChanged,
+  onDeleted,
+  scoringEnabled,
+  ready = true,
+  onEnable,
+  onDisable,
+  busy,
+}: {
+  subtitle: string;
+  onBack: () => void;
+  tripId: string;
+  competitionId: string;
+  game: GameRow;
+  scoringModel: ScoringModel;
+  canEdit: boolean;
+  isOwner: boolean;
+  onChanged: () => void;
+  onDeleted: () => void;
+  scoringEnabled: boolean;
+  /** Minimum requirements met — gates the toggle's Scoring segment (non-golf is
+   *  ready once points are configured; matches the server `assertGameReady`). */
+  ready?: boolean;
+  onEnable: () => void;
+  onDisable: () => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
+      <header
+        className="flex shrink-0 items-center"
+        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+      >
+        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+        </button>
+        <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
+          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Configuration</div>
+          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+        {/* Identity — name (tap-to-edit) + assigned-to (same as golf). */}
+        <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
+
+        {/* Competition format — relocated here as its real home, near the top
+            (it drives future matchup/bracket dev). */}
+        <CompetitionFormatRow tripId={tripId} game={game} canEdit={canEdit} onChanged={onChanged} />
+
+        {/* The points payload, by the competition's scoring model. */}
+        {scoringModel === "match_play" ? (
+          <div className="mt-2">
+            <MatchValueStepper tripId={tripId} game={game} canEdit={canEdit} onChanged={onChanged} />
+          </div>
+        ) : (
+          <div className="mt-2">
+            <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} />
+          </div>
+        )}
+
+        {/* Rules of the Day — saves on blur (same as golf). */}
+        <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />
+
+        {/* The single Setup / Scoring toggle — owner/delegate only. */}
+        {canEdit && (
+          <div className="mt-6">
+            <GameManagementPanel
+              mode={scoringEnabled ? "scoring" : "setup"}
+              ready={ready}
+              onEnable={onEnable}
+              onDisable={onDisable}
+              pending={busy}
+            />
+          </div>
+        )}
+
+        {/* Per-game danger zone — owner-only (reset / abandon / delete). */}
+        {isOwner && (
+          <GameDangerZone
+            tripId={tripId}
+            gameId={game.id}
+            competitionId={competitionId}
+            status={game.status as string | null | undefined}
+            onChanged={onChanged}
+            onDeleted={onDeleted}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Competition-format picker row — its real home (relocated from the Add/Edit
+ *  modal). Opens the shared `FormatSheet`; persists via `games.update`, optimistic
+ *  on the `getById` cache, then re-seeds the Live face (faceBootstrap, #10). */
+function CompetitionFormatRow({
+  tripId, game, canEdit, onChanged,
+}: {
+  tripId: string; game: GameRow; canEdit: boolean; onChanged: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const update = trpc.games.update.useMutation();
+  const [open, setOpen] = useState(false);
+  const label = formatLabel(game.competition_format);
+
+  function pick(key: string) {
+    setOpen(false);
+    const cur = utils.games.getById.getData({ tripId, gameId: game.id });
+    if (cur) utils.games.getById.setData({ tripId, gameId: game.id }, { ...cur, competition_format: key } as typeof cur);
+    update
+      .mutateAsync({ tripId, gameId: game.id, competitionFormat: key as never })
+      .then(() => {
+        utils.games.listByTrip.invalidate({ tripId });
+        if (game.competition_id) utils.competitions.faceBootstrap.invalidate({ tripId });
+        onChanged();
+      })
+      .catch(() => utils.games.getById.invalidate({ tripId, gameId: game.id }));
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => canEdit && setOpen(true)}
+        disabled={!canEdit}
+        className="mt-3 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
+        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        data-testid="row-competition-format"
+      >
+        <div className="flex min-w-0 flex-col">
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Competition format
+          </span>
+          <span className="truncate text-sm" style={{ color: label ? "var(--color-bt-text)" : "var(--color-bt-text-dim)", marginTop: 2 }}>
+            {label ?? "Choose how it’s played"}
+          </span>
+        </div>
+        <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+      </button>
+      {open && (
+        <FormatSheet current={game.competition_format} onPick={pick} onClose={() => setOpen(false)} />
+      )}
+    </>
+  );
+}
+
+/** The single-match game-value stepper (match_play scoring model) — the points
+ *  for the one Team-A-vs-B match. It writes `games.points_total`, the SAME value
+ *  the leaderboard derives the win/lose/tie award from ([total, 0], tie averaged);
+ *  no second points mechanism. Optimistic on `getById`, then re-seeds the board. */
+function MatchValueStepper({
+  tripId, game, canEdit, onChanged,
+}: {
+  tripId: string; game: GameRow; canEdit: boolean; onChanged: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const setTotalM = trpc.games.setPointsTotal.useMutation();
+  // Controlled straight off the persisted value — the optimistic `setData` below
+  // re-renders the parent's getById subscription with the new total, so there's
+  // no local copy to drift (and no resync effect).
+  const value = game.points_total ?? 1;
+
+  function onChange(v: number) {
+    const cur = utils.games.getById.getData({ tripId, gameId: game.id });
+    if (cur) utils.games.getById.setData({ tripId, gameId: game.id }, { ...cur, points_total: v } as typeof cur);
+    setTotalM
+      .mutateAsync({ tripId, gameId: game.id, total: v })
+      .then(() => {
+        utils.games.listByTrip.invalidate({ tripId });
+        if (game.competition_id) utils.competitions.faceBootstrap.invalidate({ tripId });
+        onChanged();
+      })
+      .catch(() => utils.games.getById.invalidate({ tripId, gameId: game.id }));
+  }
+
+  return (
+    <PointStepper
+      label="Game value"
+      caption="POINTS FOR THE MATCH"
+      value={value}
+      onChange={canEdit ? onChange : () => {}}
+      footer={
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Win / Draw
+          </span>
+          <span className="text-sm font-semibold tabular-nums" style={{ color: "var(--color-bt-text)" }}>
+            Win {fmtValue(value)} · Draw {fmtValue(value / 2)} each
+          </span>
+        </div>
+      }
+    />
+  );
+}

--- a/src/components/games/NonGolfScoreboard.tsx
+++ b/src/components/games/NonGolfScoreboard.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 import { trpc } from "@/lib/trpc-client";
 import {
-  WinLoseTieEditor,
   ManualPlacementEditor,
+  fmtValue,
   type GameRow,
   type LBTeamLite,
 } from "@/components/competition/CompetitionGamesPanel";
@@ -32,6 +32,7 @@ export function NonGolfScoreboard({
   teams,
   scoringModel,
   initialOrder,
+  initialResult,
   canEdit,
   onPosted,
 }: {
@@ -42,6 +43,9 @@ export function NonGolfScoreboard({
   scoringModel: ScoringModel;
   /** Seed order for the placement editor (posted cells when correcting, else roster). */
   initialOrder: string[];
+  /** Seed declared outcome for the match control — a team id (that side won) or
+   *  "tie", derived from the posted cells (a draw = both at place 1). */
+  initialResult?: string;
   canEdit: boolean;
   /** Posted successfully — the page navigates back to the leaderboard. */
   onPosted: () => void;
@@ -53,7 +57,7 @@ export function NonGolfScoreboard({
   const dist = game.points_distribution?.type === "placement" ? game.points_distribution.values : [];
 
   const [order, setOrder] = useState<string[]>(initialOrder.length ? initialOrder : teams.map((t) => t.id));
-  const [result, setResult] = useState<string>(() => initialOrder[0] ?? teams[0]?.id ?? "");
+  const [result, setResult] = useState<string>(() => initialResult ?? initialOrder[0] ?? teams[0]?.id ?? "");
   const [error, setError] = useState<string | null>(null);
 
   // complete + !corrections_open → "posted" (re-post re-runs the compute); active
@@ -106,7 +110,12 @@ export function NonGolfScoreboard({
       )}
 
       {winLoseTie ? (
-        <WinLoseTieEditor teams={teams} result={result} onPick={canEdit ? setResult : () => {}} />
+        <NonGolfMatchControl
+          teams={teams}
+          pointsInPlay={game.points_total ?? 0}
+          result={result}
+          onPick={canEdit ? setResult : () => {}}
+        />
       ) : (
         <ManualPlacementEditor order={order} teams={teams} dist={dist} teamById={teamById} move={canEdit ? move : () => {}} />
       )}
@@ -125,6 +134,84 @@ export function NonGolfScoreboard({
           {correcting ? "Re-post" : "Post results"}
         </button>
       )}
+    </div>
+  );
+}
+
+/**
+ * NonGolfMatchControl (Part 3) — the declared-outcome control for a non-golf
+ * head-to-head, modeled as a REAL one match: Team A **vs** Team B, with the
+ * N points in play shown, and a declared outcome (win, or draw-and-split). It
+ * replaces the old context-free "Who won?" toggle. The outcome still feeds the
+ * existing path (a team id = that side won; "tie" = draw-split) — this is the
+ * STRUCTURE (a readable one-match), not the full styled control.
+ *
+ * NOTE (follow-on, NOT this spec): the full visual REFRESH — proper VS framing,
+ * points-in-play styling, match stylings echoing the golf match control's visual
+ * language — is a deferred mockup pass. This is the correct-but-basic version.
+ */
+function NonGolfMatchControl({
+  teams, pointsInPlay, result, onPick,
+}: {
+  teams: LBTeamLite[]; pointsInPlay: number; result: string; onPick: (r: string) => void;
+}) {
+  const [a, b] = teams;
+  const split = fmtValue(pointsInPlay / 2);
+  const win = fmtValue(pointsInPlay);
+
+  const options: { id: string; label: string; pays: string; testid: string }[] = [
+    { id: a?.id ?? "", label: `${a?.name ?? "Team A"} wins`, pays: `+${win}`, testid: `match-win-${a?.id}` },
+    { id: "tie", label: "Draw — split", pays: `${split} each`, testid: "match-draw" },
+    { id: b?.id ?? "", label: `${b?.name ?? "Team B"} wins`, pays: `+${win}`, testid: `match-win-${b?.id}` },
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* The match: Team A vs Team B — the framing the bare "who won?" lacked. */}
+      <div
+        className="flex items-center justify-between gap-2 rounded-xl px-3 py-3"
+        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        data-testid="match-framing"
+      >
+        <Side team={a} align="start" />
+        <span className="shrink-0 text-[11px] font-bold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>vs</span>
+        <Side team={b} align="end" />
+      </div>
+
+      <div className="flex items-center justify-center gap-1.5 text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
+        <span className="font-semibold tabular-nums" style={{ color: "var(--color-bt-accent)" }}>{win}</span>
+        {pointsInPlay === 1 ? "point" : "points"} in play
+      </div>
+
+      <div role="radiogroup" aria-label="Match outcome" className="space-y-1.5">
+        {options.map((o) => {
+          const sel = result === o.id;
+          return (
+            <button
+              key={o.id || o.testid}
+              type="button"
+              role="radio"
+              aria-checked={sel}
+              onClick={() => onPick(o.id)}
+              data-testid={o.testid}
+              className="flex w-full items-center justify-between gap-2.5 rounded-lg px-3 py-3 text-left"
+              style={{ background: sel ? "var(--color-bt-accent-faint)" : "var(--color-bt-card-raised)", border: `1px solid ${sel ? "var(--color-bt-accent-border)" : "var(--color-bt-border)"}` }}
+            >
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold" style={{ color: sel ? "var(--color-bt-accent)" : "var(--color-bt-text)" }}>{o.label}</span>
+              <span className="shrink-0 text-xs font-bold tabular-nums" style={{ color: sel ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}>{o.pays}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Side({ team, align }: { team: LBTeamLite | undefined; align: "start" | "end" }) {
+  return (
+    <div className={`flex min-w-0 flex-1 items-center gap-2 ${align === "end" ? "flex-row-reverse text-right" : ""}`}>
+      <span className="h-3.5 w-3.5 flex-shrink-0 rounded-full" style={{ background: team?.color ?? "var(--color-bt-text-dim)" }} />
+      <span className="min-w-0 truncate text-sm font-bold" style={{ color: "var(--color-bt-text)" }}>{team?.name ?? "Team"}</span>
     </div>
   );
 }

--- a/src/components/games/NonGolfScoreboard.tsx
+++ b/src/components/games/NonGolfScoreboard.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { trpc } from "@/lib/trpc-client";
+import {
+  WinLoseTieEditor,
+  ManualPlacementEditor,
+  type GameRow,
+  type LBTeamLite,
+} from "@/components/competition/CompetitionGamesPanel";
+import type { ScoringModel } from "@/lib/gameTypes";
+
+/**
+ * NonGolfScoreboard — the scoring-mode body of the non-golf scoreboard page
+ * (W-NONGOLF lifecycle surface). This is the **promoted post-results modal**: the
+ * old `RunSheet` body, lifted out of the modal to become the live board you land
+ * on from the leaderboard. It owns its own post like the modal did (the non-golf
+ * world keeps tRPC in the surface — these aren't the pure golf scorecard
+ * components), branching the result editor on the competition's `scoring_model`:
+ *  - **match_play** (head-to-head, 2 teams): the declared-outcome control
+ *    (Part 3 gives it Team-A-vs-B framing + points-in-play).
+ *  - **points** / >2 teams: the finishing-order placement editor (#430).
+ *
+ * Posting feeds the EXISTING `games.post` path (winner→pos 1 / tie→both pos 1 /
+ * placement order) — no second points mechanism. Members get the read-only board;
+ * the post CTA is owner/delegate-only (the server enforces it too).
+ */
+export function NonGolfScoreboard({
+  tripId,
+  competitionId,
+  game,
+  teams,
+  scoringModel,
+  initialOrder,
+  canEdit,
+  onPosted,
+}: {
+  tripId: string;
+  competitionId: string;
+  game: GameRow;
+  teams: LBTeamLite[];
+  scoringModel: ScoringModel;
+  /** Seed order for the placement editor (posted cells when correcting, else roster). */
+  initialOrder: string[];
+  canEdit: boolean;
+  /** Posted successfully — the page navigates back to the leaderboard. */
+  onPosted: () => void;
+}) {
+  const utils = trpc.useUtils();
+  // Head-to-head win/lose/tie is a manual match-play game with exactly two sides;
+  // anything else (points model, >2 teams) keeps the finishing-order editor.
+  const winLoseTie = scoringModel === "match_play" && teams.length === 2;
+  const dist = game.points_distribution?.type === "placement" ? game.points_distribution.values : [];
+
+  const [order, setOrder] = useState<string[]>(initialOrder.length ? initialOrder : teams.map((t) => t.id));
+  const [result, setResult] = useState<string>(() => initialOrder[0] ?? teams[0]?.id ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  // complete + !corrections_open → "posted" (re-post re-runs the compute); active
+  // → "open"; pending shouldn't reach the board (setup mode), but treat as open.
+  const correcting = game.status === "complete";
+
+  const post = trpc.games.post.useMutation();
+  const busy = post.isPending;
+
+  function teamById(id: string) {
+    return teams.find((t) => t.id === id);
+  }
+  function move(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= order.length) return;
+    const next = [...order];
+    [next[i], next[j]] = [next[j], next[i]];
+    setOrder(next);
+  }
+
+  async function commit() {
+    setError(null);
+    try {
+      const placements = winLoseTie
+        ? result === "tie"
+          ? teams.map((t) => ({ entityId: t.id, position: 1 }))
+          : teams.map((t) => ({ entityId: t.id, position: t.id === result ? 1 : 2 }))
+        : order.map((id, i) => ({ entityId: id, position: i + 1 }));
+      await post.mutateAsync({ tripId, gameId: game.id, placements });
+      utils.games.listByTrip.invalidate({ tripId });
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+      // The Live face seeds its board from faceBootstrap — invalidate it so the
+      // posted result lands without a hard refresh (CLAUDE.md #10).
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+      onPosted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to post");
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col gap-3 px-4 py-5">
+      {correcting && (
+        <div
+          className="rounded-lg px-3 py-2.5 text-[11px] leading-relaxed"
+          style={{ background: "var(--color-bt-warning-faint)", border: "1px solid var(--color-bt-warning)", color: "var(--color-bt-warning)" }}
+        >
+          This game is posted — re-posting recomputes the leaderboard.
+        </div>
+      )}
+
+      {winLoseTie ? (
+        <WinLoseTieEditor teams={teams} result={result} onPick={canEdit ? setResult : () => {}} />
+      ) : (
+        <ManualPlacementEditor order={order} teams={teams} dist={dist} teamById={teamById} move={canEdit ? move : () => {}} />
+      )}
+
+      {error && <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>{error}</p>}
+
+      {canEdit && (
+        <button
+          type="button"
+          onClick={commit}
+          disabled={busy}
+          data-testid="nongolf-post"
+          className="w-full rounded-xl py-3 text-sm font-bold disabled:opacity-50"
+          style={{ background: correcting ? "var(--color-bt-warning)" : "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+        >
+          {correcting ? "Re-post" : "Post results"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/gameRoutes.test.ts
+++ b/src/lib/gameRoutes.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { gameHref, isGolfFormat, MANUAL_ROUTE } from "@/lib/gameRoutes";
+
+describe("gameHref", () => {
+  it("routes golf formats to their per-format game pages", () => {
+    expect(gameHref("trip1", "gtt_stroke_play", "g1")).toBe("/trips/trip1/games/new?game=g1");
+    expect(gameHref("trip1", "gtt_match_play_singles", "g1")).toBe("/trips/trip1/games/match/new?game=g1");
+    expect(gameHref("trip1", "gtt_match_play_doubles", "g1")).toBe("/trips/trip1/games/match/new?game=g1");
+    expect(gameHref("trip1", "gtt_rack_n_stack", "g1")).toBe("/trips/trip1/games/rack/new?game=g1");
+  });
+
+  it("routes non-golf manual formats to the shared manual scoreboard page", () => {
+    for (const t of ["gtt_manual", "gtt_generic_card", "gtt_generic_yard", "gtt_generic_bar"]) {
+      expect(gameHref("trip1", t, "g1")).toBe(`/trips/trip1/games/${MANUAL_ROUTE}?game=g1`);
+    }
+  });
+
+  it("returns null for a null or unregistered game type", () => {
+    expect(gameHref("trip1", null, "g1")).toBeNull();
+    expect(gameHref("trip1", "gtt_not_a_real_type", "g1")).toBeNull();
+  });
+});
+
+describe("isGolfFormat", () => {
+  it("is true only for golf formats — never for manual or unknown types", () => {
+    expect(isGolfFormat("gtt_stroke_play")).toBe(true);
+    expect(isGolfFormat("gtt_rack_n_stack")).toBe(true);
+    // The manual page route must NOT make a non-golf game read as golf (it would
+    // wrongly show the golf-only scorecard column on the board row).
+    expect(isGolfFormat("gtt_manual")).toBe(false);
+    expect(isGolfFormat("gtt_generic_card")).toBe(false);
+    expect(isGolfFormat(null)).toBe(false);
+    expect(isGolfFormat("gtt_not_a_real_type")).toBe(false);
+  });
+});

--- a/src/lib/gameRoutes.ts
+++ b/src/lib/gameRoutes.ts
@@ -1,0 +1,43 @@
+import { isManualGameType } from "@/lib/gameTypes";
+
+/**
+ * Game-board routing — the pure mapping from a game's type to the page you land
+ * on from the leaderboard. Kept client-safe + React-free (no component imports)
+ * so it's unit-testable on its own and importable anywhere.
+ */
+
+/** Map known GOLF game type IDs to their game-board route segment. (Golf-only —
+ *  `isGolfFormat` keys off this; non-golf gets its page via `MANUAL_ROUTE`, which
+ *  deliberately does NOT make it read as golf.) */
+const GAME_ROUTES: Record<string, string> = {
+  gtt_stroke_play: "new",
+  gtt_match_play_singles: "match/new",
+  gtt_match_play_doubles: "match/new",
+  gtt_rack_n_stack: "rack/new",
+};
+
+/** The shared non-golf (manual) scoreboard route segment — every manual format
+ *  lands on the one lifecycle page (W-NONGOLF lifecycle surface), the non-golf
+ *  twin of golf's per-format pages. */
+export const MANUAL_ROUTE = "manual";
+
+export function gameHref(
+  tripId: string,
+  gameTypeId: string | null,
+  gameId: string
+): string | null {
+  if (!gameTypeId) return null;
+  const seg = GAME_ROUTES[gameTypeId];
+  if (seg) return `/trips/${tripId}/games/${seg}?game=${gameId}`;
+  // Non-golf manual games now have a real scoreboard PAGE (promoted from the old
+  // post-results modal) — route there instead of opening a modal in place.
+  if (isManualGameType(gameTypeId)) return `/trips/${tripId}/games/${MANUAL_ROUTE}?game=${gameId}`;
+  return null;
+}
+
+/** Golf games carry a scorecard (the scorecard column is golf-only). "Golf" is
+ *  proxied by "has a known golf game-board route"; a manual win/lose/halve side
+ *  event (no golf route) is correctly excluded. */
+export function isGolfFormat(gameTypeId: string | null): boolean {
+  return !!gameTypeId && gameTypeId in GAME_ROUTES;
+}


### PR DESCRIPTION
Brings non-golf games up to the same lifecycle structure golf got in A2 —
reusing golf's model (scoreboard page / settings page / mode toggle /
pass-through / access wall), not a parallel one. The only non-golf-specific
part is the lean settings payload.

Part 1 — the non-golf scoreboard page (the post-results modal, promoted):
- New route src/app/trips/[tripId]/games/manual/page.tsx, the non-golf twin
  of golf's per-format pages. Mode-driven, mirroring the golf page exactly:
  setup mode (pending) → member SetupPlaceholder / owner pass-through
  (placeholder + "Set up this game" + corner gear → settings); scoring mode
  (active/complete) → the scoreboard. Interim simple header (the consistent
  projected-points header is a logged follow-on).
- NonGolfScoreboard: the old RunSheet body lifted out of the modal, owning
  its post via the EXISTING games.post path (win/lose/tie or placement order).
- Routing: non-golf manual games now get a real page href (gameHref) instead
  of opening a modal in place. Extracted gameHref/isGolfFormat into a pure,
  React-free lib/gameRoutes.ts so the routing is unit-testable; isGolfFormat
  stays golf-only so the manual route does NOT make a non-golf game read as
  golf (no spurious scorecard column). GameRow re-exports for its importer.
- The access wall holds: setup mode renders only the placeholder (no data) for
  a member; the scoreboard (teams + result) renders in scoring mode or for an
  owner setting up — mirroring golf's A2-core gate.

Part 2 — the lean non-golf settings page (NonGolfConfigurationView):
- Mirrors GameConfigurationView's structure (identity → settings → rules →
  Setup/Scoring toggle → Danger Zone), reusing GameIdentityHeader,
  GameManagementPanel, GameRulesNote, GameDangerZone — but a LEAN payload:
  competition_format (relocated here as its real home, via the shared
  FormatSheet) + by scoring_model: match_play → a single game-value stepper
  that feeds games.points_total (the value the leaderboard derives the
  win/lose/tie award from — no second mechanism); points → the two points
  sections, reusing FormatPointsPanel's placement branch.
- NO golf rows (no Matches / Course / Handicaps / Modifiers).
- Mode-toggle readiness mirrors the server assertGameReady manual branch
  (ready once points are configured).

Tests: src/lib/gameRoutes.test.ts locks the routing (golf → per-format page,
manual → shared manual page, isGolfFormat golf-only).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FkZ7GWABLr4sTuuekvaJWo