### PR TITLE
Access fixes: game-delete owner-only + revoked-delegate UI freshness

### DIFF
--- a/src/hooks/useGameEditAccess.ts
+++ b/src/hooks/useGameEditAccess.ts
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import { trpc } from "@/lib/trpc-client";
-import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useTripRole } from "./useTripRole";
 import { useCurrentUser } from "./useCurrentUser";
 
@@ -29,9 +28,18 @@ export function useGameEditAccess(
 ) {
   const { canEdit: tripCanEdit, isOwner, loading } = useTripRole(tripId);
   const me = useCurrentUser();
+  // This is the ACCESS query — deliberately NOT on STRUCTURE_QUERY's staleTime:
+  // Infinity (Spec 1, Task 2). If it were kept forever, a delegate whose grant is
+  // REVOKED would keep rendering edit affordances until a hard refresh (their
+  // actions already fail server-side — the server re-checks canEditGame live every
+  // request — but the stale UI lingers). `staleTime: 0` + an explicit
+  // `refetchOnWindowFocus` (the global default is false) re-checks access on the
+  // delegate's next mount / tab-refocus, so the affordances drop without a manual
+  // refresh. Scoped to THIS observer — the GameIdentityHeader usage keeps its own
+  // options. It's a tiny query; refetch-on-focus is negligible.
   const orgQ = trpc.games.listOrganizers.useQuery(
     { tripId: tripId!, gameId: gameId! },
-    { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId }
+    { enabled: !!tripId && !!gameId, staleTime: 0, refetchOnWindowFocus: true }
   );
   const amDelegate = useMemo(
     () =>

--- a/src/server/routers/games.d_addgame.test.ts
+++ b/src/server/routers/games.d_addgame.test.ts
@@ -30,6 +30,7 @@ beforeAll(async () => {
   ctx = await TestContext.create();
   tripId = await ctx.createTrip("D Add-Game Trip");
   await ctx.addTripMember(tripId, "member", "Member"); // delegate target (plain Member)
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // co-admin — deletes now denied (Spec 1)
   memberId = ctx.getUser("member").id;
 });
 
@@ -158,11 +159,14 @@ describe("Stage 3 — the delegation boundary", () => {
   });
 });
 
