### PR TITLE
Projection row — game-page header row 2 (#533)

### DIFF
--- a/src/app/trips/[tripId]/games/manual/page.tsx
+++ b/src/app/trips/[tripId]/games/manual/page.tsx
@@ -72,11 +72,19 @@ export default function ManualGamePage() {
   );
   const teams = useMemo(() => ((lbQ.data?.teams ?? []) as LBTeamLite[]), [lbQ.data]);
   const gameCells = useMemo(
-    () => ((lbQ.data?.cells ?? []) as { gameId: string; teamId: string; place: number }[])
+    () => ((lbQ.data?.cells ?? []) as { gameId: string; teamId: string; place: number; points: number }[])
       .filter((c) => c.gameId === urlGameId)
       .sort((a, b) => a.place - b.place),
     [lbQ.data, urlGameId]
   );
+  // #533 projection (non-golf) — a presentation rollup of the results already on
+  // the page: the posted per-team points for THIS game (the leaderboard cells).
+  // Nothing declared → an empty map → the row shows 0s. No engine call.
+  const projectionPerTeam = useMemo(() => {
+    const out: Record<string, number> = {};
+    for (const c of gameCells) out[c.teamId] = (out[c.teamId] ?? 0) + c.points;
+    return out;
+  }, [gameCells]);
   const initialOrder = useMemo(
     () => (gameCells.length ? gameCells.map((c) => c.teamId) : teams.map((t) => t.id)),
     [gameCells, teams]
@@ -218,9 +226,18 @@ export default function ManualGamePage() {
   return (
     <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
       {header(gameName)}
-      {/* Standard game header — row 1 (the collapsed cup hero), sticky over the
+      {/* Standard game header — row 1 (the collapsed cup hero) + row 2 (this
+          game's projected/final per-team contribution), sticky over the
           scoreboard. Competition games only. */}
-      <GamePageHeader tripId={tripId} competitionId={competitionId} />
+      <GamePageHeader
+        tripId={tripId}
+        competitionId={competitionId}
+        projection={{
+          perTeam: projectionPerTeam,
+          gameName,
+          final: game.status === "complete",
+        }}
+      />
       {competitionId && (
         <NonGolfScoreboard
           tripId={tripId}

--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -34,6 +34,7 @@ import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
 import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
+import { rollupMatchPlay, type ProjMatch } from "@/lib/gameProjection";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { filledMatches, allMatchesFilled, hasValidMatch, pointsReady, removeMatchRow, flushOnOverlayClose, sideMemberIds } from "@/lib/matchDraft";
@@ -861,6 +862,29 @@ export default function NewMatchGamePage() {
     [groups, selectedMatchId]
   );
   const entryParticipants = selectedGroup ? [selectedGroup.a, selectedGroup.b] : [];
+
+  // #533 header projection (row 2) — a presentation rollup of the match strips
+  // ALREADY on this page: "if the game ended now, what does each team get?" Each
+  // match's CURRENT standing (up → its team wins the match's points; all-square
+  // but started → halved; not started → nothing) summed per team. No engine call,
+  // no fetch — the same matchState the strips render, keyed by team via teamOfSide.
+  const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
+  const projectionPerTeam = useMemo(() => {
+    const projMatches: ProjMatch[] = groups.map((g) => {
+      const st = matchState(decidedFor(g), scUnits.length);
+      return {
+        aTeamId: teamOfSide(g.a.id)?.id ?? null,
+        bTeamId: teamOfSide(g.b.id)?.id ?? null,
+        leader: st.leader,
+        started: st.thru > 0,
+      };
+    });
+    return rollupMatchPlay(projMatches, pointsPerMatch);
+    // decidedFor/teamOfSide are per-render closures; we depend on the DATA they
+    // read (scores via loadedValues/values, handicaps, roster→team, scorecard).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groups, loadedValues, values, handicapOf, scIndex, scUnits, twoTeams, teamOfUser, teamById, membersOfSide, pointsPerMatch]);
+
   const entryPips = useMemo(() => {
     const m: Record<string, Set<string>> = {};
     if (selectedGroup) {
@@ -961,10 +985,19 @@ export default function NewMatchGamePage() {
         }
       />
 
-      {/* Standard game header — row 1 (the collapsed cup hero), sticky while the
-          match list scrolls under it. Competition games only (null otherwise). */}
+      {/* Standard game header — row 1 (the collapsed cup hero) + row 2 (this
+          game's projected/final per-team contribution), sticky while the match
+          list scrolls under it. Competition games only (null otherwise). */}
       {!cfgOpen && screen === "overview" && (
-        <GamePageHeader tripId={tripId} competitionId={competitionId} />
+        <GamePageHeader
+          tripId={tripId}
+          competitionId={competitionId}
+          projection={{
+            perTeam: projectionPerTeam,
+            gameName: (gameQ.data?.name as string | undefined)?.trim() || (sided ? "2v2 Match Play" : "Singles Match Play"),
+            final: status === "complete",
+          }}
+        />
       )}
 
       <div className="w-full px-4 py-5">

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -196,7 +196,7 @@ export default function RackNStackPage() {
     return m;
   }, [participants]);
 
-  const rack = useMemo(() => {
+  const rackPlayers = useMemo(() => {
     const players: RackPlayer[] = [];
     for (const p of participants) {
       const uid = p.user_id as string;
@@ -204,9 +204,13 @@ export default function RackNStackPage() {
       if (!team) continue;
       players.push({ id: uid, team, stats: playerStats(mergedFor(uid), handicapOf.get(uid) ?? 0, scUnits.map((u) => u.par ?? 0), scIndex) });
     }
-    return computeRack(players, mode, coursePar);
+    return players;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [participants, teamOf, handicapOf, scUnits, scIndex, coursePar, mode, loadedValues, values]);
+  }, [participants, teamOf, handicapOf, scUnits, scIndex, coursePar, loadedValues, values]);
+  const rack = useMemo(() => computeRack(rackPlayers, mode, coursePar), [rackPlayers, mode, coursePar]);
+  // #533 projection (rack) — REUSE the existing rack projection ("if it ended now"
+  // = computeRack in "projected" mode), NOT a rebuild. Map A/B → the two team ids.
+  const projectedPoints = useMemo(() => computeRack(rackPlayers, "projected", coursePar).points, [rackPlayers, coursePar]);
 
   // ── Foursome views ───────────────────────────────────────────────────
   const groupViews: FoursomeGroupView[] = useMemo(() => {
@@ -602,10 +606,23 @@ export default function RackNStackPage() {
         ) : undefined
       }
     >
-      {/* Standard game header — row 1 (the collapsed cup hero), sticky over the
-          scoreboard. Competition games only. RsDayScore below is rack's own live
-          projected points (its row-2 equivalent). */}
-      <GamePageHeader tripId={tripId} competitionId={competitionId} />
+      {/* Standard game header — row 1 (the collapsed cup hero) + row 2 (this
+          game's projected/final per-team contribution), sticky over the
+          scoreboard. Competition games only. RsDayScore below stays as rack's own
+          in-context day-score readout. */}
+      <GamePageHeader
+        tripId={tripId}
+        competitionId={competitionId}
+        projection={
+          teamIds.length >= 2
+            ? {
+                perTeam: { [teamIds[0]]: projectedPoints.A, [teamIds[1]]: projectedPoints.B },
+                gameName: (gameQ.data?.name as string | undefined)?.trim() || "Rack-n-Stack",
+                final,
+              }
+            : undefined
+        }
+      />
       <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); }} />
       {/* #501 Part 3: the scoring board is read-and-score only — "Edit handicaps"

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -297,13 +297,23 @@ export function CollapsedHero({
   winNumber,
   pointsAvailable,
   clincher,
+  footer,
 }: {
   teams: LBTeam[];
   teamTotals: Record<string, number>;
   winNumber: number;
   pointsAvailable: number;
   clincher: LBTeam | null;
+  /** Optional second row INSIDE the same card, below a divider — the game-page
+   *  header's projection row (#533). Omitted on the leaderboard's sticky bar. */
+  footer?: React.ReactNode;
 }) {
+  const footerBlock = footer ? (
+    <>
+      <div style={{ height: 1, background: "var(--color-bt-subtle-border)", margin: "10px 0 9px" }} />
+      {footer}
+    </>
+  ) : null;
   const targetLabel = clincher
     ? `${clincher.short_name ?? clincher.name} wins`
     : pointsAvailable > 0
@@ -337,6 +347,7 @@ export function CollapsedHero({
           <div className="flex-1 text-center">{target}</div>
           <CollapsedTeam team={b} points={b ? teamTotals[b.id] ?? 0 : 0} name={b?.name} align="right" />
         </div>
+        {footerBlock}
       </div>
     );
   }
@@ -350,6 +361,72 @@ export function CollapsedHero({
         ))}
       </div>
       <div className="mt-1.5 text-center">{target}</div>
+      {footerBlock}
+    </div>
+  );
+}
+
+/**
+ * ProjectionRow — the game-page header's ROW 2 (#533): each team's PROJECTED
+ * contribution to the cup if this game ended now (a presentation rollup of the
+ * scoreboard's on-page results — see gameProjection.ts). Provisional styling:
+ * DESATURATED team tone (the team color at reduced opacity — recognizably the
+ * team, clearly not final) while live, SOLID (full color, no "projected") once
+ * the game is complete. One tight line: contributions flank a centered game name +
+ * "projected". N-team-aware. Neutral chrome (color on the numbers only).
+ */
+export function ProjectionRow({
+  teams,
+  perTeam,
+  gameName,
+  final,
+}: {
+  teams: LBTeam[];
+  perTeam: Record<string, number>;
+  gameName: string;
+  final: boolean;
+}) {
+  const contrib = (t: LBTeam | undefined, align: "left" | "right", key?: string) => {
+    if (!t) return <div key={key} style={{ minWidth: 88 }} />;
+    const p = perTeam[t.id] ?? 0;
+    return (
+      <div key={key} className="min-w-0 flex-1" style={{ textAlign: align, minWidth: 88 }}>
+        <span
+          className="tabular-nums"
+          // Team color = data; reduced opacity = "provisional / not final" (no new
+          // hex — the desaturation is opacity over the team's identity color).
+          style={{ fontSize: 18, fontWeight: 600, color: t.color, opacity: final ? 1 : 0.5, lineHeight: 1 }}
+        >
+          {p > 0 ? `+${fmtPts(p)}` : fmtPts(p)}
+        </span>
+      </div>
+    );
+  };
+  const center = (
+    <div className="flex-1 text-center">
+      <div className="truncate" style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text)", lineHeight: 1.2 }}>{gameName}</div>
+      {!final && (
+        <div style={{ fontSize: 10, fontStyle: "italic", color: "var(--color-bt-text-dim)", marginTop: 1 }}>projected</div>
+      )}
+    </div>
+  );
+
+  if (teams.length <= 2) {
+    const [a, b] = teams;
+    return (
+      <div className="flex items-center justify-between gap-2" data-testid="header-projection">
+        {contrib(a, "left")}
+        {center}
+        {contrib(b, "right")}
+      </div>
+    );
+  }
+  return (
+    <div data-testid="header-projection">
+      <div className="flex items-stretch justify-between gap-2.5">
+        {teams.map((t) => contrib(t, "left", t.id))}
+      </div>
+      <div className="mt-1 text-center">{center}</div>
     </div>
   );
 }

--- a/src/components/competition/GamePageHeader.tsx
+++ b/src/components/competition/GamePageHeader.tsx
@@ -2,7 +2,7 @@
 
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
-import { CollapsedHero } from "./CompetitionHero";
+import { CollapsedHero, ProjectionRow } from "./CompetitionHero";
 
 /**
  * GamePageHeader (Spec: standard game header) — the shared header for the four
@@ -14,9 +14,13 @@ import { CollapsedHero } from "./CompetitionHero";
  * Sticky at the top of the game page so it pins while the match/group list scrolls
  * under it. `stickyTop` offsets it below the page's own nav bar.
  *
- * Row 2 — the per-team projection — is DEFERRED (issue #533): a uniform live
- * "project this game → per-team points" doesn't exist for match-play/stroke yet.
- * It slots directly beneath row 1 here when built.
+ * Row 2 — the per-team PROJECTION (#533) — is an optional second row inside the
+ * same card: "if this game ended now, what does each team add to the cup?" The
+ * PAGE computes it (a presentation rollup of the results already on the scoreboard
+ * — match strips / rack projection / non-golf cells; see gameProjection.ts) and
+ * passes it in via `projection`. There is no row 2 for stroke (nothing on-page to
+ * roll up) and none in setup mode — the page just omits the prop. `final` swaps
+ * the desaturated "projected" tone for the solid contribution once complete.
  *
  * Reads the PERSISTED competition board (`competitions.leaderboard`) — the same
  * source the leaderboard hero reads, so the two can't diverge. Renders nothing for
@@ -26,11 +30,15 @@ export function GamePageHeader({
   tripId,
   competitionId,
   stickyTop = 0,
+  projection,
 }: {
   tripId: string | undefined;
   competitionId: string | null | undefined;
   /** Pin offset below the page's own top bar (0 when the bar scrolls away). */
   stickyTop?: number;
+  /** Row 2 — the per-team projected/final contribution for THIS game (#533).
+   *  Omit for stroke or in setup mode (no row 2 renders). */
+  projection?: { perTeam: Record<string, number>; gameName: string; final: boolean };
 }) {
   const lb = trpc.competitions.leaderboard.useQuery(
     { tripId: tripId ?? "", competitionId: competitionId ?? "" },
@@ -53,6 +61,16 @@ export function GamePageHeader({
         winNumber={d.winNumber}
         pointsAvailable={d.pointsAvailable}
         clincher={clincher}
+        footer={
+          projection ? (
+            <ProjectionRow
+              teams={d.teams}
+              perTeam={projection.perTeam}
+              gameName={projection.gameName}
+              final={projection.final}
+            />
+          ) : undefined
+        }
       />
     </div>
   );

--- a/src/components/competition/ProjectionRow.test.tsx
+++ b/src/components/competition/ProjectionRow.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ProjectionRow } from "./CompetitionHero";
+import type { LBTeam } from "./CompetitionLeaderboard";
+
+// #533 — the game-page header's ROW 2: each team's projected/final contribution
+// to the cup for THIS game. Presentation only (the per-team map is computed by the
+// page). Live → desaturated "projected"; complete → solid, no "projected".
+
+const team = (id: string, name: string, short: string, color: string): LBTeam => ({
+  id,
+  name,
+  short_name: short,
+  color,
+});
+
+describe("ProjectionRow — two-team (match-play) row", () => {
+  const teams = [team("a", "Hammer", "HAM", "#f87171"), team("b", "Whack", "WHK", "#c084fc")];
+
+  it("shows each team's signed contribution and, while live, the 'projected' label", () => {
+    const html = renderToStaticMarkup(
+      <ProjectionRow teams={teams} perTeam={{ a: 4, b: 0 }} gameName="Front Nine" final={false} />
+    );
+    expect(html).toContain("+4"); // a's positive contribution gets a leading +
+    expect(html).toContain(">0<"); // b contributes nothing (no +)
+    expect(html).toContain("Front Nine");
+    expect(html).toContain("projected");
+    // desaturated while live — team color at reduced opacity, not full
+    expect(html).toContain("opacity:0.5");
+  });
+
+  it("drops the 'projected' label and goes solid once the game is complete", () => {
+    const html = renderToStaticMarkup(
+      <ProjectionRow teams={teams} perTeam={{ a: 4, b: 2 }} gameName="Front Nine" final />
+    );
+    expect(html).not.toContain("projected");
+    expect(html).toContain("opacity:1");
+    expect(html).toContain("+4");
+    expect(html).toContain("+2");
+  });
+
+  it("colors the numbers with the team color (data, not chrome)", () => {
+    const html = renderToStaticMarkup(
+      <ProjectionRow teams={teams} perTeam={{ a: 4, b: 0 }} gameName="Front Nine" final={false} />
+    );
+    expect(html).toContain("#f87171");
+    expect(html).toContain("#c084fc");
+  });
+});
+
+describe("ProjectionRow — N-team (points cup) row, not 2-hardcoded", () => {
+  const teams = [
+    team("a", "Alphas", "ALP", "#f87171"),
+    team("b", "Bravos", "BRV", "#c084fc"),
+    team("c", "Charlies", "CHR", "#34d399"),
+  ];
+
+  it("renders a contribution for every team", () => {
+    const html = renderToStaticMarkup(
+      <ProjectionRow teams={teams} perTeam={{ a: 3, b: 1.5, c: 0 }} gameName="Skins" final={false} />
+    );
+    expect(html).toContain("+3");
+    expect(html).toContain("+1½"); // fmtPts renders a half as ½
+    for (const c of ["#f87171", "#c084fc", "#34d399"]) expect(html).toContain(c);
+  });
+});

--- a/src/lib/gameProjection.test.ts
+++ b/src/lib/gameProjection.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { rollupMatchPlay, type ProjMatch } from "./gameProjection";
+
+// #533 — the match-play projection rule: up → leader's full points, all-square
+// (started) → halved, not-started → nothing. Summed per team, N-team-aware.
+
+const m = (aTeamId: string | null, bTeamId: string | null, leader: "A" | "B" | null, started: boolean): ProjMatch => ({
+  aTeamId,
+  bTeamId,
+  leader,
+  started,
+});
+
+describe("rollupMatchPlay", () => {
+  it("an UP match gives the leader's team the full match points", () => {
+    expect(rollupMatchPlay([m("blue", "red", "A", true)], 2)).toEqual({ blue: 2 });
+    expect(rollupMatchPlay([m("blue", "red", "B", true)], 2)).toEqual({ red: 2 });
+  });
+
+  it("an ALL-SQUARE (started) match halves the points between the two teams", () => {
+    expect(rollupMatchPlay([m("blue", "red", null, true)], 2)).toEqual({ blue: 1, red: 1 });
+  });
+
+  it("a NOT-STARTED match contributes nothing", () => {
+    expect(rollupMatchPlay([m("blue", "red", null, false)], 2)).toEqual({});
+    // even if a leader is somehow set, unstarted contributes nothing
+    expect(rollupMatchPlay([m("blue", "red", "A", false)], 2)).toEqual({});
+  });
+
+  it("sums across a game's matches (the 'if it ended now' total)", () => {
+    const matches = [
+      m("blue", "red", "A", true), // blue +2
+      m("blue", "red", "A", true), // blue +2
+      m("blue", "red", "B", true), // red +2
+      m("blue", "red", null, true), // halved: blue +1, red +1
+      m("blue", "red", null, false), // not started: 0
+    ];
+    expect(rollupMatchPlay(matches, 2)).toEqual({ blue: 5, red: 3 });
+  });
+
+  it("is N-team-aware — a points cup with matches across >2 teams", () => {
+    const matches = [
+      m("a", "b", "A", true), // a +3
+      m("c", "d", "B", true), // d +3
+      m("a", "c", null, true), // halved: a +1.5, c +1.5
+    ];
+    expect(rollupMatchPlay(matches, 3)).toEqual({ a: 4.5, c: 1.5, d: 3 });
+  });
+
+  it("ignores an unattributed side (null team) but still credits the other", () => {
+    expect(rollupMatchPlay([m("blue", null, "A", true)], 2)).toEqual({ blue: 2 });
+    expect(rollupMatchPlay([m("blue", null, null, true)], 2)).toEqual({ blue: 1 }); // halve: only blue credited
+  });
+});

--- a/src/lib/gameProjection.ts
+++ b/src/lib/gameProjection.ts
@@ -1,0 +1,48 @@
+/**
+ * Game-page header PROJECTION rollup (#533) — pure, client-safe. This is a
+ * PRESENTATION-LAYER sum of the results the scoreboard ALREADY has on the page
+ * into per-team points; it calls NO scoring engine, fetches nothing, snapshots
+ * nothing. "If this game ended right now, what does each team get?"
+ *
+ * N-team-aware: returns a per-team map `{ [teamId]: points }`, never a 2-team pair
+ * (points cups run up to 8 teams). Rack reuses its own live projection and
+ * non-golf sums its declared cells inline at the call site — only the match-play
+ * rule needs a shared function, so that's what lives here (+ its tests).
+ */
+
+/** One match's current on-page standing, as the scoreboard already shows it. */
+export interface ProjMatch {
+  /** The team on each side (null when a side isn't attributed to a team). */
+  aTeamId: string | null;
+  bTeamId: string | null;
+  /** Who is currently up on net, or null when all-square OR not started. */
+  leader: "A" | "B" | null;
+  /** Has any hole been decided yet? An unstarted match projects to nothing. */
+  started: boolean;
+}
+
+/**
+ * Match play (1v1 / 2v2) rollup — project each match's CURRENT standing to an
+ * outcome and sum the points per team:
+ *   - up (either side) → that side wins it → its team gets the match's points;
+ *   - all-square but STARTED → halved → the points split (½ to each side's team);
+ *   - not started → contributes nothing.
+ * Teams beyond two accumulate independently (a points-cup 2v2 with N teams).
+ */
+export function rollupMatchPlay(matches: ProjMatch[], pointsPerMatch: number): Record<string, number> {
+  const out: Record<string, number> = {};
+  const add = (teamId: string | null, n: number) => {
+    if (teamId) out[teamId] = (out[teamId] ?? 0) + n;
+  };
+  for (const m of matches) {
+    if (!m.started) continue; // not started → 0
+    if (m.leader === "A") add(m.aTeamId, pointsPerMatch);
+    else if (m.leader === "B") add(m.bTeamId, pointsPerMatch);
+    else {
+      // all-square, in progress → halved
+      add(m.aTeamId, pointsPerMatch / 2);
+      add(m.bTeamId, pointsPerMatch / 2);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Adds the game-page header's **row 2 — the projected-points row (#533)**: "if this game ended right now, what does each team add to the cup?" It's a **presentation-layer rollup** of the results the scoreboard already shows — no engine call, no fetch, no snapshot, no new compute.

## How

**`src/lib/gameProjection.ts` (new, pure + client-safe)** — the match-play rollup. Per match: up → the leader's team takes the match points; all-square but started → halved; not started → 0 — summed per team, N-team-aware (`{ [teamId]: points }`, never 2-hardcoded). Rack reuses its own live projection and non-golf sums its declared cells inline, so only match-play needs a shared function. 6 unit tests cover the rule.

**`CompetitionHero.tsx`** — exported `ProjectionRow`: each team's contribution on one tight line, contributions flanking the centered game name. Color on the numbers only (neutral chrome); desaturated (team color at reduced opacity) + italic "projected" while live, solid (full color, no "projected") once complete. `CollapsedHero` gains an optional `footer` slot (divider + row, same card) so row 2 sits under row 1 with no second card.

**`GamePageHeader.tsx`** — new `projection` prop, passed through as the `CollapsedHero` footer. Omit it (stroke, or setup mode) → no row 2.

**Page wiring** — each page derives the contribution from what's on-page:
- **match** — roll up each strip's `matchState` (same decided holes the strips render) via `rollupMatchPlay`, keyed by team through `teamOfSide`, at the per-match points value.
- **rack** — reuse `computeRack` in `"projected"` mode (not a rebuild); A/B → the two team ids. `RsDayScore` stays.
- **non-golf** — sum the posted leaderboard cells' points for this game.
- **stroke** — intentionally skipped (nothing on-page to roll up).

`final` (game `complete`) flips each surface to the solid contribution.

## Testing

- `npx tsc --noEmit` clean; eslint clean on all touched files.
- `gameProjection.test.ts` — 6 tests (up / tied / not-started / sum / N-team / null-side).
- `ProjectionRow.test.tsx` — 4 render tests (live vs. final, 2-team vs. N-team, team-colored numbers).

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_