### PR TITLE
feat: scoring-mode settings lock + Rules exception + delegate-aware gating (#501)

### DIFF
--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -8,7 +8,7 @@ import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { NonGolfConfigurationView } from "@/components/games/NonGolfConfigurationView";
 import { NonGolfScoreboard } from "@/components/games/NonGolfScoreboard";
-import { useTripRole } from "@/hooks/useTripRole";
+import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { GAME_TYPES, type ScoringModel } from "@/lib/gameTypes";
 import type { GameRow, LBTeamLite } from "@/components/competition/CompetitionGamesPanel";
 
@@ -47,7 +47,9 @@ export default function ManualGamePage() {
   );
   const tripId = isId ? param : resolved.data?.id;
   const utils = trpc.useUtils();
-  const { canEdit, isOwner } = useTripRole(tripId);
+  // #501 Part 1: delegate-aware — a game-delegate (even a plain Member) edits this
+  // game, mirroring the server's `canEditGame`. `isOwner` stays trip-Owner-only.
+  const { canEdit, isOwner } = useGameEditAccess(tripId, urlGameId);
 
   const gameQ = trpc.games.getById.useQuery(
     { tripId: tripId!, gameId: urlGameId! },

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight, Flag, Plus, Minus, Trash2, X, Swords, SlidersHorizontal, Sparkles, Users, Settings } from "lucide-react";
+import { ChevronLeft, ChevronRight, Flag, Plus, X, Swords, SlidersHorizontal, Sparkles, Users, Settings } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
@@ -29,8 +29,7 @@ import { GameDangerZone } from "@/components/games/GameDangerZone";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
-import { buildDecided, matchState, strokeHoles, matchHasScores, type HoleResult } from "@/lib/matchPlay";
-import { DangerConfirmModal } from "@/components/DangerZone";
+import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeOrClearMatch } from "@/lib/matchDraft";
@@ -208,11 +207,6 @@ export default function NewMatchGamePage() {
   const enableScoring = trpc.matches.enableScoring.useMutation();
   // Phase 2B.1: Disable scoring — close to the crew, back to setup, scores kept.
   const disableScoring = trpc.games.disableScoring.useMutation();
-  // Dynamic match count (+1 / −1). Each changes the game's configured match
-  // count → the clinch goalpost (value × count) on the competition board, so
-  // both refresh the board after (see refreshAfterMatchCountChange).
-  const addMatch = trpc.matches.addMatch.useMutation();
-  const removeMatch = trpc.matches.removeMatch.useMutation();
   // Modifiers (golf "special rules" — config-only, W-GAMEPAGE-01 §6.5). Persisted
   // via games.update on accordion-collapse; presence-model jsonb (lib/modifiers).
   const updateModifiers = trpc.games.update.useMutation();
@@ -739,24 +733,6 @@ export default function NewMatchGamePage() {
   // Dynamic match count — mid-life +1 / −1 (the explicit "arm with 1, add a 2nd
   // mid-life" path). Each persists incrementally (NOT a bulk re-save, so
   // in-progress matches are untouched) and refreshes the board reactively.
-  async function handleAddMatch() {
-    if (!tripId || !gameId) return;
-    try {
-      await addMatch.mutateAsync({ tripId, gameId });
-      await refreshAfterMatchCountChange();
-    } catch {
-      // surfaced via the global error toast
-    }
-  }
-  async function handleRemoveMatch(matchId: string) {
-    if (!tripId || !gameId) return;
-    try {
-      await removeMatch.mutateAsync({ tripId, gameId, matchId });
-      await refreshAfterMatchCountChange();
-    } catch {
-      // surfaced via the global error toast
-    }
-  }
 
   async function handleFinish() {
     if (!tripId || !gameId) return;
@@ -1335,15 +1311,6 @@ export default function NewMatchGamePage() {
             setView(locked ? "grid" : "entry");
             go("score");
           }}
-          // +1 mid-life: persist an empty match, then land on setup to pick its
-          // players. The board's clinch goalpost moves once the match is PAIRED
-          // (a match = assigned), not the instant the empty slot is added.
-          onAddMatch={async () => {
-            await handleAddMatch();
-            openConfig();
-          }}
-          onRemoveMatch={handleRemoveMatch}
-          mutatingCount={addMatch.isPending || removeMatch.isPending}
         />
       )}
       </div>
