### PR TITLE
chore: remove unused teams prop from ManualPlacementEditor (#506)

### DIFF
--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -550,9 +550,9 @@ export function FormatSheet({
 /** Manual placement entry — order the teams 1st→last; PAYS shows the configured
  *  distribution (the poster sets ORDER, never points). */
 export function ManualPlacementEditor({
-  order, teams, dist, teamById, move,
+  order, dist, teamById, move,
 }: {
-  order: string[]; teams: LBTeamLite[]; dist: number[];
+  order: string[]; dist: number[];
   teamById: (id: string) => LBTeamLite | undefined; move: (i: number, dir: -1 | 1) => void;
 }) {
   return (

--- a/src/components/games/NonGolfScoreboard.tsx
+++ b/src/components/games/NonGolfScoreboard.tsx
@@ -117,7 +117,7 @@ export function NonGolfScoreboard({
           onPick={canEdit ? setResult : () => {}}
         />
       ) : (
-        <ManualPlacementEditor order={order} teams={teams} dist={dist} teamById={teamById} move={canEdit ? move : () => {}} />
+        <ManualPlacementEditor order={order} dist={dist} teamById={teamById} move={canEdit ? move : () => {}} />
       )}
 
       {error && <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>{error}</p>}


### PR DESCRIPTION
Closes #506.

The last unused-var warning in `CompetitionGamesPanel.tsx`: `ManualPlacementEditor` takes a `teams: LBTeamLite[]` prop but resolves teams through the `teamById` callback instead, so `teams` was never read. Dropped it from the component signature and from its single call site (`NonGolfScoreboard.tsx`).

- `teams` stays in scope in `NonGolfScoreboard` (used by the win/lose/tie editor + `LBTeamLite` typings, 15 refs) — removing the one prop orphans nothing.
- The other half of #506 (`courseId` in `GameSheet`) was already cleared incidentally by the #509 Add-only teardown (#510), so this closes the issue out.

## Verify
- `tsc --noEmit` clean (the call-site update is type-checked).
- Lint clean — `CompetitionGamesPanel.tsx` now has **zero** warnings.
- Behavior unchanged (the prop was dead); full Vitest + Playwright run in CI.
- Net: 2 files, −2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0152CVnoS4KdBjwXUqbZWnSu)_