### PR TITLE
Leaderboard redesign: merged hero + trophy, game sections, compressed completed rows

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -168,40 +168,49 @@ export function CompetitionFace({
   }
 
   // ── Board (the home, setup + live) ──────────────────────────────────────────
+  // The merged hero (identity + gear + scores) lives INSIDE the leaderboard now,
+  // so the old CompetitionHeader is gone from the board — it survives only on the
+  // Settings sub-surface above.
+  const scoringModel = competition.scoring_model ?? "match_play";
   return (
     <div className="space-y-4">
-      {header}
-
-      {/* Rosters entry point (W-TEAMSURFACE-01) — board-level so it shows in EVERY
-          standings state (empty / setup / live / final), which is precisely when
-          you need it. Member-visible. This (and the in-overlay pencil) are the
-          ONLY ways the overlay opens; a hero team-name tap goes to the standalone
-          identity editor instead. */}
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={() => setRostersOpen(true)}
-          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-semibold"
-          style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "0.5px solid var(--color-bt-border)" }}
-          data-testid="open-rosters"
-        >
-          <Users size={14} style={{ color: "var(--color-bt-accent)" }} />
-          Rosters
-        </button>
-      </div>
+      {/* Rosters entry point (W-TEAMSURFACE-01), gated on scoring_model (R3): a
+          match_play cup is locked at 2 teams — add/delete-team is hidden and
+          per-team roster editing lives in the Edit Team modal (tap a team name),
+          so the button is redundant and removed. POINTS cups (2–N) KEEP it: it's
+          still the only path to add/delete a team (relocating that into
+          competition settings is deferred to Phase B — a known temporary). */}
+      {scoringModel === "points" && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => setRostersOpen(true)}
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-semibold"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "0.5px solid var(--color-bt-border)" }}
+            data-testid="open-rosters"
+          >
+            <Users size={14} style={{ color: "var(--color-bt-accent)" }} />
+            Rosters
+          </button>
+        </div>
+      )}
 
       <CompetitionLeaderboard
         competitionId={competition.id}
         tripId={tripId}
+        // Identity + gear for the merged hero (Task 1); the gear opens settings via
+        // the #522 history-back overlay — same handler, so back-nav is unchanged.
+        cupName={competition.name}
+        tagline={competition.tagline}
+        onSettings={canEdit ? openSettings : undefined}
         canEdit={canEdit}
         // The board layout is selected by the FROZEN scoring_model, not team
         // count (PR 2): match_play → Ryder hero, points → standings + matrix.
-        scoringModel={competition.scoring_model ?? "match_play"}
+        scoringModel={scoringModel}
         onAddGame={() => setAddingGame(true)}
-        // A hero team-short-name tap → the consolidated Edit Team modal (the
-        // team-management home). It self-gates by role: owner edits everything,
-        // captain edits identity (roster read-only), a plain member sees it
-        // read-only.
+        // A hero team-name tap → the consolidated Edit Team modal (the team-
+        // management home). It self-gates by role: owner edits everything, captain
+        // edits identity (roster read-only), a plain member sees it read-only.
         onEditTeam={handleEditTeam}
       />
 
