### PR TITLE
Settings overlay: shared hook + deep-link (?settings=1) support

### DIFF
--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ChevronLeft, Settings } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
@@ -9,6 +9,7 @@ import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { NonGolfConfigurationView } from "@/components/games/NonGolfConfigurationView";
 import { NonGolfScoreboard } from "@/components/games/NonGolfScoreboard";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
+import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { GAME_TYPES, type ScoringModel } from "@/lib/gameTypes";
 import type { GameRow, LBTeamLite } from "@/components/competition/CompetitionGamesPanel";
 
@@ -97,26 +98,12 @@ export default function ManualGamePage() {
   const enableScoring = trpc.games.enableScoring.useMutation();
   const disableScoring = trpc.games.disableScoring.useMutation();
 
-  // Settings is a browser-history-aware overlay (same pattern as the golf pages):
-  // opening it pushes a history entry so the in-page back arrow and the OS/mouse
-  // back are the SAME action and both return to this page.
-  const [showConfig, setShowConfig] = useState(false);
-  function openConfig() {
-    if (typeof window !== "undefined") window.history.pushState({ btCfg: true }, "");
-    setShowConfig(true);
-  }
-  function closeConfig() {
-    if (typeof window !== "undefined" && (window.history.state as { btCfg?: boolean } | null)?.btCfg) {
-      window.history.back();
-    } else {
-      setShowConfig(false);
-    }
-  }
-  useEffect(() => {
-    const onPop = () => setShowConfig(false);
-    window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
-  }, []);
+  // The ONE settings overlay — owns open/close/back + the leaderboard deep link
+  // (?settings=1 → land here directly for an owner/delegate of a setup-mode game).
+  const { open: showConfig, openConfig, closeConfig } = useGameSettingsOverlay({
+    canEdit,
+    deepLink: search.get("settings") === "1",
+  });
 
   async function refreshGame() {
     await gameQ.refetch();

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -7,6 +7,7 @@ import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
+import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
@@ -107,12 +108,16 @@ export default function NewMatchGamePage() {
   // centralized in useGameEditAccess. isOwner stays trip-Owner-only.
   const { canEdit, isOwner, loading: roleLoading } = useGameEditAccess(tripId, gameId);
   const [manualScreen, setManualScreen] = useState<Screen | null>(null);
-  // The settings page is an OVERLAY over the game scoreboard, browser-history aware:
-  // opening it pushes a history entry, so the in-page back arrow and the OS/mouse
-  // back are the SAME action and both return to the game page (not past it to the
-  // leaderboard). popstate (real back) closes it; closeConfig() routes the arrow
-  // through history.back() so they can't diverge.
-  const [cfgOpen, setCfgOpen] = useState(false);
+  // The settings overlay — owns open/close/back + the leaderboard deep link
+  // (?settings=1 → land here directly for an owner/delegate of a setup-mode game,
+  // back → leaderboard). The gear path pushes a history entry so the arrow and the
+  // OS/mouse back are the SAME action; the deep-link path routes back through the
+  // router to the leaderboard. (Aliased to `cfgOpen` — the rest of the page is
+  // unchanged.)
+  const { open: cfgOpen, openConfig, closeConfig } = useGameSettingsOverlay({
+    canEdit,
+    deepLink: search.get("settings") === "1",
+  });
 
   const [teeTime, setTeeTime] = useState(""); // "HH:MM" 24h
   // Setup editing state
@@ -440,26 +445,6 @@ export default function NewMatchGamePage() {
     setNavStack((s) => s.slice(0, -1));
   };
 
-  // Open the settings overlay + push a browser history entry (same URL) so a back —
-  // by the in-page arrow OR the browser/OS button — returns to the game page.
-  function openConfig() {
-    if (typeof window !== "undefined") window.history.pushState({ btCfg: true }, "");
-    setCfgOpen(true);
-  }
-  // Close via history.back() when our entry is on top, so the arrow takes the exact
-  // same path as the browser back (popstate → setCfgOpen(false)); else close direct.
-  function closeConfig() {
-    if (typeof window !== "undefined" && (window.history.state as { btCfg?: boolean } | null)?.btCfg) {
-      window.history.back();
-    } else {
-      setCfgOpen(false);
-    }
-  }
-  useEffect(() => {
-    const onPop = () => setCfgOpen(false);
-    window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
-  }, []);
   // Seed the editable draft from the server when we land on setup for an
   // existing game (e.g. owner opens a pending game, or taps Edit) and the local
   // draft is empty. Create + Edit also seed via their handlers; this covers a

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -17,6 +17,7 @@ import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
+import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import type { StrokeStanding } from "@/lib/strokePlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
@@ -75,30 +76,15 @@ export default function NewGamePage() {
   const [view, setView] = useState<"entry" | "grid" | "final">("entry");
   const [currentHole, setCurrentHole] = useState(1);
   const [standings, setStandings] = useState<StrokeStanding[]>([]);
-  const [showConfig, setShowConfig] = useState(false); // the ONE settings page
+  // The ONE settings overlay — owns open/close/back + the leaderboard deep link
+  // (?settings=1 → land here directly for an owner/delegate of a setup-mode game).
+  const { open: showConfig, openConfig, closeConfig } = useGameSettingsOverlay({
+    canEdit,
+    deepLink: search.get("settings") === "1",
+  });
   const [showHandicaps, setShowHandicaps] = useState(false); // §3 stroke handicaps step
   const [showModifiers, setShowModifiers] = useState(false); // A1 P0 — stroke modifiers step
   const [modifiersDraft, setModifiersDraft] = useState<ModifiersMap>({});
-
-  // Settings is a browser-history-aware overlay: opening it pushes a history entry
-  // so the in-page back arrow and the OS/mouse back are the SAME action and both
-  // return to the game page (not past it to the leaderboard).
-  function openConfig() {
-    if (typeof window !== "undefined") window.history.pushState({ btCfg: true }, "");
-    setShowConfig(true);
-  }
-  function closeConfig() {
-    if (typeof window !== "undefined" && (window.history.state as { btCfg?: boolean } | null)?.btCfg) {
-      window.history.back();
-    } else {
-      setShowConfig(false);
-    }
-  }
-  useEffect(() => {
-    const onPop = () => setShowConfig(false);
-    window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
-  }, []);
 
   const createGame = trpc.games.create.useMutation();
   const addParticipants = trpc.games.addParticipants.useMutation();

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, Users, Settings } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
+import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { TimePicker } from "@/components/TimePicker";
@@ -83,26 +84,12 @@ export default function RackNStackPage() {
   const [firstTee, setFirstTee] = useState(""); // "HH:MM" 24h; groups stagger +10
   const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
   const [showHandicaps, setShowHandicaps] = useState(false);
-  const [showConfig, setShowConfig] = useState(false); // the ONE settings page
-  // Settings is a browser-history-aware overlay: opening it pushes a history entry
-  // so the in-page back arrow and the OS/mouse back are the SAME action and both
-  // return to the game page (not past it to the leaderboard).
-  function openConfig() {
-    if (typeof window !== "undefined") window.history.pushState({ btCfg: true }, "");
-    setShowConfig(true);
-  }
-  function closeConfig() {
-    if (typeof window !== "undefined" && (window.history.state as { btCfg?: boolean } | null)?.btCfg) {
-      window.history.back();
-    } else {
-      setShowConfig(false);
-    }
-  }
-  useEffect(() => {
-    const onPop = () => setShowConfig(false);
-    window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
-  }, []);
+  // The ONE settings overlay — owns open/close/back + the leaderboard deep link
+  // (?settings=1 → land here directly for an owner/delegate of a setup-mode game).
+  const { open: showConfig, openConfig, closeConfig } = useGameSettingsOverlay({
+    canEdit,
+    deepLink: search.get("settings") === "1",
+  });
   const [currentHole, setCurrentHole] = useState(1);
   const [values, setValues] = useState<ScoreValues>({});
 

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -371,6 +371,7 @@ function GamesSection({
         mineSet={mineSet}
         viewer={viewer}
         onPrefetch={onPrefetch}
+        canEdit={canEdit}
       />
       {addBtn}
     </div>
@@ -629,6 +630,7 @@ function SessionBreakdown({
   mineSet,
   viewer,
   onPrefetch,
+  canEdit,
 }: {
   games: LBGame[];
   teams: LBTeam[];
@@ -638,6 +640,7 @@ function SessionBreakdown({
   mineSet: Set<string>;
   viewer: LBViewer;
   onPrefetch: (gameId: string) => void;
+  canEdit: boolean;
 }) {
   return (
     <div>
@@ -659,6 +662,7 @@ function SessionBreakdown({
             cells={cellsByGame.get(game.id)}
             tripId={tripId}
             mine={mineSet.has(game.id)}
+            canEdit={canEdit}
             viewerName={viewer.name}
             viewerAvatarIcon={viewer.avatarIcon}
             viewerTeamColor={viewer.teamColor}
@@ -757,6 +761,7 @@ function EarlyState({
                 cells={undefined}
                 tripId={tripId}
                 mine={mineSet.has(game.id)}
+                canEdit={canEdit}
                 viewerName={viewer.name}
                 viewerAvatarIcon={viewer.avatarIcon}
                 viewerTeamColor={viewer.teamColor}

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -95,6 +95,7 @@ export function GameRow({
   cells,
   tripId,
   mine,
+  canEdit,
   viewerName,
   viewerAvatarIcon,
   viewerTeamColor,
@@ -105,6 +106,10 @@ export function GameRow({
   cells: Map<string, LBCell> | undefined;
   tripId: string;
   mine: boolean;
+  /** Trip-level edit access (Owner/Organizer). ORed with `mine` (this game's
+   *  delegate) it IS useGameEditAccess/canEditGame — the gate for the deep link
+   *  to a setup-mode game's settings page. */
+  canEdit?: boolean;
   /** The viewer's display name + chosen avatar icon + competition-team color —
    *  rendered as the delegate marker when `mine` (the viewer's avatar in their
    *  team color, §10). Only needed when the viewer delegates this game. */
@@ -113,7 +118,16 @@ export function GameRow({
   viewerTeamColor?: string | null;
   onPrefetch: (gameId: string) => void;
 }) {
-  const href = gameHref(tripId, game.gameTypeId, game.id);
+  // Deep-link to SETTINGS when the viewer can edit this game (Owner/Organizer OR
+  // its delegate — mirrors useGameEditAccess) AND it's still in SETUP (nothing on
+  // the scoreboard yet). Otherwise the normal target (scoreboard / placeholder).
+  // Once scoring is on (live/final), everyone gets the scoreboard. Members never
+  // get the settings link — they hit the server-walled placeholder.
+  const canEditThisGame = !!canEdit || mine;
+  const setupMode = !(game.status === "complete" || game.status === "active" || game.scoringEnabled === true);
+  const href = gameHref(tripId, game.gameTypeId, game.id, {
+    settings: canEditThisGame && setupMode,
+  });
   const hasScores = cells && cells.size > 0;
   // The row's single source of truth — the game's actual lifecycle, not a board
   // context flag. Layout + every §A3 layer key off this one value.

--- a/src/hooks/useGameSettingsOverlay.ts
+++ b/src/hooks/useGameSettingsOverlay.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * useGameSettingsOverlay — the ONE owner of the game settings (configuration)
+ * overlay across every game page (golf stroke/match/rack + non-golf manual), so
+ * the open/close/back behavior can't drift per-surface.
+ *
+ * Two ways the overlay opens, with DIFFERENT back semantics:
+ *
+ *  1. **Gear** (`openConfig`) — opened over the game scoreboard/pass-through. It
+ *     pushes a browser history entry (same URL) so the in-page arrow and the
+ *     OS/mouse back are the SAME action and both return to the game page.
+ *     `closeConfig` → `history.back()` (popstate closes the overlay).
+ *
+ *  2. **Deep link** (`?settings=1`) — the leaderboard routes an owner/delegate of
+ *     a SETUP-mode game straight here (the scoreboard has nothing to show yet, so
+ *     the extra tap is skipped — decided at the link, not a land-then-redirect).
+ *     The leaderboard→settings navigation is ITSELF the history entry below the
+ *     overlay, so we do NOT push another one; `closeConfig` → `router.back()`
+ *     returns to the leaderboard with no scoreboard flash and no loop.
+ *
+ * Edit-access gate: the deep-link auto-open is gated on `canEdit` (mirrors the
+ * server's `canEditGame` — owner/organizer OR this game's delegate). A plain
+ * member who somehow lands on `?settings=1` never auto-opens; they fall through
+ * to the server-walled placeholder. The leaderboard only emits the param for
+ * editors anyway — this is the belt-and-suspenders on the page.
+ *
+ * Returns `open` (alias it to the page's existing flag name to keep the rest of
+ * the page untouched) plus the two handlers.
+ */
+export function useGameSettingsOverlay({
+  canEdit,
+  deepLink,
+}: {
+  /** Mirrors useGameEditAccess/canEditGame — gates the deep-link auto-open. */
+  canEdit: boolean;
+  /** The `?settings=1` deep-link marker is present on the URL. */
+  deepLink: boolean;
+}) {
+  const router = useRouter();
+  // The gear path opens imperatively; the deep-link path is DERIVED (no
+  // setState-in-effect) — it's open as long as the URL marks it and edit access
+  // holds. The leaderboard only ever closes a deep-linked overlay by navigating
+  // away (router.back), which unmounts the page, so there's no "deep-linked but
+  // closed while still here" state to track.
+  const [userOpen, setUserOpen] = useState(false);
+  const deepLinked = deepLink && canEdit;
+  const open = userOpen || deepLinked;
+
+  const openConfig = useCallback(() => {
+    if (typeof window !== "undefined") window.history.pushState({ btCfg: true }, "");
+    setUserOpen(true);
+  }, []);
+
+  const closeConfig = useCallback(() => {
+    // Deep-linked: the entry below the overlay is the LEADERBOARD — go straight
+    // back to it (single history pop, no scoreboard in between, no loop).
+    if (deepLinked) {
+      router.back();
+      return;
+    }
+    // Gear path: our pushed entry is on top — history.back() so the arrow takes
+    // the exact same path as the browser back (popstate → setUserOpen(false));
+    // else close direct (safety fallback when no entry was pushed).
+    if (typeof window !== "undefined" && (window.history.state as { btCfg?: boolean } | null)?.btCfg) {
+      window.history.back();
+    } else {
+      setUserOpen(false);
+    }
+  }, [deepLinked, router]);
+
+  // Real back (OS/mouse, or our own history.back()) closes a gear-opened overlay.
+  useEffect(() => {
+    const onPop = () => setUserOpen(false);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  return { open, openConfig, closeConfig };
+}

--- a/src/lib/gameRoutes.test.ts
+++ b/src/lib/gameRoutes.test.ts
@@ -19,6 +19,28 @@ describe("gameHref", () => {
     expect(gameHref("trip1", null, "g1")).toBeNull();
     expect(gameHref("trip1", "gtt_not_a_real_type", "g1")).toBeNull();
   });
+
+  it("appends &settings=1 when the settings deep-link is requested (golf + manual)", () => {
+    expect(gameHref("trip1", "gtt_stroke_play", "g1", { settings: true })).toBe(
+      "/trips/trip1/games/new?game=g1&settings=1"
+    );
+    expect(gameHref("trip1", "gtt_match_play_singles", "g1", { settings: true })).toBe(
+      "/trips/trip1/games/match/new?game=g1&settings=1"
+    );
+    expect(gameHref("trip1", "gtt_rack_n_stack", "g1", { settings: true })).toBe(
+      "/trips/trip1/games/rack/new?game=g1&settings=1"
+    );
+    expect(gameHref("trip1", "gtt_generic_card", "g1", { settings: true })).toBe(
+      `/trips/trip1/games/${MANUAL_ROUTE}?game=g1&settings=1`
+    );
+  });
+
+  it("omits the settings param when not requested (default = scoreboard target)", () => {
+    expect(gameHref("trip1", "gtt_stroke_play", "g1", { settings: false })).toBe(
+      "/trips/trip1/games/new?game=g1"
+    );
+    expect(gameHref("trip1", "gtt_stroke_play", "g1")).toBe("/trips/trip1/games/new?game=g1");
+  });
 });
 
 describe("isGolfFormat", () => {

--- a/src/lib/gameRoutes.ts
+++ b/src/lib/gameRoutes.ts
@@ -24,14 +24,21 @@ export const MANUAL_ROUTE = "manual";
 export function gameHref(
   tripId: string,
   gameTypeId: string | null,
-  gameId: string
+  gameId: string,
+  /** `settings: true` deep-links to the game's settings (configuration) page
+   *  instead of the scoreboard pass-through — the leaderboard uses this to drop
+   *  an owner/delegate straight into setup for a not-yet-scoring game (the page
+   *  honors `?settings=1` via useGameSettingsOverlay). Members / scoring-mode
+   *  games never get it (decided at the call site). */
+  opts?: { settings?: boolean }
 ): string | null {
   if (!gameTypeId) return null;
+  const suffix = opts?.settings ? "&settings=1" : "";
   const seg = GAME_ROUTES[gameTypeId];
-  if (seg) return `/trips/${tripId}/games/${seg}?game=${gameId}`;
+  if (seg) return `/trips/${tripId}/games/${seg}?game=${gameId}${suffix}`;
   // Non-golf manual games now have a real scoreboard PAGE (promoted from the old
   // post-results modal) — route there instead of opening a modal in place.
-  if (isManualGameType(gameTypeId)) return `/trips/${tripId}/games/${MANUAL_ROUTE}?game=${gameId}`;
+  if (isManualGameType(gameTypeId)) return `/trips/${tripId}/games/${MANUAL_ROUTE}?game=${gameId}${suffix}`;
   return null;
 }
 


### PR DESCRIPTION
Extract the four game pages' duplicated settings-overlay logic (open/close/back +
popstate) into one hook, useGameSettingsOverlay, so the open/back behavior can't
drift per-surface — and teach it the leaderboard deep link:

- `?settings=1` on the URL, for a viewer with edit access (canEdit — mirrors
  useGameEditAccess/canEditGame), renders the settings overlay directly. It's
  DERIVED open (no setState-in-effect), so a member who lands on the param never
  opens it — they fall through to the server-walled placeholder.
- Back from a deep-linked overlay routes through router.back() to the LEADERBOARD
  (the leaderboard→settings navigation is itself the entry below — no extra push,
  no scoreboard flash, no loop). The gear path is unchanged: it pushes a history
  entry and closes via history.back().

The four pages (stroke/match/rack/manual) now call the hook, aliasing its `open`
to their existing flag name (cfgOpen/showConfig) so the rest of each page is
untouched. The link that SETS the param lands in the next commit; this is inert
until then.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CbKjiu4qBswkjgJUMz8fE3