-describe("delete — hard removal, Organizer-gated (L3-b)", () => {
-  it("owner deletes a game and it's gone; a plain Member cannot", async () => {
+describe("delete — hard removal, OWNER-gated (L3-b, Spec 1)", () => {
+  it("owner deletes a game and it's gone; Organizer/co-admin and Member cannot", async () => {
     const g = await newGame(8, "To delete");
-    // Organizer-gated: a plain Member (even a would-be delegate) cannot delete.
+    // OWNER-ONLY (Spec 1): delete now matches its sibling danger-zone resets. A
+    // plain Member (would-be delegate) cannot — and neither can an Organizer/
+    // co-admin, the tightening (previously Organizer-gated).
     await expect(ctx.callerAs("member").games.delete({ tripId, gameId: g.id })).rejects.toThrow();
+    await expect(ctx.callerAs("planner").games.delete({ tripId, gameId: g.id })).rejects.toThrow(/Owner/i);
     // Owner hard-deletes → the game is gone.
     await expect(ctx.caller().games.delete({ tripId, gameId: g.id })).resolves.toBeTruthy();
     await expect(ctx.caller().games.getById({ tripId, gameId: g.id })).rejects.toThrow(/not found/i);

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -688,13 +688,16 @@ export const gamesRouter = router({
       return { success: true };
     }),
 
-  // delete — Owner/Organizer. HARD-delete a game; all dependent rows
-  // (participants, matches, play_groups, results, score_entries, organizers)
-  // cascade via ON DELETE CASCADE. A true removal (L3-b) — the danger-zone Delete.
-  // requireTripRole("Organizer") gates it to trip staff (not a game-delegate).
+  // delete — Owner-only. HARD-delete a game; all dependent rows (participants,
+  // matches, play_groups, results, score_entries, organizers) cascade via ON
+  // DELETE CASCADE. A true removal (L3-b) — the danger-zone Delete. OWNER-ONLY
+  // (Spec 1): the most destructive per-game action must match its sibling
+  // danger-zone actions (resetScoring / resetToSkeleton are requireTripRole
+  // ("Owner")) — an Organizer/co-admin no longer deletes, a game-delegate never
+  // could. The client danger zone is already isOwner-gated in all three hulls.
   delete: authedProcedure
     .input(z.object({ tripId: z.string(), gameId: z.string() }))
-    .use(requireTripRole("Organizer"))
+    .use(requireTripRole("Owner"))
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games").select("id").eq("id", input.gameId).eq("trip_id", ctx.tripId).maybeSingle();


### PR DESCRIPTION
Two access-correctness fixes (Phase 0 corrected both original premises; resolutions applied). Access-only PR — no UI polish.

## Task 1 — `games.delete` is owner-only (server)
`games.delete` was gated `requireTripRole("Organizer")` — looser than its sibling danger-zone actions (`resetScoring`/`resetToSkeleton` are `requireTripRole("Owner")`), so the **most destructive** per-game action had the **loosest** gate. Tightened to `requireTripRole("Owner")`.

Corrected premise: a game-**delegate never could** delete (a delegate is a plain Member; `requireTripRole("Organizer")` denies Member). What could delete beyond the owner was an **Organizer/co-admin** via a direct server call (the client danger zone is already `isOwner`-only in all three hulls). Now: **owner-only, client + server**, consistent with the resets. Test updated — added an Organizer member to the fixture and assert the Organizer/co-admin is now rejected (owner allowed, Member rejected).

## Task 2 — revoked delegate's UI drops without a hard refresh (option C, client-only)
Phase 0 confirmed there is **no security hole**: the server re-checks `canEditGame` live on every request and re-walls the roster in `getById` each time, so a revoked delegate is denied instantly regardless of client cache. The problem was purely **stale UI** — `useGameEditAccess` read the access query (`games.listOrganizers`) under `STRUCTURE_QUERY` (`staleTime: Infinity`), so a revoked delegate's edit affordances kept rendering until a hard refresh (their actions just failed FORBIDDEN).

Fix (option C): take **that observer** off `Infinity` → `staleTime: 0` + an explicit `refetchOnWindowFocus: true` (the global default is `false`), so access re-checks on the delegate's next mount / tab-refocus and the affordances drop without a manual refresh. Scoped to the `useGameEditAccess` observer — `GameIdentityHeader`'s `listOrganizers` usage keeps its own options. **No realtime, no migration** — a `game_delegates` revoke fires no realtime event (the channels watch `competitions`/`trip_members` only), and owner-side invalidation can't cross to the delegate's client. It's a tiny query; refetch-on-focus is negligible.

## Verify
- ✅ Delete: owner can; **Organizer/co-admin now rejected** server-side (new Vitest assertion, `games.d_addgame.test.ts`); delegate/Member still rejected. Client danger zone unchanged (already `isOwner`-only).
- ✅ Per-game delegate scoping unchanged (untouched — a delegate still gets only their game).
- ✅ `tsc` + eslint clean.
- ✅ Vitest: 822 passed, 0 failures (full run; the tripStatus date flake didn't trip this run). Worktree pollution excluded.
- ✅ Playwright: 3/3 (setup + critical-path + match-play).

**Verification note:** the delegate-side UI refresh (option C) couldn't be exercised as an actual revoked delegate — the preview + Playwright run as `test-owner`, and the fix is a client-cache `staleTime` change on the delegate's session. The server-side denial of a revoked delegate is covered by the middleware + existing delegate tests; the client change is type/lint-clean and scoped to the one observer. A quick delegate-account eyeball (revoke → navigate/refocus → affordances drop) would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)