@@ -217,7 +226,7 @@ export function CompetitionFace({
           competitionId={competition.id}
           types={gameTypes}
           canEdit={canEdit}
-          scoringModel={competition.scoring_model ?? "match_play"}
+          scoringModel={scoringModel}
           onClose={() => {
             setAddingGame(false);
             utils.competitions.faceBootstrap.invalidate({ tripId });
@@ -238,7 +247,7 @@ export function CompetitionFace({
           // is 2–N, so adds/deletes stay open. (The go-live freeze this replaced
           // was retired with GO LIVE; player-removal protection once scoring
           // starts is a separate SCORE-based lock, teamAssignments.rosterLocked.)
-          structureLocked={(competition.scoring_model ?? "match_play") === "match_play"}
+          structureLocked={scoringModel === "match_play"}
           rosterBuilding={rosterSetup === "building"}
           onSaveRosters={() => { setRosterSetup("saved"); setRostersOpen(false); }}
           onClose={() => setRostersOpen(false)}

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { Trophy, Settings, Users } from "lucide-react";
+import { fmtPts } from "./GameRow";
+import type { LBTeam } from "./CompetitionLeaderboard";
+import type { ScoringModel } from "@/lib/gameTypes";
+
+/**
+ * CompetitionHero — the merged competition header (Task 1). ONE elevated gradient
+ * card replaces the old two surfaces (the CompetitionHeader identity/gear strip +
+ * the TwoTeamHero scores/bar). "Hero gradient art" per STYLE_GUIDE's carve-out:
+ * the CARD gradient, the warm glow, and the dimensional gold trophy are raw-hex
+ * ART (the geometry is the approved `hero_trophy_reference.html`, verbatim); every
+ * STRUCTURAL element around them uses --color-bt-* tokens, and the team scores/
+ * names use the team colors (data). Dark-mode only (the app forces dark).
+ *
+ * Typography INHERITS --font-sans (no font is declared here) so the hero matches
+ * the trip-home header by construction on every device.
+ *
+ * Layout (match_play): identity + gear on top; full team names (own line,
+ * team-colored); the two big team-colored scores flanking the trophy (which is
+ * centered behind them, cropped by overflow:hidden so it bleeds); the clinch bar;
+ * and BELOW the bar ONLY the win target — the per-side "X to clinch" and "pts in
+ * play" text are stripped (Task 2: the bar carries proximity).
+ *
+ * For POINTS comps the trophy/two-score treatment doesn't apply (N teams don't
+ * flank a trophy), so the hero is the identity + gear card only; the points
+ * standings body (NTeamRankedList) stays untouched below it (board-body branching
+ * is separate work).
+ */
+export function CompetitionHero({
+  cupName,
+  tagline,
+  teams,
+  teamTotals,
+  pointsAvailable,
+  winNumber,
+  clincher,
+  scoringModel,
+  canEdit,
+  onSettings,
+  onEditTeam,
+}: {
+  cupName: string;
+  tagline: string | null;
+  teams: LBTeam[];
+  teamTotals: Record<string, number>;
+  pointsAvailable: number;
+  winNumber: number;
+  clincher: LBTeam | null;
+  scoringModel: ScoringModel;
+  /** Editors get the gear (opens competition settings via the #522 history-back
+   *  overlay — same handler, so back-nav is unchanged). */
+  canEdit: boolean;
+  onSettings?: () => void;
+  /** Tap a team name → that team's identity editor (owner / its captain). */
+  onEditTeam?: (teamId: string) => void;
+}) {
+  // The two-score + trophy treatment is the match_play hero; points keeps its own
+  // standings body below (untouched), so the hero there is identity + gear only.
+  const showScores = scoringModel === "match_play" && teams.length >= 2;
+  const [a, b] = teams;
+
+  const aTotal = a ? teamTotals[a.id] ?? 0 : 0;
+  const bTotal = b ? teamTotals[b.id] ?? 0 : 0;
+  // Each team's share of the points in play → the two end-fills. A marker sits at
+  // the relative-lead point so the bar reads as a live race (tied → centered).
+  const aWidth = pointsAvailable > 0 ? Math.min(100, (aTotal / pointsAvailable) * 100) : 0;
+  const bWidth = pointsAvailable > 0 ? Math.min(100, (bTotal / pointsAvailable) * 100) : 0;
+  const leadPct = aTotal + bTotal > 0 ? (aTotal / (aTotal + bTotal)) * 100 : 50;
+
+  return (
+    <div
+      style={{
+        // ART: gradient card + soft float shadow (raw hex per the hero carve-out).
+        position: "relative",
+        overflow: "hidden", // crops the trophy so it bleeds top/bottom
+        borderRadius: 16,
+        border: "1px solid var(--color-bt-border)",
+        background: "linear-gradient(158deg,#222e44 0%,#1a2231 100%)",
+        boxShadow: "0 10px 28px rgba(0,0,0,0.40)",
+      }}
+      data-testid="competition-hero"
+    >
+      {/* Warm gold glow behind the trophy — ties it into the surface (ART). */}
+      {showScores && (
+        <div
+          aria-hidden
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "radial-gradient(ellipse 52% 82% at 50% 50%, rgba(216,180,82,0.14), transparent 64%)",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+
+      {/* Dimensional gold trophy — authoritative geometry from
+          hero_trophy_reference.html, group opacity 0.17, centered + cropped. */}
+      {showScores && <HeroTrophy />}
+
+      {/* CONTENT — sharp, in front of the art. */}
+      <div style={{ position: "relative", padding: "20px 24px 22px" }}>
+        {/* Top row: identity (left) + gear (right). */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-2.5">
+            <span
+              className="flex flex-shrink-0 items-center justify-center rounded-xl"
+              style={{
+                width: 36,
+                height: 36,
+                background: "var(--color-bt-accent-faint)",
+                color: "var(--color-bt-accent)",
+              }}
+            >
+              <Trophy size={18} />
+            </span>
+            <div className="min-w-0">
+              <p style={{ fontSize: 22, fontWeight: 600, lineHeight: 1.1, color: "var(--color-bt-text)" }}>
+                {cupName}
+              </p>
+              {tagline && tagline.trim() && (
+                <p className="mt-0.5" style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+                  {tagline}
+                </p>
+              )}
+            </div>
+          </div>
+          {onSettings && canEdit && (
+            <button
+              type="button"
+              onClick={onSettings}
+              aria-label="Competition settings"
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
+              style={{ background: "transparent", color: "var(--color-bt-text-dim)" }}
+              data-testid="competition-settings-btn"
+            >
+              <Settings size={16} />
+            </button>
+          )}
+        </div>
+
+        {showScores && (
+          <>
+            {/* Team names row — FULL names (dedicated-row → full-name rule),
+                team-colored, each on its side, tappable → that team's editor. */}
+            <div className="mt-4 flex items-center justify-between gap-3">
+              <TeamName team={a} onEditTeam={onEditTeam} align="left" />
+              <TeamName team={b} onEditTeam={onEditTeam} align="right" />
+            </div>
+
+            {/* Scores — the two big team-colored numbers flanking the trophy. */}
+            <div className="mt-1 flex items-baseline justify-between gap-4">
+              <span style={{ fontSize: 74, fontWeight: 700, lineHeight: 1, color: a.color }} className="tabular-nums">
+                {fmtPts(aTotal)}
+              </span>
+              <span style={{ fontSize: 74, fontWeight: 700, lineHeight: 1, color: b.color }} className="tabular-nums">
+                {fmtPts(bTotal)}
+              </span>
+            </div>
+
+            {/* Clinch bar — track + each team's end-fill + a lead marker. */}
+            <div
+              className="relative mt-4 flex h-2 w-full overflow-hidden rounded-full"
+              style={{ background: "var(--color-bt-card-raised)" }}
+            >
+              <div
+                className="h-full rounded-l-full transition-all duration-500"
+                style={{ width: `${aWidth}%`, background: a.color }}
+              />
+              <div
+                className="ml-auto h-full rounded-r-full transition-all duration-500"
+                style={{ width: `${bWidth}%`, background: b.color }}
+              />
+              {/* Lead marker — slides toward whoever's ahead (centered when tied). */}
+              <div
+                className="absolute top-1/2 h-3.5 w-0.5 -translate-y-1/2 rounded-full transition-all duration-500"
+                style={{ left: `calc(${leadPct}% - 1px)`, background: "var(--color-bt-text)" }}
+              />
+            </div>
+
+            {/* Below the bar: ONLY the win target (Task 2). */}
+            <p className="mt-2 text-center" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
+              {clincher
+                ? `Final · ${clincher.name} wins`
+                : pointsAvailable > 0
+                ? `First to ${fmtPts(winNumber)} wins`
+                : "No points in play yet"}
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** A team name on its side of the hero — full name, team-colored, group icon,
+ *  tappable to that team's identity editor (owner / its captain). */
+function TeamName({
+  team,
+  onEditTeam,
+  align,
+}: {
+  team: LBTeam;
+  onEditTeam?: (teamId: string) => void;
+  align: "left" | "right";
+}) {
+  const content = (
+    <>
+      {align === "left" && <Users size={14} style={{ color: team.color, flexShrink: 0 }} />}
+      <span className="truncate" style={{ fontSize: 15, fontWeight: 600, color: team.color }}>
+        {team.name}
+      </span>
+      {align === "right" && <Users size={14} style={{ color: team.color, flexShrink: 0 }} />}
+    </>
+  );
+  return (
+    <button
+      type="button"
+      onClick={() => onEditTeam?.(team.id)}
+      disabled={!onEditTeam}
+      className={`flex min-w-0 items-center gap-1.5 disabled:cursor-default ${align === "right" ? "justify-end text-right" : ""}`}
+      data-testid={`comp-team-name-${align === "left" ? "a" : "b"}`}
+    >
+      {content}
+    </button>
+  );
+}
+
+/** The dimensional gold trophy — verbatim geometry from the approved
+ *  hero_trophy_reference.html (viewBox 0 0 300 380, group opacity 0.17). Open
+ *  modeled mouth, gradient-lit round body, slim knopped pedestal, engraved star.
+ *  Raw hex is the sanctioned hero art. IDs are prefixed to avoid <defs> clashes. */
+function HeroTrophy() {
+  return (
+    <svg
+      width="300"
+      viewBox="0 0 300 380"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        left: "50%",
+        top: "50%",
+        transform: "translate(-50%,-46%)",
+        pointerEvents: "none",
+      }}
+    >
+      <defs>
+        <linearGradient id="btHeroBowl" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stopColor="#f6e0a0" />
+          <stop offset="0.42" stopColor="#d9b350" />
+          <stop offset="1" stopColor="#8a6a24" />
+        </linearGradient>
+        <linearGradient id="btHeroBase" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" stopColor="#ecd282" />
+          <stop offset="1" stopColor="#87682a" />
+        </linearGradient>
+      </defs>
+      <g opacity="0.17">
+        {/* base (two tiers) + knop + narrow tall pedestal */}
+        <rect x="96" y="320" width="108" height="24" rx="6" fill="url(#btHeroBase)" />
+        <rect x="120" y="305" width="60" height="15" rx="4" fill="url(#btHeroBase)" />
+        <ellipse cx="150" cy="298" rx="19" ry="8" fill="url(#btHeroBase)" />
+        <rect x="142" y="258" width="16" height="42" fill="url(#btHeroBase)" />
+        {/* slim handles (lit left / shadow right) */}
+        <path d="M60,104 Q24,114 32,166 Q38,204 82,198" fill="none" stroke="#cfa94e" strokeWidth="13" strokeLinecap="round" />
+        <path d="M240,104 Q276,114 268,166 Q262,204 218,198" fill="none" stroke="#a5822f" strokeWidth="13" strokeLinecap="round" />
+        {/* bowl body: left->right gradient = round modeling */}
+        <path d="M58,88 Q58,228 150,260 Q242,228 242,88 Z" fill="url(#btHeroBowl)" />
+        {/* soft highlight on the lit side */}
+        <ellipse cx="106" cy="152" rx="11" ry="52" fill="#fff0bf" opacity="0.5" />
+        {/* engraved 5-point star (darker gold = recessed) */}
+        <path
+          d="M150,132 L157.6,151.5 L178.5,152.7 L162.4,166 L167.6,186.3 L150,175 L132.4,186.3 L137.6,166 L121.5,152.7 L142.4,151.5 Z"
+          fill="#57411a"
+        />
+        {/* open mouth: light rim ellipse + dark inner hollow + faint far-wall shadow */}
+        <ellipse cx="150" cy="86" rx="92" ry="19" fill="url(#btHeroBowl)" />
+        <ellipse cx="150" cy="85" rx="75" ry="13" fill="#4a3915" />
+        <ellipse cx="133" cy="82" rx="38" ry="6" fill="#6b5320" opacity="0.7" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -134,8 +134,10 @@ export function CompetitionHero({
               type="button"
               onClick={onSettings}
               aria-label="Competition settings"
-              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
-              style={{ background: "transparent", color: "var(--color-bt-text-dim)" }}
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-colors"
+              // Semi-transparent white pill, matching the trip header's gear on its
+              // gradient (rgba over the hero art — same treatment, same values).
+              style={{ background: "rgba(255,255,255,0.08)", color: "rgba(241,245,249,0.6)" }}
               data-testid="competition-settings-btn"
             >
               <Settings size={16} />

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -67,7 +67,6 @@ export function CompetitionHero({
   // the relative-lead point so the bar reads as a live race (tied → centered).
   const aWidth = pointsAvailable > 0 ? Math.min(100, (aTotal / pointsAvailable) * 100) : 0;
   const bWidth = pointsAvailable > 0 ? Math.min(100, (bTotal / pointsAvailable) * 100) : 0;
-  const leadPct = aTotal + bTotal > 0 ? (aTotal / (aTotal + bTotal)) * 100 : 50;
 
   return (
     <div
@@ -173,10 +172,12 @@ export function CompetitionHero({
                 className="ml-auto h-full rounded-r-full transition-all duration-500"
                 style={{ width: `${bWidth}%`, background: b.color }}
               />
-              {/* Lead marker — slides toward whoever's ahead (centered when tied). */}
+              {/* Center divider — a FIXED halfway reference. Each team's fill
+                  grows from its own end toward it, so a fill crossing the center
+                  is what shows the lead (the marker itself never moves). */}
               <div
-                className="absolute top-1/2 h-3.5 w-0.5 -translate-y-1/2 rounded-full transition-all duration-500"
-                style={{ left: `calc(${leadPct}% - 1px)`, background: "var(--color-bt-text)" }}
+                className="absolute left-1/2 top-1/2 h-full w-0.5 -translate-x-1/2 -translate-y-1/2"
+                style={{ background: "var(--color-bt-text)" }}
               />
             </div>
 

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -99,8 +99,11 @@ export function CompetitionHero({
           hero_trophy_reference.html, group opacity 0.17, centered + cropped. */}
       {showScores && <HeroTrophy />}
 
-      {/* CONTENT — sharp, in front of the art. */}
-      <div style={{ position: "relative", padding: "20px 24px 22px" }}>
+      {/* CONTENT — sharp, in front of the art. Horizontal padding matches the
+          trip-header card (16px) rather than the mockup's standalone 24px, since
+          the Live-face main already insets the card — keeps content off the edges
+          without the doubled gap. */}
+      <div style={{ position: "relative", padding: "18px 16px 20px" }}>
         {/* Top row: identity (left) + gear (right). */}
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-2.5">

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -5,7 +5,7 @@ import { Trophy, CloudOff, RefreshCw, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import type { ScoringModel } from "@/lib/gameTypes";
-import { GameRow, fmtPts } from "./GameRow";
+import { GameRow, CompletedRow, sectionOf, fmtPts, type GameSection } from "./GameRow";
 import { PointsMatrix } from "./PointsMatrix";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -195,7 +195,6 @@ export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "
     return <NoTeamsState />;
   }
 
-  const sessionsDone = liveGames.filter((g) => g.status === "complete").length;
   const allZero = teams.every((t) => (teamTotals[t.id] ?? 0) === 0);
   const nothingPlayed = liveGames.every((g) => g.status === "pending");
   const isEarly = allZero && nothingPlayed && liveGames.length > 0;
@@ -300,7 +299,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "
         games={liveGames}
         teams={teams}
         cellsByGame={cellsByGame}
-        sessionsDone={sessionsDone}
+        scoringModel={scoringModel}
         tripId={tripId}
         mineSet={mineSet}
         viewer={viewer}
@@ -317,12 +316,12 @@ export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "
 // entry). Empty → the bones prompt + "Add a game"; populated → the session
 // breakdown + "Add a game". Editor-gated; the crew sees the list only.
 function GamesSection({
-  games, teams, cellsByGame, sessionsDone, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame,
+  games, teams, cellsByGame, scoringModel, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
   cellsByGame: Map<string, Map<string, LBCell>>;
-  sessionsDone: number;
+  scoringModel: ScoringModel;
   tripId: string;
   mineSet: Set<string>;
   viewer: LBViewer;
@@ -369,7 +368,7 @@ function GamesSection({
         games={games}
         teams={teams}
         cellsByGame={cellsByGame}
-        sessionsDone={sessionsDone}
+        scoringModel={scoringModel}
         tripId={tripId}
         mineSet={mineSet}
         viewer={viewer}
@@ -624,11 +623,21 @@ function NTeamRankedList({
 
 // ── SessionBreakdown ─────────────────────────────────────────────────────────
 
+// Section order + labels (Task 4). The Completed section renders compressed
+// single-line rows; the rest use the full GameRow.
+const SECTION_ORDER: { key: GameSection; label: string }[] = [
+  { key: "completed", label: "Completed" },
+  { key: "on-tap", label: "On Tap" },
+  { key: "ready", label: "Ready for Play" },
+  { key: "preparing", label: "Preparing for Gameplay" },
+  { key: "skeleton", label: "Skeleton" },
+];
+
 function SessionBreakdown({
   games,
   teams,
   cellsByGame,
-  sessionsDone,
+  scoringModel,
   tripId,
   mineSet,
   viewer,
@@ -638,41 +647,73 @@ function SessionBreakdown({
   games: LBGame[];
   teams: LBTeam[];
   cellsByGame: Map<string, Map<string, LBCell>>;
-  sessionsDone: number;
+  scoringModel: ScoringModel;
   tripId: string;
   mineSet: Set<string>;
   viewer: LBViewer;
   onPrefetch: (gameId: string) => void;
   canEdit: boolean;
 }) {
+  // Group games by board section (single source: sectionOf) — every game lands
+  // in exactly one bucket (R1 clean partition). Server order (created_at asc) is
+  // preserved within each section.
+  const bySection = useMemo(() => {
+    const m = new Map<GameSection, LBGame[]>();
+    for (const g of games) {
+      const s = sectionOf(g);
+      const arr = m.get(s);
+      if (arr) arr.push(g);
+      else m.set(s, [g]);
+    }
+    return m;
+  }, [games]);
+
   return (
-    <div>
-      <p
-        className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
-        style={{ color: "var(--color-bt-text-dim)" }}
-      >
-        Sessions{" "}
-        <span style={{ color: "var(--color-bt-text)" }}>
-          · {sessionsDone} of {games.length} done
-        </span>
-      </p>
-      <div className="flex flex-col gap-2">
-        {games.map((game) => (
-          <GameRow
-            key={game.id}
-            game={game}
-            teams={teams}
-            cells={cellsByGame.get(game.id)}
-            tripId={tripId}
-            mine={mineSet.has(game.id)}
-            canEdit={canEdit}
-            viewerName={viewer.name}
-            viewerAvatarIcon={viewer.avatarIcon}
-            viewerTeamColor={viewer.teamColor}
-            onPrefetch={onPrefetch}
-          />
-        ))}
-      </div>
+    <div className="flex flex-col gap-4">
+      {SECTION_ORDER.map(({ key, label }) => {
+        const sectionGames = bySection.get(key);
+        if (!sectionGames || sectionGames.length === 0) return null; // empty sections hidden
+        return (
+          <div key={key} data-testid={`games-section-${key}`}>
+            <p
+              className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
+              style={{ color: "var(--color-bt-text-dim)" }}
+            >
+              {label}{" "}
+              <span style={{ color: "var(--color-bt-text)" }}>· {sectionGames.length}</span>
+            </p>
+            <div className="flex flex-col gap-2">
+              {sectionGames.map((game) =>
+                key === "completed" ? (
+                  <CompletedRow
+                    key={game.id}
+                    game={game}
+                    teams={teams}
+                    cells={cellsByGame.get(game.id)}
+                    scoringModel={scoringModel}
+                    tripId={tripId}
+                    onPrefetch={onPrefetch}
+                  />
+                ) : (
+                  <GameRow
+                    key={game.id}
+                    game={game}
+                    teams={teams}
+                    cells={cellsByGame.get(game.id)}
+                    tripId={tripId}
+                    mine={mineSet.has(game.id)}
+                    canEdit={canEdit}
+                    viewerName={viewer.name}
+                    viewerAvatarIcon={viewer.avatarIcon}
+                    viewerTeamColor={viewer.teamColor}
+                    onPrefetch={onPrefetch}
+                  />
+                )
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -35,6 +35,9 @@ export interface LBGame {
   /** Scoring is enabled (Phase 2B.1) — the real arming signal the format-icon
    *  color reads (§A4). False until the owner enables; first score → Live. */
   scoringEnabled?: boolean;
+  /** ≥1 score entry exists (R1) — splits `active` into On Tap (started) vs Ready
+   *  for Play (enabled, not started) for the board's game sections. */
+  started?: boolean;
   /** Points in play for this game — the §A5 outer-column `N PTS` value. Carries
    *  the match-play total too (whose `distribution` is null pre-decision). */
   pointsTotal?: number | null;

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -6,6 +6,7 @@ import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import type { ScoringModel } from "@/lib/gameTypes";
 import { GameRow, CompletedRow, sectionOf, fmtPts, type GameSection } from "./GameRow";
+import { CompetitionHero } from "./CompetitionHero";
 import { PointsMatrix } from "./PointsMatrix";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -74,6 +75,13 @@ interface LeaderboardData {
 interface Props {
   competitionId: string;
   tripId: string;
+  /** Cup identity for the merged hero (Task 1) — the hero replaced the separate
+   *  CompetitionHeader, so identity + gear are threaded in here. */
+  cupName: string;
+  tagline: string | null;
+  /** Opens competition settings (the #522 history-back overlay). Gear shows only
+   *  for editors; passing it keeps the SAME handler so back-nav is unchanged. */
+  onSettings?: () => void;
   /** The competition's FROZEN scoring model — selects the board layout (PR 2):
    *  `match_play` → the Ryder head-to-head hero; `points` → the standings glance
    *  + collapsible games×teams matrix. NOT team count — a 2-team points cup is
@@ -88,7 +96,7 @@ interface Props {
   onEditTeam?: (teamId: string) => void;
 }
 
-export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "match_play", canEdit = false, onAddGame, onEditTeam }: Props) {
+export function CompetitionLeaderboard({ competitionId, tripId, cupName, tagline, onSettings, scoringModel = "match_play", canEdit = false, onAddGame, onEditTeam }: Props) {
   const { data: lb, isLoading, isError, refetch } = trpc.competitions.leaderboard.useQuery(
     { tripId, competitionId },
     {
@@ -195,29 +203,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "
     return <NoTeamsState />;
   }
 
-  const allZero = teams.every((t) => (teamTotals[t.id] ?? 0) === 0);
-  const nothingPlayed = liveGames.every((g) => g.status === "pending");
-  const isEarly = allZero && nothingPlayed && liveGames.length > 0;
   const clincher = teams.find((t) => (pointsToClinch[t.id] ?? 1) <= 0) ?? null;
-
-  // The "cup hasn't started" early state is the match_play (Ryder) treatment. A
-  // POINTS cup skips it and renders its real board with zeros — the standings
-  // glance + the empty-but-structured matrix read as intentional, not broken.
-  if (isEarly && scoringModel === "match_play") {
-    return (
-      <EarlyState
-        teams={teams}
-        liveGames={liveGames}
-        winNumber={winNumber}
-        tripId={tripId}
-        mineSet={mineSet}
-        viewer={viewer}
-        onPrefetch={prefetchGame}
-        canEdit={canEdit}
-        onAddGame={onAddGame}
-      />
-    );
-  }
 
   return (
     <div className="space-y-3" data-testid="competition-leaderboard">
@@ -231,59 +217,60 @@ export function CompetitionLeaderboard({ competitionId, tripId, scoringModel = "
         />
       )}
 
-      {/* Main standings panel */}
-      <div
-        className="overflow-hidden rounded-xl"
-        style={{
-          background: "var(--color-bt-card)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        {/* Magic-number subtitle */}
-        <div className="px-4 pt-3 pb-2">
-          <p
-            className="text-[11px] font-semibold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            {clincher
-              ? "Final"
-              : pointsAvailable > 0
-              ? `First to ${fmtPts(winNumber)} wins`
-              : "Competition standings"}
-          </p>
-        </div>
+      {/* The merged hero (Task 1) — identity + gear + (match_play) team names,
+          scores, clinch bar, win target. Replaces the old CompetitionHeader +
+          TwoTeamHero AND the "cup hasn't started" EarlyState (the hero renders
+          the 0–0 setup state fine, so it's the header in every stage). */}
+      <CompetitionHero
+        cupName={cupName}
+        tagline={tagline}
+        teams={teams}
+        teamTotals={teamTotals}
+        pointsAvailable={pointsAvailable}
+        winNumber={winNumber}
+        clincher={clincher}
+        scoringModel={scoringModel}
+        canEdit={canEdit}
+        onSettings={onSettings}
+        onEditTeam={onEditTeam}
+      />
 
-        {/* Board layout is selected by scoring_model, NOT team count (PR 2): a
-            2-team POINTS cup gets the standings glance + matrix, not the Ryder
-            hero. match_play is structurally 2 teams, so the hero is safe. */}
-        {scoringModel === "match_play" ? (
-          <TwoTeamHero
-            teams={teams}
-            teamTotals={teamTotals}
-            pointsAvailable={pointsAvailable}
-            winNumber={winNumber}
-            pointsToClinch={pointsToClinch}
-            clincher={clincher}
-            onEditTeam={onEditTeam}
-          />
-        ) : (
-          <NTeamRankedList
-            teams={teams}
-            teamTotals={teamTotals}
-            pointsAvailable={pointsAvailable}
-            winNumber={winNumber}
-            pointsToClinch={pointsToClinch}
-            clincher={clincher}
-            onEditTeam={onEditTeam}
-          />
-        )}
-      </div>
-
-      {/* Points board — the collapsible games×teams matrix BELOW the standings
-          glance. Points cups only; the Ryder hero needs no matrix (one head-to-
-          head number is the whole story). */}
+      {/* POINTS body (board-body branching, left untouched): the standings glance
+          + the collapsible games×teams matrix, below the identity hero. match_play
+          needs neither — the hero's two-score head-to-head is the whole story. */}
       {scoringModel === "points" && (
-        <PointsMatrix games={liveGames} teams={teams} cellsByGame={cellsByGame} teamTotals={teamTotals} />
+        <>
+          <div
+            className="overflow-hidden rounded-xl"
+            style={{
+              background: "var(--color-bt-card)",
+              border: "1px solid var(--color-bt-border)",
+            }}
+          >
+            <div className="px-4 pt-3 pb-2">
+              <p
+                className="text-[11px] font-semibold uppercase tracking-wider"
+                style={{ color: "var(--color-bt-text-dim)" }}
+              >
+                {clincher
+                  ? "Final"
+                  : pointsAvailable > 0
+                  ? `First to ${fmtPts(winNumber)} wins`
+                  : "Competition standings"}
+              </p>
+            </div>
+            <NTeamRankedList
+              teams={teams}
+              teamTotals={teamTotals}
+              pointsAvailable={pointsAvailable}
+              winNumber={winNumber}
+              pointsToClinch={pointsToClinch}
+              clincher={clincher}
+              onEditTeam={onEditTeam}
+            />
+          </div>
+          <PointsMatrix games={liveGames} teams={teams} cellsByGame={cellsByGame} teamTotals={teamTotals} />
+        </>
       )}
 
       {/* Bones copy — the calm setup voice, only while the board is empty and
@@ -376,132 +363,6 @@ function GamesSection({
         canEdit={canEdit}
       />
       {addBtn}
-    </div>
-  );
-}
-
-// ── TwoTeamHero ──────────────────────────────────────────────────────────────
-
-function TwoTeamHero({
-  teams,
-  teamTotals,
-  pointsAvailable,
-  winNumber,
-  pointsToClinch,
-  clincher,
-  onEditTeam,
-}: {
-  teams: LBTeam[];
-  teamTotals: Record<string, number>;
-  pointsAvailable: number;
-  winNumber: number;
-  pointsToClinch: Record<string, number>;
-  clincher: LBTeam | null;
-  /** Tap a team name → that team's identity editor (owner / its captain). */
-  onEditTeam?: (teamId: string) => void;
-}) {
-  const [a, b] = teams;
-  const aTotal = teamTotals[a.id] ?? 0;
-  const bTotal = teamTotals[b.id] ?? 0;
-  const aToGo = pointsToClinch[a.id] ?? winNumber;
-  const bToGo = pointsToClinch[b.id] ?? winNumber;
-
-  // Progress bar proportions — each team's share of pointsAvailable.
-  const aWidth = pointsAvailable > 0 ? Math.min(100, (aTotal / pointsAvailable) * 100) : 0;
-  const bWidth = pointsAvailable > 0 ? Math.min(100, (bTotal / pointsAvailable) * 100) : 0;
-
-  return (
-    <div className="px-4 pb-4">
-      {/* Team name row — tap a name → Rosters focused on that team (its identity
-          editor opens for the owner / that team's captain; read-only otherwise). */}
-      <div className="flex items-center justify-between">
-        <button
-          type="button"
-          onClick={() => onEditTeam?.(a.id)}
-          disabled={!onEditTeam}
-          className="text-[11px] font-bold uppercase tracking-widest disabled:cursor-default"
-          style={{ color: a.color }}
-          data-testid="comp-team-name-a"
-        >
-          {a.short_name}
-        </button>
-        <button
-          type="button"
-          onClick={() => onEditTeam?.(b.id)}
-          disabled={!onEditTeam}
-          className="text-[11px] font-bold uppercase tracking-widest disabled:cursor-default"
-          style={{ color: b.color }}
-          data-testid="comp-team-name-b"
-        >
-          {b.short_name}
-        </button>
-      </div>
-
-      {/* Big totals */}
-      <div className="flex items-baseline justify-between">
-        <span
-          className="text-5xl font-black tabular-nums leading-none"
-          style={{ color: a.color }}
-        >
-          {fmtPts(aTotal)}
-        </span>
-        <span
-          className="mx-3 text-2xl font-light"
-          style={{ color: "var(--color-bt-text-dim)" }}
-        >
-          –
-        </span>
-        <span
-          className="text-5xl font-black tabular-nums leading-none"
-          style={{ color: b.color }}
-        >
-          {fmtPts(bTotal)}
-        </span>
-      </div>
-
-      {/* "X to clinch" sub-labels */}
-      {!clincher && (
-        <div className="mt-1 flex items-start justify-between">
-          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            {aToGo > 0 ? `${fmtPts(aToGo)} to clinch` : "Clinched"}
-          </p>
-          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            {bToGo > 0 ? `${fmtPts(bToGo)} to clinch` : "Clinched"}
-          </p>
-        </div>
-      )}
-
-      {/* Progress bar */}
-      <div
-        className="mt-3 flex h-2 w-full overflow-hidden rounded-full"
-        style={{ background: "var(--color-bt-card-raised)" }}
-      >
-        <div
-          className="h-full rounded-l-full transition-all duration-500"
-          style={{ width: `${aWidth}%`, background: a.color }}
-        />
-        <div
-          className="h-full rounded-r-full transition-all duration-500 ml-auto"
-          style={{ width: `${bWidth}%`, background: b.color }}
-        />
-      </div>
-
-      {/* Footer row */}
-      <div className="mt-1.5 flex items-center justify-between">
-        <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-          {pointsAvailable > 0 ? `${fmtPts(pointsAvailable)} pts in play` : "No pts yet"}
-        </p>
-        {!clincher && pointsAvailable > 0 && (
-          <p className="text-[11px]" style={{ color: "var(--color-bt-text-dim)" }}>
-            clinch {fmtPts(winNumber)}
-          </p>
-        )}
-        {clincher && (
-          <p className="text-[11px] font-semibold" style={{ color: "var(--color-bt-accent)" }}>
-            Final
-          </p>
-        )}
-      </div>
     </div>
   );
 }
@@ -714,122 +575,6 @@ function SessionBreakdown({
           </div>
         );
       })}
-    </div>
-  );
-}
-
-// ── EarlyState ────────────────────────────────────────────────────────────────
-
-function EarlyState({
-  teams,
-  liveGames,
-  winNumber,
-  tripId,
-  mineSet,
-  viewer,
-  onPrefetch,
-  canEdit,
-  onAddGame,
-}: {
-  teams: LBTeam[];
-  liveGames: LBGame[];
-  winNumber: number;
-  tripId: string;
-  mineSet: Set<string>;
-  viewer: LBViewer;
-  onPrefetch: (gameId: string) => void;
-  canEdit: boolean;
-  onAddGame?: () => void;
-}) {
-  return (
-    <div className="space-y-3" data-testid="competition-leaderboard">
-      {/* Team dots row */}
-      <div
-        className="flex flex-wrap items-center gap-3 rounded-xl px-4 py-4"
-        style={{
-          background: "var(--color-bt-card)",
-          border: "1px solid var(--color-bt-border)",
-        }}
-      >
-        {teams.map((team) => (
-          <div key={team.id} className="flex items-center gap-2">
-            <span
-              className="h-3 w-3 rounded-full"
-              style={{ background: team.color }}
-            />
-            <span
-              className="text-sm font-semibold"
-              style={{ color: "var(--color-bt-text)" }}
-            >
-              {team.name}
-            </span>
-          </div>
-        ))}
-
-        <div
-          className="mt-3 w-full"
-          style={{ borderTop: "1px solid var(--color-bt-border)" }}
-        />
-        <div className="w-full pt-1">
-          <p
-            className="text-sm font-semibold"
-            style={{ color: "var(--color-bt-text)" }}
-          >
-            The cup hasn&rsquo;t started
-          </p>
-          <p
-            className="mt-1 text-[12px] leading-relaxed"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            {liveGames.length} session{liveGames.length !== 1 ? "s" : ""} ·{" "}
-            first to {fmtPts(winNumber)} wins. Standings appear as games finish.
-          </p>
-        </div>
-      </div>
-
-      {/* Schedule */}
-      {liveGames.length > 0 && (
-        <div>
-          <p
-            className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
-            style={{ color: "var(--color-bt-text-dim)" }}
-          >
-            The Schedule
-          </p>
-          <div className="flex flex-col gap-2">
-            {liveGames.map((game) => (
-              <GameRow
-                key={game.id}
-                game={game}
-                teams={teams}
-                cells={undefined}
-                tripId={tripId}
-                mine={mineSet.has(game.id)}
-                canEdit={canEdit}
-                viewerName={viewer.name}
-                viewerAvatarIcon={viewer.avatarIcon}
-                viewerTeamColor={viewer.teamColor}
-                onPrefetch={onPrefetch}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Keep "Add a game" reachable in the setup/early phase — this is the
-          prime time to build the schedule, and it's the board's sole entry to
-          the add-game modal now that the aggregate panel is retired. */}
-      {canEdit && onAddGame && (
-        <button
-          type="button"
-          onClick={onAddGame}
-          className="flex w-full items-center justify-center gap-1.5 rounded-xl px-3 py-3"
-          style={{ background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
-          data-testid="comp-add-game"
-        >
-          <Plus size={16} /> Add a game
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createElement, Fragment } from "react";
+import { createElement } from "react";
 import Link from "next/link";
 import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -435,22 +435,19 @@ export function CompletedRow({
   );
 }
 
-/** match_play completed result — each team's points, team-colored, in the SAME
- *  left-right order as the hero (the `teams` array order). No winner emphasis. */
+/** match_play completed result — each team's points as a team-color dot + the
+ *  number in white, in the SAME left-right order as the hero (the `teams` array
+ *  order). No winner emphasis. */
 function CompletedScores({ teams, cells }: { teams: LBTeam[]; cells: Map<string, LBCell> | undefined }) {
   return (
-    <div className="flex shrink-0 items-center gap-1.5 tabular-nums">
-      {teams.map((t, i) => (
-        <Fragment key={t.id}>
-          {i > 0 && (
-            <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
-              –
-            </span>
-          )}
-          <span className="text-sm font-semibold" style={{ color: t.color }}>
+    <div className="flex shrink-0 items-center gap-3 tabular-nums">
+      {teams.map((t) => (
+        <span key={t.id} className="flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full" style={{ background: t.color }} />
+          <span className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
             {fmtPts(cells?.get(t.id)?.points ?? 0)}
           </span>
-        </Fragment>
+        </span>
       ))}
     </div>
   );

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { createElement } from "react";
+import { createElement, Fragment } from "react";
 import Link from "next/link";
 import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
 import { gameHref, isGolfFormat } from "@/lib/gameRoutes";
+import type { ScoringModel } from "@/lib/gameTypes";
 import type { LBGame, LBTeam, LBCell } from "./CompetitionLeaderboard";
 
 export { gameHref, isGolfFormat } from "@/lib/gameRoutes";
@@ -35,34 +36,38 @@ export function formatIcon(gameTypeId: string | null): LucideIcon {
 }
 
 /**
- * The §A lifecycle state the row reads — replaces the old 4-value RowState.
- * DERIVED from the game's actual status + readiness; it is the row's single
- * source of truth, not a layout flag (§A2). The two gravy sub-states are carried
- * as data ON TOP of these four, not as extra enum values: "configuring" is a
- * partial "setting-up", and "armed vs not-armed" lives inside "ready" (carried
- * by the format-icon color, §A4 — wired to this derived value, never a literal
- * board/layout string).
+ * The board SECTION a game belongs to — the SINGLE source of truth for both the
+ * section grouping (CompetitionLeaderboard) and this row's presentation, so a row
+ * can never render a treatment that disagrees with its section header.
  *
- * Ready must be EARNED, not assumed: a game is Setting up until the format's
- * required roster is assigned (`configured`, derived server-side from pairing /
- * participant counts). "Exists and not live/final" is NOT Ready — that was the
- * bug where an unconfigured match game rendered Ready while its points read `—`.
- * Course/handicaps never gate this (locked, readiness model). Same `configured`
- * signal feeds the outer `N PTS`/`—` column, so the two can't disagree.
+ * A2-core (#500) made enable ≡ active (`enableScoring` sets scoring_enabled AND
+ * status='active' in one write), so `status` alone gives only four reachable
+ * states; the fifth section (On Tap ↔ Ready for Play) splits `active` on
+ * `started` (≥1 score entry, R1):
+ *   complete              → completed   (done)
+ *   active  &  started    → on-tap      (scores flowing — genuinely underway)
+ *   active  & !started    → ready       (Ready for Play — enabled/pairings up, unscored)
+ *   pending &  configured → preparing   (Preparing for Gameplay — roster set, not enabled)
+ *   pending & !configured → skeleton    (barely configured)
+ * Total + disjoint = a clean 5-way partition (every game in exactly one section).
+ *
+ * `configured` (roster earned, server-derived) gates preparing↔skeleton; it also
+ * feeds the outer `N PTS`/`—` column so the two can't disagree. Course/handicaps
+ * never gate this (locked, readiness model).
  */
-export type LifecycleState = "setting-up" | "ready" | "live" | "final";
-export function lifecycleOf(game: LBGame): LifecycleState {
-  if (game.status === "complete") return "final";
-  if (game.status === "active") return "live";
-  return game.configured ? "ready" : "setting-up";
+export type GameSection = "completed" | "on-tap" | "ready" | "preparing" | "skeleton";
+export function sectionOf(game: LBGame): GameSection {
+  if (game.status === "complete") return "completed";
+  if (game.status === "active") return game.started === true ? "on-tap" : "ready";
+  return game.configured ? "preparing" : "skeleton";
 }
 
 /**
  * §A4 arm signal: the format-icon shows full color once scoring is ENABLED,
- * muted before. Phase 2B.1 wired this to the real `scoring_enabled` field
- * (replacing the Phase-3 derived stub `lifecycle !== "setting-up"`), so the two
- * §A signals finally diverge on a real state: a Ready-but-not-enabled game reads
- * full name (structure done) + muted icon (not enabled) until the owner enables.
+ * muted before. Phase 2B.1 wired this to the real `scoring_enabled` field, so the
+ * two §A signals diverge on a real state: a Preparing game (configured, not
+ * enabled) reads full name (structure done) + muted icon (not enabled) until the
+ * owner enables. On Tap / Ready for Play (both `active`) read armed.
  */
 export function iconArmed(game: LBGame): boolean {
   return game.scoringEnabled === true;
@@ -129,10 +134,11 @@ export function GameRow({
     settings: canEditThisGame && setupMode,
   });
   const hasScores = cells && cells.size > 0;
-  // The row's single source of truth — the game's actual lifecycle, not a board
-  // context flag. Layout + every §A3 layer key off this one value.
-  const lifecycle = lifecycleOf(game);
-  const isFinal = lifecycle === "final";
+  // The row's single source of truth — the game's board SECTION (shared with the
+  // section grouping so row + header always agree). Layout + every §A3 layer key
+  // off this one value.
+  const section = sectionOf(game);
+  const isFinal = section === "completed";
 
   // Final sheds the operational layer (scorecard + delegate), keeps the result
   // (round-3.1 §A2). The scorecard column is golf-only and present everywhere
@@ -151,54 +157,56 @@ export function GameRow({
   const armed = iconArmed(game);
   const armedIcon = armed && !isFinal;
 
-  // Subtitle / running state (§A3), all keyed off the one derived lifecycle:
-  //  - live   → running state (the real "Blue 2 up · thru 13" is deferred).
-  //  - ready  → SPLIT by the arm tell: armed = good to go; not-armed = the one
-  //             remaining step is ENABLING scoring (the roster IS assigned — that's
-  //             what `configured` means — and handicaps are optional/never gate, so
-  //             the old "Assign players + handicaps" was wrong; readiness rework P1a).
-  //  - setting-up → a tap-to-continue CTA, but only when the row is tappable;
-  //             an inert crew row leans on the dashed outline alone (§A3).
-  //  - final  → none; the recessed tile + outer result speak for it.
+  // Subtitle / running state (§A3), all keyed off the one derived section:
+  //  - on-tap    → running state (the real "Blue 2 up · thru 13" is deferred).
+  //  - ready     → Ready for Play: enabled + pairings up, waiting on the first score.
+  //  - preparing → the one remaining step is ENABLING scoring (the roster IS
+  //                assigned — that's what `configured` means — handicaps never gate,
+  //                readiness rework P1a). (The old `ready && armed → "Ready to play"`
+  //                branch was dead under A2-core — a pending game can't be armed —
+  //                and is gone; "Ready to play" now lives on the `ready` section.)
+  //  - skeleton  → a tap-to-continue CTA, but only when the row is tappable; an
+  //                inert crew row leans on the dashed outline alone (§A3).
+  //  - completed → none; the compressed row + outer result speak for it.
   const subtitle =
-    lifecycle === "live"
+    section === "on-tap"
       ? "Underway · scoring"
-      : lifecycle === "ready"
-      ? armed
-        ? "Ready to play"
-        : "Ready — enable scoring"
-      : lifecycle === "setting-up"
+      : section === "ready"
+      ? "Ready to play"
+      : section === "preparing"
+      ? "Ready — enable scoring"
+      : section === "skeleton"
       ? tappable
         ? "Tap to keep setting up"
         : null
       : null;
 
   // Panel surface — each game is its own standalone card (not a row inside a
-  // shared panel). Only the ACTIVE states carry a fill: Ready (a solid card,
-  // "built + waiting") and Live (the one reserved accent-faint "act now" fill,
-  // §A2). Setting-up and Final get NO fill — setting-up is an outline-only dashed
-  // shell ("not built yet"), Final a recessed, dimmed record. The border lives on
+  // shared panel). On Tap carries the one reserved accent-faint "act now" fill
+  // (§A2); Ready for Play + Preparing are solid cards ("built + waiting");
+  // Skeleton and Completed get NO fill — skeleton is an outline-only dashed shell
+  // ("not built yet"), completed a recessed, dimmed record. The border lives on
   // the panel so the inner content never shifts.
   const panelStyle: React.CSSProperties = {
     background:
-      lifecycle === "ready"
+      section === "ready" || section === "preparing"
         ? "var(--color-bt-card)"
-        : lifecycle === "live"
+        : section === "on-tap"
         ? "var(--color-bt-accent-faint)"
-        : undefined, // setting-up + final: no fill
+        : undefined, // skeleton + completed: no fill
     border:
-      lifecycle === "setting-up"
+      section === "skeleton"
         ? "1.5px dashed var(--color-bt-border)"
         : "1px solid var(--color-bt-border)",
   };
   const rowStyle: React.CSSProperties = {
-    // Final is a quiet record — recess the whole tile (§A3 "recessed").
+    // Completed is a quiet record — recess the whole tile (§A3 "recessed").
     opacity: isFinal ? 0.72 : 1,
   };
-  // Name-text strength = "is the structure done?" — dim while setting up, full
-  // the moment it's Ready (§A3). Final keeps the name full but the tile recedes.
+  // Name-text strength = "is the structure done?" — dim only while Skeleton, full
+  // the moment it's built (§A3). Completed keeps the name full but the tile recedes.
   const nameColor =
-    lifecycle === "setting-up" ? "var(--color-bt-text-dim)" : "var(--color-bt-text)";
+    section === "skeleton" ? "var(--color-bt-text-dim)" : "var(--color-bt-text)";
 
   const inner = (
     <div className="flex items-center gap-3 px-4 py-3" style={rowStyle}>
@@ -235,7 +243,7 @@ export function GameRow({
               className="shrink-0"
             />
           )}
-          {lifecycle === "live" && <LiveBadge />}
+          {section === "on-tap" && <LiveBadge />}
         </div>
         {subtitle && (
           <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -352,6 +360,130 @@ function OuterColumn({
     <span className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
       —
     </span>
+  );
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
+/**
+ * CompletedRow (Task 5) — a finished game compressed to ONE line: format icon +
+ * name (left), result (right). Recessed like the old Final tile but far shorter
+ * (the old Final `GameRow` stacked the team results vertically in the outer
+ * column). The result shape keys on scoring_model:
+ *   match_play → each team's points, team-colored, in HERO left-right order
+ *                (the `teams` array order the hero uses) so they scan against the
+ *                hero. NO winner emphasis — both read at the same weight.
+ *   points     → a horizontal placement podium (1st/2nd/3rd…) in the shared
+ *                `--color-bt-place-*` tokens (R2 — a small inline podium, not the
+ *                games-side FinalStandings screen, which doesn't fit a board row).
+ */
+export function CompletedRow({
+  game,
+  teams,
+  cells,
+  scoringModel,
+  tripId,
+  onPrefetch,
+}: {
+  game: LBGame;
+  teams: LBTeam[];
+  cells: Map<string, LBCell> | undefined;
+  scoringModel: ScoringModel;
+  tripId: string;
+  onPrefetch: (gameId: string) => void;
+}) {
+  const href = gameHref(tripId, game.gameTypeId, game.id);
+  const inner = (
+    <div className="flex items-center gap-3 px-4 py-2.5" style={{ opacity: 0.75 }}>
+      {createElement(formatIcon(game.gameTypeId), {
+        size: 16,
+        className: "shrink-0",
+        style: { color: "var(--color-bt-text-dim)" },
+      })}
+      <span
+        className="min-w-0 flex-1 truncate text-[13px] font-medium"
+        style={{ color: "var(--color-bt-text)" }}
+      >
+        {game.name}
+      </span>
+      {scoringModel === "points" ? (
+        <CompletedPodium teams={teams} cells={cells} />
+      ) : (
+        <CompletedScores teams={teams} cells={cells} />
+      )}
+    </div>
+  );
+  const panelStyle: React.CSSProperties = { border: "1px solid var(--color-bt-border)" };
+  return href ? (
+    <Link
+      href={href}
+      className="block rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
+      style={panelStyle}
+      onPointerEnter={() => onPrefetch(game.id)}
+      onPointerDown={() => onPrefetch(game.id)}
+    >
+      {inner}
+    </Link>
+  ) : (
+    <div className="rounded-xl overflow-hidden" style={panelStyle}>
+      {inner}
+    </div>
+  );
+}
+
+/** match_play completed result — each team's points, team-colored, in the SAME
+ *  left-right order as the hero (the `teams` array order). No winner emphasis. */
+function CompletedScores({ teams, cells }: { teams: LBTeam[]; cells: Map<string, LBCell> | undefined }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1.5 tabular-nums">
+      {teams.map((t, i) => (
+        <Fragment key={t.id}>
+          {i > 0 && (
+            <span className="text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+              –
+            </span>
+          )}
+          <span className="text-sm font-semibold" style={{ color: t.color }}>
+            {fmtPts(cells?.get(t.id)?.points ?? 0)}
+          </span>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+/** points completed result — a horizontal placement podium (1st/2nd/3rd…) in the
+ *  shared place tokens; each pill = place chip (gold/silver/bronze bg) + team
+ *  color dot + short name. Only teams with a resolved place are shown. */
+function CompletedPodium({ teams, cells }: { teams: LBTeam[]; cells: Map<string, LBCell> | undefined }) {
+  const ranked = teams
+    .map((t) => ({ team: t, place: cells?.get(t.id)?.place }))
+    .filter((x): x is { team: LBTeam; place: number } => x.place != null)
+    .sort((a, b) => a.place - b.place);
+  if (ranked.length === 0) return null;
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {ranked.map(({ team, place }) => {
+        const p = Math.min(Math.max(place, 1), 4);
+        return (
+          <span
+            key={team.id}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-semibold"
+            style={{
+              background: `var(--color-bt-place-${p}-bg)`,
+              color: `var(--color-bt-place-${p}-text)`,
+            }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ background: team.color }} />
+            {ordinal(place)} {team.short_name}
+          </span>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/components/competition/LiveFaceClient.tsx
+++ b/src/components/competition/LiveFaceClient.tsx
@@ -211,7 +211,7 @@ export function LiveFaceClient({
         }}
       />
 
-      <main className="mx-auto max-w-[1024px] px-4 pt-4 pb-32">{body}</main>
+      <main className="mx-auto max-w-[1024px] px-3 pt-4 pb-32">{body}</main>
 
       {/* Bottom nav persists on the face so you can always cross back to the
           trip (§11). Live is the current destination. */}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -79,9 +79,10 @@ export async function computeCompetitionLeaderboard(
 
   const gameIds = allGames.map((g) => g.id as string);
   // game_results (awarded) + the per-game match COUNT (available) + the per-game
-  // participant COUNT (the stroke/rack readiness gate). All depend on the live
-  // game ids; run them together.
-  const [resultsRes, matchRowsRes, participantRowsRes] = await Promise.all([
+  // participant COUNT (the stroke/rack readiness gate) + the per-game SCORE-entry
+  // presence (the On-Tap↔Ready-for-Play split). All depend on the live game ids;
+  // run them together.
+  const [resultsRes, matchRowsRes, participantRowsRes, scoreEntryRowsRes] = await Promise.all([
     gameIds.length
       ? supabase
           .from("game_results")
@@ -95,8 +96,21 @@ export async function computeCompetitionLeaderboard(
     gameIds.length
       ? supabase.from("game_participants").select("game_id").in("game_id", gameIds)
       : Promise.resolve({ data: [] as { game_id: string }[] }),
+    // Any score entered yet? The §A "started" signal (R1): an `active` game with
+    // ≥1 score entry is genuinely underway (On Tap); an `active` game with none is
+    // enabled/pairings-up but not started (Ready for Play). Manual games score on
+    // post (→complete) so they never carry entries — correctly staying out of On
+    // Tap until they finish.
+    gameIds.length
+      ? supabase.from("score_entries").select("game_id").in("game_id", gameIds)
+      : Promise.resolve({ data: [] as { game_id: string }[] }),
   ]);
   const results = resultsRes.data;
+  // Games with at least one score entry — drives `started` on each game below.
+  const startedByGame = new Set<string>();
+  for (const r of (scoreEntryRowsRes.data ?? []) as { game_id: string }[]) {
+    startedByGame.add(r.game_id);
+  }
   // Participant rows per game — "field picked" (stroke) / "auto-grouped" (rack).
   const participantCountByGame = new Map<string, number>();
   for (const r of (participantRowsRes.data ?? []) as { game_id: string }[]) {
@@ -267,6 +281,9 @@ export async function computeCompetitionLeaderboard(
         // Scoring enabled (Phase 2B.1) — the real arming signal the format-icon
         // color reads (§A4), replacing the Phase-3 derived stub.
         scoringEnabled: g.scoring_enabled === true,
+        // Has ≥1 score entry (R1) — splits `active` into On Tap (started) vs
+        // Ready for Play (enabled/pairings up, not started) for the board sections.
+        started: startedByGame.has(gid),
         // Points in play (§A5 outer column). Match-play games carry it here even
         // though `distribution` is null pre-decision.
         pointsTotal: ptsInPlayByGame.get(gid) ?? null,

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -426,3 +426,38 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     expect(lb.pointsAvailable).toBe(roll.pointsAvailable);
   });
 });
+
+describe("D2 R1 — `started` (On Tap ↔ Ready for Play split)", () => {
+  it("started is false with no score entries, true once one exists", async () => {
+    const comp = await ctx.createCompetition(tripId, "D2 Started Comp", { scoringModel: "points" });
+    const g = await ctx.caller().games.create({
+      tripId, gameTypeId: MANUAL, name: "Startable", competitionId: comp,
+      pointsDistribution: { type: "placement", values: [9, 6] },
+    }) as { id: string };
+    gameIds.push(g.id);
+
+    // No entries yet → not started. An `active` game in this state is Ready for
+    // Play (enabled/pairings up, nothing scored); once scored it's On Tap.
+    let lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    let game = lb.games.find((x: { id: string }) => x.id === g.id) as { started: boolean };
+    expect(game.started).toBe(false);
+
+    // One score entry → started flips true (the On Tap discriminator, R1).
+    await ctx.admin.from("score_entries").insert({
+      id: `${g.id}:${ctx.getUser("owner").id}:1`,
+      game_id: g.id,
+      participant_id: ctx.getUser("owner").id,
+      participant_type: "user",
+      unit_label: "1",
+      value: 4,
+      submitted_by: ctx.getUser("owner").id,
+      submitted_at: new Date().toISOString(),
+    });
+
+    lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    game = lb.games.find((x: { id: string }) => x.id === g.id) as { started: boolean };
+    expect(game.started).toBe(true);
+
+    await ctx.admin.from("score_entries").delete().eq("game_id", g.id);
+  });
+});


### PR DESCRIPTION
Competition/leaderboard face redesign — merge the two headers into one elevated hero, section the games by state, and compress completed rows. Built to the approved `hero_trophy_reference.html` + `leaderboard_hero_treatment.md`. Phase-0 resolutions R1–R4 applied.

## Phase 0 (the partition was the real unknown)
A2-core (#500) made `enableScoring` set `scoring_enabled` **and** `status='active'` in one write, so `status` alone yields only **four** reachable states — the spec's five sections assumed the pre-A2-core "armed but not live" state that no longer exists. **R1:** recovered the fifth by splitting `active` on a new per-game `started` signal (≥1 score entry). Clean 5-way partition:

```
complete              → Completed
active  &  started    → On Tap            (scores flowing)
active  & !started    → Ready for Play    (enabled/pairings up, not yet scored)
pending &  configured → Preparing for Gameplay
pending & !configured → Skeleton
```

## What's in it
- **`started` payload signal** (server): per-game "≥1 score entry" added to the leaderboard payload + `LBGame`. Vitest coverage in `competitions.d2.test.ts`.
- **Sections** (Task 4): flat games list → five state sections, empty sections hidden. `sectionOf()` is the single source of truth for both the grouping and each row's presentation (row + header can't disagree); it replaces the 4-state `lifecycleOf`. The dead `ready && armed → "Ready to play"` branch is removed; "Ready to play" now labels the Ready-for-Play section.
- **Compressed completed rows** (Task 5): single line. match_play → each team's points team-colored in hero left-right order (no winner emphasis); points → a new small inline horizontal placement podium (1st/2nd/3rd) in the shared `--color-bt-place-*` tokens (**R2** — the referenced "existing" podium didn't exist).
- **Merged hero** (Task 1): new `CompetitionHero` — cool-slate gradient card, warm gold glow, and the **dimensional modeled trophy** (open mouth, gradient-lit body, slim knopped pedestal, engraved star, 0.17 opacity) verbatim from the reference SVG, cropped so it emerges behind the two big team-colored scores. Identity + gear (keeps the #522 back-nav — same handler), full team names, clinch bar with lead marker. Inherits `--font-sans`. Raw hex confined to the gradient/trophy art (STYLE_GUIDE hero carve-out); structural elements use `--color-bt-*`. It also absorbs the old "cup hasn't started" EarlyState (the hero renders 0–0 fine, so it's the header in every stage). Points cups get the identity hero only; their standings body (NTeamRankedList + matrix) is untouched below.
- **Strip redundant text** (Task 2): per-side "X to clinch" and "N pts in play" gone; only "First to N wins" under the bar.
- **Rosters button** (Task 3 / **R3**): gated on scoring_model — hidden for match_play (teams locked at 2; per-team roster editing is in the Edit Team modal via the team-name tap), kept for points cups where it's still the only add/delete-team path (relocation to settings deferred to Phase B — a known temporary).

## Verify
- ✅ Browser (dark): hero renders as the elevated gradient card with the dimensional trophy, full team names, big scores, clinch bar, only the win-target text; gear opens settings and **back returns to the board** (no #522 regression); no console errors.
- ✅ Sections partition correctly (Ready for Play / Preparing / Skeleton observed; empty Completed/On Tap hidden). On Tap is the pre-existing "live" row treatment, re-gated on `started`.
- ✅ Rosters button hidden for match_play; team management reachable via the team-name → Edit Team modal.
- ✅ `tsc` clean, eslint clean.
- ✅ Vitest: 819 passed; the only 3 failures are `tripStatus.test.ts` date-boundary flakes (pre-existing, confirmed unrelated — all competition tests incl. the new `started` test pass). Worktree Vitest pollution excluded.
- ✅ Playwright: 3/3 (setup + critical-path + match-play).

**Note:** the Completed row (podium/scores) and the points-cup identity hero are typechecked/linted/guarded but not exercised with live data — the current Test Cup has no started/completed games, and I did not mutate the real event cup for a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)