### PR TITLE
Non-golf settings parity (Spec 6)

### DIFF
--- a/src/components/games/NonGolfConfigurationView.tsx
+++ b/src/components/games/NonGolfConfigurationView.tsx
@@ -10,6 +10,7 @@ import { GameRulesNote } from "@/components/games/GameRulesNote";
 import { GameFormatExplainer } from "@/components/games/GameFormatExplainer";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
+import { ZoneHeader } from "@/components/games/ZoneHeader";
 import {
   PointStepper,
   FormatSheet,
@@ -22,10 +23,11 @@ import type { ScoringModel } from "@/lib/gameTypes";
 /**
  * NonGolfConfigurationView (W-NONGOLF lifecycle surface) — the non-golf twin of
  * golf's `GameConfigurationView`: the ONE settings home, reached by the corner
- * gear, carrying the mode toggle + Danger Zone. It mirrors golf's STRUCTURE
- * (identity → settings → rules → toggle → danger zone) but ships a **LEAN
- * payload** — only what non-golf needs, no golf cruft (no Matches / Course /
- * Handicaps / Modifiers):
+ * gear, carrying the mode toggle + Danger Zone. It mirrors the cleaned golf ORDER
+ * (Spec 6): identity → explainer → **Rules (top)** → **Game Management** →
+ * **Settings** → Danger Zone — same grouping + treatment, but a **LEAN payload**:
+ * only what non-golf needs, no golf cruft (no Matches / Course / Handicaps /
+ * Modifiers):
  *
  *  - **competition_format** (its real home now — drives future matchup/bracket dev),
  *  - by the competition's `scoring_model`:
@@ -91,17 +93,59 @@ export function NonGolfConfigurationView({
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+        {/* Non-golf now mirrors the cleaned golf ORDER (Spec 6): identity → explainer
+            → Rules (top) → Game Management → Settings → Danger Zone. Non-golf's rows
+            differ (no course/handicaps/matches; it HAS Competition Format + Game
+            Value), but the grouping + treatment match golf so they read as one page
+            family. Shared primitives (identity, Rules, toggle, Danger Zone, explainer,
+            ZoneHeader) inherit the golf treatment — nothing re-implemented. */}
+
         {/* Identity — name (tap-to-edit) + assigned-to (same as golf). */}
         <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
 
-        {/* #501: live-game lock banner — settings below are frozen until toggled
-            back to Setup. */}
+        {/* Format explainer — the compact "how you compete" block that pairs directly
+            ABOVE Rules (this is the slot reserved for it). */}
+        <div className="mt-6">
+          <GameFormatExplainer gameTypeId={game.game_type_id} variant="settings" />
+        </div>
+
+        {/* RULES OF THE DAY — at the TOP (matching golf). Saves on blur; the
+            carved-out exception stays editable in scoring mode (notes, not
+            game-altering) — so it keeps plain canEdit. */}
+        <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />
+
+        {/* GAME MANAGEMENT — a labeled peer section + the single Setup/Scoring toggle
+            (owner/delegate only). ZoneHeader supplies the caption, so the panel's own
+            caption is suppressed (hideLabel) to avoid a double label — matching golf. */}
+        {canEdit && (
+          <>
+            <div className="mt-6">
+              <ZoneHeader>Game Management</ZoneHeader>
+            </div>
+            <div className="mt-2.5">
+              <GameManagementPanel
+                mode={scoringEnabled ? "scoring" : "setup"}
+                ready={ready}
+                onEnable={onEnable}
+                onDisable={onDisable}
+                pending={busy}
+                hideLabel
+              />
+            </div>
+          </>
+        )}
+
+        {/* #501: live-game lock banner — the settings below are frozen until the
+            owner/delegate flips the toggle above back to Setup (after the toggle,
+            matching golf). */}
         {scoringEnabled && canEdit && <ScoringLockBanner />}
 
-        {/* Competition format — relocated here as its real home, near the top
-            (it drives future matchup/bracket dev). Locked in scoring mode. */}
+        {/* SETTINGS — non-golf's real, different content: Competition Format ("how
+            it's played") + Game Value (points-for-the-match). Locked in scoring mode. */}
+        <div className="mt-6">
+          <ZoneHeader>Settings</ZoneHeader>
+        </div>
         <CompetitionFormatRow tripId={tripId} game={game} canEdit={settingsEditable} locked={scoringEnabled} onChanged={onChanged} />
