### PR TITLE
Responsive hero + standard game header — Pieces 1 & 2 (projection deferred)

### DIFF
--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -8,6 +8,7 @@ import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { NonGolfConfigurationView } from "@/components/games/NonGolfConfigurationView";
 import { NonGolfScoreboard } from "@/components/games/NonGolfScoreboard";
+import { GamePageHeader } from "@/components/competition/GamePageHeader";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { GAME_TYPES, type ScoringModel } from "@/lib/gameTypes";
@@ -217,6 +218,9 @@ export default function ManualGamePage() {
   return (
     <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
       {header(gameName)}
+      {/* Standard game header — row 1 (the collapsed cup hero), sticky over the
+          scoreboard. Competition games only. */}
+      <GamePageHeader tripId={tripId} competitionId={competitionId} />
       {competitionId && (
         <NonGolfScoreboard
           tripId={tripId}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -29,6 +29,7 @@ import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote } from "@/components/games/GameRulesNote";
 import { GameFormatExplainer } from "@/components/games/GameFormatExplainer";
 import { GameDangerZone } from "@/components/games/GameDangerZone";
+import { GamePageHeader } from "@/components/competition/GamePageHeader";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
@@ -959,6 +960,12 @@ export default function NewMatchGamePage() {
           ) : null
         }
       />
+
+      {/* Standard game header — row 1 (the collapsed cup hero), sticky while the
+          match list scrolls under it. Competition games only (null otherwise). */}
+      {!cfgOpen && screen === "overview" && (
+        <GamePageHeader tripId={tripId} competitionId={competitionId} />
+      )}
 
       <div className="w-full px-4 py-5">
       {!cfgOpen && screen === "new" && (

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -18,6 +18,7 @@ import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
+import { GamePageHeader } from "@/components/competition/GamePageHeader";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
 import { HandicapRoster, type HandicapPlayer } from "@/components/games/HandicapRoster";
 import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/rackNStack";
@@ -601,6 +602,10 @@ export default function RackNStackPage() {
         ) : undefined
       }
     >
+      {/* Standard game header — row 1 (the collapsed cup hero), sticky over the
+          scoreboard. Competition games only. RsDayScore below is rack's own live
+          projected points (its row-2 equivalent). */}
+      <GamePageHeader tripId={tripId} competitionId={competitionId} />
       <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
       {/* #501 Part 3: the scoring board is read-and-score only — "Edit handicaps"

--- a/src/components/competition/CollapsedHero.test.tsx
+++ b/src/components/competition/CollapsedHero.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CollapsedHero } from "./CompetitionHero";
+import type { LBTeam } from "./CompetitionLeaderboard";
+
+// Spec (standard game header) — the collapsed bar: team name OVER score, "first to
+// X" centered, neutral chrome, NO trophy. N-team-aware. Rendered via
+// react-dom/server (node env, no RTL).
+
+const team = (id: string, name: string, short: string, color: string): LBTeam => ({
+  id,
+  name,
+  short_name: short,
+  color,
+});
+
+describe("CollapsedHero — two-team (match-play) bar", () => {
+  const teams = [team("a", "Hammer", "HAM", "#f87171"), team("b", "Whack", "WHK", "#c084fc")];
+  const html = renderToStaticMarkup(
+    <CollapsedHero teams={teams} teamTotals={{ a: 5, b: 12 }} winNumber={78} pointsAvailable={100} clincher={null} />
+  );
+
+  it("renders both team names + scores and the 'first to X' target", () => {
+    expect(html).toContain("Hammer");
+    expect(html).toContain("Whack");
+    expect(html).toContain(">5<");
+    expect(html).toContain(">12<");
+    expect(html).toContain("First to 78");
+  });
+
+  it("uses team colors on the names/scores (data, not chrome)", () => {
+    expect(html).toContain("#f87171");
+    expect(html).toContain("#c084fc");
+  });
+
+  it("drops the trophy (the collapsed bar is chrome-neutral, no trophy art)", () => {
+    expect(html).not.toContain("viewBox=\"0 0 300 380\""); // the HeroTrophy svg
+  });
+
+  it("shows the clincher when the cup is decided", () => {
+    const decided = renderToStaticMarkup(
+      <CollapsedHero teams={teams} teamTotals={{ a: 5, b: 40 }} winNumber={78} pointsAvailable={100} clincher={teams[1]} />
+    );
+    expect(decided).toContain("WHK wins"); // short_name + " wins"
+    expect(decided).not.toContain("First to");
+  });
+});
+
+describe("CollapsedHero — N-team (points cup) bar, not 2-hardcoded", () => {
+  const teams = [
+    team("a", "Alphas", "ALP", "#f87171"),
+    team("b", "Bravos", "BRV", "#c084fc"),
+    team("c", "Charlies", "CHR", "#34d399"),
+  ];
+  const html = renderToStaticMarkup(
+    <CollapsedHero teams={teams} teamTotals={{ a: 9, b: 6, c: 4 }} winNumber={30} pointsAvailable={60} clincher={null} />
+  );
+
+  it("renders all N teams (short names) + their scores", () => {
+    for (const s of ["ALP", "BRV", "CHR"]) expect(html).toContain(s);
+    expect(html).toContain(">9<");
+    expect(html).toContain(">6<");
+    expect(html).toContain(">4<");
+  });
+});

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { Trophy, Settings, Users } from "lucide-react";
 import { fmtPts } from "./GameRow";
 import type { LBTeam } from "./CompetitionLeaderboard";
@@ -40,6 +41,7 @@ export function CompetitionHero({
   canEdit,
   onSettings,
   onEditTeam,
+  variant = "expanded",
 }: {
   cupName: string;
   tagline: string | null;
@@ -55,11 +57,28 @@ export function CompetitionHero({
   onSettings?: () => void;
   /** Tap a team name → that team's identity editor (owner / its captain). */
   onEditTeam?: (teamId: string) => void;
+  /** `collapsed` (Spec: standard game header) — a compact score bar: team
+   *  name OVER score + "first to X" centered, NEUTRAL chrome, NO trophy / tagline
+   *  / gear / roster. Same DATA as expanded (a restyle, not new data). Used as the
+   *  leaderboard's sticky bar and row 1 of the game-page header. */
+  variant?: "expanded" | "collapsed";
 }) {
   // The two-score + trophy treatment is the match_play hero; points keeps its own
   // standings body below (untouched), so the hero there is identity + gear only.
   const showScores = scoringModel === "match_play" && teams.length >= 2;
   const [a, b] = teams;
+
+  if (variant === "collapsed") {
+    return (
+      <CollapsedHero
+        teams={teams}
+        teamTotals={teamTotals}
+        winNumber={winNumber}
+        pointsAvailable={pointsAvailable}
+        clincher={clincher}
+      />
+    );
+  }
 
   const aTotal = a ? teamTotals[a.id] ?? 0 : 0;
   const bTotal = b ? teamTotals[b.id] ?? 0 : 0;
@@ -196,6 +215,144 @@ export function CompetitionHero({
             </p>
           </>
         )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * StickyCollapseHero — the leaderboard's expanded→collapsed swap (Spec Piece 1),
+ * PURE `position: sticky` (no scroll-listener, no size-interpolation): the collapsed
+ * bar is pinned (`sticky; top`) BEHIND the expanded hero, which sits OVER it (a
+ * negative margin equal to the collapsed bar's measured height) with its opaque
+ * gradient. Scrolling the expanded hero away REVEALS the pinned collapsed bar; no
+ * layout shift (the negative margin absorbs the collapsed bar's height). The height
+ * is measured (ResizeObserver) so it works for the 2-team bar AND the taller N-team
+ * (points-cup) bar without a magic number.
+ *
+ * `stickyTop` offsets the pin below any fixed nav (the leaderboard's TopNav is 56px).
+ */
+export function StickyCollapseHero({
+  stickyTop = 0,
+  ...hero
+}: React.ComponentProps<typeof CompetitionHero> & { stickyTop?: number }) {
+  const collapsedRef = useRef<HTMLDivElement>(null);
+  const [collapsedH, setCollapsedH] = useState(64); // sensible seed → no first-paint jump
+  useEffect(() => {
+    const el = collapsedRef.current;
+    if (!el) return;
+    const measure = () => setCollapsedH(el.offsetHeight);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return (
+    <div style={{ position: "relative" }}>
+      <div ref={collapsedRef} style={{ position: "sticky", top: stickyTop, zIndex: 10 }}>
+        <CompetitionHero {...hero} variant="collapsed" />
+      </div>
+      <div style={{ position: "relative", zIndex: 20, marginTop: -collapsedH }}>
+        <CompetitionHero {...hero} variant="expanded" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * CollapsedHero — the compact score bar (Spec: standard game header, mock state
+ * B/C). Team name OVER score, "first to X" centered, NEUTRAL chrome (the same hero
+ * gradient art, no team wash), NO trophy / tagline / gear / roster. Same data as
+ * the expanded hero — a restyle. Used as the leaderboard's sticky bar and row 1 of
+ * the game-page header (ONE component, one home).
+ *
+ * N-team-aware: exactly-two → the mock's name/score flanking a centered target;
+ * N>2 (points cups) → an evenly-spaced row of N name/score blocks with the target
+ * on its own line below (short names there to fit). Never 2-team-hardcoded.
+ */
+function CollapsedHero({
+  teams,
+  teamTotals,
+  winNumber,
+  pointsAvailable,
+  clincher,
+}: {
+  teams: LBTeam[];
+  teamTotals: Record<string, number>;
+  winNumber: number;
+  pointsAvailable: number;
+  clincher: LBTeam | null;
+}) {
+  const targetLabel = clincher
+    ? `${clincher.short_name ?? clincher.name} wins`
+    : pointsAvailable > 0
+      ? `First to ${fmtPts(winNumber)}`
+      : "No points yet";
+  const card: React.CSSProperties = {
+    borderRadius: 12,
+    // NEUTRAL chrome — the same hero gradient art as expanded (STYLE_GUIDE hero
+    // carve-out), NO team-color wash. Team color lives on the scores/names only.
+    border: "1px solid var(--color-bt-border)",
+    background: "linear-gradient(158deg,#212c40 0%,#1a2231 100%)",
+    boxShadow: "0 4px 14px rgba(0,0,0,0.35)",
+    padding: "11px 18px",
+  };
+  const target = (
+    <span
+      className="uppercase"
+      style={{ fontSize: 10, fontWeight: 600, letterSpacing: ".04em", color: "var(--color-bt-text-dim)" }}
+    >
+      {targetLabel}
+    </span>
+  );
+
+  // Two teams (match-play cup) → the mock: name/score flanking a centered target.
+  if (teams.length <= 2) {
+    const [a, b] = teams;
+    return (
+      <div style={card} data-testid="competition-hero-collapsed">
+        <div className="flex items-center justify-between gap-2">
+          <CollapsedTeam team={a} points={a ? teamTotals[a.id] ?? 0 : 0} name={a?.name} align="left" />
+          <div className="flex-1 text-center">{target}</div>
+          <CollapsedTeam team={b} points={b ? teamTotals[b.id] ?? 0 : 0} name={b?.name} align="right" />
+        </div>
+      </div>
+    );
+  }
+
+  // N teams (points cup) → an evenly-spaced row + the target on its own line.
+  return (
+    <div style={card} data-testid="competition-hero-collapsed">
+      <div className="flex items-stretch justify-between gap-2.5">
+        {teams.map((t) => (
+          <CollapsedTeam key={t.id} team={t} points={teamTotals[t.id] ?? 0} name={t.short_name ?? t.name} align="left" />
+        ))}
+      </div>
+      <div className="mt-1.5 text-center">{target}</div>
+    </div>
+  );
+}
+
+/** One team's name-over-score block in the collapsed bar (team-colored data). */
+function CollapsedTeam({
+  team,
+  points,
+  name,
+  align,
+}: {
+  team: LBTeam | undefined;
+  points: number;
+  name: string | undefined;
+  align: "left" | "right";
+}) {
+  if (!team) return <div style={{ minWidth: 100 }} />;
+  return (
+    <div className="min-w-0 flex-1" style={{ textAlign: align, minWidth: 96 }}>
+      <div className="truncate" style={{ fontSize: 11, fontWeight: 600, color: team.color, lineHeight: 1.1 }}>
+        {name ?? team.name}
+      </div>
+      <div className="tabular-nums" style={{ fontSize: 26, fontWeight: 800, color: team.color, lineHeight: 1, marginTop: 1 }}>
+        {fmtPts(points)}
       </div>
     </div>
   );

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -270,7 +270,7 @@ export function StickyCollapseHero({
  * N>2 (points cups) → an evenly-spaced row of N name/score blocks with the target
  * on its own line below (short names there to fit). Never 2-team-hardcoded.
  */
-function CollapsedHero({
+export function CollapsedHero({
   teams,
   teamTotals,
   winNumber,

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -6,7 +6,7 @@ import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import type { ScoringModel } from "@/lib/gameTypes";
 import { GameRow, CompletedRow, sectionOf, fmtPts, type GameSection } from "./GameRow";
-import { CompetitionHero } from "./CompetitionHero";
+import { StickyCollapseHero } from "./CompetitionHero";
 import { PointsMatrix } from "./PointsMatrix";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -218,10 +218,11 @@ export function CompetitionLeaderboard({ competitionId, tripId, cupName, tagline
       )}
 
       {/* The merged hero (Task 1) — identity + gear + (match_play) team names,
-          scores, clinch bar, win target. Replaces the old CompetitionHeader +
-          TwoTeamHero AND the "cup hasn't started" EarlyState (the hero renders
-          the 0–0 setup state fine, so it's the header in every stage). */}
-      <CompetitionHero
+          scores, clinch bar, win target. Now with the sticky-collapse swap (Spec
+          Piece 1): the expanded hero scrolls away and the compact score bar pins
+          just below the TopNav (56px). Same data, a restyle. */}
+      <StickyCollapseHero
+        stickyTop={56}
         cupName={cupName}
         tagline={tagline}
         teams={teams}

--- a/src/components/competition/GamePageHeader.tsx
+++ b/src/components/competition/GamePageHeader.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { CollapsedHero } from "./CompetitionHero";
+
+/**
+ * GamePageHeader (Spec: standard game header) — the shared header for the four
+ * game-page scoreboard surfaces (stroke / match / rack / non-golf). ROW 1 is the
+ * collapsed hero — IDENTICAL to the leaderboard's sticky bar (same `CollapsedHero`
+ * component, one home): the cup's team names + scores + "first to X", neutral
+ * chrome, NO roster button (that's leaderboard-only, competition-management).
+ *
+ * Sticky at the top of the game page so it pins while the match/group list scrolls
+ * under it. `stickyTop` offsets it below the page's own nav bar.
+ *
+ * Row 2 — the per-team projection — is DEFERRED (issue #533): a uniform live
+ * "project this game → per-team points" doesn't exist for match-play/stroke yet.
+ * It slots directly beneath row 1 here when built.
+ *
+ * Reads the PERSISTED competition board (`competitions.leaderboard`) — the same
+ * source the leaderboard hero reads, so the two can't diverge. Renders nothing for
+ * a standalone (non-competition) game or before the board loads.
+ */
+export function GamePageHeader({
+  tripId,
+  competitionId,
+  stickyTop = 0,
+}: {
+  tripId: string | undefined;
+  competitionId: string | null | undefined;
+  /** Pin offset below the page's own top bar (0 when the bar scrolls away). */
+  stickyTop?: number;
+}) {
+  const lb = trpc.competitions.leaderboard.useQuery(
+    { tripId: tripId ?? "", competitionId: competitionId ?? "" },
+    { ...STRUCTURE_QUERY, enabled: !!tripId && !!competitionId }
+  );
+  const d = lb.data;
+  if (!competitionId || !d || !d.teams?.length) return null;
+
+  const clincher = d.teams.find((t) => (d.pointsToClinch?.[t.id] ?? 1) <= 0) ?? null;
+
+  return (
+    <div
+      className="px-4 pt-3"
+      style={{ position: "sticky", top: stickyTop, zIndex: 20, background: "var(--color-bt-base)" }}
+      data-testid="game-page-header"
+    >
+      <CollapsedHero
+        teams={d.teams}
+        teamTotals={d.teamTotals}
+        winNumber={d.winNumber}
+        pointsAvailable={d.pointsAvailable}
+        clincher={clincher}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Unifies the leaderboard hero's scroll behavior with a shared game-page header. Per your call: **ship Pieces 1 & 2 now, defer Piece 3 (the projection row)**.

## Phase 0 — the projection is the real unknown, and it hits the STOP gate

A uniform "project this LIVE game → per-team points if it ended now" does **not** exist across formats:
- **Rack** ✅ live (`computeRack(mode:"projected")`).
- **Match-play** ⚠️ team `game_results` write on **pairing/handicap/finish**, NOT on score entry (`scores.upsertEntry` has no recompute) — no per-keystroke live per-team total.
- **Stroke** ❌ per-**user** only, no team attribution.
- **Non-golf** entered on post.

The board's `cells` are per-team + N-team-aware but reflect *persisted* results, not a per-hole projection. So Piece 3 is real per-format work → **deferred to #533**.

Pieces 1 & 2 have no projection dependency and are shipped here.

## Piece 1 — collapsed hero + sticky-collapse (leaderboard)

- `CompetitionHero` gains a `variant="collapsed"` — a compact score bar (name over score, "first to X", **neutral chrome**, no trophy/tagline/gear/roster). Same data, a restyle. **N-team-aware:** two → the mock's flanking layout; N>2 (points cups) → a row of name/score blocks + the target line.
- `StickyCollapseHero` does the swap with **pure `position: sticky`** (no scroll-listener, no size-interpolation): the collapsed bar pins (top:56, below the TopNav) *behind* the expanded hero, which sits over it via a **ResizeObserver-measured** negative margin and scrolls away to reveal it — jump-free, and the measured height handles both bar sizes.

## Piece 2 — standard game-page header (row 1)

- New `GamePageHeader` mounts `CollapsedHero` (the **same component** — one home) as a sticky row 1 on the scoreboard surfaces, reading the same persisted `competitions.leaderboard`. No roster button; renders nothing for standalone games.
- Mounted on the team-scoreboard surfaces with a scrolling overview: **match** (over the match list), **rack** (over `RsDayScore`), **non-golf manual** (over `NonGolfScoreboard` — its own docstring anticipated this shared header).
- **Stroke is intentionally not mounted** — its scoreboard is a full-screen *fixed* score-entry/grid overlay, not a scrolling team scoreboard, so the sticky cup header doesn't fit. Flagged for a preview-verified follow-up.

## Deferred / decisions

- **Piece 3 (projection row)** → **#533** (mount point ready — row 2 slots under row 1).
- **N-team collapsed layout** for points cups isn't in the mock (which is 2-team); I built a compact N-team strip to honor the "don't hardcode 2" guardrail.

## Testing

- `tsc --noEmit` + `eslint` clean. `CollapsedHero` render tests (+5: two-team + N-team bars, colors, target, clincher, no-trophy).
- Tokens only; team color on scores/names, neutral chrome (hero gradient art is the sanctioned carve-out). Competition tests are DB-backed → CI.
- ⚠️ **Needs visual verification on the Vercel preview** — I can't run a browser headlessly, so the sticky pin/reveal, the N-team bar, and the per-surface header layout should be eyeballed (dark + light). The code is additive (the header renders nothing off-competition), so it's functionally safe, but the scroll/pin polish wants a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_