### PR TITLE
fix: 2v2 match setup vanishes on reopen (seed race on the sided flag)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -34,7 +34,7 @@ import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose } from "@/lib/matchDraft";
+import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose, sideMemberIds } from "@/lib/matchDraft";
 import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
@@ -456,15 +456,26 @@ export default function NewMatchGamePage() {
     // The checklist lives on the settings overlay; seed the draft when it opens
     // with an empty local draft.
     if (!cfgOpen || draft.length > 0) return;
+    // WAIT for the game row before seeding. `sided` (→ playersPerSide) is derived
+    // from gameQ.data.game_type_id; matches.listByGame and games.getById are
+    // separate queries, and on a fresh reopen the leaderboard deep-links to
+    // `?game=X&settings=1` (no `format` hint), so matches can land BEFORE the game
+    // does. Seeding in that window uses the fallback `sided=false` and rebuilds a
+    // DOUBLES game as singles — each side's play_group id gets read as a user id —
+    // then the `draft.length > 0` guard freezes that wrong seed even after gameQ
+    // loads and sided flips true. (Singles is unaffected: sided=false is already
+    // correct, which is why 1v1 worked and 2v2 lost its matches on reopen.) Gate on
+    // the loaded row so the one seed we take uses the authoritative format.
+    if (gameId && !gameQ.data) return;
     if (serverMatches.length > 0) {
-      setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide, sided));
+      setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide));
       return;
     }
     // Resume-into-empty: a game with no game_matches starts at ZERO matches — a
     // valid empty state (the table hides; only "Add match" shows). "+ Add match"
     // grows it from there (build-as-you-go — W-GAMEPAGE-01 §6.1).
     setDraft([]);
-  }, [cfgOpen, draft.length, serverMatches, handicapOf, membersOfSide, sided]);
+  }, [cfgOpen, draft.length, serverMatches, handicapOf, membersOfSide, sided, gameId, gameQ.data]);
 
   // Seed the modifiers draft from the server — but ONLY while the row is closed,
   // so an in-progress edit is never clobbered. On collapse the row persists +
@@ -1384,19 +1395,15 @@ export default function NewMatchGamePage() {
 function serverDraftFrom(
   serverMatches: unknown[],
   handicapOf: Map<string, number>,
-  membersOfSide: Map<string, string[]>,
-  sided: boolean
+  membersOfSide: Map<string, string[]>
 ): DraftMatch[] {
-  // A server side → its member user ids. Singles: the user is the side. Doubles:
-  // the play_group's members (looked up by side id).
-  const members = (side: SideRef): string[] => {
-    if (!side?.id) return [];
-    return sided ? (membersOfSide.get(side.id) ?? []) : [side.id];
-  };
+  // A server side → its member user ids, resolved from the side's OWN type
+  // (sideMemberIds) so the reconstruction can't be corrupted by a not-yet-loaded
+  // `sided` flag — the 2v2-matches-vanish-on-reopen race.
   return (serverMatches as { match_number: number; side_a: SideRef; side_b: SideRef }[]).map((mm, i) => {
     const hcA = mm.side_a?.id ? (handicapOf.get(mm.side_a.id) ?? 0) : 0;
     const hcB = mm.side_b?.id ? (handicapOf.get(mm.side_b.id) ?? 0) : 0;
-    return { matchNumber: mm.match_number ?? i + 1, a: members(mm.side_a), b: members(mm.side_b), handicap: hcA > 0 ? -hcA : hcB > 0 ? hcB : 0 };
+    return { matchNumber: mm.match_number ?? i + 1, a: sideMemberIds(mm.side_a, membersOfSide), b: sideMemberIds(mm.side_b, membersOfSide), handicap: hcA > 0 ? -hcA : hcB > 0 ? hcB : 0 };
   });
 }
 

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose, type MatchSides } from "./matchDraft";
+import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose, sideMemberIds, type MatchSides, type ServerSide } from "./matchDraft";
 
 // Readiness rework P1b — the ONE match-play readiness threshold, shared by the
 // setup-page Enable gate and the server `isConfigured` so they can't drift.
