### PR TITLE
Task 1: rewire the board axis from team count to scoring_model

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -267,6 +267,18 @@ the header, so it rides along with Stage 4 (roles on the board). The game-page
 **live pulse** remains separately deferred (it's the ticker §2 explicitly
 excludes).
 
+### Dead-hole display on the result summary — points-board fast-follow
+
+*Captured 2026-06-30 during the PR 2 board rewire (scoring_model axis + N-team
+points board). Explicitly scoped OUT of that PR; logged so it isn't lost.*
+
+When **all teams tie a hole** (no team takes it — a "dead hole"), the per-hole
+result summary should say so ("Dead hole") rather than rendering an empty/ambiguous
+cell. Only meaningful once N-team (3+) points play is exercised on real cards — a
+2-team match already reads a tie as a halve. Small display-only change on the
+result summary; no scoring/compute change (the points are already 0-to-each). Pick
+it up when the N-team points board gets real on-course use.
+
 ---
 
 ## v2 / Circle Era

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -182,6 +182,9 @@ export function CompetitionFace({
         competitionId={competition.id}
         tripId={tripId}
         canEdit={canEdit}
+        // The board layout is selected by the FROZEN scoring_model, not team
+        // count (PR 2): match_play → Ryder hero, points → standings + matrix.
+        scoringModel={competition.scoring_model ?? "match_play"}
         onAddGame={() => setAddingGame(true)}
         // A hero team-short-name tap → the consolidated Edit Team modal (the
         // team-management home). It self-gates by role: owner edits everything,

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -6,6 +6,7 @@ import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import type { ScoringModel } from "@/lib/gameTypes";
 import { GameRow, fmtPts } from "./GameRow";
+import { PointsMatrix } from "./PointsMatrix";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -275,6 +276,13 @@ export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "
           />
         )}
       </div>
+
+      {/* Points board — the collapsible games×teams matrix BELOW the standings
+          glance. Points cups only; the Ryder hero needs no matrix (one head-to-
+          head number is the whole story). */}
+      {scoringModel === "points" && (
+        <PointsMatrix games={liveGames} teams={teams} cellsByGame={cellsByGame} teamTotals={teamTotals} />
+      )}
 
       {/* Bones copy — the calm setup voice, only while the board is empty and
           editable (nothing's required to start). */}
