### PR TITLE
Team/Roster redesign Phase A — consolidated Edit Team modal + canonical roster order

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -140,13 +140,16 @@ who's in, what they're called, what role they hold — is the Owner's.
 | View competition / teams / events / leaderboard | ✓ | ✓ | ✓ | `*.list` / `getByTrip` |
 | Create / edit competition | ✓ | ✓ | — | `competitions.create` / `update` |
 | Delete competition | ✓ | — | — | `competitions.delete` *(Owner)* |
-| Create / edit teams | ✓ | ✓ | — | `teams.create` / `update` |
+| Create a team | ✓ | ✓ | — | `teams.create` *(co-admin)* |
+| **Edit team identity** (name / short / color) | ✓ | **—** | **captain of *that* team** | `teams.update` *(Owner or that team's captain — **not** a plain Organizer; mig 065)* |
 | Delete a team | ✓ | — | — | `teams.delete` *(Owner)* |
 | Create / edit / reorder / delete events | ✓ | ✓ | — | `events.*` |
 | Link event ↔ agenda item | ✓ | ✓ | — | `events.linkToAgendaItem` |
 | Set point distributions / placements (scoring) | ✓ | ✓ | — | `events.setPointDistributions` / `setPlacements` |
 | Assign member to a team | ✓ | ✓ | — | `teamAssignments.assign` |
 | Remove a team assignment | ✓ | — | — | `teamAssignments.remove` *(Owner)* |
+| Reorder a team's roster (canonical order) | ✓ | — | — | `teamAssignments.reorder` *(Owner)* |
+| Appoint / clear a team captain | ✓ | — | — | `teamAssignments.setCaptain` *(Owner)* |
 | **Edit / configure a game** (status incl. drop, points distribution, course, participants) | ✓ | ✓ | **game organizer of *that* game** | `games.update` / `setStatus` / `setPointsDistribution` / `applyCourse` / `addParticipants` |
 | **Enter a game's results** (manual placement; finish/compute) | ✓ | ✓ | **game organizer of *that* game** | `games.setManualResults` / `finish` |
 | **RUN: post results / open score correction** | ✓ | **—** | **game organizer of *that* game** | `games.post` / `openCorrection` *(Owner or game-delegate only — **not** a plain Organizer)* |
@@ -165,6 +168,20 @@ who's in, what they're called, what role they hold — is the Owner's.
 > controls with an explanation (the add path stays live). Leaderboard standings are
 > never gated — they stay visible to all roles. Mid-competition trades are parked in
 > DEFERRED (durable per-score attribution); this lock is the BBMI-safe stance.
+
+> **Team captain — an IDENTITY tier, not a roster grant (mig 064/065).** A team's
+> captain (one per team, `team_assignments.is_captain`, even a plain trip Member)
+> may edit **only their own team's IDENTITY** — name, short name, color
+> (`teams.update`, admitted at both tRPC `requireTeamIdentityEdit` and the `teams`
+> UPDATE RLS). This deliberately **drops Organizer** from identity editing and
+> adds the captain. **Roster/structure stays OWNER-ONLY** — add/remove
+> (`teamAssignments.assign`/`remove`), reorder (`reorder`), and appointing the
+> captain itself (`setCaptain`) are not granted to a captain (a captain can't
+> sub-appoint). Captain-led roster management is parked for the future
+> captain's-draft feature. The client mirrors this exactly: `useCanEditTeam`
+> resolves identity edit = Owner OR this-team's-captain; roster controls gate on
+> `isOwner`. The consolidated Edit Team modal surfaces all three tiers — owner
+> (full), captain (identity editable, roster read-only), member (read-only).
 
 > **Per-game organizer delegation (Slice D1 §8).** Game edit/configure/enter-results
 > resolves to **`canEdit || isGameOrganizer(gameId)`** — trip Owner/Organizer, OR a

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -167,6 +167,16 @@ export default function RackNStackPage() {
   }, [teamsQ.data, teamIds]);
   const colorForUser = (id: string) => (teamOf.get(id) === "A" ? teamMeta.A.color : teamMeta.B.color);
 
+  // Canonical roster order (mig 069): assignQ.data arrives ordered by
+  // (team_id, sort_order), so its index IS the canonical order — team A's roster
+  // then team B's, each in the order set in the Edit Team modal. The handicap
+  // roster derives its display order from this, not from foursome/participant order.
+  const rosterOrder = useMemo(() => {
+    const m = new Map<string, number>();
+    (assignQ.data ?? []).forEach((a, i) => m.set(a.user_id as string, i));
+    return m;
+  }, [assignQ.data]);
+
   const hasCompetition = !!competitionId && teamIds.length >= 2;
 
   // ── Scorecard + live values ──────────────────────────────────────────
@@ -228,18 +238,21 @@ export default function RackNStackPage() {
 
   const handicapPlayers: HandicapPlayer[] = useMemo(
     () =>
-      participants.map((p) => {
-        const id = p.user_id as string;
-        return {
-          id,
-          name: nameOf.get(id) ?? "Player",
-          avatarIcon: avatarOf.get(id) ?? null,
-          teamColor: teamOf.get(id) ? colorForUser(id) : null,
-          strokes: handicapOf.get(id) ?? 0,
-        };
-      }),
+      participants
+        .map((p) => {
+          const id = p.user_id as string;
+          return {
+            id,
+            name: nameOf.get(id) ?? "Player",
+            avatarIcon: avatarOf.get(id) ?? null,
+            teamColor: teamOf.get(id) ? colorForUser(id) : null,
+            strokes: handicapOf.get(id) ?? 0,
+          };
+        })
+        // Canonical roster order — not the foursome/participant order they arrive in.
+        .sort((x, y) => (rosterOrder.get(x.id) ?? Infinity) - (rosterOrder.get(y.id) ?? Infinity)),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [participants, nameOf, avatarOf, teamOf, teamMeta, handicapOf]
+    [participants, nameOf, avatarOf, teamOf, teamMeta, handicapOf, rosterOrder]
   );
 
   // ── Handlers ─────────────────────────────────────────────────────────

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -167,7 +167,7 @@ export default function RackNStackPage() {
   }, [teamsQ.data, teamIds]);
   const colorForUser = (id: string) => (teamOf.get(id) === "A" ? teamMeta.A.color : teamMeta.B.color);
 
-  // Canonical roster order (mig 069): assignQ.data arrives ordered by
+  // Canonical roster order (mig 070): assignQ.data arrives ordered by
   // (team_id, sort_order), so its index IS the canonical order — team A's roster
   // then team B's, each in the order set in the Edit Team modal. The handicap
   // roster derives its display order from this, not from foursome/participant order.

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -9,6 +9,7 @@ import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
 import { RostersOverlay } from "./RostersOverlay";
 import { TeamSheet, type Team } from "./TeamsPanel";
+import { isTeamCaptain } from "@/hooks/useCanEditTeam";
 import { GameSheet } from "./CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 