@@ -110,6 +110,42 @@ describe("allMatchesFilled (the Enable-scoring gate)", () => {
   it("2v2: every side must be at full strength", () => {
     expect(allMatchesFilled([singles(["a", "b"], ["c", "d"])], 2)).toBe(true);
     expect(allMatchesFilled([singles(["a", "b"], ["c"])], 2)).toBe(false);
+  });
+});
+
+// Setup re-seed: a server side resolves to its member ids by the side's OWN type,
+// NOT an ambient sided flag. This is what keeps a 2v2 match from vanishing on
+// reopen when matches.listByGame lands before games.getById (so the page's `sided`
+// is still its pre-load fallback) — the play_group side must still expand to its
+// pair, and a user side must still be itself.
+describe("sideMemberIds (type-driven side → member ids)", () => {
+  const members = new Map<string, string[]>([
+    ["pgA", ["alice", "bob"]],
+    ["pgB", ["carol", "dave"]],
+  ]);
+
+  it("a user side (1v1) resolves to that single user, regardless of the map", () => {
+    const side: ServerSide = { type: "user", id: "alice" };
+    expect(sideMemberIds(side, members)).toEqual(["alice"]);
+    expect(sideMemberIds(side, new Map())).toEqual(["alice"]); // no play_group lookup needed
+  });
+
+  it("a play_group side (2v2) expands to its two members via the map", () => {
+    expect(sideMemberIds({ type: "play_group", id: "pgA" }, members)).toEqual(["alice", "bob"]);
+    expect(sideMemberIds({ type: "play_group", id: "pgB" }, members)).toEqual(["carol", "dave"]);
+  });
+
+  it("an empty slot (null) or unknown play_group resolves to []", () => {
+    expect(sideMemberIds(null, members)).toEqual([]);
+    // A play_group whose participants haven't loaded yet → empty, never the id itself
+    // (the bug: a doubles side was rebuilt as [play_group_id] and read as a user).
+    expect(sideMemberIds({ type: "play_group", id: "pgMissing" }, members)).toEqual([]);
+  });
+
+  it("a filled 2v2 match reconstructs as two 2-member sides (both fully paired)", () => {
+    const a = sideMemberIds({ type: "play_group", id: "pgA" }, members);
+    const b = sideMemberIds({ type: "play_group", id: "pgB" }, members);
+    expect(isMatchFilled({ a, b }, 2)).toBe(true); // survives the reopen as a real match
   });
 });
 

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -78,6 +78,27 @@ export function allMatchesFilled(draft: MatchSides[], playersPerSide: number): b
   return matchPlayReady(filledMatches(draft, playersPerSide).length, draft.length);
 }
 
+/** A server match side: one user (1v1), one play_group (2v2), or an empty slot. */
+export type ServerSide = { type: "user" | "play_group"; id: string } | null;
+
+/**
+ * The member user-ids on a server match side, resolved from the side's OWN `type`
+ * — NOT an ambient singles/doubles flag. A `user` side is that one user; a
+ * `play_group` side (2v2) expands to its members via the play_group→members map.
+ *
+ * Keying on the side's type keeps the setup re-seed correct even in the window
+ * before the game row (which carries the format) has loaded: `matches.listByGame`
+ * and `games.getById` are separate queries, so on a fresh reopen matches can land
+ * first, when the page's `sided` flag is still its pre-load fallback (false). The
+ * old `sided ? members : [id]` rebuilt a doubles side as a lone "user" whose id was
+ * actually the play_group id — the match then read as unfilled and silently
+ * vanished on reopen. The side already tells us what it is; trust it.
+ */
+export function sideMemberIds(side: ServerSide, membersOfSide: Map<string, string[]>): string[] {
+  if (!side?.id) return [];
+  return side.type === "play_group" ? (membersOfSide.get(side.id) ?? []) : [side.id];
+}
+
 /**
  * Which accordion row is expanded on the settings overlay (page-owned). The two
  * "draft editor" rows (matches/handicaps) persist their client draft on collapse;


### PR DESCRIPTION
## Problem

After #526 fixed match-setup persistence, **1v1 works but 2v2 (doubles) setup still disappeared on reopen**: set up a doubles match, back out, return to settings — the match is gone.

This is a **readback bug, not a save bug**. Verified against production: the most recent doubles game has its `game_matches` row, both `play_groups`, and all 4 `game_participants` (each carrying the correct `play_group_id`) written correctly. The data persists; the setup re-seed fails to reconstruct it.

## Root cause

The settings overlay rebuilds the match draft from server rows using `sided` (→ `playersPerSide`), derived from `games.getById`. But `matches.listByGame` and `games.getById` are **separate queries**, and the leaderboard deep-links a not-yet-scoring game via `?game=X&settings=1` (no `format` hint). On a fresh reopen the matches can land **before** the game row, so `sided` is still its pre-load fallback (`false`).

In that window `serverDraftFrom` rebuilds each 2v2 side as a lone `user` whose id is actually the `play_group` id. The match then reads as unfilled, and the `draft.length > 0` guard **freezes that wrong seed** even after the game loads and `sided` flips true.

Singles is unaffected — `sided=false` is already correct — which is exactly why 1v1 worked and 2v2 lost its matches.

## Fix (two layers)

1. **Gate the seed on the loaded game row** (`gameId && !gameQ.data` → wait) so the one seed we take uses the authoritative format. This also fixes handicap keying, which is `sided`-dependent via `handicapOf`.
2. **Resolve a server side's members from the side's own `type`** — new pure `sideMemberIds()` expands a `play_group` side to its pair and a `user` side to itself, independent of the ambient `sided` flag. The reconstruction is now robust to query ordering by construction.

## Changes

- `src/app/trips/[tripId]/games/match/new/page.tsx` — seed-gate on `gameQ.data`; `serverDraftFrom` uses `sideMemberIds` (drops the `sided` param).
- `src/lib/matchDraft.ts` — new pure `sideMemberIds` helper (+ `ServerSide` type).
- `src/lib/matchDraft.test.ts` — 4 new cases (doubles-side expansion, user-side identity, unloaded play_group → `[]` never the id, filled-2v2 reconstruction).

## Testing

- `tsc --noEmit` clean; `eslint` clean on changed files.
- `matchDraft.test.ts` — 26 passed (incl. the 4 new `sideMemberIds` cases).
- DB-backed router/E2E suites are env-gated on a live Supabase test DB and run in CI; no router/schema touched.

Worth a manual smoke: set up a 2v2 match, back out to the leaderboard, reopen the game's settings, and confirm the pairing (and any handicap) is still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_