### PR TITLE
Game Settings page cleanup (pre-makeover polish)

### DIFF
--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -143,6 +143,9 @@ async function driveToSetupWithHandicap(page: Page) {
   await toggle("row-matches").click();
   const pairings = page.getByTestId("match-pairings");
   await expect(pairings).toBeVisible({ timeout: 20_000 });
+  // A new game opens at 0 matches (the valid empty state — just "Add match", no
+  // table). Add the first match to get the pairing slots.
+  await pairings.getByRole("button", { name: "Add match" }).click();
   // Fill slot A then slot B. Each pick is gated open→pick→closed so the picks can't
   // race the picker mount/unmount: open the slot, wait for the picker, pick (scoped
   // to the picker so the click can't hit a filled-slot button), wait for it to

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -24,7 +24,7 @@ import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
-import { GameRulesNote, type GameRulesNoteHandle } from "@/components/games/GameRulesNote";
+import { GameRulesNote } from "@/components/games/GameRulesNote";
 import { GameDangerZone } from "@/components/games/GameDangerZone";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
@@ -32,7 +32,7 @@ import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeOrClearMatch } from "@/lib/matchDraft";
+import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeMatchRow } from "@/lib/matchDraft";
 import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
@@ -148,10 +148,6 @@ export default function NewMatchGamePage() {
   // from the game's modifiers whenever the row is CLOSED (never mid-edit — see
   // the seed effect below).
   const [modifiersDraft, setModifiersDraft] = useState<ModifiersMap>({});
-  // Zone-3 rules note (W-EDITMODAL-01) — "Save & exit" flushes any typed-but-
-  // unsaved rules through this handle before navigating (the one field with no
-  // collapse event of its own).
-  const rulesRef = useRef<GameRulesNoteHandle>(null);
   // Back-stack: forward transitions push the screen they left; Back pops to it.
   // Empty stack means we arrived directly (derived screen) → leave to trip home.
   const [navStack, setNavStack] = useState<Screen[]>([]);
@@ -464,14 +460,6 @@ export default function NewMatchGamePage() {
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
   }, []);
-  // "Save & exit" (W-EDITMODAL-01): flush the Zone-3 rules note (its only commit
-  // event) then leave. Checklist rows already persisted on collapse; this just
-  // guarantees the rules textarea isn't lost. Always available — leaving is too.
-  async function handleSaveExit() {
-    await rulesRef.current?.flush();
-    goBack();
-  }
-
   // Seed the editable draft from the server when we land on setup for an
   // existing game (e.g. owner opens a pending game, or taps Edit) and the local
   // draft is empty. Create + Edit also seed via their handlers; this covers a
@@ -486,10 +474,10 @@ export default function NewMatchGamePage() {
       setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide, sided));
       return;
     }
-    // Resume-into-empty: a competition game tapped from the leaderboard arrives
-    // with no game_matches → seed ONE empty match (build-as-you-go; no pre-seeded
-    // count — W-GAMEPAGE-01 §6.1). "+ Add match" grows it from there.
-    setDraft([{ matchNumber: 1, a: [], b: [], handicap: 0 }]);
+    // Resume-into-empty: a game with no game_matches starts at ZERO matches — a
+    // valid empty state (the table hides; only "Add match" shows). "+ Add match"
+    // grows it from there (build-as-you-go — W-GAMEPAGE-01 §6.1).
+    setDraft([]);
   }, [cfgOpen, draft.length, serverMatches, handicapOf, membersOfSide, sided]);
 
   // Seed the modifiers draft from the server — but ONLY while the row is closed,
@@ -533,18 +521,14 @@ export default function NewMatchGamePage() {
         // Non-fatal: the game still works on the template default par/index.
       }
     }
-    // Persist ONE empty match row so the game has a configured match from
-    // creation (build-as-you-go — W-GAMEPAGE-01 §6.1; "+ Add match" grows it).
-    const emptyMatches = [{ sideA: null, sideB: null, matchNumber: 1 }];
-    if (sided) await setDoublesPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
-    else await setPairings.mutateAsync({ tripId, gameId: g.id, matches: emptyMatches });
+    // A new game starts at ZERO matches (the valid empty state) — no seed row is
+    // persisted. "+ Add match" builds the first one (build-as-you-go), persisting
+    // on collapse.
     await refreshAfterMatchCountChange();
