### PR TITLE
Empty scorecard preview + wiring (Spec 5a)

### DIFF
--- a/src/app/trips/[tripId]/games/scorecard/page.tsx
+++ b/src/app/trips/[tripId]/games/scorecard/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useMemo } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { StandardGrid } from "@/components/games/StandardGrid";
+import { unitsFromSchema, teeFromSchema } from "@/lib/strokePlayConfig";
+import { isGolfFormat } from "@/lib/gameRoutes";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Empty scorecard PREVIEW (Spec 5a) — a course-setup VALIDATOR. Renders the
+ * game's PERSISTED course structure (par / yardage / stroke index, front + back,
+ * including a combined-two-nines course) with NO scores, so an owner can confirm
+ * "did I set the course up right?".
+ *
+ * It reads `games.getById` — the server's snapshotted `scorecard_schema`, the
+ * source of truth — never optimistic/cached UI state (a validator that trusted the
+ * cache it's meant to check would defeat its purpose). Format-agnostic: ONE page
+ * for every golf format, since it needs only the schema (not per-format
+ * scores/roster). Single tee box; multi-tee is Spec 5b. Reached from the
+ * leaderboard scorecard icon and the game-settings course row.
+ */
+export default function ScorecardPreviewPage() {
+  const { tripId: param } = useParams<{ tripId: string }>();
+  const router = useRouter();
+  const search = useSearchParams();
+  const gameId = search.get("game");
+
+  const isId = UUID_RE.test(param);
+  const resolved = trpc.trips.resolveSlug.useQuery(
+    { slugOrId: param },
+    { ...STRUCTURE_QUERY, enabled: !isId, retry: false }
+  );
+  const tripId = isId ? param : resolved.data?.id;
+
+  // Persisted read (the whole point of a validator): the snapshot as SAVED.
+  const gameQ = trpc.games.getById.useQuery(
+    { tripId: tripId!, gameId: gameId! },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId }
+  );
+
+  const schema = gameQ.data?.scorecard_schema as Parameters<typeof unitsFromSchema>[0];
+  const units = useMemo(() => unitsFromSchema(schema), [schema]);
+  const tee = useMemo(
+    () => teeFromSchema(schema as Parameters<typeof teeFromSchema>[0]),
+    [schema]
+  );
+  const gameTypeId = gameQ.data?.game_type_id as string | undefined;
+  // A course is applied ⟺ course_id is set (a 9-hole front counts — the preview
+  // honestly shows a lone front nine so "I forgot the back" is visible).
+  const hasCourse = !!(gameQ.data as { course_id?: string | null } | undefined)?.course_id;
+  const isGolf = isGolfFormat(gameTypeId ?? null);
+
+  const header = (title: string, subtitle?: string) => (
+    <header
+      className="flex shrink-0 items-center"
+      style={{
+        height: 52,
+        padding: "0 8px",
+        background: "var(--color-bt-nav-bg)",
+        borderBottom: "1px solid var(--color-bt-subtle-border)",
+      }}
+    >
+      <button onClick={() => router.back()} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+        <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+      </button>
+      <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
+        <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
+        {subtitle && (
+          <div className="truncate" style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
+        )}
+      </div>
+    </header>
+  );
+
+  // ── Loading ──
+  if (!tripId || !gameId || gameQ.isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--color-bt-base)" }}>
+        <div className="h-8 w-8 animate-spin rounded-full border-2" style={{ borderColor: "var(--color-bt-accent)", borderTopColor: "transparent" }} />
+      </div>
+    );
+  }
+
+  // ── No scorecard to preview (non-golf, or no course applied). The entry points
+  // are gated to golf-with-course, so this is a defensive/deep-link fallback. ──
+  if (!gameQ.data || !isGolf || !hasCourse) {
+    return (
+      <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
+        {header("Scorecard")}
+        <div className="flex flex-1 items-center justify-center px-8 text-center">
+          <p className="text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+            No course set for this game yet — apply a course in game settings to preview its scorecard.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Empty preview: course structure only (participants=[] → no score rows). ──
+  return (
+    <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
+      {header("Scorecard", (gameQ.data.name as string | undefined) ?? undefined)}
+      <div className="min-h-0 flex-1">
+        <StandardGrid units={units} tee={tee} participants={[]} values={{}} direction="low_wins" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -2,6 +2,7 @@
 
 import { createElement } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
@@ -129,10 +130,15 @@ export function GameRow({
   // Once scoring is on (live/final), everyone gets the scoreboard. Members never
   // get the settings link — they hit the server-walled placeholder.
   const canEditThisGame = !!canEdit || mine;
+  const router = useRouter();
   const setupMode = !(game.status === "complete" || game.status === "active" || game.scoringEnabled === true);
   const href = gameHref(tripId, game.gameTypeId, game.id, {
     settings: canEditThisGame && setupMode,
   });
+  // The scorecard icon opens the EMPTY scorecard PREVIEW (Spec 5a) — its own
+  // destination, distinct from the row's game link. Golf-with-course only (null
+  // for non-golf, which never shows the icon anyway).
+  const scorecardHref = gameHref(tripId, game.gameTypeId, game.id, { scorecard: true });
   const hasScores = cells && cells.size > 0;
   // The row's single source of truth — the game's board SECTION (shared with the
   // section grouping so row + header always agree). Layout + every §A3 layer key
@@ -254,18 +260,29 @@ export function GameRow({
 
       {/* Scorecard column (golf-only, dropped at Final) — inboard of the outer
           column so the right edge holds when it vanishes. Course set → a real
-          button that opens the scorecard (via the row link to the score-entry
-          route); no course → a muted, inert status icon (no nav, not an error). */}
+          button that opens the EMPTY SCORECARD PREVIEW (Spec 5a — its own route,
+          NOT the game): the span intercepts the tap (preventDefault +
+          stopPropagation so the row's game link doesn't also fire) and navigates
+          to the scorecard. No course → a muted, inert status icon. */}
       {showScorecard &&
-        (scorecardOpens ? (
+        (scorecardOpens && scorecardHref ? (
           <span
-            className="flex shrink-0 items-center justify-center rounded-lg"
+            role="button"
+            tabIndex={0}
+            aria-label="View scorecard"
+            title="View scorecard"
+            className="flex shrink-0 cursor-pointer items-center justify-center rounded-lg"
             style={{
               width: 30,
               height: 30,
               background: "var(--color-bt-card-raised)",
               border: "1px solid var(--color-bt-border)",
               color: "var(--color-bt-text)",
+            }}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              router.push(scorecardHref);
             }}
           >
             <ClipboardList size={15} />

--- a/src/components/games/GameSetupRows.tsx
+++ b/src/components/games/GameSetupRows.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Flag, Hash } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Flag, Hash, ClipboardList, ChevronRight } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
+import { gameHref, isGolfFormat } from "@/lib/gameRoutes";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { Stepper } from "@/components/games/Stepper";
 import { pointsReady } from "@/lib/matchDraft";
@@ -95,6 +97,12 @@ export function GameSetupRows({
   const backId = (game.back_course_id as string | null) ?? null;
   const count = ((game.scorecard_schema as { units?: { count?: number } } | null)?.units?.count) ?? 0;
   const courseResolved = !!frontId && count === 18;
+  // Preview-scorecard validator (Spec 5a): reachable whenever a course is APPLIED
+  // — including a lone 9-hole front (count 9), so the preview can reveal a missing
+  // back nine. Distinct from `courseResolved` (the stricter 18-hole handicaps gate).
+  const router = useRouter();
+  const courseApplied = !!frontId;
+  const scorecardHref = gameHref(tripId, game.game_type_id, game.id, { scorecard: true });
   // §5a (P-F0c): the RESOLVED Course title is the course NAME (the subtitle stays the
   // handicaps gate). Lift the two-ID name fetch (front + back) to the collapsed row —
   // CourseRowContent fetches the same names in its expanded body. Gated on
@@ -142,6 +150,38 @@ export function GameSetupRows({
               back picker composes a retained two-nines 18, swappable day-of. */}
           <CourseRowContent tripId={tripId} game={game} canEdit={canEdit} onChanged={onChanged} />
         </ChecklistRow>
+      )}
+
+      {/* Preview scorecard (Spec 5a) — a course-setup VALIDATOR right under the
+          course row: opens the EMPTY scorecard (par/yardage/stroke index, front +
+          back) read from PERSISTED state, so the owner can confirm the course is
+          set up right. Golf-only; visibly disabled (dimmed, Danger-Zone pattern)
+          until a course is applied, consistent with the handicaps-disabled row. */}
+      {slot !== "config" && isGolfFormat(game.game_type_id) && scorecardHref && (
+        <button
+          type="button"
+          data-testid="row-preview-scorecard"
+          disabled={!courseApplied}
+          onClick={() => router.push(scorecardHref)}
+          className="flex w-full items-center gap-3 rounded-xl px-3.5 py-3 text-left"
+          style={{
+            background: "var(--color-bt-card)",
+            border: "1px solid var(--color-bt-border)",
+            opacity: courseApplied ? undefined : 0.55,
+            cursor: courseApplied ? "pointer" : "not-allowed",
+          }}
+        >
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg" style={{ background: "var(--color-bt-card-raised)" }}>
+            <ClipboardList size={16} style={{ color: "var(--color-bt-text)" }} />
+          </span>
+          <span className="flex min-w-0 flex-col">
+            <span style={{ fontSize: 15, color: "var(--color-bt-text)" }}>Preview scorecard</span>
+            <span className="truncate" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
+              {courseApplied ? "Check the course setup — par, yardage, stroke index" : "Set a course to preview"}
+            </span>
+          </span>
+          {courseApplied && <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", marginLeft: "auto" }} />}
+        </button>
       )}
       {slot !== "course" && competitionId && (
         isMatchPlay ? (

--- a/src/components/games/StandardGrid.test.tsx
+++ b/src/components/games/StandardGrid.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StandardGrid } from "./StandardGrid";
+import type { ScoreUnit } from "./types";
+
+// Empty scorecard PREVIEW (Spec 5a): the grid renders the course STRUCTURE
+// (par / yardage / stroke-index rows + front/back sections) independently of
+// scores, so passing participants=[] / values={} yields a valid scores-off
+// preview with no player rows. Rendered via react-dom/server (node env, no RTL).
+
+const units: ScoreUnit[] = [
+  { label: "1", section: "front", par: 4, strokeIndex: 5, yardage: 410 },
+  { label: "2", section: "front", par: 3, strokeIndex: 17, yardage: 165 },
+  { label: "10", section: "back", par: 5, strokeIndex: 2, yardage: 540 },
+  { label: "18", section: "back", par: 4, strokeIndex: 8, yardage: 430 },
+];
+
+describe("StandardGrid — empty (scores-off) preview", () => {
+  const html = renderToStaticMarkup(
+    <StandardGrid units={units} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} />
+  );
+
+  it("renders the course-structure rows from units alone (Par / Yards / Index)", () => {
+    expect(html).toContain("Par");
+    expect(html).toContain("Yards");
+    expect(html).toContain("Index");
+    // Actual par + stroke-index + yardage values are present (structure, not scores).
+    expect(html).toContain(">4<"); // a par value
+    expect(html).toContain(">17<"); // a stroke index
+    expect(html).toContain("410"); // a yardage
+  });
+
+  it("shows front/back sections (Out / In / Total) when units span both nines", () => {
+    expect(html).toContain("Out");
+    expect(html).toContain("In");
+    expect(html).toContain("Total");
+  });
+
+  it("renders NO participant rows or score cells when participants=[]", () => {
+    expect(html).not.toContain("score-cell-"); // no per-cell score buttons
+  });
+
+  it("shows the configured tee header (single tee — 5b adds multi-tee)", () => {
+    expect(html).toContain("Blue tees");
+  });
+});

--- a/src/lib/gameRoutes.test.ts
+++ b/src/lib/gameRoutes.test.ts
@@ -41,6 +41,18 @@ describe("gameHref", () => {
     );
     expect(gameHref("trip1", "gtt_stroke_play", "g1")).toBe("/trips/trip1/games/new?game=g1");
   });
+
+  it("scorecard → the single format-agnostic empty-preview route, golf only", () => {
+    // Every golf format shares ONE scorecard route (it only needs the schema).
+    for (const t of ["gtt_stroke_play", "gtt_match_play_singles", "gtt_match_play_doubles", "gtt_rack_n_stack"]) {
+      expect(gameHref("trip1", t, "g1", { scorecard: true })).toBe("/trips/trip1/games/scorecard?game=g1");
+    }
+    // Non-golf has no course → no scorecard link.
+    for (const t of ["gtt_manual", "gtt_generic_card", "gtt_generic_yard", "gtt_generic_bar"]) {
+      expect(gameHref("trip1", t, "g1", { scorecard: true })).toBeNull();
+    }
+    expect(gameHref("trip1", null, "g1", { scorecard: true })).toBeNull();
+  });
 });
 
 describe("isGolfFormat", () => {

--- a/src/lib/gameRoutes.ts
+++ b/src/lib/gameRoutes.ts
@@ -29,10 +29,19 @@ export function gameHref(
    *  instead of the scoreboard pass-through — the leaderboard uses this to drop
    *  an owner/delegate straight into setup for a not-yet-scoring game (the page
    *  honors `?settings=1` via useGameSettingsOverlay). Members / scoring-mode
-   *  games never get it (decided at the call site). */
-  opts?: { settings?: boolean }
+   *  games never get it (decided at the call site).
+   *
+   *  `scorecard: true` → the standalone EMPTY scorecard preview (Spec 5a): the
+   *  course structure (par/yardage/stroke-index, front+back) read from the game's
+   *  PERSISTED snapshot, no scores. Format-agnostic (one page for every golf
+   *  format — it only needs the schema), so it's a single route, not per-format.
+   *  Golf-only; a non-golf game (no course) returns null → no scorecard link. */
+  opts?: { settings?: boolean; scorecard?: boolean }
 ): string | null {
   if (!gameTypeId) return null;
+  if (opts?.scorecard) {
+    return isGolfFormat(gameTypeId) ? `/trips/${tripId}/games/scorecard?game=${gameId}` : null;
+  }
   const suffix = opts?.settings ? "&settings=1" : "";
   const seg = GAME_ROUTES[gameTypeId];
   if (seg) return `/trips/${tripId}/games/${seg}?game=${gameId}${suffix}`;


### PR DESCRIPTION
Implements Spec 5a — a generic EMPTY scorecard preview (a course-setup validator) plus wiring to two entry points. Display + wiring over existing machinery; **not** a new scorecard build, **not** multi-tee (that's 5b).

## Phase 0 findings

1. **Scorecard component = `StandardGrid`.** Its Par/Yards/Index rows + front/back divider + Out/In/Total all derive from `units` (the schema), independent of scores; participant rows just `.map(participants)`. So the empty state is `participants={[]}` / `values={{}}` — **no component change needed**, no crash (`computeStrokePlayStandings([], [])` → `[]`).
2. **Leaderboard button bug** (`GameRow.tsx`): the clipboard icon sat inside the row's game `<Link>`, so it opened the game. Already gated to golf-with-course; non-golf excluded.
3. **Settings mount:** `GameSetupRows.tsx` course row (shared by all formats' settings), reads `game` = `games.getById` (persisted).
4. **Formats:** stroke / singles / doubles match / rack have a course; non-golf (card/yard/bar/manual) don't — excluded via `isGolfFormat`. Combined-two-nines already lives in the schema's front/back `sections`.
5. **Persisted read:** `games.getById → scorecard_schema` is always server-persisted (written by `applyCourse`/`setBackNine`/`clearCourse`), never optimistic. The validator reads this.

## Task 1 — Empty preview

New format-agnostic route `/trips/[tripId]/games/scorecard?game=<id>` reads the persisted `scorecard_schema` and renders `StandardGrid` empty — par/yardage/stroke-index, front + back (incl. combined-two-nines), single tee, no scores. `gameHref` gains a `{ scorecard: true }` option (one route for every golf format; non-golf → null). Render test locks in the scores-off behavior.

## Task 2 — Leaderboard button

The clipboard icon now intercepts its tap (`preventDefault` + `stopPropagation`) and navigates to the scorecard preview instead of the game — kept as a `<span role="button">` (valid inside the row anchor, no nested `<a>`), mirroring the existing no-course span. Gating unchanged.

**Behavior decision (Phase 0):** both entry points open the **empty** preview (the spec's sanctioned default; the filled scorecard remains reachable inside each game's own grid view). Filled-when-scored on the leaderboard is a noted optional follow-up — it'd require per-format participant resolution, which risks the "don't rebuild the scorecard" guardrail.

## Task 3 — Settings "Preview scorecard" affordance

A button under the course row opens the empty scorecard to validate the setup. Reachable whenever a course is **applied** — including a lone 9-hole front, so the preview can reveal a missing back nine (distinct from the stricter 18-hole handicaps gate). Visibly disabled (dimmed 0.55 — the Danger-Zone pattern, consistent with the handicaps-disabled row) until a course is set. Golf-only; the shared `GameSetupRows` mount covers every format's settings.

## Testing

- `tsc --noEmit` clean; `eslint` clean on all changed/new files.
- Unit tests: `gameRoutes` (scorecard route, golf-only, +7), `StandardGrid` empty-preview render (+4), `ChecklistRow` unaffected. All pass.
- Tokens only (`--color-bt-*`), no hardcoded hex; dark/light token-driven.
- DB-backed Vitest + Playwright run in CI. The new preview surface is off the critical path, so no new E2E; existing scorecard E2E uses the in-page grid view (unaffected by the leaderboard-icon change).

Manual smoke worth doing: leaderboard clipboard icon → empty scorecard (not the game); settings "Preview scorecard" present when a course is set, dimmed when not, absent for non-golf; combined-two-nines shows front+back correctly; the preview reflects saved course state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_