@@ -101,11 +102,11 @@ export function CompetitionFace({
   const { data: teamAssignmentsList = [] } = trpc.teamAssignments.list.useQuery({ tripId, competitionId: competition.id }, STRUCTURE_QUERY);
   const { data: me } = trpc.users.getMe.useQuery(undefined, STRUCTURE_QUERY);
 
+  // Identity-edit gate = owner OR the captain of THAT team. Shares the single
+  // captain-resolution (isTeamCaptain) with TeamSheet + TeamsPanel so the rule
+  // can't drift per-surface (Part 1 dedup).
   const canEditTeamIdentity = (teamId: string) =>
-    isOwner ||
-    (teamAssignmentsList as { user_id: string; team_id: string; is_captain?: boolean }[]).some(
-      (a) => a.user_id === me?.id && a.team_id === teamId && a.is_captain
-    );
+    isOwner || isTeamCaptain(teamAssignmentsList as { user_id: string; team_id: string; is_captain?: boolean }[], me?.id, teamId);
 
   // Owner / captain-of-that-team → standalone identity editor. Otherwise the
   // graceful read-only path: open the Rosters overlay (see the lineup, no edit).

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -9,7 +9,6 @@ import { CompetitionLeaderboard } from "./CompetitionLeaderboard";
 import { CompetitionSettings } from "./CompetitionSettings";
 import { RostersOverlay } from "./RostersOverlay";
 import { TeamSheet, type Team } from "./TeamsPanel";
-import { isTeamCaptain } from "@/hooks/useCanEditTeam";
 import { GameSheet } from "./CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 
@@ -95,28 +94,16 @@ export function CompetitionFace({
   // edit-reopen are retired (the page's gear → settings page is the edit home now,
   // like golf). So this board no longer scores/edits non-golf games inline.
 
-  // Team-identity editing from a leaderboard name tap (PR b2): the standalone
-  // editor needs full team rows; the captain check needs assignments + the viewer.
-  // All member-visible + faceBootstrap-seeded (cache hits) STRUCTURE, so kept.
+  // The leaderboard short-name tap opens the consolidated Edit Team modal for
+  // EVERYONE — the modal self-gates via useCanEditTeam (owner: full; captain:
+  // identity editable, roster read-only; member: all read-only). We only need
+  // the team rows here to resolve the tapped id. faceBootstrap-seeded STRUCTURE
+  // (cache hit).
   const { data: teamsList = [] } = trpc.teams.list.useQuery({ tripId, competitionId: competition.id }, STRUCTURE_QUERY);
-  const { data: teamAssignmentsList = [] } = trpc.teamAssignments.list.useQuery({ tripId, competitionId: competition.id }, STRUCTURE_QUERY);
-  const { data: me } = trpc.users.getMe.useQuery(undefined, STRUCTURE_QUERY);
 
-  // Identity-edit gate = owner OR the captain of THAT team. Shares the single
-  // captain-resolution (isTeamCaptain) with TeamSheet + TeamsPanel so the rule
-  // can't drift per-surface (Part 1 dedup).
-  const canEditTeamIdentity = (teamId: string) =>
-    isOwner || isTeamCaptain(teamAssignmentsList as { user_id: string; team_id: string; is_captain?: boolean }[], me?.id, teamId);
-
-  // Owner / captain-of-that-team → standalone identity editor. Otherwise the
-  // graceful read-only path: open the Rosters overlay (see the lineup, no edit).
   const handleEditTeam = (teamId: string) => {
-    if (canEditTeamIdentity(teamId)) {
-      const team = (teamsList as Team[]).find((t) => t.id === teamId);
-      if (team) setEditingTeam(team);
-    } else {
-      setRostersOpen(true);
-    }
+    const team = (teamsList as Team[]).find((t) => t.id === teamId);
+    if (team) setEditingTeam(team);
   };
   // ── Go live / back to setup (visibility switch, NOT a data lock) ───────────
   // Centralized here (not in the header) so going live can also flip the
@@ -240,8 +227,10 @@ export function CompetitionFace({
         tripId={tripId}
         canEdit={canEdit}
         onAddGame={() => setAddingGame(true)}
-        // A hero team-name tap → STANDALONE identity editor (owner / captain of
-        // that team); a non-permitted tap falls to the read-only overlay.
+        // A hero team-short-name tap → the consolidated Edit Team modal (the
+        // team-management home). It self-gates by role: owner edits everything,
+        // captain edits identity (roster read-only), a plain member sees it
+        // read-only.
         onEditTeam={handleEditTeam}
       />
 
@@ -280,9 +269,10 @@ export function CompetitionFace({
         />
       )}
 
-      {/* Standalone team-identity editor — opened by a leaderboard team-name tap
-          for the owner / that team's captain (PR b2). Reuses TeamSheet directly,
-          no overlay. The update is captain-gated server-side. */}
+      {/* Consolidated Edit Team modal — opened by a leaderboard short-name tap.
+          The team-management home: identity + roster, self-gated by role
+          (useCanEditTeam). showRoster defaults true here (the standalone home);
+          the in-overlay per-card pencil passes false. */}
       {editingTeam && (
         <TeamSheet
           tripId={tripId}

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import {
   ArrowRight,
+  ChevronDown,
+  ChevronUp,
   GripVertical,
   Pencil,
   Plus,
@@ -16,7 +18,7 @@ import {
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Avatar } from "@/components/Avatar";
-import { isTeamCaptain } from "@/hooks/useCanEditTeam";
+import { isTeamCaptain, useCanEditTeam } from "@/hooks/useCanEditTeam";
 
 interface Props {
   competitionId: string;
@@ -55,6 +57,7 @@ interface Assignment {
   user_id: string;
   team_id: string;
   is_captain?: boolean;
+  sort_order?: number;
 }
 
 interface Member {
@@ -181,6 +184,11 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
       // bootstrap-seeded competitions.leaderboard cache — invalidate it too so
       // the leaderboard reflects the change without a hard refresh.
       utils.competitions.leaderboard.invalidate(queryKey);
+      // faceBootstrap ALSO seeds teamAssignments.list (#10): the consolidated
+      // TeamSheet opens OUTSIDE the LiveFace re-seed path, so re-resolve the
+      // bootstrap or the board reads stale until the 30s poll. (setCaptain already
+      // does this; assign/remove/reorder carry it too for consistency.)
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     },
   });
 
@@ -204,6 +212,37 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
       // Removing a player changes team sizes → the leaderboard roll-up's
       // per_match points. Refresh the board's seeded cache (see `assign`).
       utils.competitions.leaderboard.invalidate(queryKey);
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+    },
+  });
+
+  // reorder (Part 3) — optimistic: rewrite sort_order for this team per the new
+  // order; other teams untouched. The roster lists derive display order from
+  // sort_order, so the rows resequence instantly. faceBootstrap seeds the list,
+  // so re-resolve it (#10) — the order survives an overlay/modal close + reopen.
+  const reorder = trpc.teamAssignments.reorder.useMutation({
+    onMutate: async (vars) => {
+      await utils.teamAssignments.list.cancel(queryKey);
+      const previous = utils.teamAssignments.list.getData(queryKey);
+      const orderIndex = new Map(vars.orderedUserIds.map((id, i) => [id, i]));
+      utils.teamAssignments.list.setData(queryKey, (old) => {
+        const list = (old as Assignment[] | undefined) ?? [];
+        return list.map((a) =>
+          a.team_id === vars.teamId && orderIndex.has(a.user_id)
+            ? { ...a, sort_order: orderIndex.get(a.user_id)! }
+            : a
+        ) as never;
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, ctxRollback) => {
+      if (ctxRollback?.previous) {
+        utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
+      }
+    },
+    onSettled: () => {
+      utils.teamAssignments.list.invalidate(queryKey);
+      utils.competitions.faceBootstrap.invalidate({ tripId });
     },
   });
 
@@ -236,7 +275,7 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
     },
   });
 
-  return { assign, remove, setCaptain };
+  return { assign, remove, setCaptain, reorder };
 }
 
 // ── TeamsPanel ──────────────────────────────────────────────────────────────
@@ -463,6 +502,10 @@ export function TeamsPanel({
           competitionId={competitionId}
           team={editingTeam}
           existingTeamNames={teamsTyped.map((t) => t.name.toLowerCase())}
+          // Inside the Rosters overlay the team CARD already owns roster mgmt, so
+          // the per-card pencil opens identity-only. The consolidated roster
+          // section lives on the STANDALONE TeamSheet (leaderboard short-name tap).
+          showRoster={false}
           onClose={() => {
             setCreating(false);
             setEditingTeam(null);
@@ -1187,6 +1230,7 @@ export function TeamSheet({
   competitionId,
   team,
   existingTeamNames,
+  showRoster = true,
   onClose,
 }: {
   tripId: string;
@@ -1196,10 +1240,26 @@ export function TeamSheet({
    *  collisions when rolling a name from a theme. The current team's own
    *  name is excluded by the caller in edit mode. */
   existingTeamNames: string[];
+  /** Render the consolidated roster section (edit mode only). Default true —
+   *  the STANDALONE TeamSheet (leaderboard short-name tap) is the full
+   *  team-management home. The in-overlay per-card pencil passes false: the
+   *  team card already owns roster mgmt there. */
+  showRoster?: boolean;
   onClose: () => void;
 }) {
   const isEdit = !!team;
   const utils = trpc.useUtils();
+
+  // Three-tier gating (mirrors the server). IDENTITY (name/short/color) = owner
+  // OR this team's captain; ROSTER (add/remove/reorder/captain) = owner only.
+  // Create mode has no team yet — only the owner can reach it (the opener gates),
+  // so identity is editable there.
+  const { canEdit: canEditIdentity, isOwner } = useCanEditTeam(
+    tripId,
+    competitionId,
+    team?.id ?? null
+  );
+  const identityEditable = isEdit ? canEditIdentity : true;
 
   const [name, setName] = useState(team?.name ?? "");
   const [shortName, setShortName] = useState(team?.short_name ?? "");
@@ -1211,6 +1271,17 @@ export function TeamSheet({
   });
   const [suggesterOpen, setSuggesterOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Roster section data (edit mode). Deduped against any other observer of the
+  // same query keys (the Rosters overlay / leaderboard), so these are cache hits.
+  const { data: rosterMembers = [] } = trpc.tripMembers.list.useQuery(
+    { tripId },
+    { enabled: isEdit && showRoster }
+  );
+  const { data: rosterAssignments = [] } = trpc.teamAssignments.list.useQuery(
+    { tripId, competitionId },
+    { enabled: isEdit && showRoster && !!competitionId }
+  );
 
   // The leaderboard roll-up (competitions.leaderboard) bakes in each team's
   // color / name / short_name, and the board renders from that bootstrap-seeded
@@ -1334,7 +1405,9 @@ export function TeamSheet({
               onChange={(e) => handleNameChange(e.target.value)}
               placeholder="e.g. Team Hammer"
               maxLength={100}
-              className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+              disabled={!identityEditable}
+              readOnly={!identityEditable}
+              className="w-full rounded-lg px-3 py-2 text-sm outline-none disabled:opacity-70"
               style={{
                 background: "var(--color-bt-card-raised)",
                 color: "var(--color-bt-text)",
@@ -1342,7 +1415,7 @@ export function TeamSheet({
               }}
               data-testid="team-name-input"
             />
-            {!suggesterOpen && !name.trim() && (
+            {identityEditable && !suggesterOpen && !name.trim() && (
               <button
                 type="button"
                 onClick={() => setSuggesterOpen(true)}
@@ -1405,7 +1478,9 @@ export function TeamSheet({
               }}
               placeholder="HAM"
               maxLength={4}
-              className="w-full rounded-lg px-3 py-2 text-sm uppercase outline-none"
+              disabled={!identityEditable}
+              readOnly={!identityEditable}
+              className="w-full rounded-lg px-3 py-2 text-sm uppercase outline-none disabled:opacity-70"
               style={{
                 background: "var(--color-bt-card-raised)",
                 color: "var(--color-bt-text)",
@@ -1414,27 +1489,42 @@ export function TeamSheet({
             />
           </Field>
 
-          <Field label="Color">
-            <div className="flex flex-wrap gap-2">
-              {TEAM_COLORS.map((c, i) => (
-                <button
-                  key={c.color}
-                  type="button"
-                  onClick={() => setPaletteIdx(i)}
-                  aria-label={`${c.label}${paletteIdx === i ? " (selected)" : ""}`}
-                  className="h-8 w-8 rounded-full transition-transform"
-                  style={{
-                    background: c.color,
-                    transform: paletteIdx === i ? "scale(1.15)" : "scale(1)",
-                    border:
-                      paletteIdx === i
-                        ? "2px solid var(--color-bt-text)"
-                        : "1px solid var(--color-bt-border)",
-                  }}
+          {/* Color — a PICKER only when identity is editable (owner / captain).
+              A read-only viewer (plain member) sees the team's color as a static
+              swatch, never a picker (spec: member = no color picker). */}
+          {identityEditable ? (
+            <Field label="Color">
+              <div className="flex flex-wrap gap-2">
+                {TEAM_COLORS.map((c, i) => (
+                  <button
+                    key={c.color}
+                    type="button"
+                    onClick={() => setPaletteIdx(i)}
+                    aria-label={`${c.label}${paletteIdx === i ? " (selected)" : ""}`}
+                    className="h-8 w-8 rounded-full transition-transform"
+                    style={{
+                      background: c.color,
+                      transform: paletteIdx === i ? "scale(1.15)" : "scale(1)",
+                      border:
+                        paletteIdx === i
+                          ? "2px solid var(--color-bt-text)"
+                          : "1px solid var(--color-bt-border)",
+                    }}
+                  />
+                ))}
+              </div>
+            </Field>
+          ) : (
+            team && (
+              <Field label="Color">
+                <span
+                  className="inline-block h-7 w-7 rounded-full"
+                  style={{ background: team.color, border: "1px solid var(--color-bt-border)" }}
+                  aria-label="Team color"
                 />
-              ))}
-            </div>
-          </Field>
+              </Field>
+            )
+          )}
 
           {error && (
             <p className="text-xs" style={{ color: "var(--color-bt-danger)" }}>
@@ -1442,19 +1532,369 @@ export function TeamSheet({
             </p>
           )}
 
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={create.isPending || update.isPending}
-            className="w-full rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
-            style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
-          >
-            {isEdit ? "Save Team" : "Add Team"}
-          </button>
+          {identityEditable && (
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={create.isPending || update.isPending}
+              className="w-full rounded-xl py-3 text-sm font-semibold disabled:opacity-50"
+              style={{ background: "var(--color-bt-accent)", color: "var(--color-bt-base)" }}
+            >
+              {isEdit ? "Save Team" : "Add Team"}
+            </button>
+          )}
+
+          {/* Consolidated roster section — the team-management home (edit mode).
+              Owner gets full controls; captain/member see it read-only. */}
+          {isEdit && showRoster && team && (
+            <TeamSheetRoster
+              tripId={tripId}
+              competitionId={competitionId}
+              team={team}
+              canManage={isOwner}
+              members={rosterMembers as Member[]}
+              assignments={rosterAssignments as Assignment[]}
+            />
+          )}
         </div>
       </div>
     </div>
     </ScrollLock>
+  );
+}
+
+// ── TeamSheetRoster ─────────────────────────────────────────────────────────
+// The consolidated roster section of the STANDALONE Edit Team modal: this team's
+// players in CANONICAL order (sort_order). Owner (canManage) gets add / remove /
+// reorder / captain ★. Captain + plain member see it READ-ONLY (names + the
+// captain ★). Reorder is ↑↓ buttons (mobile-first — they work on touch, which
+// native HTML5 drag does not) PLUS grip-drag on desktop (lg+), mirroring this
+// file's desktop-drag / mobile-fallback pattern.
+
+function TeamSheetRoster({
+  tripId,
+  competitionId,
+  team,
+  canManage,
+  members,
+  assignments,
+}: {
+  tripId: string;
+  competitionId: string;
+  team: Team;
+  /** Owner only — roster mutations (add/remove/reorder/captain) stay owner-scoped. */
+  canManage: boolean;
+  members: Member[];
+  assignments: Assignment[];
+}) {
+  const { assign, remove, setCaptain, reorder } = useTeamAssignmentMutations(
+    tripId,
+    competitionId
+  );
+  // Removals are server-blocked once scoring starts (C1) — disable the × so it
+  // isn't a surprise. Adds + reorder stay live (reorder orphans no one).
+  const { data: removalsLocked = false } = trpc.teamAssignments.rosterLocked.useQuery(
+    { tripId, competitionId },
+    { enabled: !!competitionId }
+  );
+
+  const memberById = useMemo(() => {
+    const map = new Map<string, Member>();
+    for (const m of members) map.set(m.user_id ?? m.memberId, m);
+    return map;
+  }, [members]);
+
+  // This team's roster in canonical order — sorted defensively by sort_order in
+  // case the cache array isn't pre-sorted (optimistic patches mutate sort_order,
+  // not array position).
+  const roster = useMemo(
+    () =>
+      assignments
+        .filter((a) => a.team_id === team.id)
+        .slice()
+        .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0)),
+    [assignments, team.id]
+  );
+  const orderedIds = roster.map((a) => a.user_id);
+
+  const unassigned = useMemo(() => {
+    const assignedIds = new Set(assignments.map((a) => a.user_id));
+    return members.filter((m) => !assignedIds.has(m.user_id ?? m.memberId));
+  }, [members, assignments]);
+
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+
+  function moveTo(userId: string, toIndex: number) {
+    if (toIndex < 0 || toIndex >= orderedIds.length) return;
+    const without = orderedIds.filter((x) => x !== userId);
+    without.splice(toIndex, 0, userId);
+    if (without.every((id, i) => id === orderedIds[i])) return; // no-op
+    reorder.mutate({ tripId, competitionId, teamId: team.id, orderedUserIds: without });
+  }
+
+  return (
+    <div
+      data-testid="teamsheet-roster"
+      className="pt-2"
+      style={{ borderTop: "1px solid var(--color-bt-border)" }}
+    >
+      <h4
+        className="mb-2 text-xs font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Roster · {roster.length}
+      </h4>
+
+      {roster.length === 0 ? (
+        <p
+          className="rounded-lg px-3 py-2 text-[11px] italic"
+          style={{
+            background: "var(--color-bt-card-raised)",
+            color: "var(--color-bt-text-dim)",
+            border: "1px solid var(--color-bt-border)",
+          }}
+        >
+          No players yet.{canManage ? " Add from the crew below." : ""}
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {roster.map((a, i) => {
+            const m = memberById.get(a.user_id);
+            const name = m?.displayName ?? "Unknown";
+            return (
+              <RosterRow
+                key={a.user_id}
+                name={name}
+                avatarIcon={m?.user?.avatar_icon ?? null}
+                teamColor={team.color}
+                isCaptain={!!a.is_captain}
+                canManage={canManage}
+                index={i}
+                count={orderedIds.length}
+                removeLocked={removalsLocked}
+                onMoveUp={() => moveTo(a.user_id, i - 1)}
+                onMoveDown={() => moveTo(a.user_id, i + 1)}
+                onRemove={() => remove.mutate({ tripId, competitionId, userId: a.user_id })}
+                onToggleCaptain={() =>
+                  setCaptain.mutate({
+                    tripId,
+                    competitionId,
+                    teamId: team.id,
+                    userId: a.user_id,
+                    isCaptain: !a.is_captain,
+                  })
+                }
+                removeAriaLabel={`Remove ${name} from ${team.name}`}
+                captainAriaLabel={a.is_captain ? `Remove ${name} as captain` : `Make ${name} captain`}
+                onDragStart={canManage ? () => setDragId(a.user_id) : undefined}
+                onDropRow={
+                  canManage
+                    ? () => {
+                        if (dragId) moveTo(dragId, i);
+                        setDragId(null);
+                      }
+                    : undefined
+                }
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {/* Add player (owner) — assign an unassigned crew member to THIS team. */}
+      {canManage && unassigned.length > 0 && (
+        <div className="mt-2">
+          {!adding ? (
+            <button
+              type="button"
+              onClick={() => setAdding(true)}
+              className="inline-flex items-center gap-1.5 text-[12px] font-semibold"
+              style={{ color: "var(--color-bt-accent)" }}
+              data-testid="teamsheet-add-player"
+            >
+              <Plus size={13} />
+              Add player
+            </button>
+          ) : (
+            <div className="space-y-1">
+              <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                Tap a crew member to add
+              </p>
+              {unassigned.map((m) => {
+                const id = m.user_id ?? m.memberId;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => assign.mutate({ tripId, competitionId, userId: id, teamId: team.id })}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left"
+                    style={{
+                      background: "var(--color-bt-card-raised)",
+                      border: "1px solid var(--color-bt-border)",
+                    }}
+                    data-testid={`teamsheet-add-${id}`}
+                  >
+                    <Avatar name={m.displayName} avatarIcon={m.user?.avatar_icon ?? null} size="md" />
+                    <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--color-bt-text)" }}>
+                      {m.displayName}
+                    </span>
+                    <Plus size={14} style={{ color: "var(--color-bt-accent)" }} />
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── RosterRow ───────────────────────────────────────────────────────────────
+// One player row in the TeamSheet roster. Owner sees grip + captain ★ + ↑↓ +
+// remove ×; captain/member see name (+ the captain ★ read-only) only.
+
+function RosterRow({
+  name,
+  avatarIcon,
+  teamColor,
+  isCaptain,
+  canManage,
+  index,
+  count,
+  removeLocked,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  onToggleCaptain,
+  removeAriaLabel,
+  captainAriaLabel,
+  onDragStart,
+  onDropRow,
+}: {
+  name: string;
+  avatarIcon: string | null;
+  teamColor: string;
+  isCaptain: boolean;
+  canManage: boolean;
+  index: number;
+  count: number;
+  removeLocked: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+  onToggleCaptain: () => void;
+  removeAriaLabel: string;
+  captainAriaLabel: string;
+  onDragStart?: () => void;
+  onDropRow?: () => void;
+}) {
+  return (
+    <div
+      draggable={canManage && !!onDragStart}
+      onDragStart={
+        onDragStart
+          ? (e) => {
+              e.dataTransfer.effectAllowed = "move";
+              onDragStart();
+            }
+          : undefined
+      }
+      onDragOver={onDropRow ? (e) => e.preventDefault() : undefined}
+      onDrop={
+        onDropRow
+          ? (e) => {
+              e.preventDefault();
+              onDropRow();
+            }
+          : undefined
+      }
+      className="flex items-center gap-2 rounded-lg px-2.5 py-2"
+      style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+    >
+      {canManage && (
+        <GripVertical
+          size={14}
+          className="hidden flex-shrink-0 cursor-grab lg:block"
+          style={{ color: "var(--color-bt-text-dim)" }}
+          aria-hidden
+        />
+      )}
+      <Avatar name={name} avatarIcon={avatarIcon} teamColor={teamColor} sizePx={28} />
+      <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--color-bt-text)" }}>
+        {name}
+      </span>
+
+      {/* Captain ★ — owner taps to mark/unmark; captain/member see it read-only. */}
+      {canManage ? (
+        <button
+          type="button"
+          onClick={onToggleCaptain}
+          aria-label={captainAriaLabel}
+          aria-pressed={isCaptain}
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg"
+          style={{ color: isCaptain ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
+          data-testid="captain-toggle"
+        >
+          <Star size={15} fill={isCaptain ? "currentColor" : "none"} />
+        </button>
+      ) : (
+        isCaptain && (
+          <span
+            className="flex h-7 w-7 flex-shrink-0 items-center justify-center"
+            style={{ color: "var(--color-bt-accent)" }}
+            aria-label={`${name} is captain`}
+            title="Captain"
+          >
+            <Star size={15} fill="currentColor" />
+          </span>
+        )
+      )}
+
+      {/* Reorder ↑↓ (owner) — the mobile-first canonical-order control. */}
+      {canManage && (
+        <div className="flex flex-shrink-0 items-center">
+          <button
+            type="button"
+            onClick={onMoveUp}
+            disabled={index === 0}
+            aria-label={`Move ${name} up`}
+            className="flex h-7 w-6 items-center justify-center rounded-lg disabled:opacity-30"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="roster-move-up"
+          >
+            <ChevronUp size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={onMoveDown}
+            disabled={index === count - 1}
+            aria-label={`Move ${name} down`}
+            className="flex h-7 w-6 items-center justify-center rounded-lg disabled:opacity-30"
+            style={{ color: "var(--color-bt-text-dim)" }}
+            data-testid="roster-move-down"
+          >
+            <ChevronDown size={16} />
+          </button>
+        </div>
+      )}
+
+      {/* Remove × (owner) — disabled once scoring locks removals. */}
+      {canManage && (
+        <button
+          type="button"
+          onClick={removeLocked ? undefined : onRemove}
+          disabled={removeLocked}
+          aria-label={removeAriaLabel}
+          title={removeLocked ? "Locked — scoring has started. You can still add players." : undefined}
+          className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg disabled:cursor-not-allowed disabled:opacity-40"
+          style={{ color: "var(--color-bt-text-dim)" }}
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Avatar } from "@/components/Avatar";
+import { RowNumber } from "@/components/games/RowNumber";
 import { isTeamCaptain, useCanEditTeam } from "@/hooks/useCanEditTeam";
 
 interface Props {
@@ -1402,6 +1403,9 @@ export function TeamSheet({
         </div>
 
         <div className="space-y-4 p-4">
+          {/* Team name (most of the row) + a narrow short-name box, side by side. */}
+          <div className="flex items-start gap-3">
+            <div className="min-w-0 flex-1">
           <Field label="Team Name" required>
             <input
               value={name}
@@ -1471,8 +1475,9 @@ export function TeamSheet({
               </div>
             )}
           </Field>
-
-          <Field label="Short Name" required helper="Used on scorecards — e.g. USA, EUR, FIRE">
+            </div>
+            <div className="flex-shrink-0" style={{ width: 92 }}>
+          <Field label="Short" required>
             <input
               value={shortName}
               onChange={(e) => {
@@ -1483,7 +1488,7 @@ export function TeamSheet({
               maxLength={4}
               disabled={!identityEditable}
               readOnly={!identityEditable}
-              className="w-full rounded-lg px-3 py-2 text-sm uppercase outline-none disabled:opacity-70"
+              className="w-full rounded-lg px-2 py-2 text-center text-sm uppercase outline-none disabled:opacity-70"
               style={{
                 background: "var(--color-bt-card-raised)",
                 color: "var(--color-bt-text)",
@@ -1491,6 +1496,8 @@ export function TeamSheet({
               }}
             />
           </Field>
+            </div>
+          </div>
 
           {/* Color — a PICKER only when identity is editable (owner / captain).
               A read-only viewer (plain member) sees the team's color as a static
@@ -1816,14 +1823,18 @@ function RosterRow({
       className="flex items-center gap-2 rounded-lg px-2.5 py-2"
       style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
     >
+      {/* Grip — the desktop drag handle. ALWAYS visible (was lg-gated, which made
+          it vanish below 1024px even though the fixed-width modal never resizes). */}
       {canManage && (
         <GripVertical
           size={14}
-          className="hidden flex-shrink-0 cursor-grab lg:block"
+          className="flex-shrink-0 cursor-grab"
           style={{ color: "var(--color-bt-text-dim)" }}
           aria-hidden
         />
       )}
+      {/* Row index — quiet table-number column, like the match pickers. */}
+      <RowNumber number={index + 1} className="flex-shrink-0" style={{ width: 16 }} />
       <Avatar name={name} avatarIcon={avatarIcon} teamColor={teamColor} sizePx={28} />
       <span className="min-w-0 flex-1 truncate text-sm" style={{ color: "var(--color-bt-text)" }}>
         {name}

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -617,12 +617,15 @@ function TeamCard({
 }) {
   const [dragOver, setDragOver] = useState(false);
 
-  const teamMemberIds = assignments
+  // Canonical roster order (mig 069): order this team's rows by sort_order, not
+  // the incidental tripMembers (joined_at) order. Map the ordered assignments to
+  // their Member rows so the card shows the SAME order as every other chooser.
+  const teamMembers = assignments
     .filter((a) => a.team_id === team.id)
-    .map((a) => a.user_id);
-  const teamMembers = members.filter((m) =>
-    teamMemberIds.includes(m.user_id ?? m.memberId)
-  );
+    .slice()
+    .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+    .map((a) => members.find((m) => (m.user_id ?? m.memberId) === a.user_id))
+    .filter((m): m is Member => !!m);
 
   // Optimistic — the dropped player needs to land in the target team
   // instantly, not after the server round-trip. `remove` powers the

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Avatar } from "@/components/Avatar";
+import { isTeamCaptain } from "@/hooks/useCanEditTeam";
 
 interface Props {
   competitionId: string;
@@ -289,9 +290,11 @@ export function TeamsPanel({
   // THAT team — gates the per-card pencil/header (PR b2). The leaderboard
   // team-name tap opens a STANDALONE editor instead (CompetitionFace), so the
   // overlay only edits via its own pencil.
-  const isCaptainOf = (teamId: string) =>
-    !!me && assignmentsTyped.some((a) => a.user_id === me.id && a.team_id === teamId && a.is_captain);
-  const canEditIdentity = (teamId: string) => canEdit || isCaptainOf(teamId);
+  // Identity edit = owner (canEdit prop) OR the captain of THAT team. Routes
+  // through the shared isTeamCaptain so the captain rule lives in one place
+  // (Part 1 dedup) — TeamsPanel maps over teams, so it uses the predicate (not
+  // the useCanEditTeam hook, which React forbids calling per row).
+  const canEditIdentity = (teamId: string) => canEdit || isTeamCaptain(assignmentsTyped, me?.id, teamId);
 
   const statusText = !teamsExist
     ? "Not set up"

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -617,7 +617,7 @@ function TeamCard({
 }) {
   const [dragOver, setDragOver] = useState(false);
 
-  // Canonical roster order (mig 069): order this team's rows by sort_order, not
+  // Canonical roster order (mig 070): order this team's rows by sort_order, not
   // the incidental tripMembers (joined_at) order. Map the ordered assignments to
   // their Member rows so the card shows the SAME order as every other chooser.
   const teamMembers = assignments

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -19,6 +19,7 @@ import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Avatar } from "@/components/Avatar";
 import { RowNumber } from "@/components/games/RowNumber";
+import { DragHandle } from "@/components/games/DragHandle";
 import { isTeamCaptain, useCanEditTeam } from "@/hooks/useCanEditTeam";
 
 interface Props {
@@ -1632,15 +1633,45 @@ function TeamSheetRoster({
     return members.filter((m) => !assignedIds.has(m.user_id ?? m.memberId));
   }, [members, assignments]);
 
-  const [dragId, setDragId] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
 
+  // Drag-to-reorder — mirrors the match-assignments panel: the GRIP arms the row
+  // (so the buttons inside stay tappable), an accent insertion LINE shows where it
+  // will land (`ins` = the 0..length slot), and drop persists via reorder. The ↑↓
+  // buttons stay as the touch fallback (HTML5 drag doesn't fire on touch).
+  const [dragState, setDragState] = useState<{ from: number; ins: number | null } | null>(null);
+  const [armedIdx, setArmedIdx] = useState<number | null>(null);
+
+  function persistOrder(next: string[]) {
+    if (next.every((id, i) => id === orderedIds[i])) return; // no-op
+    reorder.mutate({ tripId, competitionId, teamId: team.id, orderedUserIds: next });
+  }
+  // ↑↓ buttons: move one slot.
   function moveTo(userId: string, toIndex: number) {
     if (toIndex < 0 || toIndex >= orderedIds.length) return;
     const without = orderedIds.filter((x) => x !== userId);
     without.splice(toIndex, 0, userId);
-    if (without.every((id, i) => id === orderedIds[i])) return; // no-op
-    reorder.mutate({ tripId, competitionId, teamId: team.id, orderedUserIds: without });
+    persistOrder(without);
+  }
+  // Drag: insert the dragged row at slot `ins` (0..length), accounting for the
+  // removal shift — identical to the match panel's reorderTo.
+  function reorderTo(from: number, ins: number) {
+    if (from < 0 || from >= orderedIds.length) return;
+    if (ins === from || ins === from + 1) return; // own slot — no-op
+    const copy = orderedIds.slice();
+    const [moved] = copy.splice(from, 1);
+    const target = Math.max(0, Math.min(copy.length, ins > from ? ins - 1 : ins));
+    copy.splice(target, 0, moved);
+    persistOrder(copy);
+  }
+  function onCardDragOver(i: number, clientY: number, rect: DOMRect) {
+    setDragState((s) => {
+      if (!s) return s;
+      const isTop = clientY < rect.top + rect.height / 2;
+      let ins: number | null = isTop ? i : i + 1;
+      if (ins === s.from || ins === s.from + 1) ins = null; // adjacent = no-op, hide line
+      return s.ins === ins ? s : { ...s, ins };
+    });
   }
 
   return (
@@ -1697,15 +1728,29 @@ function TeamSheetRoster({
                 }
                 removeAriaLabel={`Remove ${name} from ${team.name}`}
                 captainAriaLabel={a.is_captain ? `Remove ${name} as captain` : `Make ${name} captain`}
-                onDragStart={canManage ? () => setDragId(a.user_id) : undefined}
+                armed={armedIdx === i}
+                dragging={dragState?.from === i}
+                dropIndicator={
+                  dragState?.ins === i
+                    ? "top"
+                    : i === orderedIds.length - 1 && dragState?.ins === orderedIds.length
+                      ? "bottom"
+                      : null
+                }
+                onArm={canManage ? () => setArmedIdx(i) : undefined}
+                onDisarm={canManage ? () => setArmedIdx(null) : undefined}
+                onDragStartRow={canManage ? () => setDragState({ from: i, ins: null }) : undefined}
+                onDragOverRow={canManage ? (y, rect) => onCardDragOver(i, y, rect) : undefined}
                 onDropRow={
                   canManage
                     ? () => {
-                        if (dragId) moveTo(dragId, i);
-                        setDragId(null);
+                        if (dragState && dragState.ins != null) reorderTo(dragState.from, dragState.ins);
+                        setDragState(null);
+                        setArmedIdx(null);
                       }
                     : undefined
                 }
+                onDragEndRow={canManage ? () => { setDragState(null); setArmedIdx(null); } : undefined}
               />
             );
           })}
@@ -1780,8 +1825,15 @@ function RosterRow({
   onToggleCaptain,
   removeAriaLabel,
   captainAriaLabel,
-  onDragStart,
+  armed = false,
+  dragging = false,
+  dropIndicator = null,
+  onArm,
+  onDisarm,
+  onDragStartRow,
+  onDragOverRow,
   onDropRow,
+  onDragEndRow,
 }: {
   name: string;
   avatarIcon: string | null;
@@ -1797,21 +1849,37 @@ function RosterRow({
   onToggleCaptain: () => void;
   removeAriaLabel: string;
   captainAriaLabel: string;
-  onDragStart?: () => void;
+  /** Drag-to-reorder (owner) — mirrors the match-assignments panel. */
+  armed?: boolean;
+  dragging?: boolean;
+  dropIndicator?: "top" | "bottom" | null;
+  onArm?: () => void;
+  onDisarm?: () => void;
+  onDragStartRow?: () => void;
+  onDragOverRow?: (clientY: number, rect: DOMRect) => void;
   onDropRow?: () => void;
+  onDragEndRow?: () => void;
 }) {
   return (
     <div
-      draggable={canManage && !!onDragStart}
+      // Draggable only while the grip arms it (so the ★/↑↓/× stay tappable).
+      draggable={armed}
       onDragStart={
-        onDragStart
+        onDragStartRow
           ? (e) => {
               e.dataTransfer.effectAllowed = "move";
-              onDragStart();
+              onDragStartRow();
             }
           : undefined
       }
-      onDragOver={onDropRow ? (e) => e.preventDefault() : undefined}
+      onDragOver={
+        onDragOverRow
+          ? (e) => {
+              e.preventDefault();
+              onDragOverRow(e.clientY, e.currentTarget.getBoundingClientRect());
+            }
+          : undefined
+      }
       onDrop={
         onDropRow
           ? (e) => {
@@ -1820,17 +1888,39 @@ function RosterRow({
             }
           : undefined
       }
-      className="flex items-center gap-2 rounded-lg px-2.5 py-2"
-      style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+      onDragEnd={onDragEndRow}
+      className="relative flex items-center gap-2 rounded-lg px-2.5 py-2"
+      style={{
+        background: "var(--color-bt-card-raised)",
+        border: "1px solid var(--color-bt-border)",
+        opacity: dragging ? 0.4 : 1,
+      }}
     >
-      {/* Grip — the desktop drag handle. ALWAYS visible (was lg-gated, which made
-          it vanish below 1024px even though the fixed-width modal never resizes). */}
+      {/* Insertion line — the landing zone, shown once the cursor crosses a
+          neighbour's midpoint (mirrors the match-assignments panel). */}
+      {dropIndicator && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: 2,
+            right: 2,
+            [dropIndicator === "top" ? "top" : "bottom"]: -3,
+            height: 2,
+            borderRadius: 2,
+            background: "var(--color-bt-accent)",
+            boxShadow: "0 0 0 2px var(--color-bt-accent-faint)",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+      {/* Grip — arms the drag (the row becomes draggable only while held), so the
+          row buttons stay tappable. Always visible. */}
       {canManage && (
-        <GripVertical
-          size={14}
-          className="flex-shrink-0 cursor-grab"
-          style={{ color: "var(--color-bt-text-dim)" }}
-          aria-hidden
+        <DragHandle
+          onMouseDown={onArm}
+          onMouseUp={onDisarm}
+          className="h-7 w-4 flex-shrink-0"
         />
       )}
       {/* Row index — quiet table-number column, like the match pickers. */}

--- a/src/hooks/useCanEditTeam.test.ts
+++ b/src/hooks/useCanEditTeam.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isTeamCaptain } from "./useCanEditTeam";
+
+describe("isTeamCaptain", () => {
+  const assignments = [
+    { user_id: "u1", team_id: "tA", is_captain: true },
+    { user_id: "u2", team_id: "tA", is_captain: false },
+    { user_id: "u3", team_id: "tB", is_captain: true },
+  ];
+
+  it("is true for the captain of the given team", () => {
+    expect(isTeamCaptain(assignments, "u1", "tA")).toBe(true);
+    expect(isTeamCaptain(assignments, "u3", "tB")).toBe(true);
+  });
+
+  it("is false for a non-captain member of the team", () => {
+    expect(isTeamCaptain(assignments, "u2", "tA")).toBe(false);
+  });
+
+  it("is false when the captain is on a different team", () => {
+    // u1 captains tA, NOT tB — captaincy is scoped to the team.
+    expect(isTeamCaptain(assignments, "u1", "tB")).toBe(false);
+    expect(isTeamCaptain(assignments, "u3", "tA")).toBe(false);
+  });
+
+  it("is false for a user with no assignment", () => {
+    expect(isTeamCaptain(assignments, "u9", "tA")).toBe(false);
+  });
+
+  it("guards null/undefined inputs", () => {
+    expect(isTeamCaptain(undefined, "u1", "tA")).toBe(false);
+    expect(isTeamCaptain(assignments, null, "tA")).toBe(false);
+    expect(isTeamCaptain(assignments, "u1", null)).toBe(false);
+  });
+});

--- a/src/hooks/useCanEditTeam.ts
+++ b/src/hooks/useCanEditTeam.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { useTripRole } from "./useTripRole";
+import { useCurrentUser } from "./useCurrentUser";
+
+/**
+ * Pure predicate: is `userId` the captain of `teamId`, given the competition's
+ * team_assignments? Shared by `useCanEditTeam` (single-team) AND multi-team
+ * consumers (TeamsPanel maps over every team — React forbids calling the hook
+ * per row, so the loop uses this predicate against the assignments it already
+ * holds). One captain-resolution, no per-surface drift.
+ */
+export function isTeamCaptain(
+  assignments:
+    | { user_id: string; team_id: string; is_captain?: boolean }[]
+    | undefined,
+  userId: string | null | undefined,
+  teamId: string | null | undefined
+): boolean {
+  return (
+    !!userId &&
+    !!teamId &&
+    (assignments ?? []).some(
+      (a) => a.user_id === userId && a.team_id === teamId && !!a.is_captain
+    )
+  );
+}
+
+/**
+ * Client mirror of the server's team-IDENTITY admission (`requireTeamIdentityEdit`,
+ * migration 065): editing a team's name / short name / color is granted to the trip
+ * **Owner** OR the **captain of THIS team** (an `is_captain` row on
+ * team_assignments). `useTripRole` only knows the TRIP role, so on its own it's
+ * blind to a captain-who-is-a-plain-Member — this ORs in the per-team captain grant,
+ * exactly as the server admits (mirrors the `useGameEditAccess`/`canEditGame` shape,
+ * with `is_captain` swapped in for the `game_delegates` row).
+ *
+ * IDENTITY ONLY. Roster/structure (add / remove / reorder / assign-captain) stays
+ * **owner-only** — the deliberate 064/065 scope; captain roster management is the
+ * future captain's-draft feature, not this. Gate identity fields on `canEdit`; gate
+ * roster controls on `isOwner`.
+ *
+ * Consolidates the two formerly-inlined captain checks (TeamsPanel `canEditIdentity`,
+ * CompetitionFace `canEditTeamIdentity`) — both now route through `isTeamCaptain`.
+ */
+export function useCanEditTeam(
+  tripId: string | undefined,
+  competitionId: string | undefined,
+  teamId: string | null | undefined
+) {
+  const { isOwner, loading } = useTripRole(tripId);
+  const me = useCurrentUser();
+  const assignQ = trpc.teamAssignments.list.useQuery(
+    { tripId: tripId!, competitionId: competitionId! },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!competitionId }
+  );
+  const amCaptain = useMemo(
+    () =>
+      isTeamCaptain(
+        assignQ.data as
+          | { user_id: string; team_id: string; is_captain?: boolean }[]
+          | undefined,
+        me?.id,
+        teamId
+      ),
+    [assignQ.data, me, teamId]
+  );
+
+  return {
+    /** Owner (any team) OR this team's captain — mirrors `requireTeamIdentityEdit`. Gates IDENTITY only. */
+    canEdit: isOwner || amCaptain,
+    /** Trip Owner only — gates roster/structure (add / remove / reorder / captain). */
+    isOwner,
+    amCaptain,
+    loading,
+  };
+}

--- a/src/server/routers/teamAssignments.test.ts
+++ b/src/server/routers/teamAssignments.test.ts
@@ -74,7 +74,7 @@ describe("teamAssignments router", () => {
   });
 });
 
-// Canonical roster order (mig 069) — sort_order on assign + the reorder mutation.
+// Canonical roster order (mig 070) — sort_order on assign + the reorder mutation.
 describe("teamAssignments roster order", () => {
   let octx: TestContext;
   let otrip: string;

--- a/src/server/routers/teamAssignments.test.ts
+++ b/src/server/routers/teamAssignments.test.ts
@@ -73,3 +73,79 @@ describe("teamAssignments router", () => {
     expect(result).toEqual({ success: true });
   });
 });
+
+// Canonical roster order (mig 069) — sort_order on assign + the reorder mutation.
+describe("teamAssignments roster order", () => {
+  let octx: TestContext;
+  let otrip: string;
+  let ocomp: string;
+  let oteam: string;
+  let p1: string; // planner
+  let p2: string; // member
+  let p3: string; // outsider
+
+  beforeAll(async () => {
+    octx = await TestContext.create();
+    otrip = await octx.createTrip("Roster Order Test");
+    await octx.addTripMember(otrip, "planner", "Member");
+    await octx.addTripMember(otrip, "member", "Member");
+    await octx.addTripMember(otrip, "outsider", "Member");
+    ocomp = await octx.createCompetition(otrip, "Order Cup");
+    oteam = await octx.createTeam(ocomp, "Order Team");
+    p1 = octx.getUser("planner").id;
+    p2 = octx.getUser("member").id;
+    p3 = octx.getUser("outsider").id;
+  });
+
+  afterAll(async () => {
+    await octx.cleanup();
+  });
+
+  const teamOrder = (
+    list: { team_id: string; user_id: string; sort_order?: number }[]
+  ) => list.filter((a) => a.team_id === oteam);
+
+  it("assign appends each new player to the end of the team's order", async () => {
+    const caller = octx.caller();
+    await caller.teamAssignments.assign({ tripId: otrip, competitionId: ocomp, userId: p1, teamId: oteam });
+    await caller.teamAssignments.assign({ tripId: otrip, competitionId: ocomp, userId: p2, teamId: oteam });
+    await caller.teamAssignments.assign({ tripId: otrip, competitionId: ocomp, userId: p3, teamId: oteam });
+
+    const order = teamOrder(await caller.teamAssignments.list({ tripId: otrip, competitionId: ocomp }));
+    expect(order.map((a) => a.user_id)).toEqual([p1, p2, p3]);
+    expect(order.map((a) => a.sort_order)).toEqual([0, 1, 2]);
+  });
+
+  it("reorder persists a new canonical order (owner)", async () => {
+    const caller = octx.caller();
+    await caller.teamAssignments.reorder({
+      tripId: otrip,
+      competitionId: ocomp,
+      teamId: oteam,
+      orderedUserIds: [p3, p1, p2],
+    });
+
+    const order = teamOrder(await caller.teamAssignments.list({ tripId: otrip, competitionId: ocomp }));
+    expect(order.map((a) => a.user_id)).toEqual([p3, p1, p2]);
+    expect(order.map((a) => a.sort_order)).toEqual([0, 1, 2]);
+  });
+
+  it("reorder rejects a non-permutation of the roster", async () => {
+    const caller = octx.caller();
+    // Missing a member.
+    await expect(
+      caller.teamAssignments.reorder({ tripId: otrip, competitionId: ocomp, teamId: oteam, orderedUserIds: [p1, p2] })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    // Extra / foreign id.
+    await expect(
+      caller.teamAssignments.reorder({ tripId: otrip, competitionId: ocomp, teamId: oteam, orderedUserIds: [p1, p2, p3, "ghost"] })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("reorder is owner-only (a plain member is refused)", async () => {
+    const memberCaller = octx.callerAs("member");
+    await expect(
+      memberCaller.teamAssignments.reorder({ tripId: otrip, competitionId: ocomp, teamId: oteam, orderedUserIds: [p3, p1, p2] })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/src/server/routers/teamAssignments.ts
+++ b/src/server/routers/teamAssignments.ts
@@ -16,10 +16,16 @@ export async function listTeamAssignments(
   ctx: { supabase: SupabaseClient },
   competitionId: string,
 ) {
+  // Canonical roster order (mig 069): order by sort_order WITHIN each team. Every
+  // team-roster chooser filters this list by team_id, so the per-team relative
+  // order is what carries through — grouping by team_id first keeps the raw list
+  // tidy too. This single ordered read is what makes the order canonical.
   const { data, error } = await ctx.supabase
     .from("team_assignments")
     .select("*")
-    .eq("competition_id", competitionId);
+    .eq("competition_id", competitionId)
+    .order("team_id", { ascending: true })
+    .order("sort_order", { ascending: true });
 
   if (error) {
     throw new TRPCError({
@@ -72,19 +78,38 @@ export const teamAssignmentsRouter = router({
         .eq("competition_id", input.competitionId)
         .eq("user_id", input.userId)
         .maybeSingle();
+      const isSameTeam = !!existing && (existing.team_id as string) === input.teamId;
       const isMove = !!existing && (existing.team_id as string) !== input.teamId;
       if (isMove) await assertRosterUnlocked(ctx.supabase, input.competitionId);
 
+      // sort_order (mig 069): a genuine ADD or a MOVE to a different team lands at
+      // the END of the target team's canonical order. A same-team re-assign is a
+      // no-op — leave sort_order untouched so it doesn't jump to the bottom.
+      const payload: {
+        competition_id: string;
+        user_id: string;
+        team_id: string;
+        sort_order?: number;
+      } = {
+        competition_id: input.competitionId,
+        user_id: input.userId,
+        team_id: input.teamId,
+      };
+      if (!isSameTeam) {
+        const { data: maxRow } = await ctx.supabase
+          .from("team_assignments")
+          .select("sort_order")
+          .eq("competition_id", input.competitionId)
+          .eq("team_id", input.teamId)
+          .order("sort_order", { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        payload.sort_order = ((maxRow?.sort_order as number | undefined) ?? -1) + 1;
+      }
+
       const { data: inserted, error } = await ctx.supabase
         .from("team_assignments")
-        .upsert(
-          {
-            competition_id: input.competitionId,
-            user_id: input.userId,
-            team_id: input.teamId,
-          },
-          { onConflict: "competition_id,user_id" }
-        )
+        .upsert(payload, { onConflict: "competition_id,user_id" })
         .select()
         .single();
 
@@ -162,6 +187,74 @@ export const teamAssignmentsRouter = router({
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: `Failed to set captain: ${error.message}`,
+        });
+      }
+      return { success: true };
+    }),
+
+  // -----------------------------------------------------------------------
+  // reorder — set a team's canonical roster order (Owner only). Persists the
+  // drag-reorder from the Edit Team modal. Pure REORDER, not assign: the input
+  // must be exactly the team's current members (a permutation) — we validate
+  // that so reorder can never sneak a player onto/off the team or change
+  // membership. sort_order = the index in orderedUserIds. Allowed regardless of
+  // the roster-removal lock: reordering orphans no one (it's cosmetic order).
+  // -----------------------------------------------------------------------
+  reorder: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        competitionId: z.string(),
+        teamId: z.string(),
+        orderedUserIds: z.array(z.string()),
+      })
+    )
+    .use(requireTripRole("Owner"))
+    .mutation(async ({ ctx, input }) => {
+      const { data: current, error: readErr } = await ctx.supabase
+        .from("team_assignments")
+        .select("user_id")
+        .eq("competition_id", input.competitionId)
+        .eq("team_id", input.teamId);
+      if (readErr) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to read roster: ${readErr.message}`,
+        });
+      }
+
+      // The input must be a permutation of the team's current roster — same set,
+      // no extras, no omissions. Anything else is a stale/forged order; reject it
+      // rather than silently mutate membership.
+      const currentIds = new Set((current ?? []).map((r) => r.user_id as string));
+      const inputIds = new Set(input.orderedUserIds);
+      const isPermutation =
+        currentIds.size === inputIds.size &&
+        input.orderedUserIds.length === inputIds.size &&
+        [...inputIds].every((id) => currentIds.has(id));
+      if (!isPermutation) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Order must be exactly this team's current roster.",
+        });
+      }
+      if (input.orderedUserIds.length === 0) return { success: true };
+
+      // All rows already exist → the upsert resolves to UPDATE on the (comp,user)
+      // PK conflict, setting only sort_order (is_captain + team_id retained).
+      const rows = input.orderedUserIds.map((userId, i) => ({
+        competition_id: input.competitionId,
+        user_id: userId,
+        team_id: input.teamId,
+        sort_order: i,
+      }));
+      const { error } = await ctx.supabase
+        .from("team_assignments")
+        .upsert(rows, { onConflict: "competition_id,user_id" });
+      if (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to reorder roster: ${error.message}`,
         });
       }
       return { success: true };

--- a/src/server/routers/teamAssignments.ts
+++ b/src/server/routers/teamAssignments.ts
@@ -16,7 +16,7 @@ export async function listTeamAssignments(
   ctx: { supabase: SupabaseClient },
   competitionId: string,
 ) {
-  // Canonical roster order (mig 069): order by sort_order WITHIN each team. Every
+  // Canonical roster order (mig 070): order by sort_order WITHIN each team. Every
   // team-roster chooser filters this list by team_id, so the per-team relative
   // order is what carries through — grouping by team_id first keeps the raw list
   // tidy too. This single ordered read is what makes the order canonical.
@@ -82,7 +82,7 @@ export const teamAssignmentsRouter = router({
       const isMove = !!existing && (existing.team_id as string) !== input.teamId;
       if (isMove) await assertRosterUnlocked(ctx.supabase, input.competitionId);
 
-      // sort_order (mig 069): a genuine ADD or a MOVE to a different team lands at
+      // sort_order (mig 070): a genuine ADD or a MOVE to a different team lands at
       // the END of the target team's canonical order. A same-team re-assign is a
       // no-op — leave sort_order untouched so it doesn't jump to the bottom.
       const payload: {

--- a/supabase/migrations/20260629120000_069_team_assignments_sort_order.sql
+++ b/supabase/migrations/20260629120000_069_team_assignments_sort_order.sql
@@ -1,0 +1,41 @@
+-- 069 — Canonical roster order: team_assignments.sort_order.
+--
+-- Roster order is set ONCE in the Edit Team modal and becomes the canonical
+-- player order every team-roster chooser derives from (match assignment, rack
+-- foursomes, the handicap rosters). Before this, listTeamAssignments had no
+-- ORDER BY → Postgres returned rows in arbitrary physical order and every
+-- chooser inherited that arbitrariness. Derive-don't-snapshot: the order lives
+-- HERE, on the assignment row; consumers read it, none store their own copy.
+--
+-- sort_order is per-TEAM (each team's roster is 0,1,2,…). It rides the
+-- assignment row's lifecycle alongside is_captain (mig 064) — unassign the
+-- player and their slot in the order goes with the row. precedent for the
+-- column: schedule_items / logistics_items / catalog_ideas all use sort_order.
+
+ALTER TABLE public.team_assignments
+  ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 0;
+
+-- Backfill existing rosters with a STABLE initial order: insertion order
+-- (assigned_at) within each team, tie-broken by user_id so the result is
+-- deterministic. New columns default to 0; this gives every existing team a
+-- 0..n-1 sequence so a later drag-reorder has a coherent starting point.
+WITH ordered AS (
+  SELECT
+    competition_id,
+    user_id,
+    row_number() OVER (
+      PARTITION BY competition_id, team_id
+      ORDER BY assigned_at, user_id
+    ) - 1 AS rn
+  FROM public.team_assignments
+)
+UPDATE public.team_assignments ta
+  SET sort_order = ordered.rn
+  FROM ordered
+  WHERE ta.competition_id = ordered.competition_id
+    AND ta.user_id = ordered.user_id;
+
+-- Lookups + ordering are per (competition, team); the index keeps the
+-- ORDER BY sort_order read cheap once rosters carry real volume.
+CREATE INDEX IF NOT EXISTS team_assignments_team_sort_idx
+  ON public.team_assignments (competition_id, team_id, sort_order);

--- a/supabase/migrations/20260629130000_070_team_assignments_sort_order.sql
+++ b/supabase/migrations/20260629130000_070_team_assignments_sort_order.sql
@@ -1,4 +1,4 @@
--- 069 — Canonical roster order: team_assignments.sort_order.
+-- 070 — Canonical roster order: team_assignments.sort_order.
 --
 -- Roster order is set ONCE in the Edit Team modal and becomes the canonical
 -- player order every team-roster chooser derives from (match assignment, rack


### PR DESCRIPTION
Phase A of the Team/Roster management redesign. Consolidates team management into ONE surface — the **Edit Team modal** (reached by the leaderboard team short-name link) — which now owns name/short/color **and** the roster (add/remove/reorder/assign-captain). Roster order set in the modal becomes the canonical player order across the team-roster choosers. Does **not** remove the Rosters button/modal (that's Phase B, gated on competition settings absorbing add/delete-team) — the two coexist.

Built to the **revised** spec (post-Phase-0 decisions): captain stays IDENTITY-only (no net-new server permission), and only the 7 team-roster choosers are ordered (the 2 trip-wide pickers are left alone).

## Phase 0 report (audit findings that shaped the build)

**A — Captain permission.** Captain = `team_assignments.is_captain` (one-per-team via a partial unique index; mig 064). The server **already** admits a captain to edit their team's IDENTITY (name/short/color) at both tRPC (`requireTeamIdentityEdit`) and RLS (mig 065) — and deliberately drops Organizer from it. Roster/structure (`assign`/`remove`/`setCaptain`) is owner-only by design. Per Zach's decision we **keep** that scope → **no net-new server permission**; captain roster mgmt is deferred to the future captain's-draft feature.

**B — Roster order.** `team_assignments` had **no** order column and `listTeamAssignments` had **no ORDER BY** (arbitrary physical order). Added `sort_order` (mig 070). Chooser inventory (10): team-roster choosers **1,3,4,5,7,8,9** vs trip-wide **2,6,10**. Trip-wide left untouched (decision #2); stroke handicaps (#7) are teamless so there's no team order to apply.

**C — Surfaces.** `TeamSheet` (name/short/color) was opened both from the Rosters overlay's per-card pencil and standalone from the leaderboard. `RostersOverlay`→`TeamsPanel` owns add/delete-team + drag-assign + captain. `TeamSheet` absorbs the roster section; Rosters keeps add/delete-team for Phase B.

## What changed

- **Part 1** — `useCanEditTeam(tripId, competitionId, teamId)` hook mirroring `useGameEditAccess` (identity = Owner OR this team's captain; `isOwner` gates roster). One shared `isTeamCaptain` predicate replaces the two inlined duplications.
- **Part 2** — consolidated `TeamSheet`: identity + roster section, three role tiers — **owner** (full), **captain** (identity editable, roster read-only), **member** (all read-only: disabled inputs, no color picker, no Save). The short-name tap now opens this for everyone (no read-only-overlay fallback). Roster mutations carry the `faceBootstrap` invalidation (#10) since the modal opens outside the LiveFace re-seed path.
- **Part 3** — `sort_order` column (mig 070) + `ORDER BY` read + owner-only `reorder` mutation (validates the input is an exact roster permutation). Reorder UI = ↑↓ buttons (mobile-first) + grip-drag on desktop. Propagated to choosers 1,3,4,5,7,8,9; trip-wide pickers left as-is.
- **Part 4** — coexistence (no code): Rosters overlay + new modal share the same mutations + ordered read.
- **Part 5** — `PERMISSIONS.md`: corrected the team-edit rows (Organizer dropped from `teams.update`) + documented the captain identity tier.

## Verification

- `tsc` + `eslint` clean.
- **Vitest: 820 passed.** New: `isTeamCaptain` predicate; `assign` append-order, `reorder` happy-path/permutation-guard/owner-only. (3 pre-existing `tripStatus.test.ts` `countdownLabel` failures remain — time-of-day-dependent date math, untouched by this branch, flagged for a follow-up.)
- **Playwright critical-path + match-play: 3 passed** (match-play exercises the pairing/handicap choosers).
- **In-browser (owner):** leaderboard short-name tap → consolidated modal with identity + ROSTER·8 (captain ★, reorder, remove); reorder persists to the DB and round-trips; Rosters overlay TeamCard now matches the canonical order; no console errors.

## Rebase + migration note

Rebased onto `main` after **#513** ("kill Abandon at the source") merged — which added `20260629120000_069_remove_game_dropped_status.sql`, a same-timestamp/same-number collision with the original sort_order migration. Renumbered ours to **`20260629130000_070_team_assignments_sort_order.sql`** (unique version, next sequential number). The sort_order migration was applied to the linked DB via `execute_sql` (no `schema_migrations` row), so CI's `db push` applies the committed file cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)