### PR TITLE
fix: competition settings back returns to leaderboard (not trip home)

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -11,6 +11,7 @@ import { RostersOverlay } from "./RostersOverlay";
 import { TeamSheet, type Team } from "./TeamsPanel";
 import { GameSheet } from "./CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
+import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 
 interface Competition {
   id: string;
@@ -31,12 +32,16 @@ interface Competition {
  * were both retired — creation lands directly on the bones board):
  *   board    — the leaderboard (the main view for everyone, setup + live)
  *   settings — the consolidated Settings page (competition details + Team Rosters
- *              + delete) — reached from the header gear and the pre-save Team
- *              Rosters button
+ *              + delete) — reached from the header gear
+ * Settings is a history-pushed overlay (the shared `useGameSettingsOverlay`, the
+ * SAME contract the per-game settings pages use): opening it pushes a history
+ * entry so the in-page "Board" back arrow AND the OS/browser back button both
+ * dismiss it and return to the leaderboard — never past it to the trip home.
+ * (Gear-only here — no `?settings=1` deep link; competition settings is reached
+ * solely from the gear, so `deepLink: false`.)
  * "Add a game" no longer routes to a panel — it opens the GameSheet modal
  * directly over the board; existing games are managed on their per-game pages.
  */
-type FaceView = "settings" | "board";
 
 interface Props {
   tripId: string;
@@ -71,9 +76,14 @@ export function CompetitionFace({
   const utils = trpc.useUtils();
 
   // The board is the home in every stage now — creation lands here directly
-  // (the setup guide was retired); Settings is a sub-surface reached from the
-  // board and returns to it. "Add a game" opens a modal over the board.
-  const [view, setView] = useState<FaceView>("board");
+  // (the setup guide was retired). Settings is a history-pushed overlay over the
+  // board: opening pushes a history entry so back (in-page arrow OR OS/browser
+  // button) returns to the leaderboard, not the trip home. Reuses the shared
+  // game-settings overlay hook (one home for the behavior); gear-only, so
+  // deepLink is false — competition settings has no `?settings=1` deep link.
+  // "Add a game" opens a modal over the board.
+  const { open: settingsOpen, openConfig: openSettings, closeConfig: closeSettings } =
+    useGameSettingsOverlay({ canEdit, deepLink: false });
   const [addingGame, setAddingGame] = useState(false);
   const [rostersOpen, setRostersOpen] = useState(false);
   // Leaderboard team-name tap → a STANDALONE identity editor (owner / captain-of-
@@ -125,18 +135,20 @@ export function CompetitionFace({
     <CompetitionHeader
       competition={competition}
       tripId={tripId}
-      onSettings={canEdit ? () => setView("settings") : undefined}
+      onSettings={canEdit ? openSettings : undefined}
     />
   );
 
-  // ── Sub-surface: the consolidated Settings page — reached from the board ─────
-  if (view === "settings") {
+  // ── Sub-surface: the consolidated Settings page — a history-pushed overlay ───
+  // over the board. Back (in-page arrow OR OS/browser button) returns to the
+  // leaderboard via useGameSettingsOverlay, never past it to the trip home.
+  if (settingsOpen) {
     return (
       <div className="space-y-4">
         {header}
         <button
           type="button"
-          onClick={() => setView("board")}
+          onClick={closeSettings}
           className="inline-flex items-center gap-1 text-[13px] font-semibold"
           style={{ color: "var(--color-bt-accent)" }}
           data-testid="comp-back-to-board"


### PR DESCRIPTION
## The bug

Competition settings (the header gear on the competition/leaderboard face) opened as a local `view`-state swap (`CompetitionFace.tsx`) that pushed **no history entry**. So hitting **back** from settings bounced to the **trip home** instead of returning to the **leaderboard** — users (Zach) reflexively hit back to return to the board and got kicked out of the competition entirely.

## The fix (navigation only — no UI redesign)

Make competition settings a **history-pushed, navigable state** by **reusing the existing shared `useGameSettingsOverlay` hook** (added in #520) with `deepLink: false`:

- Opening settings (gear) pushes a history entry (same URL).
- The in-page **"‹ Board"** back arrow **and** the OS/browser/mouse **back** button both dismiss settings and return to the **leaderboard** — never past it to the trip home.
- This is the **same contract game settings uses**, so the two surfaces behave identically (muscle-memory parity).

**Gear-only** — `deepLink: false` (no `?settings=1` deep link; competition settings is reached solely from the gear, per spec). The settings panel UI is untouched.

## Why reuse, not a new hook

Phase 0 found there's no `useGameSettingsOverlay`-by-that-exact-name fork needed — #520 already extracted the shared overlay hook and it's cleanly reusable for the gear path (`deepLink: false`). Reusing it keeps **one home** for settings-overlay nav behavior, so game and competition settings can't drift.

## Verify

- ✅ Gear → settings shows; **OS/browser back** → returns to leaderboard (not trip home); history entry confirmed pushed/popped (`btCfg`).
- ✅ In-page "Board" back → returns to leaderboard, consistent with back.
- ✅ No console errors; settings UI unchanged.
- ✅ Game-settings back behavior **unchanged** — zero changes to `useGameSettingsOverlay` or any game page; Playwright critical-path + match-play spines green (3/3).
- ✅ `tsc --noEmit` clean, eslint clean.
- ✅ Vitest: 820 passed; the single failure is the pre-existing `news.test.ts > unreadCount` timestamp flake, confirmed failing identically on clean `main` with this change stashed (independent of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)