-
         {/* The points payload, by the competition's scoring model. Locked in scoring —
             #512 Option B: dim the read-only panel so it reads as frozen. */}
         {scoringModel === "match_play" ? (
@@ -114,40 +158,20 @@ export function NonGolfConfigurationView({
           </div>
         )}
 
-        {/* Format explainer — compact "how you compete" block, pairs directly
-            above Rules (orients the owner on the format they're configuring). */}
-        <div className="mt-6">
-          <GameFormatExplainer gameTypeId={game.game_type_id} variant="settings" />
-        </div>
-
-        {/* Rules of the Day — saves on blur (same as golf). The carved-out exception:
-            stays editable in scoring mode (notes, not game-altering). */}
-        <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />
-
-        {/* The single Setup / Scoring toggle — owner/delegate only. */}
-        {canEdit && (
+        {/* Per-game danger zone — owner-only (reset scores / reset settings / delete).
+            Dimmed-header + disabled wholesale in scoring mode (#501, shared treatment)
+            — switch to Setup to manage it. */}
+        {isOwner && (
           <div className="mt-6">
-            <GameManagementPanel
-              mode={scoringEnabled ? "scoring" : "setup"}
-              ready={ready}
-              onEnable={onEnable}
-              onDisable={onDisable}
-              pending={busy}
+            <GameDangerZone
+              tripId={tripId}
+              gameId={game.id}
+              competitionId={competitionId}
+              onChanged={onChanged}
+              onDeleted={onDeleted}
+              disabled={scoringEnabled}
             />
           </div>
-        )}
-
-        {/* Per-game danger zone — owner-only (reset scores / reset settings / delete).
-            Disabled wholesale in scoring mode (#501) — switch to Setup to manage it. */}
-        {isOwner && (
-          <GameDangerZone
-            tripId={tripId}
-            gameId={game.id}
-            competitionId={competitionId}
-            onChanged={onChanged}
-            onDeleted={onDeleted}
-            disabled={scoringEnabled}
-          />
         )}
       </div>
     </div>

--- a/src/components/games/ZoneHeader.test.tsx
+++ b/src/components/games/ZoneHeader.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ZoneHeader } from "./ZoneHeader";
+
+// The shared section divider (Spec 6) — non-golf settings reuse it for golf-parity
+// grouping. Rendered via react-dom/server (node env, no RTL).
+describe("ZoneHeader", () => {
+  const html = renderToStaticMarkup(<ZoneHeader>Game Management</ZoneHeader>);
+
+  it("renders the caption text", () => {
+    expect(html).toContain("Game Management");
+  });
+
+  it("is a quiet uppercase, token-styled caption with a hairline rule", () => {
+    expect(html).toContain("uppercase");
+    expect(html).toContain("var(--color-bt-text-dim)"); // caption color token
+    expect(html).toContain("var(--color-bt-border)"); // the trailing rule token
+  });
+});

--- a/src/components/games/ZoneHeader.tsx
+++ b/src/components/games/ZoneHeader.tsx
@@ -1,0 +1,22 @@
+/**
+ * ZoneHeader — a labeled section divider on the game-settings surfaces (W-GAMEPAGE
+ * §5): the groups are LABELS, not panes (one scrolling column). A quiet uppercase
+ * caption with a hairline rule to its right, token-styled.
+ *
+ * Shared so non-golf settings inherit the SAME grouping treatment golf uses (the
+ * match-page checklist has an identical local copy predating this extraction — it
+ * can migrate to this one later; kept untouched here to leave golf settings alone).
+ */
+export function ZoneHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 pt-2">
+      <span
+        className="text-[11px] font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        {children}
+      </span>
+      <span className="h-px flex-1" style={{ background: "var(--color-bt-border)" }} />
+    </div>
+  );
+}


### PR DESCRIPTION
Brings `NonGolfConfigurationView` up to the cleaned golf settings PATTERN — same structural treatment + ordering, keeping non-golf's real (different) content.

## Phase 0

**Current non-golf order:** identity → lock banner → Competition Format → points → explainer → Rules → Game Management toggle → Danger Zone.

**Golf pattern (the cleaned match-page checklist):** identity → explainer → **Rules (top)** → ZoneHeader "Game Management" + toggle (`hideLabel`) → lock banner → ZoneHeader "Settings" + rows → Danger Zone.

**Delta (the finishing touches non-golf was missing):**
- Rules was mid-page, not at the top.
- Game Management toggle came *after* the settings; golf puts it right after Rules.
- No section grouping (ZoneHeaders); the toggle showed its own caption instead of a "Game Management" header + `hideLabel`.
- **Already at parity (unchanged):** Danger Zone dimmed-when-locked (shared `GameDangerZone`, `disabled={scoringEnabled}`); auto-save (format on pick, value on change, Rules on blur — no Save & exit). Continuous-panel / no-under-header-divider / scroll-when-needed are **N/A** — non-golf has no accordion drill-downs.

**Shared vs forked:** identity, Rules, toggle, Danger Zone, explainer, points panel are all shared and already used by non-golf. Only `ZoneHeader` was forked (local to the match page).

## Changes

- **Extract a shared `ZoneHeader`** so non-golf inherits the golf grouping treatment instead of re-implementing it. The match page's identical local copy is left untouched (DO-NOT: don't touch golf settings) and can migrate later.
- **Reorder `NonGolfConfigurationView`** to the golf order: identity → explainer → Rules (top) → "Game Management" ZoneHeader + toggle (`hideLabel`) + lock banner → "Settings" ZoneHeader + Competition Format + Game Value → Danger Zone.
- **Kept non-golf's real content:** Competition Format (the "how it's played" selector) and Game Value (points-for-the-match stepper) — grouped under Settings, unchanged in behavior.

## Testing

- `tsc --noEmit` clean; `eslint` clean on changed/new files.
- `ZoneHeader` render test (+2). No existing tests referenced the non-golf order; the component's props are unchanged, so the `manual` page call site is unaffected.
- Tokens only (`--color-bt-*`), no hardcoded hex; dark/light token-driven.
- DB-backed Vitest + Playwright run in CI.

Manual smoke worth doing: put a golf game and a non-golf game settings side by side — Rules on top, Game Management, settings, Danger Zone in both; Danger Zone header dims when locked; Competition Format + Game Value still present and functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_