### PR TITLE
fix: leaderboard hero doesn't collapse/pin on scroll (sticky containing block)

### DIFF
--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -230,6 +230,16 @@ export function CompetitionHero({
  * is measured (ResizeObserver) so it works for the 2-team bar AND the taller N-team
  * (points-cup) bar without a magic number.
  *
+ * ⚠ Renders as a FRAGMENT, NOT a wrapping element — deliberately. A `position:
+ * sticky` element can only pin WITHIN its containing block (its parent's box); it
+ * can't outlive it. An earlier wrapping `<div>` was only as tall as the expanded
+ * hero (the negative margin collapsed the wrapper's height to the hero's), so the
+ * whole wrapper scrolled off the top and took the sticky child with it — the bar
+ * never pinned (the shipped bug). By spreading these two nodes straight into the
+ * leaderboard's LONG scrolling column (which also holds the games list), the sticky
+ * bar's containing block is that tall column, so it pins at `top` and stays while
+ * the games scroll under it. Keep this a fragment; do not re-wrap it.
+ *
  * `stickyTop` offsets the pin below any fixed nav (the leaderboard's TopNav is 56px).
  */
 export function StickyCollapseHero({
@@ -248,14 +258,14 @@ export function StickyCollapseHero({
     return () => ro.disconnect();
   }, []);
   return (
-    <div style={{ position: "relative" }}>
+    <>
       <div ref={collapsedRef} style={{ position: "sticky", top: stickyTop, zIndex: 10 }}>
         <CompetitionHero {...hero} variant="collapsed" />
       </div>
       <div style={{ position: "relative", zIndex: 20, marginTop: -collapsedH }}>
         <CompetitionHero {...hero} variant="expanded" />
       </div>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Fixes Piece 1's sticky-collapse (from #534) — the collapsed bar never pinned on scroll.

## Phase 0 — root cause (confirmed)

`StickyCollapseHero` wrapped the sticky collapsed bar **and** the expanded hero together in a `position: relative` `<div>`:
```
<div style="position: relative">           ← the sticky bar's containing block
  <div style="position: sticky; top: 56">  ← collapsed bar
  <div style="margin-top: -collapsedH">     ← expanded hero (pulls the wrapper's height down)
</div>
```
The expanded hero's negative margin collapses that wrapper's height to ≈ the hero's height. A `position: sticky` element **cannot outlive its containing block** — so once you scroll past the hero, the wrapper (and its sticky child) scroll off the top and the collapsed bar never appears. This is exactly the spec's primary hypothesis (the sticky element's parent scrolls away).

Diagnosis of the other candidates:
- **Overflow trap:** none — walked the chain `space-y-3` → `space-y-4` → `main` → `min-h-screen`; no `overflow: hidden/auto/scroll` ancestor.
- **Sticky actually applied?** Yes — `position: sticky; top: 56` was on the bar; the problem was purely the too-short containing block.
- **Scroll root:** the document scrolls; the games list (`GamesSection`) lives in `CompetitionLeaderboard`'s `space-y-3`, below the hero — so that column is the tall ancestor the sticky bar needs.

## Fix (structural, no scroll listener)

`StickyCollapseHero` now renders a **Fragment** instead of the wrapping `<div>`, so the collapsed bar + expanded hero spread straight into `space-y-3` (the long column that also holds the games list). The sticky bar's containing block is now that tall column → it pins at `top: 56` (below the TopNav) and **stays** while the games scroll under it.

The jump-free overlap is preserved: the expanded hero's inline negative margin overrides `space-y`'s inter-child margin, so it still covers the collapsed bar until it scrolls away. Piece 2 (game-page mounts) and the collapsed-variant styling are unchanged.

## Verify

- `tsc` + `eslint` clean; existing `CollapsedHero` tests unaffected. Competition/E2E run in CI.
- ⚠️ **This is a scroll-behavior fix — it must be eyeballed on the Vercel preview** (tests can't prove pinning): scroll up → expanded hero scrolls off AND the collapsed bar pins to the top and stays; scroll down → releases and the expanded hero returns; no jump at the swap; dark + light; N-team points cup shows N teams pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_