@@ -594,10 +602,11 @@ function NTeamRankedList({
                 </div>
               </div>
 
-              {/* Points */}
+              {/* Points — the leader's total is emphasized (larger) so "who's
+                  ahead" reads instantly; trailing teams stay quieter. */}
               <span
-                className="shrink-0 text-base font-bold tabular-nums"
-                style={{ color: hasClinched ? team.color : "var(--color-bt-text)" }}
+                className={`shrink-0 font-bold tabular-nums ${idx === 0 ? "text-2xl" : "text-base"}`}
+                style={{ color: idx === 0 || hasClinched ? team.color : "var(--color-bt-text)" }}
               >
                 {fmtPts(total)}
               </span>

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { Trophy, CloudOff, RefreshCw, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import type { ScoringModel } from "@/lib/gameTypes";
 import { GameRow, fmtPts } from "./GameRow";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -69,6 +70,11 @@ interface LeaderboardData {
 interface Props {
   competitionId: string;
   tripId: string;
+  /** The competition's FROZEN scoring model — selects the board layout (PR 2):
+   *  `match_play` → the Ryder head-to-head hero; `points` → the standings glance
+   *  + collapsible games×teams matrix. NOT team count — a 2-team points cup is
+   *  still a points cup and gets the matrix. Defaults to match_play. */
+  scoringModel?: ScoringModel;
   /** Editor affordances on the board (the setup guide was retired — the board is
    *  the home now). Crew (non-editors) get none of these. */
   canEdit?: boolean;
@@ -78,7 +84,7 @@ interface Props {
   onEditTeam?: (teamId: string) => void;
 }
 
-export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false, onAddGame, onEditTeam }: Props) {
+export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "match_play", canEdit = false, onAddGame, onEditTeam }: Props) {
   const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
@@ -191,7 +197,10 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
   const isEarly = allZero && nothingPlayed && liveGames.length > 0;
   const clincher = teams.find((t) => (pointsToClinch[t.id] ?? 1) <= 0) ?? null;
 
-  if (isEarly) {
+  // The "cup hasn't started" early state is the match_play (Ryder) treatment. A
+  // POINTS cup skips it and renders its real board with zeros — the standings
+  // glance + the empty-but-structured matrix read as intentional, not broken.
+  if (isEarly && scoringModel === "match_play") {
     return (
       <EarlyState
         teams={teams}
@@ -241,7 +250,10 @@ export function CompetitionLeaderboard({ competitionId, tripId, canEdit = false,
           </p>
         </div>
 
-        {teams.length === 2 ? (
+        {/* Board layout is selected by scoring_model, NOT team count (PR 2): a
+            2-team POINTS cup gets the standings glance + matrix, not the Ryder
+            hero. match_play is structurally 2 teams, so the hero is safe. */}
+        {scoringModel === "match_play" ? (
           <TwoTeamHero
             teams={teams}
             teamTotals={teamTotals}
@@ -484,6 +496,9 @@ function TwoTeamHero({
 }
 
 // ── NTeamRankedList ───────────────────────────────────────────────────────────
+// The POINTS standings glance (PR 2): "are we winning?" at a glance. Ordered by
+// total desc, the leader emphasized (larger total), trailing teams present but
+// quieter. Reached only by points cups now — match_play renders the Ryder hero.
 
 function NTeamRankedList({
   teams,

--- a/src/components/competition/PointsMatrix.tsx
+++ b/src/components/competition/PointsMatrix.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, Table2 } from "lucide-react";
+import { fmtPts } from "./GameRow";
+import type { LBTeam, LBGame, LBCell } from "./CompetitionLeaderboard";
+
+/**
+ * PointsMatrix — the points board's game-by-game detail (PR 2). The proven
+ * spreadsheet model: **games are ROWS, teams are COLUMNS, cells are per-game
+ * points, the pinned top row is the column totals = standings.** It sits BELOW
+ * the standings glance as a collapsible section (NOT a tab) — the glance answers
+ * "are we winning?", the matrix is the on-demand audit of where the points came
+ * from. Points cups only (a head-to-head's single number needs no matrix).
+ *
+ * Columns are ordered by total desc so the leader's column is leftmost and the
+ * totals row mirrors the glance. The first (Game) column is sticky so the table
+ * body scrolls horizontally under it past ~4 teams while staying readable; up to
+ * 4 teams fit a phone without scrolling.
+ *
+ * Pure presentational — all data is the already-computed leaderboard payload
+ * (cells + teamTotals), so the matrix can't diverge from the glance.
+ */
+export function PointsMatrix({
+  games,
+  teams,
+  cellsByGame,
+  teamTotals,
+}: {
+  games: LBGame[];
+  teams: LBTeam[];
+  cellsByGame: Map<string, Map<string, LBCell>>;
+  teamTotals: Record<string, number>;
+}) {
+  // Calmer default: collapsed. The glance is the hero; the matrix is opt-in audit.
+  const [open, setOpen] = useState(false);
+
+  // Columns ordered by total desc → leader leftmost, totals row mirrors the glance.
+  const cols = [...teams].sort((a, b) => (teamTotals[b.id] ?? 0) - (teamTotals[a.id] ?? 0));
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl"
+      style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+      data-testid="points-matrix"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-4 py-3"
+        data-testid="points-matrix-toggle"
+      >
+        <Table2 size={14} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+        <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          Game by game
+        </span>
+        <ChevronDown
+          size={16}
+          className="ml-auto transition-transform"
+          style={{ color: "var(--color-bt-text-dim)", transform: open ? "rotate(180deg)" : undefined }}
+        />
+      </button>
+
+      {open && (
+        <div className="overflow-x-auto" style={{ borderTop: "1px solid var(--color-bt-border)" }}>
+          <table className="w-full border-collapse text-sm" data-testid="points-matrix-table">
+            <thead>
+              <tr>
+                <Th sticky>{""}</Th>
+                {cols.map((t) => (
+                  <Th key={t.id} align="center">
+                    <span className="inline-flex items-center gap-1">
+                      <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: t.color }} />
+                      <span className="font-bold uppercase tracking-wider" style={{ color: t.color }}>
+                        {t.short_name}
+                      </span>
+                    </span>
+                  </Th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {/* Totals row, pinned at the top — this IS the standings, mirrored. */}
+              <tr style={{ background: "var(--color-bt-card-raised)" }}>
+                <Td sticky bg="var(--color-bt-card-raised)">
+                  <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                    Total
+                  </span>
+                </Td>
+                {cols.map((t) => (
+                  <Td key={t.id} align="center" bg="var(--color-bt-card-raised)">
+                    <span className="text-base font-bold tabular-nums" style={{ color: t.color }}>
+                      {fmtPts(teamTotals[t.id] ?? 0)}
+                    </span>
+                  </Td>
+                ))}
+              </tr>
+
+              {games.length === 0 ? (
+                <tr>
+                  <Td sticky colSpan={1 + cols.length} bg="var(--color-bt-card)">
+                    <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
+                      No games yet — points appear here as games are scored.
+                    </span>
+                  </Td>
+                </tr>
+              ) : (
+                games.map((g, i) => {
+                  // Zebra on the data rows (the totals row owns card-raised).
+                  const rowBg = i % 2 === 0 ? "var(--color-bt-card)" : "var(--color-bt-card-raised)";
+                  const row = cellsByGame.get(g.id);
+                  return (
+                    <tr key={g.id} style={{ background: rowBg }}>
+                      <Td sticky bg={rowBg}>
+                        <span className="block max-w-[140px] truncate" style={{ color: "var(--color-bt-text)" }}>
+                          {g.name}
+                        </span>
+                      </Td>
+                      {cols.map((t) => {
+                        const cell = row?.get(t.id);
+                        return (
+                          <Td key={t.id} align="center" bg={rowBg}>
+                            {cell ? (
+                              <span className="tabular-nums" style={{ color: "var(--color-bt-text)" }}>
+                                {fmtPts(cell.points)}
+                              </span>
+                            ) : (
+                              <span style={{ color: "var(--color-bt-text-dim)" }}>—</span>
+                            )}
+                          </Td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Cell primitives ──────────────────────────────────────────────────────────
+// The first column is `sticky left:0` with an explicit background so rows scroll
+// horizontally under it (legible past ~4 team columns) without bleed-through.
+
+function Th({
+  children,
+  align = "left",
+  sticky = false,
+}: {
+  children: React.ReactNode;
+  align?: "left" | "center";
+  sticky?: boolean;
+}) {
+  return (
+    <th
+      className="px-3 py-2 text-[11px]"
+      style={{
+        textAlign: align,
+        minWidth: sticky ? 96 : 52,
+        position: sticky ? "sticky" : undefined,
+        left: sticky ? 0 : undefined,
+        background: sticky ? "var(--color-bt-card)" : undefined,
+        zIndex: sticky ? 1 : undefined,
+        borderBottom: "1px solid var(--color-bt-border)",
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({
+  children,
+  align = "left",
+  sticky = false,
+  bg,
+  colSpan,
+}: {
+  children: React.ReactNode;
+  align?: "left" | "center";
+  sticky?: boolean;
+  bg?: string;
+  colSpan?: number;
+}) {
+  return (
+    <td
+      colSpan={colSpan}
+      className="px-3 py-2.5"
+      style={{
+        textAlign: align,
+        minWidth: sticky ? 96 : 52,
+        position: sticky ? "sticky" : undefined,
+        left: sticky ? 0 : undefined,
+        background: sticky ? bg : undefined,
+        zIndex: sticky ? 1 : undefined,
+      }}
+    >
+      {children}
+    </td>
+  );
+}

--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -507,6 +507,7 @@ export function TeamsPanel({
           competitionId={competitionId}
           team={editingTeam}
           existingTeamNames={teamsTyped.map((t) => t.name.toLowerCase())}
+          existingColors={teamsTyped.map((t) => t.color)}
           // Inside the Rosters overlay the team CARD already owns roster mgmt, so
           // the per-card pencil opens identity-only. The consolidated roster
           // section lives on the STANDALONE TeamSheet (leaderboard short-name tap).
@@ -1238,6 +1239,7 @@ export function TeamSheet({
   competitionId,
   team,
   existingTeamNames,
+  existingColors = [],
   showRoster = true,
   onClose,
 }: {
@@ -1248,6 +1250,10 @@ export function TeamSheet({
    *  collisions when rolling a name from a theme. The current team's own
    *  name is excluded by the caller in edit mode. */
   existingTeamNames: string[];
+  /** Colors already taken by other teams — used in CREATE mode to default the
+   *  swatch to the first UNUSED palette color, so adding a 3rd/4th team doesn't
+   *  silently collide on Blue (the old index-0 default). N-team legibility. */
+  existingColors?: string[];
   /** Render the consolidated roster section (edit mode only). Default true —
    *  the STANDALONE TeamSheet (leaderboard short-name tap) is the full
    *  team-management home. The in-overlay per-card pencil passes false: the
@@ -1273,9 +1279,17 @@ export function TeamSheet({
   const [shortName, setShortName] = useState(team?.short_name ?? "");
   const [shortNameDirty, setShortNameDirty] = useState(isEdit);
   const [paletteIdx, setPaletteIdx] = useState(() => {
-    if (!team) return 0;
-    const idx = TEAM_COLORS.findIndex((c) => c.color === team.color);
-    return idx >= 0 ? idx : 0;
+    if (team) {
+      const idx = TEAM_COLORS.findIndex((c) => c.color === team.color);
+      return idx >= 0 ? idx : 0;
+    }
+    // CREATE: default to the first palette color not already used by another
+    // team, so each added team gets a distinct color (no Blue-on-Blue). If every
+    // palette color is taken (8+ teams), fall back to index 0 — the swatch picker
+    // still lets the owner choose.
+    const used = new Set(existingColors);
+    const firstFree = TEAM_COLORS.findIndex((c) => !used.has(c.color));
+    return firstFree >= 0 ? firstFree : 0;
   });
   const [suggesterOpen, setSuggesterOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
The leaderboard selected its layout on `teams.length === 2`, so a points
competition that happens to have 2 teams rendered the wrong (Ryder) board. The
axis is now the FROZEN `scoring_model`:
- match_play → the existing Ryder head-to-head hero, UNCHANGED (it's structurally
  2 teams, so TwoTeamHero is safe).
- points → the ranked standings list (the matrix lands in Task 2).

scoringModel is threaded from CompetitionFace (competition.scoring_model) into
CompetitionLeaderboard; the "cup hasn't started" EarlyState short-circuit is
gated to match_play so a points cup renders its real board with zeros instead of
the Ryder early card.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CbKjiu4qBswkjgJUMz8fE3