### PR TITLE
Game setup polish: course ×-to-remove, setup-timing constraints, disabled handicaps row

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -1035,9 +1035,10 @@ export default function NewMatchGamePage() {
         const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
         const enableReady = allFilled && allRosterValid && (!gameCompId || pointsReady(pointsPerMatch));
         const anyHandicap = draft.some((d) => d.handicap !== 0);
-        // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points,
-        // Handicaps, and Modifiers stay LOCKED until a match exists (they mean nothing
-        // before there's a match to apply them to). One named predicate, shared.
+        // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points
+        // and Handicaps stay LOCKED until a match exists (they attach to a matchup).
+        // Modifiers are NO LONGER gated on this (Task 3b — they're an early format
+        // decision, decidable before matchups are set). One named predicate, shared.
         const matchesExist = hasValidMatch(draft, playersPerSide);
         const savingSetup =
           setPairings.isPending || setHandicap.isPending ||
@@ -1045,6 +1046,22 @@ export default function NewMatchGamePage() {
         // Standalone-only readout now (T4 hides this row for competitions), so the
         // count is just the trip crew — no roster branch.
         const availableCount = crew.data?.length ?? 0;
+        // Task 3a: cap the "add match" affordance for 1v1 ONLY, at the number of
+        // players per team (each player gets one match). In a 2-team cup that's
+        // min(team sizes) — each 1v1 match pairs one player from each team;
+        // standalone pairs any two of the crew (floor(crew/2)). Cap only when the
+        // roster has actually loaded (>0) so a not-yet-loaded roster never hides
+        // "add match".
+        //
+        // DELIBERATELY NOT capping 2v2: a rigid doubles cap assumes perfectly even,
+        // perfectly paired teams — but injury/illness can force a 1v2 or an odd
+        // pairing, and a hard cap would BLOCK a legitimate real-world lineup. Cap
+        // only where the maximum is genuinely fixed (1v1); leave 2v2 open (the 24
+        // ceiling only) so it flexes to reality.
+        const singlesCap = twoTeams
+          ? Math.min(rosterOfTeam(teams[0].id).length, rosterOfTeam(teams[1].id).length)
+          : Math.floor(availableCount / 2);
+        const maxMatchesForAdd = !sided && singlesCap > 0 ? Math.min(MAX_MATCHES, singlesCap) : MAX_MATCHES;
         // §5 row copy (visual-pass P-A). Matches title is the format name; the
         // subtitle is a status line ("x of y matches assigned"), not a value dump
         // (team names live in the expanded editor). Matches uses the INVALID state
@@ -1069,7 +1086,16 @@ export default function NewMatchGamePage() {
           (((gameQ.data?.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0) === 18;
         const handicapsReady = matchesExist && courseResolved;
         const handicapsState: ChecklistRowState = anyHandicap ? "resolved" : "empty";
-        const handicapsSubtitle = anyHandicap ? "Handicaps assigned" : "No handicaps assigned";
+        // When the row is disabled (course/matches not yet resolved) the subtitle
+        // NAMES the missing prerequisite, so the dimmed row reads "not available
+        // yet" (Task 2c) rather than an unexplained inert control.
+        const handicapsSubtitle = !matchesExist
+          ? "Set the matchups first"
+          : !courseResolved
+            ? "Choose a course first"
+            : anyHandicap
+              ? "Handicaps assigned"
+              : "No handicaps assigned";
         // Modifiers (W-GAMEPAGE-01 §6.5) — applicability is data-driven from the
         // format's gameTypes.ts compatibleModifiers (NOT the deprecated DB column).
         // Empty → the row is hidden entirely.
@@ -1195,6 +1221,7 @@ export default function NewMatchGamePage() {
                 teamColorOf={teamColorOf}
                 avatarIconOf={avatarIconOf}
                 teamForSlot={teamForSlot}
+                maxMatches={maxMatchesForAdd}
                 openSelector={(matchIdx, slot, memberIdx) => setSelector({ matchIdx, slot, memberIdx })}
               />
             </ChecklistRow>
@@ -1250,8 +1277,12 @@ export default function NewMatchGamePage() {
               // #501: non-expandable AND force-collapsed in scoring mode (HandicapsSection
               // has no read-only mode). #512: locked → dim + lock icon.
               locked={scoringEnabled}
+              // Task 2c: when the prerequisites aren't met (no course / no matches)
+              // the row is VISIBLY disabled (dimmed), not silently unclickable — pass
+              // the real toggle but mark it disabled so it reads "not available yet".
+              disabled={!handicapsReady}
               expanded={openRow === "handicaps" && settingsEditable}
-              onToggle={handicapsReady && settingsEditable ? () => toggleRow("handicaps") : undefined}
+              onToggle={settingsEditable ? () => toggleRow("handicaps") : undefined}
               testId="row-handicaps"
             >
               <HandicapsSection
@@ -1280,7 +1311,11 @@ export default function NewMatchGamePage() {
                 state={modifiersState}
                 locked={scoringEnabled}
                 expanded={openRow === "modifiers"}
-                onToggle={matchesExist && settingsEditable ? () => toggleRow("modifiers") : undefined}
+                // Task 3b: modifiers are an EARLY format decision (carry-over, moving
+                // tees); matches (who plays whom) is often decided the day before.
+                // Don't gate early-decidable config on late-decided data — no
+                // matchesExist dependency here (settingsEditable only).
+                onToggle={settingsEditable ? () => toggleRow("modifiers") : undefined}
                 testId="row-modifiers"
               >
                 <ModifierCards
@@ -1566,6 +1601,7 @@ function MatchSetup({
   teamColorOf,
   avatarIconOf,
   teamForSlot,
+  maxMatches,
   openSelector,
 }: {
   tripId: string;
@@ -1584,6 +1620,10 @@ function MatchSetup({
    *  the shared branded column header. Undefined in a standalone (non-2-team) game,
    *  where the header falls back to a neutral "Side A / Side B". */
   teamForSlot: (slot: "a" | "b") => { name: string; color: string } | undefined;
+  /** Ceiling on the number of matches — "add match" hides once reached. For 1v1
+   *  this is the players-per-team cap (Task 3a); for 2v2 it's the generous 24
+   *  ceiling (no team cap — see the call site's reasoning). */
+  maxMatches: number;
   openSelector: (matchIdx: number, slot: "a" | "b", memberIdx: number) => void;
 }) {
   // Drag-to-reorder (mirrors the news composer): `ins` is the insertion slot in
@@ -1761,8 +1801,10 @@ function MatchSetup({
         </>
       )}
 
-      {/* Add another match — dynamic count grows one at a time (up to the cap). */}
-      {draft.length < MAX_MATCHES && (
+      {/* Add another match — dynamic count grows one at a time, up to `maxMatches`
+          (the 1v1 players-per-team cap, or the 24 ceiling for 2v2 — Task 3a). Once
+          at the cap the affordance is hidden: every player already has a match. */}
+      {draft.length < maxMatches && (
         <button
           type="button"
           onClick={() => setDraft((prev) => [...prev, { matchNumber: prev.length + 1, a: [], b: [], handicap: 0 }])}

--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -106,6 +106,11 @@ export function ChecklistRow({
    *  accordion** (W-GAMEPAGE Phase C: the Points row). Mutually exclusive with
    *  accordion/overlay; the control owns its own taps. */
   control?: React.ReactNode;
+  /** Dependency not yet met — the row would be an accordion, but its prerequisite
+   *  isn't satisfied (e.g. Handicaps before a course is chosen). Renders VISIBLY
+   *  disabled (dimmed, non-interactive — the Danger-Zone dimming pattern) instead
+   *  of silently inert, so it reads as "not available yet", not "broken". Distinct
+   *  from `locked` (the live-scoring freeze, which also shows a lock icon). */
   disabled?: boolean;
   /** #512 Option B: the row is frozen by the live-scoring lock — dim it and swap the
    *  expand chevron for a LOCK icon (kills the false "expandable" affordance and names
@@ -203,8 +208,10 @@ export function ChecklistRow({
   );
   const headerClass = "flex w-full items-center gap-3 px-3.5 py-3 text-left disabled:opacity-60";
   // #512 Option B: a live-locked row reads dimmed (reduced emphasis) so it clearly
-  // looks frozen, not merely chevron-less.
-  const containerStyle = { background: surface, border, opacity: locked ? 0.55 : undefined } as React.CSSProperties;
+  // looks frozen, not merely chevron-less. A `disabled` (dependency-unmet) row dims
+  // the SAME way — the Danger-Zone dimming pattern — so it reads "not available
+  // yet", never silently inert. (locked also gets a lock icon; disabled does not.)
+  const containerStyle = { background: surface, border, opacity: locked || disabled ? 0.55 : undefined } as React.CSSProperties;
 
   // Accordion: a header button toggling an in-place panel below (same bordered
   // frame — the row IS the frame; the panel sheds all modal chrome).

--- a/src/components/games/course/CourseRowContent.tsx
+++ b/src/components/games/course/CourseRowContent.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Check, RefreshCw, X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { CourseSearchPanel } from "./CourseSearchPanel";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
@@ -13,12 +12,14 @@ import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
  *    resolves the row as today; a 9-hole course lands as the FRONT nine.
  *  - 9-hole front, no back → "needs a back nine": shows the front + a BACK picker
  *    (9-hole courses only). The row is NOT resolved until the back is composed.
- *  - Composed/18 → the resolved view: a real 18 shows the course; a two-nines 18
- *    shows Front + Back with a "Swap back nine" (clears the back, keeps the front)
- *    and "Change course" (clears all → re-pick).
+ *  - Composed/18 → the resolved view: ×-to-remove throughout (matching removable
+ *    items elsewhere). A real 18 shows the course with one × (clears → re-pick); a
+ *    two-nines 18 shows Front + Back, each with its own × — front × clears the
+ *    course, back × drops just the back (→ "needs a back nine", re-pick from there).
  *
- * All course mutations live here (applyCourse = front, setBackNine = back/swap,
- * clearCourse). They're live — the accordion collapse just recedes.
+ * All course mutations live here (applyCourse = front / also used to drop the back
+ * by re-applying the front alone, setBackNine = back, clearCourse). They're live —
+ * the accordion collapse just recedes.
  */
 export function CourseRowContent({
   tripId, game, canEdit, onChanged,
@@ -56,17 +57,24 @@ export function CourseRowContent({
     !!backId && !!appliedTeeName && backTees.length > 0 &&
     !backTees.some((t) => (t.name ?? "").trim() === appliedTeeName);
 
-  // Swap/change sub-views (only meaningful in the resolved state).
-  const [view, setView] = useState<"default" | "swapBack">("default");
-
   function refresh(courseId?: string) {
     if (courseId) utils.courses.getById.invalidate({ courseId });
     onChanged();
   }
   const onPickFront = ({ id, teeName }: { id: string; teeName?: string }) =>
-    applyCourse.mutate({ tripId, gameId, courseId: id, teeSetName: teeName }, { onSuccess: () => { setView("default"); refresh(id); } });
+    applyCourse.mutate({ tripId, gameId, courseId: id, teeSetName: teeName }, { onSuccess: () => refresh(id) });
   const onPickBack = ({ id, teeName }: { id: string; teeName?: string }) =>
-    setBackNine.mutate({ tripId, gameId, backCourseId: id, backTeeSetName: teeName }, { onSuccess: () => { setView("default"); refresh(id); } });
+    setBackNine.mutate({ tripId, gameId, backCourseId: id, backTeeSetName: teeName }, { onSuccess: () => refresh(id) });
+  // Remove the back nine (per-nine × — Task 2b): re-apply the FRONT alone, which
+  // resets back_course_id and shrinks the schema back to 9 → the "needs a back
+  // nine" state (re-pick from there). Reuses applyCourse — no new server machinery
+  // (the composed tee name is the front's, so it round-trips the front's tee).
+  const onRemoveBack = () =>
+    applyCourse.mutate(
+      { tripId, gameId, courseId: frontId!, teeSetName: appliedTeeName || undefined },
+      { onSuccess: () => refresh(frontId!) }
+    );
+  const onClearCourse = () => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => refresh() });
 
   // ── No course → front picker ──────────────────────────────────────────────
   if (!frontId) {
@@ -77,7 +85,7 @@ export function CourseRowContent({
   if (needsBack) {
     return (
       <div className="flex flex-col gap-3" data-testid="course-needs-back">
-        <NineSummary label="Front nine" name={frontName} onClear={canEdit ? () => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => refresh() }) : undefined} />
+        <NineSummary label="Front nine" name={frontName} onClear={canEdit ? onClearCourse : undefined} />
         <div>
           <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-accent)" }}>Add the back nine</span>
           <p className="mb-2 mt-0.5 text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>A 9-hole course needs a back nine to make a full 18.</p>
@@ -87,25 +95,19 @@ export function CourseRowContent({
     );
   }
 
-  // ── Resolved (18) — swap sub-view ─────────────────────────────────────────
-  if (view === "swapBack") {
-    return (
-      <div className="flex flex-col gap-2" data-testid="course-swap-back">
-        <button onClick={() => setView("default")} className="self-start text-[13px]" style={{ color: "var(--color-bt-accent)" }}>‹ Cancel</button>
-        <p className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>Pick the new back nine. Front nine + its scores stay; back-nine scores are cleared.</p>
-        <CourseSearchPanel tripId={tripId} gameId={gameId} mode="back" onApply={onPickBack} />
-      </div>
-    );
-  }
-
   // ── Resolved (18) — default view ──────────────────────────────────────────
+  // ×-to-remove throughout (Task 2a/2b), matching how removable items work
+  // elsewhere: a single 18 gets ONE × (clears the course → re-pick); a two-nines
+  // 18 gets a per-nine × (front × clears the course; back × drops just the back →
+  // "needs a back nine"). The old "Swap back nine" / "Change course" buttons are
+  // gone — the × on each item is the affordance.
   const twoNines = !!backId;
   return (
     <div className="flex flex-col gap-3" data-testid="course-resolved">
       {twoNines ? (
         <div className="flex flex-col gap-2">
-          <NineSummary label="Front nine" name={frontName} />
-          <NineSummary label="Back nine" name={backName} />
+          <NineSummary label="Front nine" name={frontName} onClear={canEdit ? onClearCourse : undefined} />
+          <NineSummary label="Back nine" name={backName} onClear={canEdit ? onRemoveBack : undefined} />
           {backTeeFallback && (
             <p className="px-1 text-[11px] leading-snug" style={{ color: "var(--color-bt-text-dim)" }} data-testid="back-tee-fallback">
               {backName} has no {appliedTeeName} tee — its first tee’s yardages are used for the back nine.
@@ -113,28 +115,7 @@ export function CourseRowContent({
           )}
         </div>
       ) : (
-        <NineSummary label="Course" name={frontName} />
-      )}
-      {canEdit && (
-        <div className="flex flex-wrap gap-2">
-          {twoNines && (
-            <button
-              onClick={() => setView("swapBack")}
-              data-testid="course-swap-back-btn"
-              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[13px] font-semibold"
-              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-            >
-              <RefreshCw size={13} style={{ color: "var(--color-bt-accent)" }} /> Swap back nine
-            </button>
-          )}
-          <button
-            onClick={() => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => refresh() })}
-            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-[13px] font-semibold"
-            style={{ background: "transparent", color: "var(--color-bt-text-dim)", border: "1px solid var(--color-bt-border)" }}
-          >
-            <X size={13} /> Change course
-          </button>
-        </div>
+        <NineSummary label="Course" name={frontName} onClear={canEdit ? onClearCourse : undefined} />
       )}
     </div>
   );


### PR DESCRIPTION
Implements the Game-setup-polish spec (Tasks 2 + 3) from Zach's QA pass. Five low-risk fixes on the game-settings / match-setup surface, per-task commits.

## Phase 0 findings

- **Task 3a (match cap):** "Add match" lives in `MatchSetup`, gated only on `MAX_MATCHES` (24) — no team-size cap today. Team size is knowable via `teamsQ`/`rosterOfTeam` (2-team cup) or `crew` (standalone). 2v2 has no cap. ✅ built.
- **Task 4 (rack handicaps): already correct on `main` — no change.** The rack flow renders `HandicapRoster` (per-player absolute strokes, wired to `playGroups.setParticipantStrokes`); it does **not** import the match-play per-matchup control (`RelHandicapControl`/`HandicapsSection`) anywhere. Nothing recent touched it. Confirmed with Zach → skip.
- **Task 2c (handicaps↔course):** `handicapsReady = matchesExist && courseResolved`; when unmet the row was passed `onToggle={undefined}` → silently inert (no dim/lock) — the "feels broken" state. ✅ fixed.

## Task 2 — Golf course row

- **2a** — "Change course" button → an **×** on the course (`NineSummary.onClear` → `clearCourse`).
- **2b** — "Swap back nine" removed; each nine gets its own **×**. Front × clears the course (a back-only course isn't representable — the front is the anchor; mirrors the existing needs-back front-×). Back × drops just the back by re-applying the front alone (`applyCourse` resets `back_course_id` + shrinks the schema to 9 → "needs a back nine") — **reuses existing machinery, no new server code**.

## Task 3 — Setup-timing constraints

- **3a** — Cap "add match" for **1v1 only** at players-per-team (min team size in a 2-team cup, else `floor(crew/2)`); hidden once reached. **2v2 deliberately uncapped** — a rigid doubles cap assumes even, perfectly-paired teams, but injury/illness can force an odd/1v2 lineup a hard cap would block. Reasoning preserved in a code comment.
- **3b** — Un-gate game modifiers from matches. Modifiers are an early format decision; matches are often day-before. Removed the `matchesExist` dependency on the modifiers row.

## Task 2c — Handicaps shown-disabled

`ChecklistRow` gains a visible `disabled` treatment (dimmed 0.55 — the Danger-Zone dimming pattern). The handicaps row now passes its real toggle + `disabled=!handicapsReady`, and the subtitle names the missing prerequisite ("Choose a course first" / "Set the matchups first") so it reads "not available yet", not broken. (`locked` still additionally shows a lock icon; `disabled` does not.)

## Testing

- `tsc --noEmit` clean; `eslint` clean on changed files.
- Runnable unit tests pass (`matchDraft`, `ChecklistRow` visuals, `rowPattern` — 36 tests). `checklistRowVisuals` is unchanged (the dim is in the container style, mirroring the existing `locked` dim).
- Tokens only (`--color-bt-*`), no hardcoded hex. Dark/light unaffected (token-driven).
- DB-backed Vitest + Playwright E2E are env-gated on the test DB / a browser and run in CI. The `match-play.spec.ts` flow is compatible (it clicks `row-handicaps` only after readiness, and adds a single match).

Manual smoke worth doing on the preview: course × removes it (→ no-course); per-nine × on a two-nines 18; no-course handicaps row is visibly dimmed; **2v2 add-match still works past an even count** (the injury case); modifiers configurable with zero matches; 1v1 add-match disappears at players-per-team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_