### PR TITLE
fix: persist match setup when the settings overlay closes

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -34,7 +34,7 @@ import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeMatchRow } from "@/lib/matchDraft";
+import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose } from "@/lib/matchDraft";
 import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
@@ -700,6 +700,53 @@ export default function NewMatchGamePage() {
   }
   // Accordion header tap: toggle this row (collapsing whatever else was open).
   const toggleRow = (row: typeof openRow) => changeOpenRow(openRow === row ? null : row);
+
+  // Persist-on-CLOSE (companion to persist-on-collapse). The accordion only
+  // commits a draft editor when the OPEN ROW changes (changeOpenRow). Closing the
+  // whole settings overlay with a row still expanded — the common "assign the
+  // matches → tap Back" path — never routed through changeOpenRow, so the
+  // just-entered pairings/handicaps were dropped (they looked saved via the
+  // optimistic draft, but nothing hit the server; reopening the game showed no
+  // matches). Two distinct teardown paths, so we cover BOTH:
+  //   • Gear path — closeConfig/OS-back → popstate → the page STAYS mounted and
+  //     cfgOpen flips true→false. The effect below catches that transition.
+  //   • Deep-link path (?settings=1) — closeConfig → router.back() UNMOUNTS the
+  //     whole page (no cfgOpen transition ever commits). The unmount cleanup
+  //     catches that. (mutateAsync's network write runs to completion even after
+  //     unmount — React Query doesn't abort mutations — so the pairings persist.)
+  // The pure decision (flushOnOverlayClose) picks which write, gating
+  // matches/handicaps on draftTouched so an untouched row closing writes nothing.
+  const runCloseFlush = () => {
+    // Setup-mode only. Draft writes (setPairings clean-replaces game_matches) must
+    // never fire against a live/scoring game — enabling always clears openRow, so
+    // this is belt-and-suspenders against a stray unmount mid-transition.
+    if (scoringEnabled) return;
+    const flush = flushOnOverlayClose(openRow, draftTouched.current);
+    if (flush === "draft") void persistDraftOnCollapse();
+    else if (flush === "modifiers") void persistModifiersOnCollapse();
+  };
+  // Latest-ref so the unmount handler (empty deps) reads current draft/openRow.
+  const closeFlushRef = useRef(runCloseFlush);
+  closeFlushRef.current = runCloseFlush;
+
+  const prevCfgOpen = useRef(cfgOpen);
+  useEffect(() => {
+    const wasOpen = prevCfgOpen.current;
+    prevCfgOpen.current = cfgOpen;
+    if (!wasOpen || cfgOpen) return; // only the true→false transition (stays mounted)
+    runCloseFlush();
+    if (openRow !== null) setOpenRow(null);
+    // persistDraftOnCollapse/persistModifiersOnCollapse are per-render closures
+    // (not memoized); we intentionally react to the cfgOpen/openRow transition
+    // only, not to their identity, so they stay out of the dep list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cfgOpen, openRow]);
+
+  // Unmount flush — the deep-link/navigate-away teardown the cfgOpen effect can't
+  // see (the component leaves without a committed cfgOpen=false render).
+  useEffect(() => {
+    return () => closeFlushRef.current();
+  }, []);
 
   // Dynamic match count — mid-life +1 / −1 (the explicit "arm with 1, add a 2nd
   // mid-life" path). Each persists incrementally (NOT a bulk re-save, so

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeMatchRow, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose, type MatchSides } from "./matchDraft";
 
 // Readiness rework P1b — the ONE match-play readiness threshold, shared by the
 // setup-page Enable gate and the server `isConfigured` so they can't drift.
@@ -110,6 +110,36 @@ describe("allMatchesFilled (the Enable-scoring gate)", () => {
   it("2v2: every side must be at full strength", () => {
     expect(allMatchesFilled([singles(["a", "b"], ["c", "d"])], 2)).toBe(true);
     expect(allMatchesFilled([singles(["a", "b"], ["c"])], 2)).toBe(false);
+  });
+});
+
+// Persist-on-CLOSE: closing the settings overlay with a draft editor still open
+// (the "assign matches → tap Back" path) must flush the same write a row-collapse
+// would — otherwise the pairings are dropped and reopening the game shows no
+// matches. flushOnOverlayClose is the pure decision the close effect fires on.
+describe("flushOnOverlayClose (persist-on-overlay-close decision)", () => {
+  it("flushes the draft when the Matches row is open AND was edited", () => {
+    // The exact bug: matches entered, row left open, overlay closed.
+    expect(flushOnOverlayClose("matches", true)).toBe("draft");
+    expect(flushOnOverlayClose("handicaps", true)).toBe("draft");
+  });
+
+  it("does NOT flush the draft for an opened-but-untouched row (no needless churn)", () => {
+    // setPairings clean-replaces (new match ids), so skip it when nothing changed.
+    expect(flushOnOverlayClose("matches", false)).toBeNull();
+    expect(flushOnOverlayClose("handicaps", false)).toBeNull();
+  });
+
+  it("flushes modifiers whenever the Modifiers row is open (idempotent games.update)", () => {
+    expect(flushOnOverlayClose("modifiers", false)).toBe("modifiers");
+    expect(flushOnOverlayClose("modifiers", true)).toBe("modifiers");
+  });
+
+  it("no flush for rows that persist elsewhere or need none, or when nothing is open", () => {
+    expect(flushOnOverlayClose("course", true)).toBeNull(); // persists via its own editor
+    expect(flushOnOverlayClose("config", true)).toBeNull(); // Format·Points saves inline
+    expect(flushOnOverlayClose("players", true)).toBeNull(); // read-only echo
+    expect(flushOnOverlayClose(null, true)).toBeNull(); // overlay closed with no row open
   });
 });
 

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -79,6 +79,44 @@ export function allMatchesFilled(draft: MatchSides[], playersPerSide: number): b
 }
 
 /**
+ * Which accordion row is expanded on the settings overlay (page-owned). The two
+ * "draft editor" rows (matches/handicaps) persist their client draft on collapse;
+ * the rest either persist another way (modifiers) or need no flush.
+ */
+export type SettingsRow =
+  | "matches"
+  | "handicaps"
+  | "players"
+  | "course"
+  | "config"
+  | "modifiers"
+  | null;
+
+/** The persist to run when the settings overlay CLOSES with a row still open. */
+export type CloseFlush = "draft" | "modifiers" | null;
+
+/**
+ * Persist-on-CLOSE decision (companion to the accordion's persist-on-collapse).
+ * The accordion only commits a draft editor when the OPEN ROW changes; closing
+ * the whole settings overlay with a row still expanded — the common "assign the
+ * matches → tap Back" path — bypassed that commit, so the just-entered pairings
+ * were dropped and reopening the game showed no matches. This is the pure core of
+ * the close handler: given the open row and whether the draft was actually edited,
+ * say which persist (if any) the overlay-close must fire.
+ *
+ * - matches/handicaps → "draft" (the pairings/handicaps write) — but ONLY when the
+ *   draft was touched, so an opened-but-untouched row closing writes nothing (a
+ *   `setPairings` clean-replace would needlessly churn match rows otherwise).
+ * - modifiers → "modifiers" (a single idempotent `games.update`).
+ * - everything else (course/config/players, or no open row) → null.
+ */
+export function flushOnOverlayClose(openRow: SettingsRow, draftTouched: boolean): CloseFlush {
+  if ((openRow === "matches" || openRow === "handicaps") && draftTouched) return "draft";
+  if (openRow === "modifiers") return "modifiers";
+  return null;
+}
+
+/**
  * The POINTS term of the Enable gate (W-GAMEPAGE Phase C / P-C). A match game can't
  * Enable scoring at 0 points-per-match — there's nothing to award — so points > 0
  * joins all-matches-paired in the gate. This is the SAME truth the Points row reads


### PR DESCRIPTION
## Problem

Match pairings/handicaps entered on the game settings overlay were **lost on "assign matches → tap Back"**. The setup validated correctly on-screen, but backing out to the leaderboard and reopening the game showed no matches assigned. The Setup→Scoring switch was also affected.

## Root cause

The settings overlay auto-saves via *persist-on-collapse*: a draft editor (Matches / Handicaps) only writes to the server when the **open accordion row changes** (`changeOpenRow → persistDraftOnCollapse`). Closing the *whole overlay* with the Matches row still expanded never routed through `changeOpenRow`, so nothing hit the server — the optimistic client draft made it look saved, but `game_matches` stayed empty.

The Setup→Scoring switch being broken was a **downstream effect**: `matches.enableScoring` runs a server readiness gate (`assertGameReady`), and with no persisted matches the game isn't configured, so the toggle can't flip.

## Fix

Flush the open draft editor whenever the overlay closes, covering both teardown paths:

- **Gear path** — closing keeps the page mounted (`popstate → cfgOpen` goes true→false): caught by a `cfgOpen`-transition effect.
- **Deep-link path** (`?settings=1`, opened straight from the leaderboard) — closing calls `router.back()` and *unmounts* the page with no `cfgOpen` transition: caught by an unmount cleanup. (`mutateAsync`'s network write runs to completion past unmount — React Query doesn't abort mutations.)

Guards:
- matches/handicaps flush only when `draftTouched` — an opened-but-untouched row closing writes nothing (avoids a needless `setPairings` clean-replace).
- whole flush is **setup-mode only** (`!scoringEnabled`) — never clean-replaces a live game with scores.

The which-to-flush decision is extracted to a pure, unit-tested helper `flushOnOverlayClose` in `src/lib/matchDraft.ts`, alongside the other setup predicates.

## Changes

- `src/app/trips/[tripId]/games/match/new/page.tsx` — persist-on-close effect + unmount flush.
- `src/lib/matchDraft.ts` — new pure `flushOnOverlayClose` helper (+ `SettingsRow`/`CloseFlush` types).
- `src/lib/matchDraft.test.ts` — 4 new cases covering the close-flush decision.

## Testing

- `tsc --noEmit` clean; `eslint` clean on changed files.
- `matchDraft.test.ts` — 22 passed (incl. the 4 new close-flush cases).
- DB-backed router/E2E suites (`matches.test.ts`, `match-play.spec.ts`) are env-gated on a live Supabase test DB and run in CI. No router/schema touched, so their existing coverage stays valid.

Worth a manual smoke on the deploy: assign matches, immediately tap Back (both from the gear and from the leaderboard's setup deep-link), reopen the game, and confirm the pairings persist and the Setup→Scoring toggle enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_