### PR TITLE
Multi-tee yardage rows on the scorecard (Spec 5b)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -16,6 +16,7 @@ import { GameManagementPanel } from "@/components/games/GameManagementPanel";
 import { ChecklistRow, type ChecklistRowState } from "@/components/games/ChecklistRow";
 import { MatchCard } from "@/components/games/MatchCard";
 import { StandardGrid } from "@/components/games/StandardGrid";
+import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { RelHandicapControl } from "@/components/games/RelHandicapControl";
 import { DragHandle } from "@/components/games/DragHandle";
 import { RowNumber } from "@/components/games/RowNumber";
@@ -173,6 +174,8 @@ export default function NewMatchGamePage() {
   // it — not on the fast score cadence — so it caches as structure too). Only the
   // raw scores stay short, so a reopen refreshes them while the rest is instant.
   const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
+  // Multi-tee scorecard yardage rows (Spec 5b) — reads the persisted course record(s).
+  const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const matchesQ = trpc.matches.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
 
@@ -891,6 +894,7 @@ export default function NewMatchGamePage() {
               <StandardGrid
                 units={scUnits}
                 tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+                teeRows={teeRows}
                 participants={entryParticipants}
                 values={values}
                 direction="low_wins"

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -8,6 +8,7 @@ import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
+import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { FinalStandings } from "@/components/games/FinalStandings";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
@@ -64,6 +65,8 @@ export default function NewGamePage() {
     { tripId: tripId!, gameId: urlGameId! },
     { ...STRUCTURE_QUERY, enabled: !!tripId && !!urlGameId }
   );
+  // Multi-tee scorecard yardage rows (Spec 5b) — reads the persisted course record.
+  const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const scoresQ = trpc.scores.listByGame.useQuery(
     { tripId: tripId!, gameId: urlGameId! },
     { enabled: !!tripId && !!urlGameId }
@@ -487,6 +490,7 @@ export default function NewGamePage() {
               <StandardGrid
                 units={scUnits}
                 tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+                teeRows={teeRows}
                 participants={game.participants}
                 values={values}
                 direction="low_wins"

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -13,6 +13,7 @@ import { TimePicker } from "@/components/TimePicker";
 import { parseTime, toTime24 } from "@/lib/time";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
+import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
@@ -102,6 +103,8 @@ export default function RackNStackPage() {
   // game config + foursomes are STRUCTURE (kept); only the raw scores stay short
   // (STATE) so a reopen is instant while the scores re-fetch.
   const gameQ = trpc.games.getById.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
+  // Multi-tee scorecard yardage rows (Spec 5b) — reads the persisted course record(s).
+  const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
   const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
 
@@ -430,6 +433,7 @@ export default function RackNStackPage() {
             <StandardGrid
               units={scUnits}
               tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+              teeRows={teeRows}
               participants={ps}
               values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
               direction="low_wins"

--- a/src/app/trips/[tripId]/games/scorecard/page.tsx
+++ b/src/app/trips/[tripId]/games/scorecard/page.tsx
@@ -8,6 +8,7 @@ import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { unitsFromSchema, teeFromSchema } from "@/lib/strokePlayConfig";
 import { isGolfFormat } from "@/lib/gameRoutes";
+import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -49,6 +50,8 @@ export default function ScorecardPreviewPage() {
     () => teeFromSchema(schema as Parameters<typeof teeFromSchema>[0]),
     [schema]
   );
+  // Multi-tee yardage rows (Spec 5b) — reads the persisted course record(s).
+  const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const gameTypeId = gameQ.data?.game_type_id as string | undefined;
   // A course is applied ⟺ course_id is set (a 9-hole front counts — the preview
   // honestly shows a lone front nine so "I forgot the back" is visible).
@@ -106,7 +109,7 @@ export default function ScorecardPreviewPage() {
     <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
       {header("Scorecard", (gameQ.data.name as string | undefined) ?? undefined)}
       <div className="min-h-0 flex-1">
-        <StandardGrid units={units} tee={tee} participants={[]} values={{}} direction="low_wins" />
+        <StandardGrid units={units} tee={tee} participants={[]} values={{}} direction="low_wins" teeRows={teeRows} />
       </div>
     </div>
   );

--- a/src/components/games/StandardGrid.test.tsx
+++ b/src/components/games/StandardGrid.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { StandardGrid } from "./StandardGrid";
 import type { ScoreUnit } from "./types";
+import type { TeeRow } from "@/lib/teeRows";
 
 // Empty scorecard PREVIEW (Spec 5a): the grid renders the course STRUCTURE
 // (par / yardage / stroke-index rows + front/back sections) independently of
@@ -42,5 +43,43 @@ describe("StandardGrid — empty (scores-off) preview", () => {
 
   it("shows the configured tee header (single tee — 5b adds multi-tee)", () => {
     expect(html).toContain("Blue tees");
+  });
+});
+
+// Spec 5b — multi-tee yardage rows. When teeRows is supplied, the grid renders a
+// checkbox legend + one yardage row per VISIBLE tee (default = chosen + neighbors),
+// replacing the single snapshot Yards row; the chosen tee is highlighted + in play.
+describe("StandardGrid — multi-tee yardage rows (5b)", () => {
+  const teeRows: TeeRow[] = [
+    { name: "Blue", color: "#3b82f6", yards: [410, 165, 540, 430], total: 1545, isChosen: false, defaultVisible: true },
+    { name: "White", color: "#e5e7eb", yards: [380, 150, 505, 400], total: 1435, isChosen: true, defaultVisible: true },
+    { name: "Red", color: "#ef4444", yards: [300, 120, 430, 340], total: 1190, isChosen: false, defaultVisible: false },
+  ];
+  const html = renderToStaticMarkup(
+    <StandardGrid units={units} participants={[]} values={{}} direction="low_wins" teeRows={teeRows} />
+  );
+
+  it("renders the checkbox legend listing every tee (even hidden ones)", () => {
+    expect(html).toContain("tee-legend");
+    expect(html).toContain("Blue");
+    expect(html).toContain("White");
+    expect(html).toContain("Red"); // in the legend even though its row is hidden by default
+  });
+
+  it("renders a yardage row for each DEFAULT-VISIBLE tee, and hides the rest", () => {
+    expect(html).toContain("tee-row-Blue");
+    expect(html).toContain("tee-row-White");
+    expect(html).not.toContain("tee-row-Red"); // default-hidden → no row (only the legend entry)
+  });
+
+  it("marks the chosen tee in play and highlights it (accent-faint token)", () => {
+    expect(html).toContain("· in play");
+    expect(html).toContain("var(--color-bt-accent-faint)"); // the chosen row's brighter fill
+    expect(html).toContain("var(--color-bt-accent)"); // the chosen row's left accent rail
+  });
+
+  it("shows per-tee yardage values (a display-only reference row)", () => {
+    expect(html).toContain("410"); // Blue hole 1
+    expect(html).toContain("380"); // White (chosen) hole 1
   });
 });

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
+import type { TeeRow } from "@/lib/teeRows";
 import { Avatar } from "@/components/Avatar";
 import { GolfChip } from "./GolfChip";
 import {
@@ -53,6 +55,15 @@ interface StandardGridProps {
    * yardage rides on `units[].yardage` instead.
    */
   tee?: { name: string; courseRating?: number | null; slopeRating?: number | null; bogeyRating?: number | null } | null;
+  /**
+   * Multi-tee yardage rows (Spec 5b) — DISPLAY ONLY (scoring/structure/handicaps
+   * are unchanged; these are reference rows). When present + non-empty, the grid
+   * shows one yardage row per tee (with a checkbox legend to hide/reveal tees)
+   * INSTEAD of the single snapshot `Yards` row. Omit/empty → the single-tee row
+   * (today's behavior) is kept. The rows arrive pre-assembled (order, default
+   * visibility, chosen flag, color) from `useScorecardTeeRows`.
+   */
+  teeRows?: TeeRow[];
 }
 
 const NAME_W = 124;
@@ -60,11 +71,22 @@ const HOLE_W = 30;
 const SUB_W = 44;
 const TOTAL_W = 50;
 
-export function StandardGrid({ units, participants, values, onCellTap, pips, saveStatus, tee }: StandardGridProps) {
+export function StandardGrid({ units, participants, values, onCellTap, pips, saveStatus, tee, teeRows = [] }: StandardGridProps) {
   const front = units.filter((u) => u.section === "front");
   const back = units.filter((u) => u.section === "back");
   const hasSections = front.length > 0 && back.length > 0;
   const firstBackLabel = back[0]?.label;
+
+  // Multi-tee rows (Spec 5b): user overrides on top of each row's default
+  // visibility; the CHOSEN tee is always shown (non-hidable — it's in play).
+  const multiTee = teeRows.length > 0;
+  const [teeOverrides, setTeeOverrides] = useState<Record<string, boolean>>({});
+  const teeVisible = (row: TeeRow) => row.isChosen || (teeOverrides[row.name] ?? row.defaultVisible);
+  const toggleTee = (row: TeeRow) =>
+    setTeeOverrides((o) => ({ ...o, [row.name]: !(o[row.name] ?? row.defaultVisible) }));
+  // A tee's front/back/total yardage — its yards align with `units` by index.
+  const teeSum = (ys: (number | null)[], from: number, to: number) =>
+    ys.slice(from, to).reduce((a: number, y) => a + (y ?? 0), 0);
 
   const valOf = (pid: string, l: string) => values[pid]?.[l];
   const sumOf = (pid: string, list: ScoreUnit[]) =>
@@ -138,14 +160,42 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
 
   return (
     <div className="h-full" style={{ background: "var(--color-bt-base)" }}>
-      {tee && (
+      {/* Multi-tee checkbox legend (Spec 5b) — reveal/hide each tee's yardage row.
+          The chosen tee is checked + disabled (in play, never hidable). Replaces the
+          single-tee header when tee rows are present. */}
+      {multiTee ? (
+        <div
+          className="flex flex-wrap items-center gap-x-3 gap-y-1.5"
+          style={{ padding: "8px 12px", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+          data-testid="tee-legend"
+        >
+          {teeRows.map((row) => {
+            const on = teeVisible(row);
+            return (
+              <label key={row.name} className="flex items-center gap-1.5" style={{ cursor: row.isChosen ? "default" : "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={on}
+                  disabled={row.isChosen}
+                  onChange={() => toggleTee(row)}
+                  style={{ accentColor: "var(--color-bt-accent)" }}
+                />
+                <span style={{ width: 9, height: 9, borderRadius: "50%", background: row.color, border: "1px solid var(--color-bt-subtle-border)", flexShrink: 0 }} />
+                <span style={{ fontSize: 12, fontWeight: row.isChosen ? 700 : 500, color: on ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>
+                  {row.name}{row.isChosen ? " · in play" : ""}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      ) : tee ? (
         <div className="flex items-center gap-2" style={{ padding: "8px 12px", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
           <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text)" }}>{tee.name} tees</span>
           {teeRatings && (
             <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>· {teeRatings}</span>
           )}
         </div>
-      )}
+      ) : null}
       <div className="relative">
         <div className="no-scrollbar overflow-x-auto">
           <div style={{ minWidth: "max-content" }}>
@@ -177,24 +227,62 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
             <HeaderSub label="Total" wide />
           </div>
 
-          {/* Yards row (configured tee) — informational; sits on base like Index. */}
-          {hasYards && (
-            <div className="flex" style={{ height: 26, background: "var(--color-bt-base)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-              <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-base)", padding: "0 10px" }}>
-                <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
-                  Yards
-                </span>
-              </div>
-              {units.map((u) => (
-                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
-                  <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.yardage ?? "—"}</span>
+          {/* Yardage — DISPLAY ONLY. Multi-tee (Spec 5b): one row per VISIBLE tee,
+              zebra-striped, the chosen tee brighter (accent-faint fill + an accent
+              rail). Falls back to the single snapshot Yards row when no tee rows are
+              supplied. Sits on base like Index; informational only. */}
+          {multiTee
+            ? teeRows.filter(teeVisible).map((row, ti) => {
+                const zebraBg = row.isChosen
+                  ? "var(--color-bt-accent-faint)"
+                  : ti % 2 === 0
+                    ? "var(--color-bt-card-raised)"
+                    : "var(--color-bt-base)";
+                const valColor = row.isChosen ? "var(--color-bt-text)" : "var(--color-bt-text-dim)";
+                // The chosen row gets a left accent rail on the sticky name cell
+                // (inset shadow — no layout shift), so it's unmistakable at a glance.
+                const nameStyle = {
+                  ...nameCell,
+                  background: zebraBg,
+                  padding: "0 10px",
+                  ...(row.isChosen ? { boxShadow: "inset 3px 0 0 var(--color-bt-accent)" } : {}),
+                } as React.CSSProperties;
+                return (
+                  <div key={row.name} className="flex" style={{ height: 26, background: zebraBg, borderBottom: "1px solid var(--color-bt-subtle-border)" }} data-testid={`tee-row-${row.name}`}>
+                    <div className="flex items-center gap-1.5" style={nameStyle}>
+                      <span style={{ width: 8, height: 8, borderRadius: "50%", background: row.color, border: "1px solid var(--color-bt-subtle-border)", flexShrink: 0 }} />
+                      <span className="truncate" style={{ fontSize: 11, fontWeight: row.isChosen ? 700 : 600, letterSpacing: "0.02em", color: valColor }}>
+                        {row.name}
+                      </span>
+                    </div>
+                    {units.map((u, i) => (
+                      <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                        <span style={{ fontSize: 11, color: valColor, opacity: row.isChosen ? 1 : 0.75, fontVariantNumeric: "tabular-nums" }}>{row.yards[i] ?? "—"}</span>
+                      </div>
+                    ))}
+                    {hasSections && <ParSub value={teeSum(row.yards, 0, front.length)} />}
+                    {hasSections && <ParSub value={teeSum(row.yards, front.length, units.length)} />}
+                    <ParSub value={teeSum(row.yards, 0, units.length)} wide />
+                  </div>
+                );
+              })
+            : hasYards && (
+                <div className="flex" style={{ height: 26, background: "var(--color-bt-base)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+                  <div className="flex items-center" style={{ ...nameCell, background: "var(--color-bt-base)", padding: "0 10px" }}>
+                    <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
+                      Yards
+                    </span>
+                  </div>
+                  {units.map((u) => (
+                    <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                      <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.yardage ?? "—"}</span>
+                    </div>
+                  ))}
+                  {hasSections && <ParSub value={yardSum(front)} />}
+                  {hasSections && <ParSub value={yardSum(back)} />}
+                  <ParSub value={yardSum(units)} wide />
                 </div>
-              ))}
-              {hasSections && <ParSub value={yardSum(front)} />}
-              {hasSections && <ParSub value={yardSum(back)} />}
-              <ParSub value={yardSum(units)} wide />
-            </div>
-          )}
+              )}
 
           {/* Par row — same surface as the Hole header. */}
           {hasPar && (

--- a/src/hooks/useScorecardTeeRows.ts
+++ b/src/hooks/useScorecardTeeRows.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { buildTeeRows, type RawTee, type TeeRow } from "@/lib/teeRows";
+
+/**
+ * useScorecardTeeRows (Spec 5b) — assemble the scorecard's per-tee yardage rows
+ * for a game, fetching the course record(s) that carry every tee's yardage.
+ *
+ * The scorecard grid stays presentational (pattern #7: no tRPC/DB inside it), so
+ * the course fetch lives HERE and the built rows go in as a prop. Reads the
+ * PERSISTED course library (`courses.getById` by the game's `course_id` /
+ * `back_course_id`) — the game snapshot only kept the chosen tee. Returns [] until
+ * the course loads or when the game has no course (→ the grid keeps its single
+ * snapshot yardage row).
+ */
+type GameLike = {
+  course_id?: string | null;
+  back_course_id?: string | null;
+  scorecard_schema?: {
+    units?: { labels?: string[]; metadata?: { tee?: { name?: string } } };
+  } | null;
+} | null | undefined;
+
+export function useScorecardTeeRows(tripId: string | undefined, game: GameLike): TeeRow[] {
+  const courseId = game?.course_id ?? null;
+  const backCourseId = game?.back_course_id ?? null;
+  const chosenTeeName = game?.scorecard_schema?.units?.metadata?.tee?.name ?? null;
+  const holeCount = game?.scorecard_schema?.units?.labels?.length ?? 18;
+
+  const frontQ = trpc.courses.getById.useQuery(
+    { courseId: courseId ?? "" },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!courseId }
+  );
+  const backQ = trpc.courses.getById.useQuery(
+    { courseId: backCourseId ?? "" },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!backCourseId }
+  );
+
+  const frontTees = (frontQ.data?.tee_sets as RawTee[] | undefined) ?? null;
+  const backTees = (backQ.data?.tee_sets as RawTee[] | undefined) ?? null;
+
+  return useMemo(() => {
+    if (!frontTees?.length) return [];
+    return buildTeeRows({
+      chosenTeeName,
+      holeCount,
+      frontTees,
+      // Only a two-nines game has a back course; else undefined → single-course path.
+      backTees: backCourseId ? backTees : null,
+    });
+  }, [frontTees, backTees, backCourseId, chosenTeeName, holeCount]);
+}

--- a/src/lib/teeRows.test.ts
+++ b/src/lib/teeRows.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildTeeRows, type RawTee } from "./teeRows";
+
+// Spec 5b — the multi-tee scorecard rows (DISPLAY only). These lock in the order
+// (longest→shortest), the default window (chosen ± one neighbor, clamped at the
+// ends with no phantom), and the two-nines composition.
+
+const t = (name: string, ...yards: (number | null)[]): RawTee => ({ name, yards });
+// Four 18-hole tees, distinct totals so order is unambiguous.
+const tees18 = (): RawTee[] => [
+  { name: "Blue", yards: Array(18).fill(400) }, // total 7200 (longest)
+  { name: "White", yards: Array(18).fill(350) }, // 6300
+  { name: "Gold", yards: Array(18).fill(300) }, // 5400
+  { name: "Red", yards: Array(18).fill(250) }, // 4500 (shortest)
+];
+
+describe("buildTeeRows — order + defaults", () => {
+  it("orders rows longest→shortest (back tees first)", () => {
+    const rows = buildTeeRows({ chosenTeeName: "White", holeCount: 18, frontTees: tees18() });
+    expect(rows.map((r) => r.name)).toEqual(["Blue", "White", "Gold", "Red"]);
+    expect(rows[0].total).toBeGreaterThan(rows[3].total);
+  });
+
+  it("flags the chosen tee and derives its color from the name", () => {
+    const rows = buildTeeRows({ chosenTeeName: "White", holeCount: 18, frontTees: tees18() });
+    expect(rows.find((r) => r.name === "White")!.isChosen).toBe(true);
+    expect(rows.filter((r) => r.isChosen)).toHaveLength(1);
+    expect(rows.find((r) => r.name === "Blue")!.color).toBe("#3b82f6"); // teeColor("Blue")
+  });
+
+  it("default-visible = chosen + one neighbor each side (3 in the middle)", () => {
+    const rows = buildTeeRows({ chosenTeeName: "White", holeCount: 18, frontTees: tees18() });
+    const vis = rows.filter((r) => r.defaultVisible).map((r) => r.name);
+    expect(vis).toEqual(["Blue", "White", "Gold"]); // White ± 1
+  });
+
+  it("clamps at the HARD end (chosen is longest → no phantom behind): 2 rows", () => {
+    const rows = buildTeeRows({ chosenTeeName: "Blue", holeCount: 18, frontTees: tees18() });
+    const vis = rows.filter((r) => r.defaultVisible).map((r) => r.name);
+    expect(vis).toEqual(["Blue", "White"]); // nothing harder than Blue
+  });
+
+  it("clamps at the EASY end (chosen is shortest → no phantom in front): 2 rows", () => {
+    const rows = buildTeeRows({ chosenTeeName: "Red", holeCount: 18, frontTees: tees18() });
+    const vis = rows.filter((r) => r.defaultVisible).map((r) => r.name);
+    expect(vis).toEqual(["Gold", "Red"]); // nothing easier than Red
+  });
+});
+
+describe("buildTeeRows — two-nines composition", () => {
+  it("composes front-9 ⊕ back-9 per tee, matching the back tee by name", () => {
+    const frontTees: RawTee[] = [t("Blue", ...Array(9).fill(400)), t("White", ...Array(9).fill(350))];
+    const backTees: RawTee[] = [t("White", ...Array(9).fill(360)), t("Blue", ...Array(9).fill(410))];
+    const rows = buildTeeRows({ chosenTeeName: "Blue", holeCount: 18, frontTees, backTees });
+    const blue = rows.find((r) => r.name === "Blue")!;
+    expect(blue.yards).toHaveLength(18);
+    expect(blue.yards.slice(0, 9)).toEqual(Array(9).fill(400)); // front from front course
+    expect(blue.yards.slice(9)).toEqual(Array(9).fill(410)); // back matched by name
+    expect(blue.total).toBe(9 * 400 + 9 * 410);
+  });
+
+  it("falls back to the back course's first tee when the name doesn't match", () => {
+    const frontTees: RawTee[] = [t("Championship", ...Array(9).fill(420))];
+    const backTees: RawTee[] = [t("Tips", ...Array(9).fill(430))];
+    const rows = buildTeeRows({ chosenTeeName: "Championship", holeCount: 18, frontTees, backTees });
+    expect(rows[0].yards.slice(9)).toEqual(Array(9).fill(430)); // back's first tee
+  });
+});
+
+describe("buildTeeRows — edge cases", () => {
+  it("returns [] when there are no tees (→ scorecard falls back to its single row)", () => {
+    expect(buildTeeRows({ chosenTeeName: "Blue", holeCount: 18, frontTees: [] })).toEqual([]);
+  });
+
+  it("a single-tee course yields exactly one row (that one tee)", () => {
+    const rows = buildTeeRows({ chosenTeeName: "White", holeCount: 18, frontTees: [t("White", ...Array(18).fill(350))] });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].defaultVisible).toBe(true);
+    expect(rows[0].isChosen).toBe(true);
+  });
+});

--- a/src/lib/teeRows.ts
+++ b/src/lib/teeRows.ts
@@ -1,0 +1,100 @@
+import { teeColor } from "@/lib/courseService";
+
+/**
+ * Multi-tee scorecard yardage rows (Spec 5b) — DISPLAY ONLY. The game still runs
+ * off the ONE chosen tee (scoring / structure / handicaps all key off the snapshot
+ * as before); this just assembles the *reference* yardage rows the scorecard shows
+ * for every tee.
+ *
+ * The data is already there: `courses.tee_sets` stores each tee's per-hole yardage
+ * (migration 059). par + stroke index are course-level (identical across tees), so
+ * only yardage varies — one row per tee. Colors are derived from the tee NAME via
+ * the shared `teeColor()` helper (the app's tee-color convention; not stored).
+ *
+ * Pure + client-safe (no React / tRPC / DB) so it's unit-testable and shared by
+ * every scorecard consumer through the hook that fetches the course record(s).
+ */
+
+/** A stored tee (a `courses.tee_sets` element — only the fields we render). */
+export interface RawTee {
+  name: string;
+  yards: (number | null)[];
+}
+
+/** One assembled tee row for the scorecard. */
+export interface TeeRow {
+  name: string;
+  /** Display color from the tee name (identity palette, e.g. Blue → blue). */
+  color: string;
+  /** Per-hole yardage across the full round (holeCount long; null where absent). */
+  yards: (number | null)[];
+  /** Sum of present yardages — drives the hardest→easiest order + the Total cell. */
+  total: number;
+  /** The tee actually in play (matches the game's snapshot tee) — brighter + never hidable. */
+  isChosen: boolean;
+  /** Shown by default: the chosen tee + its immediate neighbors (one each side). */
+  defaultVisible: boolean;
+}
+
+const sum = (ys: (number | null)[]) => ys.reduce((a: number, y) => a + (y ?? 0), 0);
+
+/** Front-9 slice of a tee's yards, padded to 9 (mirrors composeTwoNines' f9). */
+function nine(ys: (number | null)[] | undefined): (number | null)[] {
+  return (ys ?? []).slice(0, 9).concat(Array<number | null>(9).fill(null)).slice(0, 9);
+}
+
+/**
+ * Assemble the tee rows for a game's course.
+ *
+ * - Single course → each tee's yards as-is (clipped to holeCount).
+ * - Combined two-nines (backTees present) → the tee LIST is the FRONT course's
+ *   tees; each is composed front-9 ⊕ back-9, matching the back tee BY NAME with a
+ *   first-tee fallback — exactly the inheritance `setBackNine` uses. (par/index are
+ *   already course-level; only yardage is composed here.)
+ *
+ * Rows are ordered longest→shortest total (back tees first, "behind"→"in front").
+ * `defaultVisible` = the chosen tee + one neighbor each side, clamped at the ends
+ * (no phantom neighbor). If no tee matches the chosen name, none is marked chosen
+ * and the first (longest) row anchors the default window.
+ */
+export function buildTeeRows(opts: {
+  chosenTeeName: string | null;
+  holeCount: number;
+  frontTees: RawTee[];
+  backTees?: RawTee[] | null;
+}): TeeRow[] {
+  const { chosenTeeName, holeCount, frontTees, backTees } = opts;
+  if (!frontTees?.length) return [];
+
+  const chosen = (chosenTeeName ?? "").trim().toLowerCase();
+  const composed: { name: string; yards: (number | null)[] }[] = frontTees.map((ft) => {
+    if (backTees && backTees.length > 0) {
+      const bt =
+        backTees.find((b) => b.name.trim().toLowerCase() === ft.name.trim().toLowerCase()) ??
+        backTees[0];
+      return { name: ft.name, yards: [...nine(ft.yards), ...nine(bt?.yards)] };
+    }
+    return { name: ft.name, yards: (ft.yards ?? []).slice(0, holeCount) };
+  });
+
+  const rows: TeeRow[] = composed.map((t) => ({
+    name: t.name,
+    color: teeColor(t.name),
+    yards: t.yards,
+    total: sum(t.yards),
+    isChosen: !!chosen && t.name.trim().toLowerCase() === chosen,
+    defaultVisible: false,
+  }));
+
+  // Longest → shortest (back → front). Stable enough for equal totals (rare).
+  rows.sort((a, b) => b.total - a.total);
+
+  // Default window: chosen ± 1 neighbor, clamped. Anchor on the chosen row, else
+  // the first (longest) row so a course with an unrecognized chosen name still
+  // shows a sensible default set.
+  const anchor = Math.max(0, rows.findIndex((r) => r.isChosen));
+  for (let i = anchor - 1; i <= anchor + 1; i++) {
+    if (i >= 0 && i < rows.length) rows[i].defaultVisible = true;
+  }
+  return rows;
+}


### PR DESCRIPTION
Adds reference yardage rows to the scorecard — one per tee box, with a checkbox legend to hide/reveal tees. **DISPLAY-ONLY: zero functional change** — scoring, structure, and handicaps still key off the one chosen tee exactly as before.

## Phase 0 — DATA GATE: ✅ PASS

**All tees' per-hole yardage is already stored.** `courses.tee_sets` (migration 059 — "the moving-tees storage foundation") holds every tee as `{ name, ratings, yards[] }`; the live DB confirms real courses with 5–9 tees each, all with per-hole yards. `par`/`handicap_index` are course-level (same across tees), so only yardage varies → one row per tee. The game snapshot keeps only the chosen tee, but `games.course_id` + `back_course_id` make the full set reachable via `courses.getById`.

Two spec assumptions resolved cleanly:
- **Tee color isn't stored** → derived from the tee *name* via the existing `teeColor()` helper (the app's tee-color convention; identity palette).
- **Combined-two-nines** needs a small cross-course compose (match tees by name across front+back — the same inheritance `setBackNine` uses), not just reusing the chosen-tee structure.

Order = by total yardage (longest=hardest="behind"); highlight = `--color-bt-accent-faint`/`-border`; zebra = the grid's existing base/card-raised rhythm.

## Build

- **`buildTeeRows`** (pure, client-safe) — assembles/orders the rows, flags the chosen tee, derives color, marks the default-visible window (chosen ± one neighbor, **clamped at the ends — no phantom neighbor**), and composes front-9 ⊕ back-9 for combined courses.
- **`useScorecardTeeRows`** — fetches the persisted course record(s) and builds the rows, keeping tRPC out of the presentational grid (pattern #7). No-op (`[]`) when the game has no course.
- **`StandardGrid`** — renders one yardage row per visible tee + a checkbox legend when `teeRows` is supplied; **fully additive** (omit/empty → today's single-tee row). Zebra striping; the **chosen tee row is brighter** (accent-faint fill + a left accent rail) and its legend checkbox is **checked + disabled** ("· in play", never hidable). Tokens only.
- **Wired all four scorecard surfaces**: stroke / match / rack grid views + the empty-scorecard preview (5a).

## Testing

- `tsc --noEmit` clean; `eslint` clean.
- Unit tests: `buildTeeRows` (+9 — order, end-clamp, two-nines compose + name fallback, single-tee/no-course edges); `StandardGrid` multi-tee render (+4 — legend lists all tees, only default-visible rows render, chosen highlighted + in play, yardage values). 17 total pass.
- Tokens only (`--color-bt-*`); tee identity colors via the existing `teeColor()` palette (the sanctioned identity-color exception, like team colors).
- **Zero functional change:** score cells, standings, and the single-tee fallback are untouched. DB-backed Vitest + Playwright run in CI; the scorecard E2E reads `score-cell-*` testids (unchanged) — the tee rows render above them.

Manual smoke worth doing: open a scorecard for a golf game with a multi-tee course → default shows chosen + one-in-front + one-behind (2 at the order ends, 3 in the middle); the legend toggles each tee; the chosen row stays visible and brighter; combined-two-nines shows front+back correctly; a single-tee course shows just the one row; and a game plays/scores exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_