@@ -1871,9 +1838,6 @@ function Overview({
   onCorrect,
   correctingPending,
   onOpenMatch,
-  onAddMatch,
-  onRemoveMatch,
-  mutatingCount,
 }: {
   groups: MatchGroupData[];
   myId: string | undefined;
@@ -1895,17 +1859,7 @@ function Overview({
   onCorrect: () => void;
   correctingPending: boolean;
   onOpenMatch: (matchId: string) => void;
-  /** Dynamic match count — mid-life +1 / −1. */
-  onAddMatch: () => void;
-  onRemoveMatch: (matchId: string) => void;
-  mutatingCount: boolean;
 }) {
-  // Destructive-edit guard (W-GAMEPAGE-01 §11): removing a SCORED match clears its
-  // entered scores, so it confirms first via the shared DangerConfirmModal (the one
-  // in-app confirm vocabulary, #433 — replaces the old window.confirm). An UNSCORED
-  // match removes with no friction. Holds the pending match while the modal is open.
-  // (Declared before the early return below — hooks must run every render.)
-  const [pendingRemoval, setPendingRemoval] = useState<{ matchId: string; label: string } | null>(null);
   if (!published) return <MemberNotReady gameName={gameName} />;
   const decideds = groups.map(decidedFor);
   const allOver = groups.length > 0 && decideds.every((d) => matchState(d, holeCount).over);
@@ -1927,59 +1881,25 @@ function Overview({
         </div>
       )}
 
+      {/* #501 Part 3: the scoring board is read-and-score only — match count is
+          config, so the live +1/−1 affordances are gone. Add/remove matches in Setup
+          mode (toggle back → Matches row), where mid-game config is deliberate. */}
       <div className="flex flex-col gap-2.5">
         {groups.map((g, i) => (
-          <div key={g.matchId} className="flex items-center gap-2">
-            <div className="min-w-0 flex-1">
-              <MatchCard
-                a={g.a}
-                b={g.b}
-                results={decideds[i]}
-                label={`Match ${i + 1}`}
-                youId={myId}
-                leftColor={g.leftColor}
-                rightColor={g.rightColor}
-                hideFormat
-                onClick={() => onOpenMatch(g.matchId)}
-              />
-            </div>
-            {/* −1: remove this match (live count). A SCORED match confirms first
-                (the modal below) — never silently drop entry; an unscored one goes
-                straight through. Down to the minimum of 1. */}
-            {canEdit && !complete && groups.length > 1 && (
-              <button
-                type="button"
-                onClick={() => {
-                  if (matchHasScores(decideds[i])) setPendingRemoval({ matchId: g.matchId, label: `Match ${i + 1}` });
-                  else onRemoveMatch(g.matchId);
-                }}
-                disabled={mutatingCount}
-                title="Remove match"
-                aria-label={`Remove match ${i + 1}`}
-                className="flex shrink-0 items-center justify-center disabled:opacity-40"
-                style={{ width: 34, height: 34, borderRadius: 9999, color: "var(--color-bt-danger)", border: "1px solid var(--color-bt-danger-border)" }}
-              >
-                <Minus size={16} />
-              </button>
-            )}
-          </div>
+          <MatchCard
+            key={g.matchId}
+            a={g.a}
+            b={g.b}
+            results={decideds[i]}
+            label={`Match ${i + 1}`}
+            youId={myId}
+            leftColor={g.leftColor}
+            rightColor={g.rightColor}
+            hideFormat
+            onClick={() => onOpenMatch(g.matchId)}
+          />
         ))}
       </div>
-
-      {/* +1: add another match mid-life (lands on setup to pick its players).
-          The board's "first to XX" moves once the new match is PAIRED. */}
-      {canEdit && !complete && groups.length < MAX_MATCHES && (
-        <button
-          type="button"
-          onClick={onAddMatch}
-          disabled={mutatingCount}
-          className="mt-3 flex w-full items-center justify-center gap-1.5 disabled:opacity-40"
-          style={{ height: 46, borderRadius: 12, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
-        >
-          <Plus size={16} />
-          Add match
-        </button>
-      )}
 
       <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", margin: "12px 0 0 2px" }}>
         {complete
@@ -2007,27 +1927,6 @@ function Overview({
         <button onClick={onFinish} disabled={finishing} className="mt-5 w-full disabled:opacity-40" style={{ height: 50, borderRadius: 12, background: "var(--color-bt-warning)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
           {finishing ? "Re-locking…" : "Re-lock result"}
         </button>
-      )}
-
-      {/* Scored-match removal confirm (W-GAMEPAGE-01 §11). Cancel preserves the
-          scores; confirm fires removeMatch, which clears the orphaned entries
-          server-side. Copy is honest placeholder — final voice pending Zach. */}
-      {pendingRemoval && (
-        <DangerConfirmModal
-          tone="danger"
-          icon={<Trash2 size={18} />}
-          title={`Remove ${pendingRemoval.label}?`}
-          body={`${pendingRemoval.label} has scores entered — removing it discards them. This can't be undone.`}
-          confirmLabel="Remove & discard"
-          pendingLabel="Removing…"
-          isPending={mutatingCount}
-          testId="confirm-remove-scored-match"
-          onCancel={() => setPendingRemoval(null)}
-          onConfirm={() => {
-            onRemoveMatch(pendingRemoval.matchId);
-            setPendingRemoval(null);
-          }}
-        />
       )}
     </div>
   );

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -6,7 +6,7 @@ import { ChevronLeft, ChevronRight, Flag, Plus, Minus, Trash2, X, Swords, Slider
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
-import { useTripRole } from "@/hooks/useTripRole";
+import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
@@ -81,7 +81,6 @@ export default function NewMatchGamePage() {
   const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { ...STRUCTURE_QUERY, enabled: !isId, retry: false });
   const tripId = isId ? param : resolved.data?.id;
 
-  const { canEdit: tripCanEdit, isOwner, loading: roleLoading } = useTripRole(tripId);
   const me = useCurrentUser();
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
@@ -104,6 +103,9 @@ export default function NewMatchGamePage() {
   );
 
   const [gameId, setGameId] = useState<string | null>(search.get("game"));
+  // #501 Part 1: delegate-aware canEdit (owner/org OR this game's delegate),
+  // centralized in useGameEditAccess. isOwner stays trip-Owner-only.
+  const { canEdit, isOwner, loading: roleLoading } = useGameEditAccess(tripId, gameId);
   const [manualScreen, setManualScreen] = useState<Screen | null>(null);
   // The settings page is an OVERLAY over the game scoreboard, browser-history aware:
   // opening it pushes a history entry, so the in-page back arrow and the OS/mouse
@@ -171,11 +173,6 @@ export default function NewMatchGamePage() {
   const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
   const matchesQ = trpc.matches.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
-  // Per-game delegate (§10): a member granted as this game's organizer runs it
-  // like an editor — config, pairings, score, finish. The server gate
-  // (requireGameEdit) admits them; the UI must light up the same way. Trip
-  // Owner/Organizer keep edit on every game; a delegate only on theirs.
-  const orgQ = trpc.games.listOrganizers.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
 
   // Format: the resumed game's type is authoritative; a brand-new game (no game
   // yet) reads the `?format=doubles` hint. `sided` switches the whole flow
@@ -200,11 +197,6 @@ export default function NewMatchGamePage() {
   // play_group), so the saver tags writes with participant_type='play_group'.
   const { values, setValues, saveStatus, onChange, onClear, retryCell } =
     useScoreSaver(tripId, gameId, sided ? "play_group" : undefined);
-  const amDelegate = useMemo(
-    () => !!me && (orgQ.data as { user_id: string }[] | undefined ?? []).some((o) => o.user_id === me.id),
-    [orgQ.data, me]
-  );
-  const canEdit = tripCanEdit || amDelegate;
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -26,6 +26,7 @@ import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/GameRulesNote";
 import { GameDangerZone } from "@/components/games/GameDangerZone";
+import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, matchHasScores, type HoleResult } from "@/lib/matchPlay";
@@ -266,6 +267,10 @@ export default function NewMatchGamePage() {
   // longer goes Live — first score does, #396). The owner lands on the overview
   // once enabled (or active/complete); members see it once enabled (= published).
   const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+  // #501: game-altering config (matches/course/points/handicaps/modifiers) freezes
+  // in scoring mode. MatchSetup/HandicapsSection have no read-only mode, so their
+  // rows go non-expandable; GameSetupRows/ModifierCards take settingsEditable directly.
+  const settingsEditable = canEdit && !scoringEnabled;
   // Lifecycle #7: Final = locked. `locked` (posted, no correction) → read-only;
   // `correcting` (owner re-opened) → editable again until re-locked.
   const correctionsOpen = !!(gameQ.data as { corrections_open?: boolean } | undefined)?.corrections_open;
@@ -1098,6 +1103,10 @@ export default function NewMatchGamePage() {
               />
             )}
 
+            {/* #501: live-game lock — the settings below freeze until the owner/
+                delegate flips the toggle above back to Setup. */}
+            {scoringEnabled && canEdit && <ScoringLockBanner />}
+
             {/* Available players (W-GAMEPAGE-01 §8) — STANDALONE games only. In a
                 competition the rosters live on the competition face (the leaderboard
                 + RostersOverlay own team membership), so this read-only echo is
@@ -1134,8 +1143,10 @@ export default function NewMatchGamePage() {
               title={matchesTitle}
               subtitle={matchesSubtitle}
               state={matchesState}
-              expanded={openRow === "matches"}
-              onToggle={() => toggleRow("matches")}
+              // #501: non-expandable AND force-collapsed in scoring mode (MatchSetup
+              // has no read-only mode, so it must not render interactively when live).
+              expanded={openRow === "matches" && settingsEditable}
+              onToggle={settingsEditable ? () => toggleRow("matches") : undefined}
               testId="row-matches"
             >
               <MatchSetup
@@ -1162,7 +1173,7 @@ export default function NewMatchGamePage() {
                 tripId={tripId}
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
-                canEdit={canEdit}
+                canEdit={settingsEditable}
                 courseOpen={openRow === "course"}
                 onOpenCourse={() => changeOpenRow("course")}
                 onCloseEditor={() => changeOpenRow(null)}
@@ -1177,7 +1188,7 @@ export default function NewMatchGamePage() {
                 tripId={tripId}
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
-                canEdit={canEdit}
+                canEdit={settingsEditable}
                 matchCount={filledDraft.length}
                 configLocked={!matchesExist}
                 configOpen={openRow === "config"}
@@ -1198,8 +1209,10 @@ export default function NewMatchGamePage() {
               title="Handicaps"
               subtitle={handicapsSubtitle}
               state={handicapsState}
-              expanded={openRow === "handicaps"}
-              onToggle={handicapsReady ? () => toggleRow("handicaps") : undefined}
+              // #501: non-expandable AND force-collapsed in scoring mode (HandicapsSection
+              // has no read-only mode).
+              expanded={openRow === "handicaps" && settingsEditable}
+              onToggle={handicapsReady && settingsEditable ? () => toggleRow("handicaps") : undefined}
               testId="row-handicaps"
             >
               <HandicapsSection
@@ -1227,14 +1240,14 @@ export default function NewMatchGamePage() {
                 subtitle={modifiersSubtitle}
                 state={modifiersState}
                 expanded={openRow === "modifiers"}
-                onToggle={matchesExist ? () => toggleRow("modifiers") : undefined}
+                onToggle={matchesExist && settingsEditable ? () => toggleRow("modifiers") : undefined}
                 testId="row-modifiers"
               >
                 <ModifierCards
                   available={availableModifiers}
                   modifiers={modifiersDraft}
                   onChange={setModifiersDraft}
-                  readOnly={!canEdit}
+                  readOnly={!settingsEditable}
                 />
               </ChecklistRow>
             )}
@@ -1289,6 +1302,7 @@ export default function NewMatchGamePage() {
                 status={gameQ.data.status as string | null | undefined}
                 onChanged={onSetupChanged}
                 onDeleted={() => router.push(competitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
+                disabled={scoringEnabled}
               />
             )}
           </div>

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -16,7 +16,7 @@ import { ModifierCards } from "@/components/games/ModifierCards";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
-import { useTripRole } from "@/hooks/useTripRole";
+import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import type { StrokeStanding } from "@/lib/strokePlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
@@ -48,7 +48,9 @@ export default function NewGamePage() {
   );
   const tripId = isId ? param : resolved.data?.id;
   const utils = trpc.useUtils();
-  const { canEdit, isOwner } = useTripRole(tripId);
+  // #501 Part 1: delegate-aware — a game-delegate (even a plain Member) edits this
+  // game, mirroring the server's `canEditGame`. `isOwner` stays trip-Owner-only.
+  const { canEdit, isOwner } = useGameEditAccess(tripId, urlGameId);
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -181,6 +181,9 @@ export default function NewGamePage() {
   const activeGameId = urlGameId ?? createdGame?.id;
   // Phase 2B.1: a configured game must be Enabled before its score screen opens.
   const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+  // #501: game-altering settings freeze in scoring mode (the page-level Handicaps +
+  // Modifiers drill-downs; GameConfigurationView locks its own rows internally).
+  const settingsEditable = canEdit && !scoringEnabled;
   const gameCompetitionId = (gameQ.data as { competition_id?: string | null } | undefined)?.competition_id ?? null;
   async function refreshGame() {
     await gameQ.refetch();
@@ -349,7 +352,7 @@ export default function NewGamePage() {
   // ── §3 Handicaps step — per-player ABSOLUTE strokes (stroke is per-player, not
   // per-matchup). Reached from the setup hull's Handicaps row AND Configuration.
   // Drives `netStrokeEntries`/`strokeHoles`: the input Phase 1 deferred. ──
-  if (game && showHandicaps && canEdit) {
+  if (game && showHandicaps && settingsEditable) {
     return (
       <div className="flex flex-col" style={{ height: "100vh" }}>
         <HandicapRoster
@@ -366,7 +369,7 @@ export default function NewGamePage() {
 
   // A1 P0 — Game Modifiers drill-down (mirrors the Handicaps overlay above): the
   // SAME ModifierCards the match setup page uses, persisted on-change.
-  if (game && showModifiers && canEdit) {
+  if (game && showModifiers && settingsEditable) {
     return (
       <div className="flex flex-col" style={{ height: "100vh", background: "var(--color-bt-base)" }}>
         <div className="flex items-center gap-2 px-4 py-3" style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
@@ -381,7 +384,7 @@ export default function NewGamePage() {
           <h2 className="text-base font-bold" style={{ color: "var(--color-bt-text)" }}>Game Modifiers</h2>
         </div>
         <div className="flex-1 overflow-y-auto p-4">
-          <ModifierCards available={availableModifiers} modifiers={modifiersDraft} onChange={persistModifiers} readOnly={!canEdit} />
+          <ModifierCards available={availableModifiers} modifiers={modifiersDraft} onChange={persistModifiers} readOnly={!settingsEditable} />
         </div>
       </div>
     );
@@ -457,7 +460,7 @@ export default function NewGamePage() {
               <ModifiersRow
                 count={enabledCount(modifiersDraft, availableModifiers)}
                 onClick={() => setShowModifiers(true)}
-                disabled={!canEdit}
+                disabled={!settingsEditable}
               />
             ) : undefined
           }

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -598,13 +598,9 @@ export default function RackNStackPage() {
     >
       <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
-      {canEdit && !final && (
-        <div className="px-3">
-          <button onClick={() => setShowHandicaps(true)} style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-accent)" }}>
-            Edit handicaps
-          </button>
-        </div>
-      )}
+      {/* #501 Part 3: the scoring board is read-and-score only — "Edit handicaps"
+          (config) is gone. Edit handicaps in Setup mode (gear → Who's playing ·
+          Handicaps), where mid-game config is deliberate. */}
       <RackBoard
         teamA={teamMeta.A}
         teamB={teamMeta.B}

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, Users, Settings } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
-import { useTripRole } from "@/hooks/useTripRole";
+import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { TimePicker } from "@/components/TimePicker";
@@ -61,7 +61,6 @@ export default function RackNStackPage() {
   const resolved = trpc.trips.resolveSlug.useQuery({ slugOrId: param }, { ...STRUCTURE_QUERY, enabled: !isId, retry: false });
   const tripId = isId ? param : resolved.data?.id;
 
-  const { canEdit: tripCanEdit, isOwner, loading: roleLoading } = useTripRole(tripId);
   const me = useCurrentUser();
   const utils = trpc.useUtils();
 
@@ -75,6 +74,9 @@ export default function RackNStackPage() {
     return (g?.id as string | undefined) ?? null;
   }, [gamesList.data]);
   const gid = gameId ?? resumeId;
+  // #501 Part 1: delegate-aware canEdit (owner/org OR this game's delegate),
+  // centralized in useGameEditAccess. isOwner stays trip-Owner-only.
+  const { canEdit, isOwner, loading: roleLoading } = useGameEditAccess(tripId, gid);
   const [mode, setMode] = useState<RackMode>("current");
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
   const [pendingCourse, setPendingCourse] = useState<{ id: string; name: string } | null>(null);
@@ -115,14 +117,6 @@ export default function RackNStackPage() {
   const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
   const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
-  // Per-game delegate (§10): this game's delegate runs it like an editor (the
-  // server's requireGameEdit admits them); trip staff keep edit everywhere.
-  const orgQ = trpc.games.listOrganizers.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
-  const amDelegate = useMemo(
-    () => !!me && (orgQ.data as { user_id: string }[] | undefined ?? []).some((o) => o.user_id === me.id),
-    [orgQ.data, me]
-  );
-  const canEdit = tripCanEdit || amDelegate;
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -6,6 +6,7 @@ import { GameDangerZone } from "@/components/games/GameDangerZone";
 import { GameManagementPanel } from "@/components/games/GameManagementPanel";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote } from "@/components/games/GameRulesNote";
+import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 
 /**
@@ -68,6 +69,11 @@ export function GameConfigurationView({
   onDisable: () => void;
   busy: boolean;
 }) {
+  // #501: in scoring mode game-altering settings freeze. `settingsEditable` gates
+  // every game-altering editor (course/points/who's-playing/handicaps/modifiers);
+  // Rules of the Day keeps plain `canEdit` (the carved-out exception), the toggle
+  // stays active (the path back to Setup), and the Danger Zone disables wholesale.
+  const settingsEditable = canEdit && !scoringEnabled;
   return (
     <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
       <header
@@ -89,19 +95,24 @@ export function GameConfigurationView({
           <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
         )}
 
-        {/* Same editors as the setup hull — reused, never rebuilt. */}
+        {/* #501: live-game lock banner — the settings below are frozen until the
+            owner/delegate toggles back to Setup. */}
+        {scoringEnabled && canEdit && <ScoringLockBanner />}
+
+        {/* Same editors as the setup hull — reused, never rebuilt. Locked in
+            scoring mode via settingsEditable. */}
         <GameSetupRows
           tripId={tripId}
           competitionId={competitionId}
           game={game}
-          canEdit={canEdit}
+          canEdit={settingsEditable}
           onChanged={onChanged}
         />
         {onEditWhosPlaying && (
           <button
             type="button"
             onClick={onEditWhosPlaying}
-            disabled={!canEdit}
+            disabled={!settingsEditable}
             className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
             style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
           >
@@ -146,6 +157,7 @@ export function GameConfigurationView({
             status={game.status as string | null | undefined}
             onChanged={onChanged}
             onDeleted={onDeleted}
+            disabled={scoringEnabled}
           />
         )}
       </div>

--- a/src/components/games/GameDangerZone.tsx
+++ b/src/components/games/GameDangerZone.tsx
@@ -27,6 +27,7 @@ export function GameDangerZone({
   status,
   onChanged,
   onDeleted,
+  disabled = false,
 }: {
   tripId: string;
   gameId: string;
@@ -37,6 +38,10 @@ export function GameDangerZone({
   onChanged: () => void;
   /** Game removed — leave the page (back to the board / trip). */
   onDeleted: () => void;
+  /** #501: the whole zone is locked while the game is LIVE (scoring mode) — wiping
+   *  scores / settings or deleting mid-competition is a terrible UX. Switch back to
+   *  Setup (the toggle) to manage the game. Every action row disables. */
+  disabled?: boolean;
 }) {
   const utils = trpc.useUtils();
   const [confirm, setConfirm] = useState<"scoring" | "skeleton" | "drop" | "delete" | null>(null);
@@ -86,6 +91,11 @@ export function GameDangerZone({
         className="space-y-3 rounded-xl p-4"
         style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
       >
+        {disabled && (
+          <p className="text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }} data-testid="danger-zone-locked">
+            Locked while the game is live — switch back to Setup to reset or remove it.
+          </p>
+        )}
         <DangerRow
           icon={<RotateCcw size={14} />}
           tone="warning"
@@ -93,6 +103,7 @@ export function GameDangerZone({
           blurb="Clears this game's scores. Pairings, course, handicaps, and points stay — the game is ready to re-score."
           onClick={() => setConfirm("scoring")}
           testId="game-reset-scoring-btn"
+          disabled={disabled}
         />
         <DangerRow
           icon={<Eraser size={14} />}
@@ -101,6 +112,7 @@ export function GameDangerZone({
           blurb="Resets this game to unconfigured. Pairings, course, handicaps, and scores are cleared; the name and point value stay."
           onClick={() => setConfirm("skeleton")}
           testId="game-reset-skeleton-btn"
+          disabled={disabled}
         />
         {isDropped ? (
           <DangerRow
@@ -110,6 +122,7 @@ export function GameDangerZone({
             blurb="Brings this abandoned game back onto the board. Its pairings and any scores are intact."
             onClick={() => setStatus.mutate({ tripId, gameId, status: "pending" })}
             testId="game-restore-btn"
+            disabled={disabled}
           />
         ) : (
           <DangerRow
@@ -119,6 +132,7 @@ export function GameDangerZone({
             blurb="Pulls this game from the board without deleting it — keeps it and its scores, hidden from the standings. Reversible."
             onClick={() => setConfirm("drop")}
             testId="game-drop-btn"
+            disabled={disabled}
           />
         )}
         <DangerRow
@@ -128,6 +142,7 @@ export function GameDangerZone({
           blurb="Removes this game and everything in it — pairings, scores, and results. This can't be undone."
           onClick={() => setConfirm("delete")}
           testId="game-delete-btn"
+          disabled={disabled}
         />
       </div>
 

--- a/src/components/games/NonGolfConfigurationView.tsx
+++ b/src/components/games/NonGolfConfigurationView.tsx
@@ -8,6 +8,7 @@ import { GameManagementPanel } from "@/components/games/GameManagementPanel";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote } from "@/components/games/GameRulesNote";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
+import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import {
   PointStepper,
   FormatSheet,
@@ -69,6 +70,10 @@ export function NonGolfConfigurationView({
   onDisable: () => void;
   busy: boolean;
 }) {
+  // #501: in scoring mode game-altering settings freeze (competition_format +
+  // points). Rules keeps plain canEdit (the exception), the toggle stays active
+  // (the path back to Setup), and the Danger Zone disables wholesale.
+  const settingsEditable = canEdit && !scoringEnabled;
   return (
     <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
       <header
@@ -88,22 +93,27 @@ export function NonGolfConfigurationView({
         {/* Identity — name (tap-to-edit) + assigned-to (same as golf). */}
         <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
 
-        {/* Competition format — relocated here as its real home, near the top
-            (it drives future matchup/bracket dev). */}
-        <CompetitionFormatRow tripId={tripId} game={game} canEdit={canEdit} onChanged={onChanged} />
+        {/* #501: live-game lock banner — settings below are frozen until toggled
+            back to Setup. */}
+        {scoringEnabled && canEdit && <ScoringLockBanner />}
 
-        {/* The points payload, by the competition's scoring model. */}
+        {/* Competition format — relocated here as its real home, near the top
+            (it drives future matchup/bracket dev). Locked in scoring mode. */}
+        <CompetitionFormatRow tripId={tripId} game={game} canEdit={settingsEditable} onChanged={onChanged} />
+
+        {/* The points payload, by the competition's scoring model. Locked in scoring. */}
         {scoringModel === "match_play" ? (
           <div className="mt-2">
-            <MatchValueStepper tripId={tripId} game={game} canEdit={canEdit} onChanged={onChanged} />
+            <MatchValueStepper tripId={tripId} game={game} canEdit={settingsEditable} onChanged={onChanged} />
           </div>
         ) : (
           <div className="mt-2">
-            <FormatPointsPanel tripId={tripId} game={game} canEdit={canEdit} />
+            <FormatPointsPanel tripId={tripId} game={game} canEdit={settingsEditable} />
           </div>
         )}
 
-        {/* Rules of the Day — saves on blur (same as golf). */}
+        {/* Rules of the Day — saves on blur (same as golf). The carved-out exception:
+            stays editable in scoring mode (notes, not game-altering). */}
         <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />
 
         {/* The single Setup / Scoring toggle — owner/delegate only. */}
@@ -119,7 +129,8 @@ export function NonGolfConfigurationView({
           </div>
         )}
 
-        {/* Per-game danger zone — owner-only (reset / abandon / delete). */}
+        {/* Per-game danger zone — owner-only (reset / abandon / delete). Disabled
+            wholesale in scoring mode (#501) — switch to Setup to manage the game. */}
         {isOwner && (
           <GameDangerZone
             tripId={tripId}
@@ -128,6 +139,7 @@ export function NonGolfConfigurationView({
             status={game.status as string | null | undefined}
             onChanged={onChanged}
             onDeleted={onDeleted}
+            disabled={scoringEnabled}
           />
         )}
       </div>

--- a/src/components/games/ScoringLockBanner.tsx
+++ b/src/components/games/ScoringLockBanner.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Lock } from "lucide-react";
+
+/**
+ * #501: shown at the top of a game's settings surface when the game is LIVE
+ * (scoring mode). Game-altering settings are frozen mid-game — changing them
+ * alters a game in progress, which must be intentional, not casual. The sanctioned
+ * path is the Setup/Scoring toggle (rendered below): switch back to Setup to edit
+ * (scores are kept), then re-enable. Rules of the Day stays editable in both modes
+ * (it's notes, not game-altering), so it is NOT covered by this lock.
+ *
+ * Friction, not prohibition — the edit path exists, it's just deliberate.
+ */
+export function ScoringLockBanner() {
+  return (
+    <div
+      className="mb-3 flex items-start gap-2.5 rounded-xl px-3.5 py-3"
+      style={{ background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}
+      data-testid="scoring-lock-banner"
+    >
+      <Lock size={16} style={{ color: "var(--color-bt-accent)", flexShrink: 0, marginTop: 1 }} />
+      <div>
+        <p className="text-sm font-semibold" style={{ color: "var(--color-bt-accent)" }}>
+          This game is live
+        </p>
+        <p className="mt-0.5 text-[12px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
+          Settings are locked while it’s being scored. Switch back to Setup (the Game Play toggle) to change
+          them — any scores entered are kept. Rules of the day can still be edited.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useGameEditAccess.ts
+++ b/src/hooks/useGameEditAccess.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { useTripRole } from "./useTripRole";
+import { useCurrentUser } from "./useCurrentUser";
+
+/**
+ * Client mirror of the server's `canEditGame` admission (middleware): edit access
+ * is granted to a trip Owner/Organizer **OR a DELEGATE of THIS game** (a
+ * `game_delegates` grant). `useTripRole` only knows the TRIP role, so on its own it
+ * is blind to a delegate-who-is-a-plain-Member — this ORs in the per-game delegate
+ * grant via `games.listOrganizers`, exactly as the server does (#501 Part 1), so the
+ * UI lights up the same way the server admits: Owner/Organizer keep edit on every
+ * game; a delegate only on theirs; a plain Member gets neither.
+ *
+ * The cross-cutting fix — every game surface (golf match/stroke/rack + non-golf,
+ * settings + board) reads `canEdit` from HERE, not from `useTripRole` directly, so
+ * the gating can't drift per-surface again.
+ *
+ * `isOwner` stays trip-Owner-only (delegates are NOT owners): the per-game Danger
+ * Zone and the delegation grant itself remain owner-gated, matching the server
+ * (`requireTripRole("Owner")`).
+ */
+export function useGameEditAccess(
+  tripId: string | undefined,
+  gameId: string | null | undefined
+) {
+  const { canEdit: tripCanEdit, isOwner, loading } = useTripRole(tripId);
+  const me = useCurrentUser();
+  const orgQ = trpc.games.listOrganizers.useQuery(
+    { tripId: tripId!, gameId: gameId! },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId }
+  );
+  const amDelegate = useMemo(
+    () =>
+      !!me &&
+      ((orgQ.data as { user_id: string }[] | undefined) ?? []).some(
+        (o) => o.user_id === me.id
+      ),
+    [orgQ.data, me]
+  );
+
+  return {
+    /** Owner/Organizer (any game) OR this game's delegate — mirrors `canEditGame`. */
+    canEdit: tripCanEdit || amDelegate,
+    /** Trip Owner only — NOT a delegate. Gates the owner-only Danger Zone + grant. */
+    isOwner,
+    amDelegate,
+    loading,
+  };
+}


### PR DESCRIPTION
Closes #501. Retires #501's original affordance sweep (subsumed by the lock).

**The model (settled with Zach):** once a game is **live (scoring mode)** its parameters freeze — changing settings mid-game alters a game in progress, which must be intentional, not casual. Setup mode = fully editable; scoring mode = game-altering settings locked read-only **except Rules of the Day**; to change anything else you deliberately toggle back to Setup (scores kept), edit, re-enable. The friction is the feature.

## Phase 0 audit

### A. Delegate-aware gating (the prerequisite)
- **Delegate source / server admission:** the server's `canEditGame` (middleware) admits **competition role ≥ co_admin OR a `game_delegates` grant for THIS game**. The client can read the per-game grant via `games.listOrganizers` (and `myDelegateGameIds`).
- **Where client `canEdit` came from:** `match` + `rack` pages already ORed in the delegate inline (`tripCanEdit || amDelegate`); **`stroke` (games/new) + `non-golf` (manual) used `useTripRole` only** → blind to a delegate-who-is-a-plain-Member, even though the server admits them. That was the gating seam.
- **Fix:** new `useGameEditAccess(tripId, gameId)` mirrors the server exactly; all four pages read `canEdit` from it. `isOwner` stays trip-Owner-only (the owner-only Danger Zone + delegation grant must not widen to delegates).

### B. The lock
- **Settings inventory** (per page): game-altering → **lock** (course, points/distribution/per-match, matches/who's-playing/pairings, handicaps, modifiers, competition_format); non-altering → **stay** (Rules of the Day; the Setup/Scoring toggle). Name/delegate (identity) stay editable (a label / owner reassignment, not game-altering).
- **Board affordance inventory** (config on scoring boards → removed): match **Add match** + **Remove match**; rack **Edit handicaps**. The settings **gear** stays on every board (it's navigation into the settings page, not a config action).
- **Danger Zone in scoring mode** — flagged to Zach; decision: **disabled wholesale** (resetting/deleting while people compete is terrible UX), stricter than the spec's lean.

## Build (3 parts, per-commit)

**Part 1 — delegate gating** (`f944c11`): `useGameEditAccess` hook; all four game pages route through it; match + rack drop their duplicated inline `amDelegate`.

**Part 2 — the lock** (`3d93c17`): minimal-surface — each settings surface derives `settingsEditable = canEdit && !scoringEnabled` and passes it as the `canEdit` to game-altering editors (their existing `!canEdit` disable/read-only logic does the locking — no editor internals touched). Shared `ScoringLockBanner` heads the surface in scoring mode. Golf (`GameConfigurationView` + the stroke page's Handicaps/Modifiers overlays), non-golf (`NonGolfConfigurationView`), and the match inline checklist (course/points via `settingsEditable`; Matches + Handicaps rows go non-expandable + force-collapsed since `MatchSetup`/`HandicapsSection` have no read-only mode). **Rules** keeps plain `canEdit`; the **toggle** stays active; **`GameDangerZone`** gains a `disabled` prop, set in scoring mode.

**Part 3 — boards read-and-score** (`40ea6c9`): removed match Add/Remove (+ handlers, client mutations, the scored-removal confirm, orphaned imports) and rack "Edit handicaps". The capability lives in Setup (the match draft builder → `setPairings`; rack handicaps via the gear → Who's-playing drill-down).

## Verify
- `tsc --noEmit` clean; lint clean (the backstops — tsc caught the dropped `game` prop's caller mid-edit).
- No test references the removed affordances; `matches.addMatch`/`removeMatch` server procedures are untouched.
- **Verification note:** the lock/banner/delegate behavior is verified by tsc + lint + reading — I can't run the app/E2E in this environment. The critical-path Playwright E2E (auth → stroke game → **settings page → enable scoring** → score → scorecard) runs in CI and exercises the locked settings + enable path; full Vitest + Playwright are the merge gate.
- Net: 9 files, +201 / −173 (the match page is −156 net — Part 3 removed more than the lock added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0152CVnoS4KdBjwXUqbZWnSu)_