### PR TITLE
fix(#512): lock-UX polish + Danger Zone trip-pattern + kill Abandon at the source

### DIFF
--- a/e2e/critical-path.spec.ts
+++ b/e2e/critical-path.spec.ts
@@ -98,15 +98,17 @@ test("scoring spine — stroke game: create → enter scores → scorecard refle
   //    PASS-THROUGH (A2-ux correction): open the ONE settings page via the "set it
   //    up" button, then flip the Setup/Scoring toggle's Scoring segment. Enabling
   //    fires enableScoring AND refetches the game (two sequential remote round-trips)
-  //    before scoring_enabled flips; only then does the settings page unmount and the
-  //    keypad mount. The first keypad tap used to race that settle (#454), so wait for
-  //    the FULL transition: the Scoring toggle disappearing is the precise
-  //    "settings→play transition complete" signal.
+  //    before scoring_enabled flips. #512 correction: enabling now flips the toggle
+  //    IN PLACE (it no longer auto-navigates) — the "This game is live" lock banner
+  //    appearing is the precise "now live, transition complete" signal (it can't show
+  //    until scoring_enabled has flipped). Then the settings back arrow returns to the
+  //    game page, which is now in scoring mode → the keypad mounts.
   await page.getByTestId("setup-go-to-settings").click();
   const scoringSeg = page.getByTestId("mode-scoring");
   await expect(scoringSeg).toBeEnabled({ timeout: 20_000 });
   await scoringSeg.click();
-  await expect(scoringSeg).toBeHidden({ timeout: 20_000 });
+  await expect(page.getByTestId("scoring-lock-banner")).toBeVisible({ timeout: 20_000 });
+  await page.getByRole("button", { name: "Back" }).click();
 
   // 4. Enter hole 1 for both players (confirm auto-advances to the next player).
   //    Distinct values so the assertion can't pass on par/coincidence. Wait for

--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -196,13 +196,19 @@ test("match-play spine — pair + relocated handicap → enable → enter a hole
   test.setTimeout(60_000);
   await driveToSetupWithHandicap(page);
 
-  // Switch to Scoring → the overview (A2-ux: the Game-Play toggle's Scoring segment
-  // replaced the bottom Enable button). Gate on it being ENABLED — under the T2 hard
-  // block that's the signal EVERY match is fully paired (the single match here), so
-  // the click can't race an incomplete pairing.
+  // Switch to Scoring (A2-ux: the Game-Play toggle's Scoring segment replaced the
+  // bottom Enable button). Gate on it being ENABLED — under the T2 hard block that's
+  // the signal EVERY match is fully paired (the single match here), so the click
+  // can't race an incomplete pairing.
   const scoringSeg = page.getByTestId("mode-scoring");
   await expect(scoringSeg).toBeEnabled({ timeout: 10_000 });
   await scoringSeg.click();
+
+  // #512 correction: enabling now flips the toggle IN PLACE (no auto-navigate) — the
+  // "This game is live" lock banner appearing is the "now live" signal. The settings
+  // back arrow then returns to the game page, which is now in scoring mode → overview.
+  await expect(page.getByTestId("scoring-lock-banner")).toBeVisible({ timeout: 20_000 });
+  await page.getByRole("button", { name: "Back" }).click();
 
   // 4. Open the single match (the strip card button) → the per-hole entry view.
   const matchCard = page.getByRole("button", { name: /Match 1.*MP Owner/ });

--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -131,7 +131,8 @@ export default function ManualGamePage() {
     try {
       await enableScoring.mutateAsync({ tripId, gameId: urlGameId });
       await refreshGame();
-      closeConfig(); // leave settings for the live board (consumes the history entry)
+      // #512 correction: STAY on the settings page — the toggle flips in place. The
+      // back arrow still returns to the game page via the openConfig history entry.
     } catch {
       // surfaced via the global error toast
     }

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -621,12 +621,13 @@ export default function NewMatchGamePage() {
   // draft editor persists it via persistDraftOnCollapse, so leaving the checklist
   // with rows collapsed has already saved everything.)
 
-  // Enable scoring = save THEN enable, land on the overview. The save carries the
-  // full config; enabling is the separate, readiness-gated step. The board refresh
-  // runs AFTER enableScoring so matchesQ.published is true on the overview (the
-  // refetch in saveSetup would otherwise predate the publish). Optimistically flip
-  // scoring_enabled in the game cache so the overview transition doesn't wait on a
-  // refetch (#459).
+  // Enable scoring = save THEN enable, then STAY on the settings page in place
+  // (#512 correction: flipping the toggle changes the mode here, it does NOT
+  // navigate — the user reads the now-live banner + locked panels and uses the back
+  // arrow to return when ready). The save carries the full config; enabling is the
+  // separate, readiness-gated step. Optimistically flip scoring_enabled in the game
+  // cache so the banner + lock appear without waiting on a refetch (#459); the
+  // board refresh runs AFTER enableScoring so the leaderboard/overview reflect it.
   async function commitReady() {
     if (!tripId || !gameId) return;
     const ok = await saveSetup();
@@ -637,9 +638,9 @@ export default function NewMatchGamePage() {
       utils.games.getById.setData({ tripId, gameId }, { ...cur, scoring_enabled: true } as typeof cur);
     }
     await refreshAfterMatchCountChange();
-    // Leave the settings overlay for the live board (derived → overview now that
-    // scoring is enabled). closeConfig pops the pushed history entry too.
-    closeConfig();
+    // No closeConfig() — the overlay stays open so the toggle flips in place. The
+    // back arrow (closeConfig → history.back) still pops the openConfig entry → game
+    // page, so the user is never stranded.
   }
 
   // ── Accordion control (one panel open at a time) ──────────────────────────
@@ -1070,13 +1071,20 @@ export default function NewMatchGamePage() {
                 setup, scores kept). Rendered for any canEdit game (NOT competition-gated,
                 so a standalone match game still toggles — it has no GameIdentityHeader). */}
             {canEdit && (
-              <GameManagementPanel
-                mode={scoringEnabled ? "scoring" : "setup"}
-                ready={enableReady}
-                onEnable={attemptReady}
-                onDisable={handleDisable}
-                pending={savingSetup || enableScoring.isPending || disableScoring.isPending}
-              />
+              <>
+                {/* #512 §4: GAME MANAGEMENT is a peer section — a labeled divider above
+                    the toggle matching SETTINGS / OPTIONS (the panel's own caption is
+                    suppressed via hideLabel so it isn't double-labeled). */}
+                <ZoneHeader>Game Management</ZoneHeader>
+                <GameManagementPanel
+                  mode={scoringEnabled ? "scoring" : "setup"}
+                  ready={enableReady}
+                  onEnable={attemptReady}
+                  onDisable={handleDisable}
+                  pending={savingSetup || enableScoring.isPending || disableScoring.isPending}
+                  hideLabel
+                />
+              </>
             )}
 
             {/* #501: live-game lock — the settings below freeze until the owner/
@@ -1121,6 +1129,8 @@ export default function NewMatchGamePage() {
               state={matchesState}
               // #501: non-expandable AND force-collapsed in scoring mode (MatchSetup
               // has no read-only mode, so it must not render interactively when live).
+              // #512: locked → dim + lock icon (it reads as frozen, not just chevron-less).
+              locked={scoringEnabled}
               expanded={openRow === "matches" && settingsEditable}
               onToggle={settingsEditable ? () => toggleRow("matches") : undefined}
               testId="row-matches"
@@ -1150,6 +1160,7 @@ export default function NewMatchGamePage() {
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
                 canEdit={settingsEditable}
+                locked={scoringEnabled}
                 courseOpen={openRow === "course"}
                 onOpenCourse={() => changeOpenRow("course")}
                 onCloseEditor={() => changeOpenRow(null)}
@@ -1165,6 +1176,7 @@ export default function NewMatchGamePage() {
                 competitionId={gameCompId}
                 game={gameQ.data as unknown as GameRow}
                 canEdit={settingsEditable}
+                locked={scoringEnabled}
                 matchCount={filledDraft.length}
                 configLocked={!matchesExist}
                 configOpen={openRow === "config"}
@@ -1186,7 +1198,8 @@ export default function NewMatchGamePage() {
               subtitle={handicapsSubtitle}
               state={handicapsState}
               // #501: non-expandable AND force-collapsed in scoring mode (HandicapsSection
-              // has no read-only mode).
+              // has no read-only mode). #512: locked → dim + lock icon.
+              locked={scoringEnabled}
               expanded={openRow === "handicaps" && settingsEditable}
               onToggle={handicapsReady && settingsEditable ? () => toggleRow("handicaps") : undefined}
               testId="row-handicaps"
@@ -1215,6 +1228,7 @@ export default function NewMatchGamePage() {
                 title="Game Modifiers"
                 subtitle={modifiersSubtitle}
                 state={modifiersState}
+                locked={scoringEnabled}
                 expanded={openRow === "modifiers"}
                 onToggle={matchesExist && settingsEditable ? () => toggleRow("modifiers") : undefined}
                 testId="row-modifiers"
@@ -1269,13 +1283,12 @@ export default function NewMatchGamePage() {
 
             {/* Danger zone — owner-only (A2-ux correction: the settings page is now the
                 ONE home, so the per-game danger ladder lives here too: reset scores /
-                reset settings / abandon / delete). */}
+                reset settings / delete). */}
             {isOwner && gameQ.data && (
               <GameDangerZone
                 tripId={tripId}
                 gameId={gameQ.data.id as string}
                 competitionId={gameCompId}
-                status={gameQ.data.status as string | null | undefined}
                 onChanged={onSetupChanged}
                 onDeleted={() => router.push(competitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
                 disabled={scoringEnabled}

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, ChevronRight, Settings } from "lucide-react";
+import { ChevronLeft, ChevronRight, Lock, Settings } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
@@ -198,7 +198,9 @@ export default function NewGamePage() {
     try {
       await enableScoring.mutateAsync({ tripId, gameId: activeGameId });
       await refreshGame();
-      closeConfig(); // leave settings for the live board (consumes the history entry)
+      // #512 correction: STAY on the settings page — the toggle flips in place (the
+      // now-live banner + locked panels render here). The back arrow still returns to
+      // the game page via the openConfig history entry; no closeConfig() here.
     } catch {
       // surfaced via the global error toast
     }
@@ -461,6 +463,7 @@ export default function NewGamePage() {
                 count={enabledCount(modifiersDraft, availableModifiers)}
                 onClick={() => setShowModifiers(true)}
                 disabled={!settingsEditable}
+                locked={scoringEnabled}
               />
             ) : undefined
           }
@@ -587,14 +590,15 @@ export default function NewGamePage() {
  *  was missing; the match page had it). Mirrors HandicapsRow's style; opens the
  *  full-screen ModifierCards overlay. Shown only when the format offers modifiers
  *  (stroke → moving_tees / glorious_holes; a format with none hides the row). */
-function ModifiersRow({ count, onClick, disabled }: { count: number; onClick: () => void; disabled?: boolean }) {
+function ModifiersRow({ count, onClick, disabled, locked }: { count: number; onClick: () => void; disabled?: boolean; locked?: boolean }) {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
+      // #512 Option B: live-locked → dim + a lock icon in place of the chevron.
       className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
-      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: locked ? 0.55 : undefined }}
     >
       <div className="flex min-w-0 flex-col">
         <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -604,7 +608,9 @@ function ModifiersRow({ count, onClick, disabled }: { count: number; onClick: ()
           {count > 0 ? `${count} modifier${count === 1 ? "" : "s"} added` : "Add special rules"}
         </span>
       </div>
-      <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+      {locked
+        ? <Lock size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+        : <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />}
     </button>
   );
 }

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -359,7 +359,8 @@ export default function RackNStackPage() {
     try {
       await enableScoring.mutateAsync({ tripId, gameId: gid });
       await refreshGame();
-      closeConfig(); // leave settings for the live board (consumes the history entry)
+      // #512 correction: STAY on the settings page — the toggle flips in place. The
+      // back arrow still returns to the game page via the openConfig history entry.
     } catch {
       // surfaced via the global error toast
     }

--- a/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
+++ b/src/app/trips/[tripId]/tabs/ScheduleTab.tsx
@@ -534,7 +534,7 @@ export function ScheduleTab({
     { enabled: !!competition?.id }
   );
   const compGames = (allGames as GameRow[]).filter(
-    (g) => g.competition_id === competition?.id && g.status !== "dropped"
+    (g) => g.competition_id === competition?.id
   );
   // On Deck shows only games not yet linked to an agenda item.
   const unlinkedCompGames = compGames.filter((g) => !g.schedule_item_id);

--- a/src/components/DangerZone.tsx
+++ b/src/components/DangerZone.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronRight } from "lucide-react";
 import { ScrollLock } from "@/hooks/useScrollLock";
 
 /**
@@ -10,7 +11,10 @@ import { ScrollLock } from "@/hooks/useScrollLock";
  * delete) render the SAME escalating shape, one level apart.
  *
  *  - SectionLabel        — the uppercase danger-zone heading.
- *  - DangerRow           — one action: a cost blurb + a tone-colored button.
+ *  - DangerRow           — one action, in the TRIP danger-zone pattern (#512): an
+ *                          icon-square + label + one-line description + chevron that
+ *                          opens a focused confirm. The row→confirm friction IS the
+ *                          point (destructive = deliberate).
  *  - DangerConfirmModal  — the cost-naming confirm (warning = reversible-but-heavy;
  *                          danger = gone).
  *
@@ -28,8 +32,10 @@ export function SectionLabel({ children, danger }: { children: React.ReactNode; 
   );
 }
 
-/** One danger-zone action: a labelled button with a one-line cost blurb above it.
- *  `tone` colors the text/icon (warning = reversible-but-heavy; danger = gone). */
+/** One danger-zone action in the TRIP danger-zone pattern (#512): a row of
+ *  [icon-square · label + one-line description · chevron] that opens a focused
+ *  confirm. `tone` colors the icon-square + label (warning = reversible-but-heavy;
+ *  danger = gone). The chevron signals "leads to a confirm", matching trip settings. */
 export function DangerRow({
   icon, tone, label, blurb, onClick, testId, disabled,
 }: {
@@ -42,23 +48,32 @@ export function DangerRow({
   disabled?: boolean;
 }) {
   const color = tone === "danger" ? "var(--color-bt-danger)" : "var(--color-bt-warning)";
+  const faint = tone === "danger" ? "var(--color-bt-danger-faint)" : "var(--color-bt-warning-faint)";
   return (
-    <div>
-      <p className="mb-1.5 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }}>
-        {blurb}
-      </p>
-      <button
-        type="button"
-        onClick={onClick}
-        disabled={disabled}
-        className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2.5 text-sm font-semibold disabled:opacity-50"
-        style={{ background: "transparent", color, border: "1px solid var(--color-bt-border)" }}
-        data-testid={testId}
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex w-full items-center gap-3 rounded-[11px] px-3 py-3 text-left transition-colors hover:bg-[var(--color-bt-hover)] disabled:opacity-50 disabled:hover:bg-transparent"
+      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      data-testid={testId}
+    >
+      <span
+        className="flex h-[34px] w-[34px] flex-shrink-0 items-center justify-center rounded-[9px]"
+        style={{ background: faint, color }}
       >
         {icon}
-        {label}
-      </button>
-    </div>
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-semibold" style={{ color }}>
+          {label}
+        </span>
+        <span className="mt-0.5 block text-xs leading-snug" style={{ color: "var(--color-bt-text-dim)" }}>
+          {blurb}
+        </span>
+      </span>
+      <ChevronRight size={17} className="flex-shrink-0" style={{ color: "var(--color-bt-text-dim)" }} />
+    </button>
   );
 }
 

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -46,7 +46,7 @@ export interface GameRow {
   competition_id: string | null;
   game_type_id: string | null;
   name: string | null;
-  status: "pending" | "active" | "complete" | "dropped";
+  status: "pending" | "active" | "complete";
   points_distribution: PointsDistribution | null;
   points_total: number | null;
   competition_format: string | null;

--- a/src/components/competition/CompetitionHeader.tsx
+++ b/src/components/competition/CompetitionHeader.tsx
@@ -11,7 +11,7 @@ import type { CSSProperties } from "react";
 // Quiet, not a live ticker (the live pulse belongs on game pages — deferred).
 interface StripLB {
   teams: { id: string; short_name: string }[];
-  games: { name: string; status: string; dropped: boolean }[];
+  games: { name: string; status: string }[];
   teamTotals: Record<string, number>;
 }
 function fmtHalf(n: number): string {
@@ -22,8 +22,7 @@ function fmtHalf(n: number): string {
 }
 function buildStatusStrip(lb: StripLB | undefined): string | null {
   if (!lb) return null;
-  const live = (lb.games ?? []).filter((g) => !g.dropped);
-  const active = live.filter((g) => g.status === "active");
+  const active = (lb.games ?? []).filter((g) => g.status === "active");
   if (active.length > 0) return `On tap: ${active.map((g) => g.name).join(", ")}`;
   const teams = lb.teams ?? [];
   const totals = lb.teamTotals ?? {};

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -20,7 +20,6 @@ export interface LBGame {
   name: string;
   distribution: number[] | null;
   status: string;
-  dropped: boolean;
   gameTypeId: string | null;
   /** Points configured (scoring-ready). Kept for the games-panel/test consumers. */
   ready?: boolean;
@@ -126,7 +125,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
   }, [me, assignments, data?.teams]);
 
   const liveGames = useMemo(
-    () => (data?.games ?? []).filter((g) => !g.dropped),
+    () => data?.games ?? [],
     [data]
   );
 

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { ChevronRight, ChevronDown, Check, X, type LucideIcon } from "lucide-react";
+import { ChevronRight, ChevronDown, Check, X, Lock, type LucideIcon } from "lucide-react";
 
 /**
  * ChecklistRow — the ONE canonical config-checklist row (W-GAMEPAGE visual pass
@@ -76,6 +76,7 @@ export function ChecklistRow({
   children,
   control,
   disabled,
+  locked,
   testId,
 }: {
   /** The row's semantic type-icon (lucide). Persists in every state. */
@@ -100,10 +101,15 @@ export function ChecklistRow({
    *  accordion/overlay; the control owns its own taps. */
   control?: React.ReactNode;
   disabled?: boolean;
+  /** #512 Option B: the row is frozen by the live-scoring lock — dim it and swap the
+   *  expand chevron for a LOCK icon (kills the false "expandable" affordance and names
+   *  the state). Non-interactive (no accordion / overlay). The toggle back to Setup
+   *  is the way out; Rules of the Day is never passed `locked` (the editable carve-out). */
+  locked?: boolean;
   testId?: string;
 }) {
-  const accordion = !!onToggle && !disabled;
-  const overlay = !!onClick && !disabled && !accordion;
+  const accordion = !!onToggle && !disabled && !locked;
+  const overlay = !!onClick && !disabled && !locked && !accordion;
   // A control row carries an inline control and never toggles (no accordion/overlay).
   const controlRow = !!control && !accordion && !overlay;
   const isOpen = accordion && !!expanded;
@@ -161,7 +167,13 @@ export function ChecklistRow({
     </div>
   );
 
-  const trailing = controlRow ? (
+  const trailing = locked ? (
+    // #512 Option B: a lock icon REPLACES the chevron — names the frozen state and
+    // kills the false expand affordance. (Lower opacity comes from the dimmed container.)
+    <span className="flex shrink-0 items-center">
+      <Lock size={15} style={{ color: "var(--color-bt-text-dim)" }} />
+    </span>
+  ) : controlRow ? (
     // The inline control sits where the chevron would — it owns its own taps.
     <span className="flex shrink-0 items-center">{control}</span>
   ) : (
@@ -182,7 +194,9 @@ export function ChecklistRow({
     </>
   );
   const headerClass = "flex w-full items-center gap-3 px-3.5 py-3 text-left disabled:opacity-60";
-  const containerStyle = { background: surface, border } as React.CSSProperties;
+  // #512 Option B: a live-locked row reads dimmed (reduced emphasis) so it clearly
+  // looks frozen, not merely chevron-less.
+  const containerStyle = { background: surface, border, opacity: locked ? 0.55 : undefined } as React.CSSProperties;
 
   // Accordion: a header button toggling an in-place panel below (same bordered
   // frame — the row IS the frame; the panel sheds all modal chrome).

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Lock } from "lucide-react";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { GameDangerZone } from "@/components/games/GameDangerZone";
 import { GameManagementPanel } from "@/components/games/GameManagementPanel";
@@ -106,6 +106,7 @@ export function GameConfigurationView({
           competitionId={competitionId}
           game={game}
           canEdit={settingsEditable}
+          locked={scoringEnabled}
           onChanged={onChanged}
         />
         {onEditWhosPlaying && (
@@ -113,8 +114,9 @@ export function GameConfigurationView({
             type="button"
             onClick={onEditWhosPlaying}
             disabled={!settingsEditable}
+            // #512 Option B: when live-locked, dim + swap the chevron for a lock icon.
             className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
-            style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+            style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: scoringEnabled ? 0.55 : undefined }}
           >
             <div className="flex min-w-0 flex-col">
               <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -122,7 +124,9 @@ export function GameConfigurationView({
               </span>
               <span className="truncate text-sm" style={{ color: "var(--color-bt-text)", marginTop: 2 }}>{whosPlayingLabel}</span>
             </div>
-            <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+            {scoringEnabled
+              ? <Lock size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+              : <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />}
           </button>
         )}
 
@@ -154,7 +158,6 @@ export function GameConfigurationView({
             tripId={tripId}
             gameId={game.id}
             competitionId={competitionId}
-            status={game.status as string | null | undefined}
             onChanged={onChanged}
             onDeleted={onDeleted}
             disabled={scoringEnabled}

--- a/src/components/games/GameDangerZone.tsx
+++ b/src/components/games/GameDangerZone.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import { useState } from "react";
-import { RotateCcw, Eraser, Trash2, Archive, ArchiveRestore } from "lucide-react";
+import { RotateCcw, Eraser, Trash2 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { SectionLabel, DangerRow, DangerConfirmModal } from "@/components/DangerZone";
 
 /**
  * The per-game danger zone — the escalating ladder ONE LEVEL DOWN from the
- * competition's (CompetitionSettings), reusing the same shared primitives:
+ * competition's (CompetitionSettings), reusing the same shared primitives in the
+ * TRIP danger-zone pattern (#512): each action is a row (icon + label + one-line
+ * description + chevron) that opens a focused confirm sheet.
  *
  *   Reset scores  → games.resetScoring   (clears this game's results; config kept)
  *   Reset settings → games.resetToSkeleton (clears config to a shell; identity +
  *                    per-match point VALUE kept — §E-1)
  *   Delete game   → games.delete
+ *
+ * THREE actions only — Abandon/Drop was removed at the source (#512 §6a: the
+ * `dropped` status was a CC-introduced concept that was never requested; do not
+ * re-add a drop/abandon/archive-game capability).
  *
  * Owner-only (the resets are owner-gated server-side; the host renders this only
  * for the owner). The resets call the Phase A primitives (migration 066). After a
@@ -24,7 +30,6 @@ export function GameDangerZone({
   tripId,
   gameId,
   competitionId,
-  status,
   onChanged,
   onDeleted,
   disabled = false,
@@ -32,8 +37,6 @@ export function GameDangerZone({
   tripId: string;
   gameId: string;
   competitionId: string | null;
-  /** The game's status — drives Drop vs Restore (A2-ux: Drop/abandon's home). */
-  status?: string | null;
   /** Refetch the host's game view after a reset (config/scoring changed). */
   onChanged: () => void;
   /** Game removed — leave the page (back to the board / trip). */
@@ -44,8 +47,7 @@ export function GameDangerZone({
   disabled?: boolean;
 }) {
   const utils = trpc.useUtils();
-  const [confirm, setConfirm] = useState<"scoring" | "skeleton" | "drop" | "delete" | null>(null);
-  const isDropped = status === "dropped";
+  const [confirm, setConfirm] = useState<"scoring" | "skeleton" | "delete" | null>(null);
 
   function invalidateAfterReset() {
     void utils.games.getById.invalidate({ tripId, gameId });
@@ -77,69 +79,39 @@ export function GameDangerZone({
       onDeleted();
     },
   });
-  // A2-ux: Drop/abandon (status ⇄ dropped) — reversible archive, excluded from the
-  // leaderboard roll-up. Its ONLY home was the Edit modal; bringing it here (the one
-  // settings surface) unblocks retiring that modal. Restore is safe (no confirm).
-  const setStatus = trpc.games.setStatus.useMutation({
-    onSuccess: () => { setConfirm(null); invalidateAfterReset(); },
-  });
 
   return (
     <section className="mt-8 space-y-3">
       <SectionLabel danger>Danger zone</SectionLabel>
-      <div
-        className="space-y-3 rounded-xl p-4"
-        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
-      >
-        {disabled && (
-          <p className="text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }} data-testid="danger-zone-locked">
-            Locked while the game is live — switch back to Setup to reset or remove it.
-          </p>
-        )}
+      {disabled && (
+        <p className="px-1 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }} data-testid="danger-zone-locked">
+          Locked while the game is live — switch back to Setup to reset or remove it.
+        </p>
+      )}
+      <div className="space-y-2.5">
         <DangerRow
-          icon={<RotateCcw size={14} />}
+          icon={<RotateCcw size={16} />}
           tone="warning"
           label="Reset scores"
-          blurb="Clears this game's scores. Pairings, course, handicaps, and points stay — the game is ready to re-score."
+          blurb="Clears scores; pairings, course, handicaps, and points stay."
           onClick={() => setConfirm("scoring")}
           testId="game-reset-scoring-btn"
           disabled={disabled}
         />
         <DangerRow
-          icon={<Eraser size={14} />}
+          icon={<Eraser size={16} />}
           tone="warning"
           label="Reset game settings"
-          blurb="Resets this game to unconfigured. Pairings, course, handicaps, and scores are cleared; the name and point value stay."
+          blurb="Clears the setup; the name and point value are kept."
           onClick={() => setConfirm("skeleton")}
           testId="game-reset-skeleton-btn"
           disabled={disabled}
         />
-        {isDropped ? (
-          <DangerRow
-            icon={<ArchiveRestore size={14} />}
-            tone="warning"
-            label="Restore game"
-            blurb="Brings this abandoned game back onto the board. Its pairings and any scores are intact."
-            onClick={() => setStatus.mutate({ tripId, gameId, status: "pending" })}
-            testId="game-restore-btn"
-            disabled={disabled}
-          />
-        ) : (
-          <DangerRow
-            icon={<Archive size={14} />}
-            tone="warning"
-            label="Abandon game"
-            blurb="Pulls this game from the board without deleting it — keeps it and its scores, hidden from the standings. Reversible."
-            onClick={() => setConfirm("drop")}
-            testId="game-drop-btn"
-            disabled={disabled}
-          />
-        )}
         <DangerRow
-          icon={<Trash2 size={14} />}
+          icon={<Trash2 size={16} />}
           tone="danger"
           label="Delete game"
-          blurb="Removes this game and everything in it — pairings, scores, and results. This can't be undone."
+          blurb="Removes the game and everything in it. This can’t be undone."
           onClick={() => setConfirm("delete")}
           testId="game-delete-btn"
           disabled={disabled}
@@ -172,20 +144,6 @@ export function GameDangerZone({
           testId="game-reset-skeleton-confirm"
           onCancel={() => setConfirm(null)}
           onConfirm={() => resetToSkeleton.mutate({ tripId, gameId })}
-        />
-      )}
-      {confirm === "drop" && (
-        <DangerConfirmModal
-          tone="warning"
-          icon={<Archive size={18} />}
-          title="Abandon this game?"
-          body="Pulls it from the board and the standings without deleting it — the game and any scores are kept and can be restored later."
-          confirmLabel="Abandon game"
-          pendingLabel="Abandoning…"
-          isPending={setStatus.isPending}
-          testId="game-drop-confirm"
-          onCancel={() => setConfirm(null)}
-          onConfirm={() => setStatus.mutate({ tripId, gameId, status: "dropped" })}
         />
       )}
       {confirm === "delete" && (

--- a/src/components/games/GameManagementPanel.tsx
+++ b/src/components/games/GameManagementPanel.tsx
@@ -26,6 +26,7 @@ export function GameManagementPanel({
   onEnable,
   onDisable,
   pending = false,
+  hideLabel = false,
 }: {
   /** Current game mode — `scoring` once scoring is enabled, else `setup`. */
   mode: "setup" | "scoring";
@@ -35,6 +36,11 @@ export function GameManagementPanel({
   onEnable: () => void;
   onDisable: () => void;
   pending?: boolean;
+  /** #512: the match settings page renders a peer `GAME MANAGEMENT` section header
+   *  (ZoneHeader) above the panel, so suppress the internal caption there to avoid a
+   *  double label. Other hosts (stroke/rack/non-golf) have no section headers — they
+   *  keep the internal caption as the panel's only label. */
+  hideLabel?: boolean;
 }) {
   const isScoring = mode === "scoring";
   const scoringLocked = !isScoring && !ready;
@@ -47,11 +53,13 @@ export function GameManagementPanel({
       style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
       data-testid="game-management-panel"
     >
-      <div className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-        Game Play
-      </div>
+      {!hideLabel && (
+        <div className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          Game Play
+        </div>
+      )}
 
-      <div className="mt-2 flex gap-1.5 rounded-xl p-1" style={{ background: "var(--color-bt-card-raised)" }}>
+      <div className={`${hideLabel ? "" : "mt-2 "}flex gap-1.5 rounded-xl p-1`} style={{ background: "var(--color-bt-card-raised)" }}>
         {/* Setup segment — active in setup mode; the disable action in scoring mode. */}
         <Segment
           testId="mode-setup"
@@ -104,25 +112,19 @@ function Segment({
   onClick?: () => void;
   disabled?: boolean;
 }) {
-  // Teal = "go / live" in the system, reserved for the LIVE state:
+  // One signal, never two (#512 correction): teal = "go / live" and appears ONLY on
+  // the ACTIVE segment in scoring mode. The inactive segment is ALWAYS plain muted
+  // grey — never teal — so setup mode can't read as "scoring active".
   //  - Scoring active  → teal FILL, dark text (this game is LIVE / in scoring).
   //  - Setup active    → a quiet/neutral fill (base surface + primary text) — Setup
   //    is "in progress, not live", so it must NOT borrow the teal that means live.
-  //  - Scoring as the enable ACTION (setup mode) → teal text/outline (the "go" CTA),
-  //    lock-dimmed until ready.
-  //  - Setup as the disable action (scoring mode) → quiet/dim (not a "go" state).
+  //  - Either segment inactive → muted grey, transparent (the enable/disable action is
+  //    the SAME quiet treatment in both directions; lock icon + dim when not ready).
   const style: React.CSSProperties = active
     ? accent
       ? { background: "var(--color-bt-accent)", color: "#0d1f1a", border: "1px solid transparent" }
       : { background: "var(--color-bt-base)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }
-    : accent
-      ? {
-          background: "transparent",
-          color: locked ? "var(--color-bt-text-dim)" : "var(--color-bt-accent)",
-          border: `1px solid ${locked ? "transparent" : "var(--color-bt-accent-border)"}`,
-          opacity: locked ? 0.6 : 1,
-        }
-      : { background: "transparent", color: "var(--color-bt-text-dim)", border: "1px solid transparent" };
+    : { background: "transparent", color: "var(--color-bt-text-dim)", border: "1px solid transparent", opacity: locked ? 0.6 : 1 };
   return (
     <button
       type="button"

--- a/src/components/games/GameRulesNote.tsx
+++ b/src/components/games/GameRulesNote.tsx
@@ -44,21 +44,34 @@ export const GameRulesNote = forwardRef<GameRulesNoteHandle, {
 
   return (
     <div className="mt-6">
-      <label className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-        Rules of the day
-      </label>
-      <textarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        onBlur={() => void commit()}
-        readOnly={!canEdit}
-        rows={3}
-        maxLength={2000}
-        placeholder="Tap out the rules of the day — formats, gimmes, mulligans, tiebreakers…"
-        className="mt-2 w-full resize-none rounded-xl px-3 py-2.5 text-sm outline-none"
-        style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", opacity: canEdit ? 1 : 0.7 }}
-        data-testid="game-rules-note"
-      />
+      {/* #512 §5: label + divider rule, matching the SETTINGS / OPTIONS section
+          headers (which had a divider; Rules previously had a bare label). */}
+      <div className="flex items-center gap-2 pt-2">
+        <label className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          Rules of the day
+        </label>
+        <span className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
+      </div>
+      {/* #512 §8: a bordered card PANEL containing the textarea (surface + border +
+          padding) so it reads as a peer of the Matches/Course/Points card-rows, not a
+          loose field. The textarea itself is transparent — it's the panel's interior. */}
+      <div
+        className="mt-2 rounded-xl px-3.5 py-3"
+        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      >
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={() => void commit()}
+          readOnly={!canEdit}
+          rows={3}
+          maxLength={2000}
+          placeholder="Tap out the rules of the day — formats, gimmes, mulligans, tiebreakers…"
+          className="w-full resize-none bg-transparent text-sm outline-none"
+          style={{ color: "var(--color-bt-text)", opacity: canEdit ? 1 : 0.7 }}
+          data-testid="game-rules-note"
+        />
+      </div>
     </div>
   );
 });

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -38,6 +38,7 @@ export function GameSetupRows({
   slot = "both",
   matchCount,
   configLocked = false,
+  locked = false,
   courseOpen: courseOpenProp,
   configOpen: configOpenProp,
   onOpenCourse,
@@ -63,6 +64,10 @@ export function GameSetupRows({
    *  — points mean nothing before a match). Locked = read-only, no chevron, same as
    *  a gated Handicaps row. Default false (unlocked). */
   configLocked?: boolean;
+  /** #512 Option B: the live-scoring lock — render these rows dimmed + lock-icon
+   *  (read-only because the game is live). Distinct from `configLocked` (the readiness
+   *  gate that holds Points until a match exists). Default false. */
+  locked?: boolean;
   /** Page-owned one-open state (controlled). Omit → self-managed (uncontrolled). */
   courseOpen?: boolean;
   configOpen?: boolean;
@@ -128,6 +133,7 @@ export function GameSetupRows({
           subtitle={courseResolved ? "Handicaps enabled" : "Handicaps disabled"}
           state={courseResolved ? "resolved" : "empty"}
           disabled={!canEdit}
+          locked={locked}
           expanded={courseOpen}
           onToggle={courseOpen ? closeEditor : openCourse}
           testId="row-course"
@@ -158,6 +164,7 @@ export function GameSetupRows({
             // points term satisfied (they can't disagree).
             state={pointsReady(perMatch) ? "resolved" : "empty"}
             disabled={!canEdit}
+            locked={locked}
             testId="row-format-points"
             control={
               <PointsPerMatchControl
@@ -185,6 +192,7 @@ export function GameSetupRows({
             }
             state={perMatch > 0 ? "resolved" : "empty"}
             disabled={!canEdit}
+            locked={locked}
             expanded={configOpen}
             onToggle={configLocked ? undefined : configOpen ? closeEditor : openConfig}
             testId="row-format-points"

--- a/src/components/games/NonGolfConfigurationView.tsx
+++ b/src/components/games/NonGolfConfigurationView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Lock } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { GameDangerZone } from "@/components/games/GameDangerZone";
 import { GameManagementPanel } from "@/components/games/GameManagementPanel";
@@ -99,15 +99,16 @@ export function NonGolfConfigurationView({
 
         {/* Competition format — relocated here as its real home, near the top
             (it drives future matchup/bracket dev). Locked in scoring mode. */}
-        <CompetitionFormatRow tripId={tripId} game={game} canEdit={settingsEditable} onChanged={onChanged} />
+        <CompetitionFormatRow tripId={tripId} game={game} canEdit={settingsEditable} locked={scoringEnabled} onChanged={onChanged} />
 
-        {/* The points payload, by the competition's scoring model. Locked in scoring. */}
+        {/* The points payload, by the competition's scoring model. Locked in scoring —
+            #512 Option B: dim the read-only panel so it reads as frozen. */}
         {scoringModel === "match_play" ? (
-          <div className="mt-2">
+          <div className="mt-2" style={{ opacity: scoringEnabled ? 0.55 : undefined }}>
             <MatchValueStepper tripId={tripId} game={game} canEdit={settingsEditable} onChanged={onChanged} />
           </div>
         ) : (
-          <div className="mt-2">
+          <div className="mt-2" style={{ opacity: scoringEnabled ? 0.55 : undefined }}>
             <FormatPointsPanel tripId={tripId} game={game} canEdit={settingsEditable} />
           </div>
         )}
@@ -129,14 +130,13 @@ export function NonGolfConfigurationView({
           </div>
         )}
 
-        {/* Per-game danger zone — owner-only (reset / abandon / delete). Disabled
-            wholesale in scoring mode (#501) — switch to Setup to manage the game. */}
+        {/* Per-game danger zone — owner-only (reset scores / reset settings / delete).
+            Disabled wholesale in scoring mode (#501) — switch to Setup to manage it. */}
         {isOwner && (
           <GameDangerZone
             tripId={tripId}
             gameId={game.id}
             competitionId={competitionId}
-            status={game.status as string | null | undefined}
             onChanged={onChanged}
             onDeleted={onDeleted}
             disabled={scoringEnabled}
@@ -151,9 +151,9 @@ export function NonGolfConfigurationView({
  *  modal). Opens the shared `FormatSheet`; persists via `games.update`, optimistic
  *  on the `getById` cache, then re-seeds the Live face (faceBootstrap, #10). */
 function CompetitionFormatRow({
-  tripId, game, canEdit, onChanged,
+  tripId, game, canEdit, locked, onChanged,
 }: {
-  tripId: string; game: GameRow; canEdit: boolean; onChanged: () => void;
+  tripId: string; game: GameRow; canEdit: boolean; locked?: boolean; onChanged: () => void;
 }) {
   const utils = trpc.useUtils();
   const update = trpc.games.update.useMutation();
@@ -180,8 +180,9 @@ function CompetitionFormatRow({
         type="button"
         onClick={() => canEdit && setOpen(true)}
         disabled={!canEdit}
+        // #512 Option B: live-locked → dim + a lock icon in place of the chevron.
         className="mt-3 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
-        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: locked ? 0.55 : undefined }}
         data-testid="row-competition-format"
       >
         <div className="flex min-w-0 flex-col">
@@ -192,7 +193,9 @@ function CompetitionFormatRow({
             {label ?? "Choose how it’s played"}
           </span>
         </div>
-        <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+        {locked
+          ? <Lock size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+          : <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />}
       </button>
       {open && (
         <FormatSheet current={game.competition_format} onPick={pick} onClose={() => setOpen(false)} />

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -27,9 +27,7 @@ function matchFormat(gameTypeId: string | null): MatchFormat {
  *    SYNTHETIC distribution (sorted actual points) so rollUp's placementPoints
  *    passes the values through directly (direction high_wins).
  *
- * `dropped` games are excluded from the roll-up — which is why
- * dropping/restoring a game recomputes the win number (§4): it is derived here,
- * never stored.
+ * The win number is DERIVED here from the competition's games, never stored.
  */
 export async function computeCompetitionLeaderboard(
   supabase: SupabaseClient,
@@ -48,8 +46,7 @@ export async function computeCompetitionLeaderboard(
       .select("defending_team_id, scoring_model")
       .eq("id", competitionId)
       .maybeSingle(),
-    // Games of this competition. We fetch ALL (incl. dropped) so the grid can
-    // show an "Abandoned" column, but only LIVE ones feed the roll-up.
+    // Games of this competition — all feed the roll-up.
     supabase
       .from("games")
       .select("id, name, points_distribution, points_total, status, game_type_id, course_id, scoring_enabled")
@@ -73,7 +70,6 @@ export async function computeCompetitionLeaderboard(
   // Only manual games get the match-play winner-take-all award; golf untouched.
   const isManualType = (typeId: string | null) => isManualGameType(typeId);
   const allGames = gameRowsRes.data ?? [];
-  const live = allGames.filter((g) => g.status !== "dropped");
   const sizeByTeam = new Map<string, number>();
   for (const a of assignmentsRes.data ?? []) {
     const tid = a.team_id as string;
@@ -81,7 +77,7 @@ export async function computeCompetitionLeaderboard(
   }
   const teamSizes = teamIds.map((id) => sizeByTeam.get(id) ?? 0);
 
-  const gameIds = live.map((g) => g.id as string);
+  const gameIds = allGames.map((g) => g.id as string);
   // game_results (awarded) + the per-game match COUNT (available) + the per-game
   // participant COUNT (the stroke/rack readiness gate). All depend on the live
   // game ids; run them together.
@@ -135,7 +131,7 @@ export async function computeCompetitionLeaderboard(
     standingsByGame.set(r.game_id as string, arr);
   }
 
-  const liveGames: LiveGame[] = live.map((g) => {
+  const liveGames: LiveGame[] = allGames.map((g) => {
     const rawDist = g.points_distribution as PointsDistribution | null;
     const standings = standingsByGame.get(g.id as string) ?? [];
 
@@ -250,7 +246,6 @@ export async function computeCompetitionLeaderboard(
         name: (g.name as string | null) ?? "Game",
         distribution: isPlacement(rawDist) ? rawDist.values : null,
         status: g.status as string,
-        dropped: g.status === "dropped",
         gameTypeId: typeId,
         // "ready to score" = points are configured (a distribution shape or an
         // owner-set total). Kept for the games-panel/test consumers.
@@ -273,8 +268,7 @@ export async function computeCompetitionLeaderboard(
         // color reads (§A4), replacing the Phase-3 derived stub.
         scoringEnabled: g.scoring_enabled === true,
         // Points in play (§A5 outer column). Match-play games carry it here even
-        // though `distribution` is null pre-decision; dropped games (not in the
-        // roll-up) get null and the row never renders them anyway.
+        // though `distribution` is null pre-decision.
         pointsTotal: ptsInPlayByGame.get(gid) ?? null,
       };
     }),

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -87,7 +87,6 @@ describe("D2 §6 — 2-team hero data (N-team structure holds at 2)", () => {
     // Game is present in the response
     const game = lb.games.find((g: { id: string }) => g.id === gameId);
     expect(game).toBeDefined();
-    expect(game!.dropped).toBe(false);
   });
 
   it("in-progress: scores entered, teamTotals and pointsToClinch update", async () => {
@@ -224,46 +223,6 @@ describe("D2 §6 — N-team (3+ teams) ranked list data", () => {
   });
 });
 
-describe("D2 §6 — dropped game excluded from totals and winNumber", () => {
-  it("dropping a game moves the winNumber and removes it from cells", async () => {
-    const comp = await ctx.createCompetition(tripId, "D2 Drop Comp", { scoringModel: "points" });
-    const ta = await ctx.createTeam(comp, "Blue", { shortName: "BLU" });
-    const tb = await ctx.createTeam(comp, "Red", { shortName: "RED" });
-
-    const g1r = await ctx.caller().games.create({
-      tripId, gameTypeId: MANUAL, name: "Live", competitionId: comp,
-      pointsDistribution: { type: "placement", values: [9, 6] },
-    }) as { id: string };
-    const g1 = g1r.id;
-    gameIds.push(g1);
-    const g2r = await ctx.caller().games.create({
-      tripId, gameTypeId: MANUAL, name: "To Drop", competitionId: comp,
-      pointsDistribution: { type: "placement", values: [9, 6] },
-    }) as { id: string };
-    const g2 = g2r.id;
-    gameIds.push(g2);
-
-    await ctx.caller().games.setManualResults({ tripId, gameId: g1, placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 2 }] });
-    await ctx.caller().games.setManualResults({ tripId, gameId: g2, placements: [{ entityId: ta, position: 1 }, { entityId: tb, position: 2 }] });
-
-    const before = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
-    expect(before.pointsAvailable).toBe(30); // 15+15
-    expect(before.teamTotals[ta]).toBe(18); // 9+9
-
-    await ctx.caller().games.setStatus({ tripId, gameId: g2, status: "dropped" });
-
-    const after = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
-    // Dropped game excluded from roll-up
-    expect(after.pointsAvailable).toBe(15);
-    expect(after.teamTotals[ta]).toBe(9);
-    // Dropped game still present in games[] but with dropped:true
-    const droppedGame = after.games.find((g: { id: string }) => g.id === g2);
-    expect(droppedGame?.dropped).toBe(true);
-    // No cells for dropped game
-    expect(after.cells.filter((c: { gameId: string }) => c.gameId === g2)).toHaveLength(0);
-  });
-});
-
 describe("D2 §6 — non-engine game with no entry shows at 0, not hidden", () => {
   it("manual game with no results contributes to pointsAvailable but has no cells", async () => {
     const comp = await ctx.createCompetition(tripId, "D2 NoEntry Comp", { scoringModel: "points" });
@@ -281,7 +240,6 @@ describe("D2 §6 — non-engine game with no entry shows at 0, not hidden", () =
     // Game is present (honest, not hidden)
     const game = lb.games.find((g2: { id: string }) => g2.id === g.id);
     expect(game).toBeDefined();
-    expect(game!.dropped).toBe(false);
     // Points-available counts it (8 in play)
     expect(lb.pointsAvailable).toBe(8);
     // No cells (no results entered)

--- a/src/server/routers/games.d1.test.ts
+++ b/src/server/routers/games.d1.test.ts
@@ -113,30 +113,6 @@ describe("manual adapter → universal roll-up (§5)", () => {
   });
 });
 
-describe("dropping recomputes the win number (§4/§6)", () => {
-  it("dropping a game lowers points-available + win number; restoring raises them", async () => {
-    const comp3 = await ctx.createCompetition(tripId, "Drop Comp", { scoringModel: "points" });
-    await ctx.createTeam(comp3, "A");
-    await ctx.createTeam(comp3, "B");
-    const g1 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G1", competitionId: comp3, pointsDistribution: DIST_96 })) as { id: string };
-    const g2 = (await ctx.caller().games.create({ tripId, gameTypeId: MANUAL, name: "G2", competitionId: comp3, pointsDistribution: DIST_96 })) as { id: string };
-    gameIds.push(g1.id, g2.id);
-
-    let lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
-    expect(lb.pointsAvailable).toBe(30);
-    expect(lb.winNumber).toBe(15.5);
-
-    await ctx.caller().games.setStatus({ tripId, gameId: g2.id, status: "dropped" });
-    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
-    expect(lb.pointsAvailable).toBe(15); // dropped game excluded
-    expect(lb.winNumber).toBe(8); // the win number MOVED
-
-    await ctx.caller().games.setStatus({ tripId, gameId: g2.id, status: "pending" });
-    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp3 });
-    expect(lb.pointsAvailable).toBe(30); // restored
-  });
-});
-
 describe("per-game organizer delegation (§8)", () => {
   it("a delegated organizer can edit THEIR game but not another; non-members blocked", async () => {
     const mine = await newGame(DIST_96, "Pickem-BJ");

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -593,16 +593,15 @@ export const gamesRouter = router({
       return { success: true };
     }),
 
-  // setStatus — game-edit gate. A game pulled for time is `dropped`, NOT deleted
-  // (§4): reversible, kept, and excluded from the leaderboard roll-up (which reads
-  // only live games). The win number is DERIVED from the live set, so dropping /
-  // restoring moves it automatically — there is no stored win number to update.
+  // setStatus — game-edit-gated status setter over the lifecycle states (pending /
+  // active / complete). (No `dropped`: the abandon/drop concept was removed at the
+  // source — #512 §6a — and must not be re-added.)
   setStatus: authedProcedure
     .input(
       z.object({
         tripId: z.string(),
         gameId: z.string(),
-        status: z.enum(["pending", "active", "complete", "dropped"]),
+        status: z.enum(["pending", "active", "complete"]),
       })
     )
     .use(requireGameEdit())
@@ -691,8 +690,7 @@ export const gamesRouter = router({
 
   // delete — Owner/Organizer. HARD-delete a game; all dependent rows
   // (participants, matches, play_groups, results, score_entries, organizers)
-  // cascade via ON DELETE CASCADE. Distinct from setStatus('dropped')
-  // ("Abandoned"), which is a reversible archive — this is a true removal (L3-b).
+  // cascade via ON DELETE CASCADE. A true removal (L3-b) — the danger-zone Delete.
   // requireTripRole("Organizer") gates it to trip staff (not a game-delegate).
   delete: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))

--- a/supabase/migrations/20260629120000_069_remove_game_dropped_status.sql
+++ b/supabase/migrations/20260629120000_069_remove_game_dropped_status.sql
@@ -1,0 +1,95 @@
+-- 069 — Remove the game `dropped` (abandon) status at the source (#512 §6a).
+--
+-- BACKGROUND: the `dropped` status backed an "Abandon game" capability that was
+-- never requested — Claude Code introduced it on its own and it self-perpetuated:
+-- the writable status value kept re-justifying a danger-zone button, so removing
+-- the button alone never stuck. This migration kills the CONCEPT in the data model
+-- so it cannot regenerate. Do NOT re-add a drop/abandon/archive-game status.
+--
+-- The app-layer removal (the Abandon/Restore UI, the `dropped` value in the
+-- games.setStatus Zod enum, and the leaderboard read-filters / `dropped` payload
+-- field) ships in the same change. This file is the DB half:
+--
+--   1. Delete any existing `dropped` games. (Zach confirmed there is no
+--      "abandoned-but-kept" state to preserve — see the spec.) Two such games
+--      existed in BBMI 2026 at authoring time; they are removed here, their child
+--      rows cascading via ON DELETE CASCADE. Idempotent: a no-op if none remain.
+--   2. Tighten games_status_check to the three live lifecycle states. This is why
+--      step 1 must run first — the constraint cannot be added while a `dropped`
+--      row exists.
+--   3. Recreate the two per-game reset CORES (migration 066) WITHOUT their
+--      now-dead `status <> 'dropped'` guard. With `dropped` unrepresentable, the
+--      guard is provably moot; dropping it removes the last in-DB reference to the
+--      concept. Behavior-preserving (no row can satisfy `status = 'dropped'`).
+
+-- ── 1. Remove existing dropped games (children cascade) ──────────────────────
+DELETE FROM public.games WHERE status = 'dropped';
+
+-- ── 2. Tighten the status CHECK constraint ───────────────────────────────────
+ALTER TABLE public.games DROP CONSTRAINT IF EXISTS games_status_check;
+ALTER TABLE public.games ADD CONSTRAINT games_status_check
+  CHECK (status = ANY (ARRAY['pending'::text, 'active'::text, 'complete'::text]));
+
+-- ── 3. Reset cores without the dead `<> 'dropped'` guard ─────────────────────
+-- Bodies are migration 066's verbatim, minus `AND status <> 'dropped'` on the
+-- games-row UPDATEs. The DELETEs were already unconditional by game_id; the §E-1
+-- per-match point-value CASE is unchanged.
+CREATE OR REPLACE FUNCTION public._reset_game_scoring(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  -- Results + raw scores (all game types that score).
+  DELETE FROM public.game_results WHERE game_id = p_game_id;
+  DELETE FROM public.score_entries WHERE game_id = p_game_id;
+
+  -- Match-play RESULT columns only — keep the pairings (side_a/side_b). No-op for
+  -- non-match types (no game_matches rows).
+  UPDATE public.game_matches
+    SET result = NULL, margin = NULL, status = 'pending'
+    WHERE game_id = p_game_id;
+
+  -- Unscored lifecycle: active/complete → pending, corrections closed.
+  -- scoring_enabled KEPT (re-scoreable).
+  UPDATE public.games
+    SET status = 'pending', corrections_open = false
+    WHERE id = p_game_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public._reset_game_to_skeleton(p_game_id text)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO ''
+AS $$
+BEGIN
+  -- Built ON the scoring core — NOT reimplemented (results can't outlive config).
+  PERFORM public._reset_game_scoring(p_game_id);
+
+  -- Config rows: pairings, roster, foursomes/pairs. (game_matches results were
+  -- already nulled above; here the rows go entirely.) Unconditional by game_id.
+  DELETE FROM public.game_matches WHERE game_id = p_game_id;
+  DELETE FROM public.game_participants WHERE game_id = p_game_id;
+  DELETE FROM public.play_groups WHERE game_id = p_game_id;
+
+  -- Per-game config columns. Point VALUE survives (identity): for placement games
+  -- clear only the SPLIT (points_distribution → NULL, keep points_total); a
+  -- per-match distribution holds the value itself, so it is kept untouched.
+  UPDATE public.games
+    SET course_id = NULL,
+        scorecard_schema = NULL,
+        modifiers = '{}'::jsonb,
+        rules_for_today = NULL,
+        competition_format = NULL,
+        pairings_published_at = NULL,
+        scoring_enabled = false,
+        points_distribution = CASE
+          WHEN points_distribution->>'type' = 'placement' THEN NULL
+          ELSE points_distribution
+        END
+    WHERE id = p_game_id;
+END;
+$$;


### PR DESCRIPTION
Follow-up corrections to the merged #512 lock/delegate work — the lock worked but didn't communicate well, plus Danger Zone cleanup and removing Abandon for good. The two "report-first" gates (§6a, §7) were reported and resolved before changing.

## Toggle (`GameManagementPanel`)
- **§1 One signal** — the inactive segment is now ALWAYS muted grey, never teal. Teal fill appears ONLY on the active Scoring segment in scoring mode (killed the inactive-segment teal that made setup mode read as "scoring active"). Verified dark + light.
- **§2 No auto-navigate** — enabling scoring flips the toggle IN PLACE (removed `closeConfig()` from `commitReady`/`handleEnable` across match/stroke/rack/non-golf). The live banner + locks update where you are; the back arrow returns to the game page (history entry intact — verified in-browser).

## Locked panels (§3, Option B)
In scoring mode the game-altering `ChecklistRow`s + button-rows dim and swap their chevron for a **lock icon** (kills the false expand affordance). Wired across all four formats. Rules of the Day stays editable; the toggle stays active.

## Sections (§4 / §5)
- **GAME MANAGEMENT** `ZoneHeader` above the toggle on the match page (the panel's internal caption is suppressed via `hideLabel` to avoid a double label).
- **RULES OF THE DAY** gains the divider rule that SETTINGS/OPTIONS already had.

## Rules of the Day (§8)
The textarea is now a bordered card **panel** (surface + border + padding) so it reads as a peer of the Matches/Course/Points card-rows.

## Danger Zone (§6)
Adopts the trip danger-zone pattern — each action is a **row** (icon-square + label + one-line description + chevron) → focused confirm sheet (shared `DangerRow` updated; propagates to the competition danger zone too). **THREE actions only**. Stays disabled wholesale in scoring mode.

## Kill Abandon at the source (§6a)
The `dropped` status was a CC-introduced concept that kept re-justifying the button — removed **root-first**:
- **migration 069** — delete `dropped` games, tighten `games_status_check` to `pending/active/complete`, drop the now-dead `<> 'dropped'` guard from the per-game reset cores.
- removed `dropped` from `games.setStatus`'s Zod enum, the `competitions.leaderboard` `dropped` payload field + every read-filter (`competitionLeaderboard`, `CompetitionLeaderboard`, `CompetitionHeader`, `CompetitionGamesPanel`, `ScheduleTab`), and the Abandon/Restore UI.
- updated d1/d2 tests; removed the dropped-exclusion specs.

**Do not re-add a drop/abandon/archive-game concept.** The 2 live `dropped` games (BBMI 2026 test data) were deleted with approval; the migration's delete is therefore an idempotent no-op, with the constraint + function changes applying on push.

## §7 — panel-background-on-expand (diagnosis only)
Diagnosed as **intended per-row elevation** (`card → card-raised` on open), correctly scoped to the row — no container bleed. Left as-is.

## E2E
`critical-path` + `match-play` updated for the in-place enable flow (wait for the `scoring-lock-banner`, then the back arrow → game page) since enabling no longer auto-navigates.

## Verification
- `tsc` + lint clean; **Vitest 811 pass** (3 pre-existing date-flake failures in `tripStatus.test.ts`, confirmed failing on clean `main`, unrelated — flagged separately).
- Browser eye-verified dark + light across the match and `GameConfigurationView` hosts: toggle, locks, labels, Rules chrome, and the 3-row danger zone with **no Abandon anywhere**.
- The full automated Playwright run was blocked locally by Supabase auth in `auth.setup` (environmental); CI runs the suite in a clean prebuilt environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)