### PR TITLE
Fix: game settings page can't scroll to the bottom (non-golf + stroke)

### DIFF
--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -155,27 +155,30 @@ export default function ManualGamePage() {
   );
 
   // ── The ONE settings page — reached via the corner gear in BOTH modes. ──
+  // Returned DIRECTLY (not in a `fixed inset-0` wrapper): it's a full-page view,
+  // and its own `min-h-screen` root document-scrolls. Wrapping it in `fixed`
+  // pinned it to the viewport, so tall content (e.g. the points panel + danger
+  // zone) overflowed past the bottom with no way to scroll — the reported bug.
+  // This matches the rack page, which already renders the config view directly.
   if (showConfig && canEdit && competitionId) {
     return (
-      <div className="fixed inset-0 z-50">
-        <NonGolfConfigurationView
-          subtitle={typeName}
-          onBack={closeConfig}
-          tripId={tripId}
-          competitionId={competitionId}
-          game={game}
-          scoringModel={scoringModel}
-          canEdit={canEdit}
-          isOwner={isOwner}
-          onChanged={() => void refreshGame()}
-          onDeleted={() => router.push(`/trips/${tripId}/leaderboard`)}
-          scoringEnabled={scoringEnabled}
-          ready={ready}
-          onEnable={handleEnable}
-          onDisable={handleDisable}
-          busy={enableScoring.isPending || disableScoring.isPending}
-        />
-      </div>
+      <NonGolfConfigurationView
+        subtitle={typeName}
+        onBack={closeConfig}
+        tripId={tripId}
+        competitionId={competitionId}
+        game={game}
+        scoringModel={scoringModel}
+        canEdit={canEdit}
+        isOwner={isOwner}
+        onChanged={() => void refreshGame()}
+        onDeleted={() => router.push(`/trips/${tripId}/leaderboard`)}
+        scoringEnabled={scoringEnabled}
+        ready={ready}
+        onEnable={handleEnable}
+        onDisable={handleDisable}
+        busy={enableScoring.isPending || disableScoring.isPending}
+      />
     );
   }
 

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -427,38 +427,40 @@ export default function NewGamePage() {
   // ── The ONE settings page — reached via the corner gear in BOTH modes. The full
   // checklist (course/points/handicaps/modifiers) + the single Setup/Scoring toggle
   // + the Danger Zone, all here. ──
+  // Returned DIRECTLY (not in a `fixed inset-0` wrapper): it's a full-page view
+  // whose own `min-h-screen` root document-scrolls. A `fixed` wrapper pinned it to
+  // the viewport so tall content overflowed past the bottom unscrollably (the same
+  // class of bug reported on the non-golf settings page). Matches the rack page.
   if (game && showConfig && gameQ.data && canEdit) {
     return (
-      <div className="fixed inset-0 z-50">
-        <GameConfigurationView
-          subtitle="Stroke Play"
-          onBack={closeConfig}
-          tripId={tripId}
-          competitionId={gameCompetitionId}
-          game={gameQ.data as unknown as GameRow}
-          canEdit={canEdit}
-          isOwner={isOwner}
-          onChanged={() => void refreshGame()}
-          onDeleted={() => router.push(gameCompetitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
-          whosPlayingLabel={`${game.participants.length} player${game.participants.length === 1 ? "" : "s"} · per-player strokes`}
-          // Keep showConfig set so the handicaps/modifiers drill-downs return HERE.
-          onEditWhosPlaying={() => setShowHandicaps(true)}
-          extraRows={
-            availableModifiers.length > 0 ? (
-              <ModifiersRow
-                count={enabledCount(modifiersDraft, availableModifiers)}
-                onClick={() => setShowModifiers(true)}
-                disabled={!settingsEditable}
-                locked={scoringEnabled}
-              />
-            ) : undefined
-          }
-          scoringEnabled={scoringEnabled}
-          onEnable={handleEnable}
-          onDisable={handleDisable}
-          busy={enableScoring.isPending || disableScoring.isPending}
-        />
-      </div>
+      <GameConfigurationView
+        subtitle="Stroke Play"
+        onBack={closeConfig}
+        tripId={tripId}
+        competitionId={gameCompetitionId}
+        game={gameQ.data as unknown as GameRow}
+        canEdit={canEdit}
+        isOwner={isOwner}
+        onChanged={() => void refreshGame()}
+        onDeleted={() => router.push(gameCompetitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
+        whosPlayingLabel={`${game.participants.length} player${game.participants.length === 1 ? "" : "s"} · per-player strokes`}
+        // Keep showConfig set so the handicaps/modifiers drill-downs return HERE.
+        onEditWhosPlaying={() => setShowHandicaps(true)}
+        extraRows={
+          availableModifiers.length > 0 ? (
+            <ModifiersRow
+              count={enabledCount(modifiersDraft, availableModifiers)}
+              onClick={() => setShowModifiers(true)}
+              disabled={!settingsEditable}
+              locked={scoringEnabled}
+            />
+          ) : undefined
+        }
+        scoringEnabled={scoringEnabled}
+        onEnable={handleEnable}
+        onDisable={handleDisable}
+        busy={enableScoring.isPending || disableScoring.isPending}
+      />
     );
   }
 


### PR DESCRIPTION
## What

The non-golf (manual) game settings page couldn't scroll to the bottom — the points panel, Setup/Scoring toggle, and Danger Zone were unreachable. Fixed it, and the identical latent bug on the stroke settings page.

## Root cause

Both pages wrapped their full-page config view in `<div className="fixed inset-0 z-50">`. The config view's root is `min-h-screen` — a **minimum** height. Inside a viewport-pinned `fixed` box, tall content grows the root past `100vh`, so the inner `min-h-0 flex-1 overflow-y-auto` never gets a bounded height to scroll within, and the `fixed` wrapper clips everything past the viewport bottom.

## Fix

The settings view is a full-page `return` (nothing renders behind it), so the `fixed` wrapper was unnecessary. Render the config view **directly** — its own `min-h-screen` root then document-scrolls normally.

This matches the **rack** and **match** settings pages, which already render in normal document flow and scroll correctly; only **manual** and **stroke** carried the stray wrapper. No shared component changed (rack relies on the config view staying `min-h-screen`).

## Files

- `src/app/trips/[tripId]/games/manual/page.tsx` — drop the `fixed inset-0 z-50` wrapper around `NonGolfConfigurationView` (the reported bug).
- `src/app/trips/[tripId]/games/new/page.tsx` — drop the same wrapper around `GameConfigurationView` (identical latent bug; the recent leaderboard→settings deep-link now lands owners here directly).

## Verify

- tsc + lint clean. Pure wrapper removal — no logic, ordering, or back-behavior change (the deep-link `closeConfig`/`router.back` path is untouched).
- Visual scroll confirmation is best eyeballed on the preview deploy (needs an authenticated session); the CSS reasoning is definitive and brings these two pages in line with the two settings pages that already scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbKjiu4qBswkjgJUMz8fE3)_