### PR TITLE
Rack-n-Stack: manual playing-group assignment

### DIFF
--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -9,8 +9,8 @@ import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
-import { TimePicker } from "@/components/TimePicker";
-import { parseTime, toTime24 } from "@/lib/time";
+import { RackGroupBuilder, type GroupBuilderTeam } from "@/components/games/rack/RackGroupBuilder";
+import { toPersist as groupsToPersist } from "@/lib/rackGroupDraft";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
@@ -37,25 +37,6 @@ function teeLabel(t: string | null | undefined): string | null {
   const h12 = h % 12 === 0 ? 12 : h % 12;
   return `${h12}:${String(m).padStart(2, "0")}`;
 }
-/** Add minutes to "HH:MM" 24h (wraps within a day). */
-function addMinutes(t: string, mins: number): string {
-  const [h, m] = t.split(":").map(Number);
-  const total = (h * 60 + m + mins) % (24 * 60);
-  return `${String(Math.floor(total / 60)).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
-}
-
-/** Chunk into groups of `size`, interleaving the two teams so groups are mixed. */
-function autoFoursomes(teamA: string[], teamB: string[], size = 4): string[][] {
-  const woven: string[] = [];
-  for (let i = 0; i < Math.max(teamA.length, teamB.length); i++) {
-    if (teamA[i]) woven.push(teamA[i]);
-    if (teamB[i]) woven.push(teamB[i]);
-  }
-  const out: string[][] = [];
-  for (let i = 0; i < woven.length; i += size) out.push(woven.slice(i, i + size));
-  return out;
-}
-
 export default function RackNStackPage() {
   const { tripId: param } = useParams<{ tripId: string }>();
   const router = useRouter();
@@ -83,9 +64,12 @@ export default function RackNStackPage() {
   const [mode, setMode] = useState<RackMode>("current");
   const [coursePickerOpen, setCoursePickerOpen] = useState(false);
   const [pendingCourse, setPendingCourse] = useState<{ id: string; name: string } | null>(null);
-  const [firstTee, setFirstTee] = useState(""); // "HH:MM" 24h; groups stagger +10
   const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
   const [showHandicaps, setShowHandicaps] = useState(false);
+  // Manual playing-group builder (replaces auto-assign): its own screen, seeded from
+  // the persisted groups on open. `groupDraft` = one array of user ids per group.
+  const [showGroups, setShowGroups] = useState(false);
+  const [groupDraft, setGroupDraft] = useState<string[][]>([]);
   // The ONE settings overlay — owns open/close/back + the leaderboard deep link
   // (?settings=1 → land here directly for an owner/delegate of a setup-mode game).
   const { open: showConfig, openConfig, closeConfig } = useGameSettingsOverlay({
@@ -167,6 +151,21 @@ export default function RackNStackPage() {
     (assignQ.data ?? []).forEach((a, i) => m.set(a.user_id as string, i));
     return m;
   }, [assignQ.data]);
+
+  // Each team's roster in canonical sort_order (assignQ arrives ordered by
+  // team_id, sort_order) — the combined pool the group builder picks from. Picking
+  // top-to-bottom therefore follows the captain's order (handicap order if set).
+  const teamRosters = useMemo(() => {
+    const A: GroupBuilderTeam["players"] = [];
+    const B: GroupBuilderTeam["players"] = [];
+    for (const a of assignQ.data ?? []) {
+      const uid = a.user_id as string;
+      const entry = { id: uid, name: nameOf.get(uid) ?? "Player", avatarIcon: avatarOf.get(uid) ?? null };
+      if (teamOf.get(uid) === "A") A.push(entry);
+      else if (teamOf.get(uid) === "B") B.push(entry);
+    }
+    return { A, B };
+  }, [assignQ.data, teamOf, nameOf, avatarOf]);
 
   const hasCompetition = !!competitionId && teamIds.length >= 2;
 
@@ -251,10 +250,16 @@ export default function RackNStackPage() {
   );
 
   // ── Handlers ─────────────────────────────────────────────────────────
-  // Seed the rack's structure from the competition roster. Two entry points,
-  // ONE path: a brand-new game (no gid → create it first), or an existing
-  // competition game tapped from the leaderboard that has no foursomes yet
-  // (gid set, groups empty → seed onto it, don't mint a new game).
+  // The current persisted groups as a builder draft (one user-id array per group,
+  // in group order) — seeds the builder when editing an existing game's groups.
+  const currentGroupDraft = (): string[][] => {
+    const gs = groupsQ.data?.groups ?? [];
+    return gs.map((grp) => participants.filter((p) => p.play_group_id === grp.id).map((p) => p.user_id as string));
+  };
+
+  // Start a rack: create the game (if new) + apply the course, then open the MANUAL
+  // group builder. No auto-assignment — deliberate grouping is the point of this
+  // round (see spec), so the owner builds the carts from an empty state.
   async function startRack() {
     if (!tripId || !competitionId) return;
     let gameId: string;
@@ -271,17 +276,31 @@ export default function RackNStackPage() {
         /* template default par/index still applies */
       }
     }
-    const aIds = [...teamOf.entries()].filter(([, t]) => t === "A").map(([id]) => id);
-    const bIds = [...teamOf.entries()].filter(([, t]) => t === "B").map(([id]) => id);
-    const groups = autoFoursomes(aIds, bIds).map((userIds, i) => ({
-      name: `Group ${i + 1}`,
-      userIds,
-      teeTime: firstTee ? addMinutes(firstTee, i * 10) : null,
-    }));
-    await setFoursomes.mutateAsync({ tripId, gameId, groups });
     await utils.playGroups.listByGame.invalidate({ tripId, gameId });
     setGameId(gameId);
-    setShowHandicaps(true); // Pairings ✓ → Handicaps step
+    setGroupDraft([]); // start empty — the owner builds the groups
+    setShowGroups(true);
+  }
+
+  // Open the builder to edit existing groups (from the settings "who's playing"
+  // drill-down), seeded from what's persisted.
+  function openGroupBuilder() {
+    setGroupDraft(currentGroupDraft());
+    setShowGroups(true);
+  }
+
+  // Persist the built groups. Empty groups (an unfinished "add group") are dropped;
+  // the survivors renumber Group 1..N. Clean-replaces via setFoursomes, then
+  // refreshes the board (incl. faceBootstrap, CLAUDE.md #10).
+  async function saveGroups() {
+    if (!tripId || !gid) return;
+    await setFoursomes.mutateAsync({ tripId, gameId: gid, groups: groupsToPersist(groupDraft) });
+    await utils.playGroups.listByGame.invalidate({ tripId, gameId: gid });
+    if (competitionId) {
+      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+      utils.competitions.faceBootstrap.invalidate({ tripId });
+      utils.games.listByTrip.invalidate({ tripId });
+    }
   }
 
   const onSetStrokes = (userId: string, strokes: number) =>
@@ -350,6 +369,10 @@ export default function RackNStackPage() {
   // (created as a bare games row by add-game). Route it to the setup step instead
   // of the empty play screen — startRack seeds onto the existing game.
   const needsSetup = !!gid && groupsQ.isSuccess && (groupsQ.data?.groups?.length ?? 0) === 0;
+  // Task 2 readiness: rack can't switch to scoring until at least one playing group
+  // exists (players assigned). Mirrors the server enable guard (grouped participants
+  // > 0) so the client toggle and the server refuse agree.
+  const groupsAssigned = (groupsQ.data?.groups?.length ?? 0) > 0;
   // Phase 2B.1: a rack with its groups set must be Enabled before the play screen
   // opens (the score saver server-rejects entries until then).
   const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
@@ -483,14 +506,51 @@ export default function RackNStackPage() {
         isOwner={isOwner}
         onChanged={() => void refreshGame()}
         onDeleted={() => router.push(competitionId ? `/trips/${tripId}/leaderboard` : `/trips/${tripId}`)}
-        whosPlayingLabel={`${groupsQ.data?.groups?.length ?? 0} group${(groupsQ.data?.groups?.length ?? 0) === 1 ? "" : "s"} · auto-grouped · strokes`}
-        // Keep showConfig set so the handicaps drill-down returns to the settings page.
-        onEditWhosPlaying={() => setShowHandicaps(true)}
+        whosPlayingLabel={
+          groupsAssigned
+            ? `${groupsQ.data?.groups?.length ?? 0} group${(groupsQ.data?.groups?.length ?? 0) === 1 ? "" : "s"} · strokes`
+            : "No groups yet — build the carts"
+        }
+        // Keep showConfig set so the builder/handicaps drill-downs return here.
+        onEditWhosPlaying={openGroupBuilder}
         scoringEnabled={scoringEnabled}
+        // Task 2: gate the Setup→Scoring toggle on groups being assigned.
+        ready={groupsAssigned}
         onEnable={handleEnable}
         onDisable={handleDisable}
         busy={enableScoring.isPending || disableScoring.isPending}
       />
+    );
+  }
+
+  // Manual playing-group builder (owner/delegate) — the replacement for auto-assign.
+  // Reached from "Start the rack" (new game) and the settings "who's playing"
+  // drill-down. Persists on leave; "Save & set handicaps" continues to the roster.
+  if (showGroups && gid) {
+    const teamA: GroupBuilderTeam = { id: teamIds[0] ?? "A", name: teamMeta.A.name, color: teamMeta.A.color, players: teamRosters.A };
+    const teamB: GroupBuilderTeam = { id: teamIds[1] ?? "B", name: teamMeta.B.name, color: teamMeta.B.color, players: teamRosters.B };
+    const anyAssigned = groupDraft.some((g) => g.length > 0);
+    const leave = async () => { await saveGroups(); setShowGroups(false); };
+    const toHandicaps = async () => { await saveGroups(); setShowGroups(false); setShowHandicaps(true); };
+    return (
+      <Shell onBack={() => void leave()} title="Playing groups" subtitle="Build the carts — any mix of 1–4">
+        <div className="w-full px-4 py-5">
+          <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", marginBottom: 14 }}>
+            Add a group for each cart, then pick its players from either team. Anyone left out sits this round out.
+          </p>
+          <RackGroupBuilder groups={groupDraft} onChange={setGroupDraft} teamA={teamA} teamB={teamB} />
+          {anyAssigned && (
+            <button
+              onClick={() => void toHandicaps()}
+              disabled={setFoursomes.isPending}
+              className="mt-5 w-full disabled:opacity-40"
+              style={{ height: 50, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 15, fontWeight: 600 }}
+            >
+              {setFoursomes.isPending ? "Saving…" : "Save & set handicaps"}
+            </button>
+          )}
+        </div>
+      </Shell>
     );
   }
 
@@ -531,13 +591,12 @@ export default function RackNStackPage() {
                 <span style={{ color: pendingCourse ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>{pendingCourse?.name ?? "Select a course (optional)"}</span>
               </button>
             </div>
-            <TimePicker label="First tee time" presets="tee" value={parseTime(firstTee)} onChange={(v) => setFirstTee(toTime24(v))} />
             <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)" }}>
-              {assignQ.data?.length ?? 0} players across {teamMeta.A.name} &amp; {teamMeta.B.name} — they&apos;ll be auto-grouped into foursomes (tee times stagger by 10 min) you can regroup later.
+              {assignQ.data?.length ?? 0} players across {teamMeta.A.name} &amp; {teamMeta.B.name} — you&apos;ll build them into playing groups (carts) yourself, any mix of 1–4 per group.
             </p>
             {canEdit && (
-              <button onClick={startRack} disabled={createGame.isPending || setFoursomes.isPending} className="mt-2 w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
-                Start the rack
+              <button onClick={startRack} disabled={createGame.isPending || applyCourse.isPending} className="mt-2 w-full disabled:opacity-40" style={{ height: 52, borderRadius: 12, background: "var(--color-bt-accent)", color: "#0d1f1a", fontSize: 16, fontWeight: 600 }}>
+                Set up playing groups
               </button>
             )}
           </div>

--- a/src/components/games/rack/RackGroupBuilder.tsx
+++ b/src/components/games/rack/RackGroupBuilder.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, X } from "lucide-react";
+import { PlayerChip } from "@/components/games/PlayerChip";
+import { Avatar } from "@/components/Avatar";
+import { addGroup as addGroupOp, removeGroup as removeGroupOp, assignPlayer, removePlayer as removePlayerOp, assignedIds, MAX_PER_GROUP, MAX_GROUPS } from "@/lib/rackGroupDraft";
+
+export interface GroupBuilderPlayer {
+  id: string;
+  name: string;
+  avatarIcon: string | null;
+}
+export interface GroupBuilderTeam {
+  id: string;
+  name: string;
+  color: string;
+  /** Roster in the parent's canonical sort_order (handicap order if the captain
+   *  set it) — the picker shows this order top-to-bottom. */
+  players: GroupBuilderPlayer[];
+}
+
+/**
+ * RackGroupBuilder — manual playing-group assignment for Rack-n-Stack, forked from
+ * the 2v2 match-builder's add/remove + player-picker interaction. Presentation-only
+ * per the persistence-agnostic pattern (CLAUDE.md #7): the draft (`groups` = arrays
+ * of user ids, one array per group) arrives via props and every edit emits through
+ * `onChange`; the parent owns tRPC persistence.
+ *
+ * The one departure from the 2v2 builder is the COMBINED-POOL picker — both teams in
+ * ONE bottom sheet, two columns (team A left / team B right) — so a group takes any
+ * mix (no forced 2+2). A player already in a group leaves the pool (each player in at
+ * most one group). Unassigned players simply stay in the pool: no bench warning — the
+ * scoring rack's empty/forfeited slots carry that consequence downstream.
+ */
+export function RackGroupBuilder({
+  groups,
+  onChange,
+  teamA,
+  teamB,
+}: {
+  groups: string[][];
+  onChange: (next: string[][]) => void;
+  teamA: GroupBuilderTeam;
+  teamB: GroupBuilderTeam;
+}) {
+  // Which group the combined picker is adding to (null = closed).
+  const [pickerFor, setPickerFor] = useState<number | null>(null);
+
+  const metaOf = new Map<string, { name: string; color: string }>();
+  for (const p of teamA.players) metaOf.set(p.id, { name: p.name, color: teamA.color });
+  for (const p of teamB.players) metaOf.set(p.id, { name: p.name, color: teamB.color });
+
+  const assigned = assignedIds(groups);
+
+  const addGroup = () => onChange(addGroupOp(groups));
+  const removeGroup = (i: number) => onChange(removeGroupOp(groups, i));
+  const removePlayer = (gi: number, uid: string) => onChange(removePlayerOp(groups, gi, uid));
+  const addPlayer = (gi: number, uid: string) => onChange(assignPlayer(groups, gi, uid));
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="rack-group-builder">
+      {groups.map((g, i) => (
+        <div
+          key={i}
+          className="rounded-xl"
+          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", padding: 12 }}
+        >
+          <div className="flex items-center justify-between" style={{ marginBottom: g.length ? 10 : 0 }}>
+            <span style={{ fontSize: 13, fontWeight: 700, color: "var(--color-bt-text)" }}>Group {i + 1}</span>
+            <button
+              type="button"
+              onClick={() => removeGroup(i)}
+              aria-label={`Remove group ${i + 1}`}
+              className="flex items-center justify-center"
+              style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)" }}
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {g.length > 0 && (
+            <div className="flex flex-col gap-1.5" style={{ marginBottom: 10 }}>
+              {g.map((uid) => {
+                const meta = metaOf.get(uid);
+                return (
+                  <div key={uid} className="flex items-center gap-1.5">
+                    <div className="min-w-0 flex-1">
+                      <PlayerChip name={meta?.name ?? "Player"} teamColor={meta?.color ?? null} />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removePlayer(i, uid)}
+                      aria-label={`Remove ${meta?.name ?? "player"}`}
+                      className="flex items-center justify-center"
+                      style={{ width: 24, height: 24, color: "var(--color-bt-text-dim)" }}
+                    >
+                      <X size={15} />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {g.length < MAX_PER_GROUP && (
+            <button
+              type="button"
+              onClick={() => setPickerFor(i)}
+              className="flex w-full items-center justify-center gap-1.5"
+              style={{ height: 44, borderRadius: 10, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text-dim)" }}
+            >
+              <Plus size={15} />
+              <span style={{ fontSize: 14, fontWeight: 500 }}>Add player</span>
+            </button>
+          )}
+        </div>
+      ))}
+
+      {groups.length < MAX_GROUPS && (
+        <button
+          type="button"
+          onClick={addGroup}
+          className="flex w-full items-center justify-center gap-1.5"
+          style={{ height: 46, borderRadius: 12, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
+        >
+          <Plus size={16} /> Add group
+        </button>
+      )}
+
+      {pickerFor !== null && (
+        <CombinedPicker
+          teamA={teamA}
+          teamB={teamB}
+          assigned={assigned}
+          groupFull={(groups[pickerFor]?.length ?? 0) >= MAX_PER_GROUP}
+          groupNumber={pickerFor + 1}
+          onPick={(uid) => addPlayer(pickerFor, uid)}
+          onClose={() => setPickerFor(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * The combined-pool picker — a bottom sheet with BOTH teams as two columns (A left,
+ * B right). Available = roster minus everyone already in a group. Tap adds to the
+ * open group and the sheet stays up (multi-add up to 4); Done closes.
+ */
+function CombinedPicker({
+  teamA,
+  teamB,
+  assigned,
+  groupFull,
+  groupNumber,
+  onPick,
+  onClose,
+}: {
+  teamA: GroupBuilderTeam;
+  teamB: GroupBuilderTeam;
+  assigned: Set<string>;
+  groupFull: boolean;
+  groupNumber: number;
+  onPick: (uid: string) => void;
+  onClose: () => void;
+}) {
+  const column = (team: GroupBuilderTeam) => {
+    const available = team.players.filter((p) => !assigned.has(p.id));
+    return (
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5" style={{ marginBottom: 8 }}>
+          <span className="inline-block rounded-full" style={{ width: 9, height: 9, background: team.color }} />
+          <span className="truncate" style={{ fontSize: 12, fontWeight: 700, color: "var(--color-bt-text)" }}>{team.name}</span>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          {available.length === 0 ? (
+            <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", padding: "6px 2px" }}>All assigned</span>
+          ) : (
+            available.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                disabled={groupFull}
+                onClick={() => onPick(p.id)}
+                className="flex w-full items-center gap-2 text-left disabled:opacity-40"
+                style={{ padding: "8px 10px", borderRadius: 10, background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+              >
+                <Avatar name={p.name} teamColor={team.color} sizePx={28} />
+                <span className="min-w-0 truncate" style={{ fontSize: 14, color: "var(--color-bt-text)" }}>{p.name}</span>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onClose}>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full"
+        style={{ background: "var(--color-bt-card-float)", borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: "16px 16px 24px", maxHeight: "75vh", overflowY: "auto" }}
+      >
+        <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+          <span style={{ fontSize: 16, fontWeight: 700, color: "var(--color-bt-text)" }}>Add to Group {groupNumber}</span>
+          <button type="button" onClick={onClose} style={{ fontSize: 14, fontWeight: 600, color: "var(--color-bt-accent)" }}>Done</button>
+        </div>
+        {groupFull && (
+          <p style={{ fontSize: 12.5, color: "var(--color-bt-text-dim)", marginBottom: 10 }}>
+            This group is full (max 4). Remove someone to swap.
+          </p>
+        )}
+        <div className="flex gap-3">
+          {column(teamA)}
+          {column(teamB)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/rackGroupDraft.test.ts
+++ b/src/lib/rackGroupDraft.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { addGroup, removeGroup, assignPlayer, removePlayer, assignedIds, toPersist, MAX_GROUPS } from "./rackGroupDraft";
+
+// The manual rack group-builder rules: any 1–4 mix per group, each player in at
+// most one group, empty groups droppable, and the persist shape for setFoursomes.
+
+describe("rackGroupDraft", () => {
+  it("adds and removes groups", () => {
+    expect(addGroup([])).toEqual([[]]);
+    expect(addGroup([["a"]])).toEqual([["a"], []]);
+    expect(removeGroup([["a"], ["b"]], 0)).toEqual([["b"]]);
+  });
+
+  it("caps the number of groups at MAX_GROUPS", () => {
+    const full = Array.from({ length: MAX_GROUPS }, () => [] as string[]);
+    expect(addGroup(full)).toBe(full); // unchanged at the cap
+  });
+
+  it("assigns a player and keeps them in at most one group (a move, not a copy)", () => {
+    let g: string[][] = [[], []];
+    g = assignPlayer(g, 0, "alice"); // → group 0
+    expect(g).toEqual([["alice"], []]);
+    g = assignPlayer(g, 1, "alice"); // moving alice to group 1 vacates group 0
+    expect(g).toEqual([[], ["alice"]]);
+  });
+
+  it("allows any mix from either team — no forced 2+2", () => {
+    let g: string[][] = [[]];
+    g = assignPlayer(g, 0, "a1");
+    g = assignPlayer(g, 0, "a2");
+    g = assignPlayer(g, 0, "b1"); // 2 from A + 1 from B in one group is fine
+    expect(g).toEqual([["a1", "a2", "b1"]]);
+  });
+
+  it("refuses a 5th player (max 4 per group) — draft unchanged", () => {
+    const four = [["a", "b", "c", "d"]];
+    expect(assignPlayer(four, 0, "e")).toBe(four);
+  });
+
+  it("removes a player back to the pool", () => {
+    expect(removePlayer([["a", "b"]], 0, "a")).toEqual([["b"]]);
+  });
+
+  it("assignedIds is everyone currently grouped (the picker excludes them)", () => {
+    expect(assignedIds([["a", "b"], ["c"]])).toEqual(new Set(["a", "b", "c"]));
+    expect(assignedIds([[], []])).toEqual(new Set());
+  });
+
+  it("toPersist drops empty groups and renumbers the survivors 1..N", () => {
+    expect(toPersist([["a"], [], ["b", "c"]])).toEqual([
+      { name: "Group 1", userIds: ["a"] },
+      { name: "Group 2", userIds: ["b", "c"] },
+    ]);
+    expect(toPersist([[], []])).toEqual([]); // the valid empty state
+  });
+});

--- a/src/lib/rackGroupDraft.ts
+++ b/src/lib/rackGroupDraft.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure draft operations for the Rack-n-Stack manual playing-group builder — the
+ * client-safe logic behind `RackGroupBuilder` (mirrors how the 2v2 match-builder
+ * factors its draft edits into `matchDraft.ts`). A draft is `string[][]`: one array
+ * of user ids per group, in group order. No React, no tRPC — so it unit-tests
+ * directly and the component stays a thin view over these.
+ */
+
+export const MAX_PER_GROUP = 4;
+export const MAX_GROUPS = 12;
+
+/** Append an empty group (capped at MAX_GROUPS). */
+export function addGroup(groups: string[][]): string[][] {
+  return groups.length < MAX_GROUPS ? [...groups, []] : groups;
+}
+
+/** Drop a group; its players return to the pool (no longer in any group). */
+export function removeGroup(groups: string[][], index: number): string[][] {
+  return groups.filter((_, i) => i !== index);
+}
+
+/**
+ * Assign a player to group `index`. Enforces "at most one group": the player is
+ * first removed from every group, then added to the target — unless it's already
+ * full (MAX_PER_GROUP), in which case the draft is returned unchanged.
+ */
+export function assignPlayer(groups: string[][], index: number, userId: string): string[][] {
+  const cleared = groups.map((g) => g.filter((u) => u !== userId));
+  if ((cleared[index]?.length ?? 0) >= MAX_PER_GROUP) return groups;
+  return cleared.map((g, i) => (i === index ? [...g, userId] : g));
+}
+
+/** Remove a player from group `index` (back to the pool). */
+export function removePlayer(groups: string[][], index: number, userId: string): string[][] {
+  return groups.map((g, i) => (i === index ? g.filter((u) => u !== userId) : g));
+}
+
+/** Everyone currently in a group — the set removed from the combined picker pool. */
+export function assignedIds(groups: string[][]): Set<string> {
+  return new Set(groups.flat());
+}
+
+/**
+ * The persist shape for `playGroups.setFoursomes`: empty groups (an unfinished
+ * "add group") are dropped and the survivors renumber Group 1..N.
+ */
+export function toPersist(groups: string[][]): { name: string; userIds: string[] }[] {
+  return groups.filter((g) => g.length > 0).map((userIds, i) => ({ name: `Group ${i + 1}`, userIds }));
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -5,7 +5,7 @@ import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
 import { isManualGameType } from "@/lib/gameTypes";
 // isConfigured (+ the type sets) moved to gameReadiness.ts (A2-core) so the same
 // "is it configured?" signal backs both this display AND the server enable guard.
-import { isConfigured, MATCH_PLAY_TYPES } from "@/server/lib/gameReadiness";
+import { isConfigured, MATCH_PLAY_TYPES, RACK_TYPE } from "@/server/lib/gameReadiness";
 
 /** Singles vs doubles head-to-head sizing for the team-size-derived formats
  *  (rack-n-stack). Match play itself counts its configured rows instead. */
@@ -94,8 +94,8 @@ export async function computeCompetitionLeaderboard(
       ? supabase.from("game_matches").select("game_id, side_a, side_b").in("game_id", gameIds)
       : Promise.resolve({ data: [] as { game_id: string; side_a: unknown; side_b: unknown }[] }),
     gameIds.length
-      ? supabase.from("game_participants").select("game_id").in("game_id", gameIds)
-      : Promise.resolve({ data: [] as { game_id: string }[] }),
+      ? supabase.from("game_participants").select("game_id, play_group_id").in("game_id", gameIds)
+      : Promise.resolve({ data: [] as { game_id: string; play_group_id: string | null }[] }),
     // Any score entered yet? The §A "started" signal (R1): an `active` game with
     // ≥1 score entry is genuinely underway (On Tap); an `active` game with none is
     // enabled/pairings-up but not started (Ready for Play). Manual games score on
@@ -111,10 +111,17 @@ export async function computeCompetitionLeaderboard(
   for (const r of (scoreEntryRowsRes.data ?? []) as { game_id: string }[]) {
     startedByGame.add(r.game_id);
   }
-  // Participant rows per game — "field picked" (stroke) / "auto-grouped" (rack).
+  // Participant rows per game — "field picked" (stroke). For rack we track the
+  // GROUPED count separately: rack readiness needs players assigned to a playing
+  // group (the manual builder), so a bare roster with no groups isn't Ready — the
+  // same bar the server enable guard uses, so the two can't disagree.
   const participantCountByGame = new Map<string, number>();
-  for (const r of (participantRowsRes.data ?? []) as { game_id: string }[]) {
+  const groupedParticipantCountByGame = new Map<string, number>();
+  for (const r of (participantRowsRes.data ?? []) as { game_id: string; play_group_id: string | null }[]) {
     participantCountByGame.set(r.game_id, (participantCountByGame.get(r.game_id) ?? 0) + 1);
+    if (r.play_group_id != null) {
+      groupedParticipantCountByGame.set(r.game_id, (groupedParticipantCountByGame.get(r.game_id) ?? 0) + 1);
+    }
   }
   // A match game's available points = value × the number of ASSIGNED matches
   // (both sides paired). "A match = assigned, everywhere" (round-3.1 addendum):
@@ -271,7 +278,8 @@ export async function computeCompetitionLeaderboard(
           typeId,
           matchCountByGame.get(gid) ?? 0,
           totalMatchRowsByGame.get(gid) ?? 0,
-          participantCountByGame.get(gid) ?? 0,
+          // Rack gates on GROUPED players (manual builder); stroke on all participants.
+          (typeId === RACK_TYPE ? groupedParticipantCountByGame : participantCountByGame).get(gid) ?? 0,
           hasPoints
         ),
         // Course presence (§ scorecard three-way) — surfaced so the row's

--- a/src/server/lib/gameReadiness.ts
+++ b/src/server/lib/gameReadiness.ts
@@ -13,16 +13,21 @@ import { matchPlayReady } from "@/lib/matchDraft";
  */
 
 export const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
-// Roster-gated golf formats: a stroke field / rack auto-grouping is "configured"
-// once it has participants (match play instead needs pairing rows — see below).
-export const ROSTER_TYPES = new Set(["gtt_stroke_play", "gtt_rack_n_stack"]);
+export const RACK_TYPE = "gtt_rack_n_stack";
+// Roster-gated golf formats: a stroke field is "configured" once it has
+// participants; rack additionally requires those participants to be GROUPED into
+// playing groups (the manual group builder) — see the grouped-count branch below.
+export const ROSTER_TYPES = new Set(["gtt_stroke_play", RACK_TYPE]);
 
 /**
  * Is the game configured enough to be Ready (vs still Setting up)?
  *  - match play → ALL pairings assigned (`matchPlayReady`: paired === total, ≥1) —
  *    the SAME threshold the setup-page Enable gate uses, so list-ready ⟺
  *    setup-can-enable (readiness rework P1b).
- *  - stroke / rack → participants assigned (game_participants rows)
+ *  - stroke → participants assigned (game_participants rows)
+ *  - rack → participants assigned to a PLAYING GROUP (the manual group builder);
+ *    the caller passes the GROUPED participant count, so ungrouped players
+ *    (e.g. groups later cleared) don't read as ready
  *  - manual / side events → points configured (no roster to assign)
  */
 export function isConfigured(
@@ -66,10 +71,14 @@ export async function assertGameReady(supabase: SupabaseClient, gameId: string):
     matchTotal = matches.length;
     matchPaired = matches.filter((m) => m.side_a?.id && m.side_b?.id).length;
   } else if (typeId && ROSTER_TYPES.has(typeId)) {
-    const { count } = await supabase
+    let query = supabase
       .from("game_participants")
       .select("user_id", { count: "exact", head: true })
       .eq("game_id", gameId);
+    // Rack requires players actually GROUPED (the manual group builder) — a bare
+    // roster with no playing groups isn't ready. Stroke counts all participants.
+    if (typeId === RACK_TYPE) query = query.not("play_group_id", "is", null);
+    const { count } = await query;
     participantCount = count ?? 0;
   }
 

--- a/src/server/routers/rackNStack.test.ts
+++ b/src/server/routers/rackNStack.test.ts
@@ -181,3 +181,41 @@ describe("rack-n-stack — per-match points (Stage 3)", () => {
     expect(lb.teamTotals[tb]).toBe(0);
   });
 });
+
+describe("rack-n-stack — scoring is blocked until playing groups are assigned", () => {
+  it("enableScoring refuses a rack with no groups, then allows once groups exist", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "Gate", competitionId });
+    const gameId = game.id as string;
+
+    // No groups yet → the enable guard refuses (manual grouping is required).
+    await expect(
+      ctx.callerAs("planner").games.enableScoring({ tripId, gameId })
+    ).rejects.toThrow(/setting up/i);
+
+    // Build one group → now ready.
+    await ctx.callerAs("planner").playGroups.setFoursomes({
+      tripId,
+      gameId,
+      groups: [{ name: "G1", userIds: [owner, member] }],
+    });
+    await expect(ctx.callerAs("planner").games.enableScoring({ tripId, gameId })).resolves.toBeTruthy();
+  });
+
+  it("clearing all groups makes the leaderboard read Setting-up again (grouped-count gate)", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "Clear", competitionId });
+    const gameId = game.id as string;
+    await ctx.callerAs("planner").playGroups.setFoursomes({
+      tripId,
+      gameId,
+      groups: [{ name: "G1", userIds: [owner, member] }],
+    });
+    const before = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+    expect(before.games.find((g) => g.id === gameId)!.configured).toBe(true);
+
+    // Clear the groups — participants may linger with a null play_group_id, but the
+    // readiness signal counts GROUPED players, so it flips back to not-configured.
+    await ctx.callerAs("planner").playGroups.setFoursomes({ tripId, gameId, groups: [] });
+    const after = await ctx.caller().competitions.leaderboard({ tripId, competitionId });
+    expect(after.games.find((g) => g.id === gameId)!.configured).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Replaces Rack-n-Stack's **auto-assignment** of on-course playing groups (first-2-of-A + first-2-of-B → group 1, …) with a **manual builder** so the owner/delegate builds the carts deliberately. This is the one BBMI round where players get to play with anyone, so deliberate grouping *is* the point — auto-assigning it away undercut the feature. No auto-assign, starts empty, scoring blocked until groups are set.

Everything else about rack (shared scorecard, shared score entry, the sort-and-match scoring rack + its dynamic sizing) is unchanged — this is only the assignment interface. No schema/migration; writes to the existing `play_groups` / `game_participants.play_group_id` model via the existing `playGroups.setFoursomes`.

## How

**Task 1 — remove auto-assign.** Deleted `autoFoursomes` + the auto-seed in `startRack()`. "Start the rack" now creates the game + applies the course, then opens the builder from an empty state. "No groups yet" is a valid setup state; downstream readers (scorecard / entry / scoring rack) read the manually-built groups unchanged.

**Task 2 — block scoring until groups set.** Rack readiness now requires players actually *grouped*, not just a bare roster. `assertGameReady` counts `game_participants` with a non-null `play_group_id` for rack (stroke still counts all); the competition leaderboard's Ready/Setting-up display uses the same grouped count, so the client toggle, the server enable guard, and the board can't disagree. The client Setup→Scoring toggle is gated on `groupsAssigned`.

**Task 3 — the builder (forked from the 2v2 match-builder).** `RackGroupBuilder` — add/remove group, 1–4 players each, starts empty, owner/delegate-gated (existing `canEdit` + server `requireGameEdit`). Persists on leave (`setFoursomes` clean-replace, empty groups dropped, survivors renumbered); "Save & set handicaps" continues to the roster.

**Task 4 — the combined-pool picker (the one new element).** A bottom sheet with **both teams as two columns** (A left / B right) drawn from the canonical roster order (handicap order if the captain set it), so a group takes any mix — no forced 2+2. An assigned player leaves the pool (each player in at most one group).

**Silent bench:** unassigned players stay in the pool; no warning — the scoring rack's empty/forfeited slots + total already carry the consequence.

Pure draft ops live in `src/lib/rackGroupDraft.ts` (mirrors `matchDraft.ts` for the 2v2 builder); the component and the page's persist both use them, so there's one source of truth for the rules.

## Testing

- `npx tsc --noEmit` clean; eslint clean on all touched files.
- `rackGroupDraft.test.ts` — 8 unit tests (any 1–4 mix, at-most-one-group move, 12-group cap, 4-per-group cap, persist shape).
- `rackNStack.test.ts` (DB-backed, CI) — enableScoring refuses a groupless rack then allows once a group exists; clearing groups flips the leaderboard back to Setting-up.
- Full Vitest + Playwright run in CI.

## DO-NOT compliance

No auto-assign fallback · scorecard/entry/scoring-rack/sizing untouched · no bench warning · no forced even split · no schema/migration · downstream readers intact · no handicap-sort button (roster order is inherent) · tokens only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Qpy8dCa5zQEhJoKmdqPu7)_