-    // The DERIVED screen flips to "setup" the instant setGameId ran (above), so the
-    // checklist is already interactive — and the user may have started pairing while
-    // this create flow finished its awaits. Only seed the blank card if they
-    // HAVEN'T (the seed effect already seeded otherwise); never clobber a touched draft.
+    // The checklist is interactive the instant setGameId ran (above); leave the
+    // draft empty unless the user already started adding (never clobber a touched draft).
     if (!draftTouched.current) {
-      setDraft([{ matchNumber: 1, a: [], b: [], handicap: 0 }]);
+      setDraft([]);
     }
     // Land straight on the settings page (the checklist's home) — the owner just
     // created the game and wants to configure it (A2-ux correction).
@@ -651,15 +635,15 @@ export default function NewMatchGamePage() {
   // failure the draft is KEPT (never discard edits) and an inline retry surfaces.
   async function persistDraftOnCollapse() {
     if (filledDraft.length === 0) {
-      // Clear-to-empty: the floor-of-one × emptied the last match's slots, so the
-      // draft has its row(s) but nothing filled. Persist them as EMPTY matches (null
-      // sides — the shape creation seeds) so the clear SURVIVES reload; otherwise
-      // saveSetup's filled-only write skips it and the server keeps the old players
-      // (the revert-on-reload bug). Scoped to a draft that is ALL-empty (every slot
-      // empty) — the deliberate post-clear state — so a transient half-filled slot is
-      // left unpersisted (existing behavior), never wiped. saveSetup itself stays
-      // filled-only: it's also the Enable gate's "ready" signal, which empty is not.
-      const allEmpty = draft.length > 0 && draft.every((m) => m.a.length === 0 && m.b.length === 0);
+      // Nothing filled — persist the EMPTY shape so it SURVIVES reload (saveSetup's
+      // filled-only write would skip it and the server would keep the old players —
+      // the revert-on-reload bug). Two sub-cases, both handled here:
+      //   • draft === []  → 0 matches (deleted the last one); persist [].
+      //   • all rows empty → persist the null-sided rows.
+      // `every` is true on an empty array, so this covers both. A transient
+      // half-filled slot is left unpersisted (existing behavior), never wiped.
+      // saveSetup stays filled-only: it's also the Enable gate's "ready" signal.
+      const allEmpty = draft.every((m) => m.a.length === 0 && m.b.length === 0);
       if (!allEmpty || !tripId || !gameId) return;
       try {
         const empty = draft.map((_, i) => ({ sideA: null, sideB: null, matchNumber: i + 1 }));
@@ -1021,14 +1005,15 @@ export default function NewMatchGamePage() {
         // while any slot is empty (§4/§6.1 hard-block) — never plain dashed-empty,
         // since the seeded match always has a slot to fill until paired.
         const matchesTitle = sided ? "2v2 Matches" : "1-on-1 Matches";
-        const matchesSubtitle = filledDraft.length === 0
-          ? "0 matches assigned"
+        const matchesSubtitle = draft.length === 0
+          ? "No matches yet — add one to start"
           : `${filledDraft.length} of ${draft.length} matches assigned`;
-        // Resolved only when slots are filled AND every paired side is rostered;
-        // a dropped-after-paired side flips it to the invalid (red) verdict, surfaced
-        // the same way as the slot-filled hard-block (P2/P2b collapse-boundary timing
-        // unchanged — this only adds a reason a match is invalid).
-        const matchesState: ChecklistRowState = allFilled && allRosterValid ? "resolved" : "invalid";
+        // Three-way: 0 matches is a VALID EMPTY state (neutral, not red — a brand-new
+        // game shouldn't open in error); a draft with any unfilled/under-rostered slot
+        // is invalid (red); all filled + rostered is resolved. (P2/P2b collapse-boundary
+        // timing unchanged — this only adds the empty state ahead of the invalid one.)
+        const matchesState: ChecklistRowState =
+          draft.length === 0 ? "empty" : allFilled && allRosterValid ? "resolved" : "invalid";
         // Handicaps is hard-gated on Matches AND Course (W-9HOLE-01): the per-hole
         // stroke allocation needs the course's stroke-index table, so a complete
         // 18 must resolve first. "Course resolved" = a course applied AND an 18-hole
@@ -1062,6 +1047,15 @@ export default function NewMatchGamePage() {
                 competition-scoped (a standalone game has no delegate/config row). */}
             {gameCompId && gameQ.data && (
               <GameIdentityHeader tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} isOwner={isOwner} />
+            )}
+
+            {/* RULES OF THE DAY — at the TOP (out of the awkward middle zone that
+                disables in scoring mode). Always editable (incl. scoring mode) per
+                the carved-out exception (plain canEdit). Saves on blur — the back
+                arrow blurs the field, so there's no Save&exit to flush. (A game-type
+                explainer block will pair ABOVE this later — future add, not here.) */}
+            {gameCompId && gameQ.data && (
+              <GameRulesNote tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} />
             )}
 
             {/* A2-ux: the single Setup/Scoring toggle — the keystone game-mode control,
@@ -1244,10 +1238,6 @@ export default function NewMatchGamePage() {
 
             {/* Rules of the Day — freeform note (W-EDITMODAL-01). Saves on blur;
                 "Save & exit" flushes it via rulesRef. Competition games only. */}
-            {gameCompId && gameQ.data && (
-              <GameRulesNote ref={rulesRef} tripId={tripId} game={gameQ.data as unknown as GameRow} canEdit={canEdit} />
-            )}
-
             {collapseError && (
               <button
                 type="button"
@@ -1259,27 +1249,10 @@ export default function NewMatchGamePage() {
               </button>
             )}
 
-            {/* Exit (W-EDITMODAL-01): Enable scoring (primary, readiness-gated, the
-                commit-to-play) + Save & exit (secondary, always enabled — the
-                leave-and-resume door; flushes the rules note then navigates). */}
-            {/* A2-ux: the bottom "Enable scoring" button is gone — enabling now lives
-                in the Game-Play toggle at the top (header slot). Only "Save & exit"
-                remains here (the leave-and-resume door). The Enable spine (all matches
-                paired AND points > 0) is unchanged — it's `enableReady`, which now
-                gates the toggle's Scoring segment. */}
-            <div className="flex flex-col gap-2 pt-2">
-              {gameCompId && (
-                <button
-                  type="button"
-                  onClick={handleSaveExit}
-                  className="w-full"
-                  style={{ height: 48, borderRadius: 12, background: "transparent", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", fontSize: 15, fontWeight: 600 }}
-                  data-testid="match-save-exit"
-                >
-                  Save &amp; exit
-                </button>
-              )}
-            </div>
+            {/* Auto-save (W-EDITMODAL-01): the whole page persists on change — the
+                checklist rows on collapse, Rules on blur — so there's no page-level
+                Save & exit (removed). The back arrow leaves cleanly; the back tap
+                blurs the Rules field, committing any unsaved text. */}
 
             {/* Danger zone — owner-only (A2-ux correction: the settings page is now the
                 ONE home, so the per-game danger ladder lives here too: reset scores /
@@ -1626,10 +1599,11 @@ function MatchSetup({
 
   return (
     <div data-testid="match-pairings">
-      <p style={{ fontSize: 13, color: "var(--color-bt-text-dim)", marginBottom: 14 }}>
-        Tap a slot to pick a player · drag to reorder.
-      </p>
-
+      {/* The table (team-name header + match rows) appears only once there's at
+          least one match — a brand-new game shows just "Add match". 0 matches is a
+          valid empty state, not an error. */}
+      {draft.length > 0 && (
+        <>
       {/* Shared branded column header (BOTH formats): team names centered +
           team-colored in their columns, "vs" centered in its; grab/#/× columns
           empty. Same MATCH_GRID template as the rows below → the columns line up. */}
@@ -1710,19 +1684,14 @@ function MatchSetup({
               {sideSlots(d.b, i, "b")}
               {/* Remove = the itinerary-builder "×" dismiss (NOT a trash can), DIM not
                   red — draft removal is free (no persisted scores) and the open panel
-                  must never read as an error. Far right. The runtime-overview remove
-                  (a scored, destructive match) keeps its danger color; this one does
-                  not. ALWAYS present, floor-aware: with >1 match it REMOVES the row;
-                  on the LAST match it CLEARS the slots (empties both sides back to the
-                  dashed "+ add player" state) rather than deleting it — the server
-                  enforces a floor of ≥1 match (setPairings .min(1) / removeMatch's
-                  throw), so the last match is cleared, never removed. One glyph, both
-                  meanings (no room for a label). */}
+                  must never read as an error. Far right. Always REMOVES the row —
+                  0 matches is now a valid empty state (the table hides, leaving just
+                  "Add match"), so the last match is deletable, not floor-clamped. */}
               <button
                 type="button"
-                onClick={() => setDraft((prev) => removeOrClearMatch(prev, i))}
-                title={draft.length > 1 ? "Remove match" : "Clear players"}
-                aria-label={draft.length > 1 ? `Remove match ${i + 1}` : `Clear match ${i + 1}`}
+                onClick={() => setDraft((prev) => removeMatchRow(prev, i))}
+                title="Remove match"
+                aria-label={`Remove match ${i + 1}`}
                 className="flex items-center justify-center"
                 style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)" }}
               >
@@ -1732,6 +1701,8 @@ function MatchSetup({
           );
         })}
       </div>
+        </>
+      )}
 
       {/* Add another match — dynamic count grows one at a time (up to the cap). */}
       {draft.length < MAX_MATCHES && (

--- a/src/components/games/ChecklistRow.test.ts
+++ b/src/components/games/ChecklistRow.test.ts
@@ -30,10 +30,13 @@ describe("checklistRowVisuals", () => {
     expect(v.badge).toBe("x");
   });
 
-  it("open (editing) → raised surface, solid border, NO badge regardless of state", () => {
+  it("open (editing) → card surface (continuous with collapsed-resolved), solid border, NO badge", () => {
     expect(checklistRowVisuals("resolved", true).badge).toBeNull();
     expect(checklistRowVisuals("invalid", true).badge).toBeNull();
-    expect(checklistRowVisuals("empty", true).surface).toBe("var(--color-bt-card-raised)");
+    // The panel is ONE continuous surface open or closed — open shares the
+    // resolved card surface (no card-raised jump that read flat/base-like).
+    expect(checklistRowVisuals("empty", true).surface).toBe("var(--color-bt-card)");
+    expect(checklistRowVisuals("resolved", true).surface).toBe("var(--color-bt-card)");
     // An open empty row is no longer dashed (it's the active editor frame).
     expect(checklistRowVisuals("empty", true).border).toBe("1px solid var(--color-bt-border)");
   });

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -53,7 +53,13 @@ export function checklistRowVisuals(state: ChecklistRowState, isOpen: boolean): 
   const invalid = state === "invalid" && !isOpen;
   const active = resolved || isOpen;
   return {
-    surface: isOpen ? "var(--color-bt-card-raised)" : resolved ? "var(--color-bt-card)" : "transparent",
+    // The panel is ONE continuous surface open or closed — the body shares the
+    // header's token, and an open panel reads identically to a collapsed-resolved
+    // one (only the chevron + body presence change). `--color-bt-card` is the
+    // panel surface (STYLE_GUIDE Level 1); the inner editor cards sit ON it at
+    // card-raised. (Was `card-raised` when open — a tonal jump that made the body
+    // read flat/base-like against its own raised inner cards.)
+    surface: isOpen || resolved ? "var(--color-bt-card)" : "transparent",
     border: invalid
       ? "1.5px solid var(--color-bt-danger)"
       : state === "empty" && !isOpen
@@ -120,11 +126,13 @@ export function ChecklistRow({
   // floating dot. (Badge only shows collapsed, so the surface is card/transparent.)
   const ringColor = state === "resolved" ? "var(--color-bt-card)" : "var(--color-bt-base)";
 
-  // Auto-scroll: when the panel opens, lift the row's top to the top of the screen
-  // so the dropped-down editor has full vertical room.
+  // Auto-scroll: reveal-don't-relocate. Only scroll if the (now-expanded) panel
+  // would otherwise be partly off-screen, and only enough to bring it into view —
+  // `block: "nearest"` is a no-op when the panel already fits, and scrolls the
+  // minimum otherwise (never a slam-to-top).
   const rowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (isOpen) rowRef.current?.scrollIntoView({ block: "start" });
+    if (isOpen) rowRef.current?.scrollIntoView({ block: "nearest" });
   }, [isOpen]);
 
   const iconBlock = (
@@ -207,7 +215,9 @@ export function ChecklistRow({
           {headerInner}
         </button>
         {isOpen && (
-          <div className="px-3.5 pb-3.5 pt-1" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          // No under-header divider — the body is the SAME surface as the header,
+          // so there's no seam to mark; an abrupt border read as a defect.
+          <div className="px-3.5 pb-3.5 pt-1">
             {children}
           </div>
         )}

--- a/src/components/games/GameDangerZone.tsx
+++ b/src/components/games/GameDangerZone.tsx
@@ -82,12 +82,12 @@ export function GameDangerZone({
 
   return (
     <section className="mt-8 space-y-3">
-      <SectionLabel danger>Danger zone</SectionLabel>
-      {disabled && (
-        <p className="px-1 text-[12px] leading-relaxed" style={{ color: "var(--color-bt-text-dim)" }} data-testid="danger-zone-locked">
-          Locked while the game is live — switch back to Setup to reset or remove it.
-        </p>
-      )}
+      {/* In scoring mode the header dims to match its already-locked rows (it was
+          the lone un-dimmed element). The per-section "locked" descriptor is dropped
+          — the top-of-page explainer already states the lock. */}
+      <div style={{ opacity: disabled ? 0.55 : undefined }}>
+        <SectionLabel danger>Danger zone</SectionLabel>
+      </div>
       <div className="space-y-2.5">
         <DangerRow
           icon={<RotateCcw size={16} />}

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeOrClearMatch, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeMatchRow, type MatchSides } from "./matchDraft";
 
 // Readiness rework P1b — the ONE match-play readiness threshold, shared by the
 // setup-page Enable gate and the server `isConfigured` so they can't drift.
@@ -113,40 +113,37 @@ describe("allMatchesFilled (the Enable-scoring gate)", () => {
   });
 });
 
-// The floor-aware "×" action: remove the match when there's more than one, CLEAR
-// the slots when it's the last (the server enforces ≥1 match — the last is cleared,
-// never deleted, so there's no zero-match state).
-describe("removeOrClearMatch (the floor-aware × action)", () => {
+// The "×" action: REMOVE the match at the index. 0 matches is a valid empty state
+// (the table hides; only "Add match" shows), so the last match is deletable — no
+// floor-clamp.
+describe("removeMatchRow (the × action)", () => {
   const m = (a: string[], b: string[], handicap = 0) => ({ a, b, handicap, matchNumber: 0 });
 
   it("with >1 match, REMOVES the match at the index", () => {
     const draft = [m(["a"], ["b"]), m(["c"], ["d"]), m(["e"], ["f"])];
-    const out = removeOrClearMatch(draft, 1);
+    const out = removeMatchRow(draft, 1);
     expect(out).toHaveLength(2);
     expect(out[0]).toBe(draft[0]); // untouched rows are the same refs
     expect(out[1]).toBe(draft[2]);
   });
 
-  it("with exactly 1 match, CLEARS its slots — keeps ONE empty match (never zero)", () => {
+  it("with exactly 1 match, DELETES it → an empty draft (0 matches is valid)", () => {
     const draft = [m(["a", "b"], ["c", "d"], 3)];
-    const out = removeOrClearMatch(draft, 0);
-    expect(out).toHaveLength(1); // the floor — not deleted
-    expect(out[0].a).toEqual([]);
-    expect(out[0].b).toEqual([]);
-    expect(out[0].handicap).toBe(0); // strokes reset with the pairing
-    expect(out[0].matchNumber).toBe(0); // other fields preserved
+    const out = removeMatchRow(draft, 0);
+    expect(out).toHaveLength(0);
   });
 
-  it("a cleared last match reads as NOT ready (Enable blocked, downstream locked)", () => {
-    const cleared = removeOrClearMatch([m(["a"], ["b"])], 0);
-    expect(allMatchesFilled(cleared, 1)).toBe(false); // can't enable
-    expect(hasValidMatch(cleared, 1)).toBe(false); // Points/Handicaps/Modifiers stay locked
+  it("an empty draft reads as NOT ready (Enable still blocked on 0 matches)", () => {
+    const empty = removeMatchRow([m(["a"], ["b"])], 0);
+    expect(empty).toHaveLength(0);
+    expect(allMatchesFilled(empty, 1)).toBe(false); // can't enable an empty game
+    expect(hasValidMatch(empty, 1)).toBe(false); // Points/Handicaps/Modifiers stay locked
   });
 
   it("does not mutate the input draft", () => {
     const draft = [m(["a"], ["b"])];
     const snapshot = JSON.parse(JSON.stringify(draft));
-    removeOrClearMatch(draft, 0);
+    removeMatchRow(draft, 0);
     expect(draft).toEqual(snapshot);
   });
 });

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -18,17 +18,14 @@ export interface MatchSides {
 }
 
 /**
- * The floor-aware "×" action on the setup draft (Matches panel). With MORE than one
- * match, REMOVE the match at `index`. With exactly ONE match, CLEAR its slots instead
- * — empty both sides + reset the handicap — keeping one empty match rather than
- * deleting it. The server enforces a floor of ≥1 match (`setPairings`/
- * `setDoublesPairings` `.min(1)`, `removeMatch`'s throw), so the last match is
- * cleared, never removed (no zero-match state). Pure — returns a new draft, never
- * mutates; preserves any other fields on the match (e.g. `matchNumber`) via spread.
+ * The "×" action on the setup draft (Matches panel): REMOVE the match at `index`.
+ * 0 matches is now a VALID empty state — the table hides and only "Add match"
+ * shows — so the last match is deletable (no floor-clamp). The server allows an
+ * empty match list (`setPairings`/`setDoublesPairings` `.min(0)`, `removeMatch`
+ * with no ≥1 throw). Pure — returns a new draft, never mutates.
  */
-export function removeOrClearMatch<M extends MatchSides & { handicap: number }>(draft: M[], index: number): M[] {
-  if (draft.length > 1) return draft.filter((_, j) => j !== index);
-  return draft.map((m, j) => (j === index ? { ...m, a: [], b: [], handicap: 0 } : m));
+export function removeMatchRow<M extends MatchSides>(draft: M[], index: number): M[] {
+  return draft.filter((_, j) => j !== index);
 }
 
 /** True when both sides carry exactly `playersPerSide` players. */

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -74,7 +74,9 @@ export const matchesRouter = router({
               matchNumber: z.number().int().min(1),
             })
           )
-          .min(1)
+          // 0 matches is a valid empty state (the last match is deletable); the
+          // Enable gate still refuses to score an empty game (assertGameReady).
+          .min(0)
           .max(MAX_MATCHES),
       })
     )
@@ -301,7 +303,8 @@ export const matchesRouter = router({
               matchNumber: z.number().int().min(1),
             })
           )
-          .min(1)
+          // 0 matches is a valid empty state (see setPairings).
+          .min(0)
           .max(MAX_MATCHES),
       })
     )
@@ -519,8 +522,8 @@ export const matchesRouter = router({
   // sides' participants/play_groups, and ANY entered scores + side results for
   // those sides (a player/pair is in exactly one match) — then recomputes the
   // rest. The CLIENT confirms first when the match has scores (don't silently
-  // drop entry); the server still cleans up fully. Refuses to drop below 1 (a
-  // match game always keeps ≥1 configured match).
+  // drop entry); the server still cleans up fully. 0 matches is a valid empty
+  // state, so the last match is deletable (no ≥1 floor).
   removeMatch: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string(), matchId: z.string().min(1) }))
     .use(requireGameEdit())
@@ -533,9 +536,6 @@ export const matchesRouter = router({
         .eq("game_id", input.gameId);
       type Side = { type: string; id: string } | null;
       const rows = (all ?? []) as { id: string; side_a: Side; side_b: Side }[];
-      if (rows.length <= 1) {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "A match game must keep at least one match" });
-      }
       const target = rows.find((r) => r.id === input.matchId);
       if (!target) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });


### PR DESCRIPTION
Cleans up the GAME settings/configuration page (the `1v1 Match Play Workflow` / Configuration screen) before it becomes the pattern the competition-settings makeover copies. Does not touch competition settings, the leaderboard, or scoring logic.

## Phase 0 (diagnose-before-fixing)

**A — Panel layering (`ChecklistRow`).** The accordion's surface SWAPPED on expand (`isOpen ? card-raised : resolved ? card : transparent`) so a resolved panel was `--color-bt-card` collapsed but `--color-bt-card-raised` open; the under-header line was a **real** `borderTop` divider (not a seam) with asymmetric `pt-1` padding; and the body read flat/base-like because it sat at the same `card-raised` shade as its own inner editor cards (which use card-raised). The child editors do **not** paint base. `ChecklistRow` is **not** shared with `CompetitionSettings`, so the fix is game-scoped.

**B — 0-matches constraint: PURE GATE, no downstream assumes ≥1 match** (safe to relax — no STOP). `computeMatchPlayResults`, `finish`/`post`, the per-team points adapter, the leaderboard roll-up (`value × matchCount` → ×0), `winNumber`/`pointsAvailable`, and the client overview (`groups[0] ?? null`) all handle 0 matches gracefully — no divide-by-zero, no unguarded `[0]`, no throw. Guards live only in: server `.min(1)` (×2), `removeMatch`'s ≥1 throw, the client `removeOrClearMatch` floor-clamp, the create seed, and `matchesState`. The Enable gate stays (`matchPlayReady(0,0) === false`).

## Fixes (all 7)

1. **Layering** — expanded body shares the header surface (`--color-bt-card`); panels read identically open/closed; under-header divider removed.
2. **0-matches empty state** — a new game opens not-red; the last match is deletable; at 0 matches the table hides, leaving only "Add match"; the row reads neutral, not red. Server `.min(0)`, no `removeMatch` floor, `persistDraftOnCollapse` persists the empty list. Enable still refuses an empty game.
3. **Remove** the "Tap a slot to pick a player · drag to reorder" instruction line.
4. **Full auto-save** — "Save & exit" removed; Rules saves on blur (the back arrow blurs the field), checklist rows persist on collapse. Back arrow is the only exit.
5. **RULES OF THE DAY moved to the TOP**, out of the mid-page zone that locks in scoring mode; stays always-editable (room left above for a future game-type explainer — not added).
6. **Danger Zone header dimmed** in scoring mode to match its locked rows; redundant per-section "locked" descriptor removed.
7. **Scroll-into-view** is reveal-don't-relocate (`block: "nearest"`) — no slam-to-top, no move when the panel already fits.

## Verification (in-browser)

- **Setup-mode game:** Rules at top; Matches panel expands onto a continuous surface with **no under-header divider** (`borderTop: 0px`, header/body same surface); **no instruction line**; **no Save & exit**.
- **0 matches:** deleting the last match hides the table → just "Add match"; the collapsed row shows "No matches yet — add one to start" with the neutral slate border (not red).
- **Scoring-mode game:** Danger Zone header dimmed to `0.55` with its locked rows; **no** "locked" descriptor; the live-lock banner still notes "Rules of the day can still be edited," and Rules is editable at the top.
- tsc + lint clean; **Vitest 823/823**; **Playwright critical-path + match-play 3/3** (the match-play E2E adds the first match before pairing, per the new empty-state model).

Layering is purely token-based (no hardcoded hex), so it holds in light as in dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)