### PR TITLE
Score durability + honest advance (Spec 1a — correctness, September-critical)

### DIFF
--- a/src/app/trips/[tripId]/games/match/new/page.tsx
+++ b/src/app/trips/[tripId]/games/match/new/page.tsx
@@ -43,7 +43,8 @@ import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
-import type { Participant, ScoreValues } from "@/components/games/types";
+import { unconfirmedCount, type Participant, type ScoreValues } from "@/components/games/types";
+import { showToast } from "@/lib/toast";
 
 /** "07:40" → "7:40 AM". Empty/invalid → "". */
 function formatTee(t: string | null | undefined): string {
@@ -782,6 +783,17 @@ export default function NewMatchGamePage() {
 
   async function handleFinish() {
     if (!tripId || !gameId) return;
+    // Spec 1a: never finalize over unconfirmed scores — finish computes from
+    // server rows, so an unsaved cell would be silently omitted from standings.
+    const gate = unconfirmedCount(saveStatus);
+    if (gate.total > 0) {
+      showToast(
+        gate.errored > 0
+          ? `${gate.errored} score${gate.errored > 1 ? "s" : ""} didn’t save — retry before finishing`
+          : "Still saving scores — try again in a moment",
+      );
+      return;
+    }
     try {
       await finishGame.mutateAsync({ tripId, gameId });
       await Promise.all([gameQ.refetch(), matchesQ.refetch(), scoresQ.refetch()]);

--- a/src/app/trips/[tripId]/games/new/page.tsx
+++ b/src/app/trips/[tripId]/games/new/page.tsx
@@ -24,7 +24,8 @@ import type { StrokeStanding } from "@/lib/strokePlay";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
 import { strokeHoles } from "@/lib/matchPlay";
-import type { Participant, ScoreValues } from "@/components/games/types";
+import { unconfirmedCount, type Participant, type ScoreValues } from "@/components/games/types";
+import { showToast } from "@/lib/toast";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const STROKE_PLAY = "gtt_stroke_play";
@@ -321,6 +322,17 @@ export default function NewGamePage() {
 
   async function handleFinish() {
     if (!tripId || !game) return;
+    // Spec 1a: never finish over unconfirmed scores — finish computes from server
+    // rows, so an unsaved cell would be silently omitted. Block + say why.
+    const gate = unconfirmedCount(saveStatus);
+    if (gate.total > 0) {
+      showToast(
+        gate.errored > 0
+          ? `${gate.errored} score${gate.errored > 1 ? "s" : ""} didn’t save — retry before finishing`
+          : "Still saving scores — try again in a moment",
+      );
+      return;
+    }
     try {
       const res = await finishGame.mutateAsync({ tripId, gameId: game.id });
       setStandings(res.standings);

--- a/src/app/trips/[tripId]/games/rack/new/page.tsx
+++ b/src/app/trips/[tripId]/games/rack/new/page.tsx
@@ -8,6 +8,8 @@ import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useScoreSaver } from "@/hooks/useScoreSaver";
+import { showToast } from "@/lib/toast";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { RackGroupBuilder, type GroupBuilderTeam } from "@/components/games/rack/RackGroupBuilder";
 import { toPersist as groupsToPersist } from "@/lib/rackGroupDraft";
@@ -27,7 +29,7 @@ import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/
 import { strokeHoles } from "@/lib/matchPlay";
 import { unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
-import type { Participant, ScoreValues } from "@/components/games/types";
+import { unconfirmedCount, type Participant, type ScoreValues } from "@/components/games/types";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const RACK = "gtt_rack_n_stack";
@@ -92,7 +94,11 @@ export default function RackNStackPage() {
     deepLink: search.get("settings") === "1",
   });
   const [currentHole, setCurrentHole] = useState(1);
-  const [values, setValues] = useState<ScoreValues>({});
+  // Rack scores now go through the durable, confirmation-tracked saver (Spec 1a) —
+  // same idempotent upsert + retry + outbox + per-cell status as stroke/match
+  // (was a raw fire-and-forget mutate with no retry/status). Per-user entries, so
+  // no participantType. `values` is seeded once from the server below.
+  const { values, setValues, saveStatus, onChange, onClear, retryCell } = useScoreSaver(tripId, gid);
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
   const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
@@ -115,8 +121,6 @@ export default function RackNStackPage() {
   const enableScoring = trpc.games.enableScoring.useMutation();
   const disableScoring = trpc.games.disableScoring.useMutation();
   const setStrokes = trpc.playGroups.setParticipantStrokes.useMutation();
-  const upsertEntry = trpc.scores.upsertEntry.useMutation();
-  const deleteEntry = trpc.scores.deleteEntry.useMutation();
   const finishGame = trpc.games.finish.useMutation();
   // #7 correction path (owner/co-admin/delegate — server-gated by
   // requireGameRunAction). "Re-lock" reuses finish().
@@ -200,7 +204,16 @@ export default function RackNStackPage() {
     }
     return v;
   }, [scoresQ.data]);
-  const mergedFor = (pid: string) => ({ ...(loadedValues[pid] ?? {}), ...(values[pid] ?? {}) });
+  // Seed the saver's values from the server ONCE on resume (mirrors stroke) — the
+  // saver's `values` is then the single source (server seed + live edits), so a
+  // clear removes from it cleanly and the outbox recovery re-populates it.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !gid || !scoresQ.data) return;
+    setValues((v) => (Object.keys(v).length ? v : loadedValues));
+    seededRef.current = true;
+  }, [gid, scoresQ.data, loadedValues, setValues]);
+  const mergedFor = (pid: string) => values[pid] ?? {};
 
   // ── Rack read-model (the spec's novelty) ─────────────────────────────
   const participants = useMemo(() => groupsQ.data?.participants ?? [], [groupsQ.data]);
@@ -372,29 +385,19 @@ export default function RackNStackPage() {
       .mutateAsync({ tripId: tripId!, gameId: gid!, userId, strokes })
       .then(() => utils.playGroups.listByGame.invalidate({ tripId: tripId!, gameId: gid! }));
 
-  const handleChange = (pid: string, unit: string, value: number) => {
-    setValues((v) => ({ ...v, [pid]: { ...(v[pid] ?? {}), [unit]: value } }));
-    if (!tripId || !gid) return;
-    upsertEntry.mutate(
-      { tripId, gameId: gid, participantId: pid, unitLabel: unit, value },
-      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId: gid }) }
-    );
-  };
-  const handleClear = (pid: string, unit: string) => {
-    setValues((v) => {
-      const next = { ...(v[pid] ?? {}) };
-      delete next[unit];
-      return { ...v, [pid]: next };
-    });
-    if (!tripId || !gid) return;
-    deleteEntry.mutate(
-      { tripId, gameId: gid, participantId: pid, unitLabel: unit },
-      { onSettled: () => utils.scores.listByGame.invalidate({ tripId, gameId: gid }) }
-    );
-  };
-
   async function finish() {
     if (!tripId || !gid) return;
+    // Spec 1a: block finalize over unconfirmed scores (finish computes from server
+    // rows — an unsaved cell would be silently omitted from standings).
+    const gate = unconfirmedCount(saveStatus);
+    if (gate.total > 0) {
+      showToast(
+        gate.errored > 0
+          ? `${gate.errored} score${gate.errored > 1 ? "s" : ""} didn’t save — retry before finishing`
+          : "Still saving scores — try again in a moment",
+      );
+      return;
+    }
     await finishGame.mutateAsync({ tripId, gameId: gid });
     await utils.games.getById.invalidate({ tripId, gameId: gid });
     // #6: finalize changes the leaderboard — invalidate it so the board reflects
@@ -558,8 +561,10 @@ export default function RackNStackPage() {
           direction="low_wins"
           currentHole={currentHole}
           onHoleChange={setCurrentHole}
-          onChange={handleChange}
-          onClear={handleClear}
+          onChange={onChange}
+          onClear={onClear}
+          saveStatus={saveStatus}
+          onRetryCell={retryCell}
           onBack={back}
           onOpenGrid={() => setEntryView("grid")}
           onFinish={back}

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -15,6 +15,8 @@ import { strokeIndexOf } from "@/lib/strokePlayConfig";
 import {
   parseScoreCellKey,
   scoreCellKey,
+  unconfirmedOnHole,
+  unconfirmedCount,
   type ScoreUnit,
   type Participant,
   type ScoreValues,
@@ -168,6 +170,21 @@ export function MatchEntryView({
       onRetryCell?.(participantId, unitLabel);
     }
   };
+
+  // ── Confirmation gate (Spec 1a — honest advance) ──────────────────────────
+  // Gate on the cells that must be scored THIS hole (interactive, non-dead ones).
+  const holeGate = unconfirmedOnHole(saveStatus, interactiveHere.map((p) => p.id), label);
+  const gameGate = unconfirmedCount(saveStatus);
+  const advanceReason = holeGate.errored > 0
+    ? `${holeGate.errored} score${holeGate.errored > 1 ? "s" : ""} didn’t save — retry above`
+    : holeGate.saving > 0
+      ? "Saving scores…"
+      : undefined;
+  const finishReason = gameGate.errored > 0
+    ? `${gameGate.errored} score${gameGate.errored > 1 ? "s" : ""} didn’t save — retry before finishing`
+    : gameGate.saving > 0
+      ? "Saving scores…"
+      : undefined;
 
   // The board reflects a hole only once it's confirmed: while the keypad is open
   // on the current hole (activePid set), exclude that hole from the match-state
@@ -388,9 +405,20 @@ export function MatchEntryView({
           onConfirm={confirmAdvance}
         />
       ) : canFinish ? (
-        <BottomCTA label={finishLabel} icon onClick={() => onFinish?.()} subtext={finishSubtext} />
+        <BottomCTA
+          label={finishLabel}
+          icon
+          onClick={() => onFinish?.()}
+          disabled={gameGate.total > 0}
+          subtext={finishReason ?? finishSubtext}
+        />
       ) : currentComplete && hole < units.length ? (
-        <BottomCTA label={`Hole ${units[hole]?.label ?? hole + 1} ›`} onClick={() => goHole(hole + 1)} />
+        <BottomCTA
+          label={`Hole ${units[hole]?.label ?? hole + 1} ›`}
+          onClick={() => goHole(hole + 1)}
+          disabled={holeGate.blocked}
+          subtext={advanceReason}
+        />
       ) : null}
     </div>
   );

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -13,6 +13,8 @@ import { golfWord, golfResult, GOLF_STYLE } from "./golfScore";
 import {
   parseScoreCellKey,
   scoreCellKey,
+  unconfirmedOnHole,
+  unconfirmedCount,
   type ScoreUnit,
   type Participant,
   type ScoreValues,
@@ -169,6 +171,22 @@ export function ScoreEntryView({
       onRetryCell?.(participantId, unitLabel);
     }
   };
+
+  // ── Confirmation gate (Spec 1a — honest advance) ──────────────────────────
+  // Never advance past / finish over scores that aren't CONFIRMED on the server.
+  const participantIds = participants.map((p) => p.id);
+  const holeGate = unconfirmedOnHole(saveStatus, participantIds, label);
+  const gameGate = unconfirmedCount(saveStatus);
+  const advanceReason = holeGate.errored > 0
+    ? `${holeGate.errored} score${holeGate.errored > 1 ? "s" : ""} didn’t save — retry above`
+    : holeGate.saving > 0
+      ? "Saving scores…"
+      : undefined;
+  const finishReason = gameGate.errored > 0
+    ? `${gameGate.errored} score${gameGate.errored > 1 ? "s" : ""} didn’t save — retry before finishing`
+    : gameGate.saving > 0
+      ? "Saving scores…"
+      : undefined;
 
   return (
     <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
@@ -394,9 +412,20 @@ export function ScoreEntryView({
           onConfirm={confirmAdvance}
         />
       ) : allComplete ? (
-        <BottomCTA label="Finish" icon onClick={() => onFinish?.()} subtext="Saves results · shows final standings" />
+        <BottomCTA
+          label="Finish"
+          icon
+          onClick={() => onFinish?.()}
+          disabled={gameGate.total > 0}
+          subtext={finishReason ?? "Saves results · shows final standings"}
+        />
       ) : currentComplete && hole < units.length ? (
-        <BottomCTA label={`Hole ${units[hole]?.label ?? hole + 1} ›`} onClick={() => goHole(hole + 1)} />
+        <BottomCTA
+          label={`Hole ${units[hole]?.label ?? hole + 1} ›`}
+          onClick={() => goHole(hole + 1)}
+          disabled={holeGate.blocked}
+          subtext={advanceReason}
+        />
       ) : null}
     </div>
   );

--- a/src/components/games/entryChrome.tsx
+++ b/src/components/games/entryChrome.tsx
@@ -90,11 +90,15 @@ export function BottomCTA({
   onClick,
   subtext,
   icon,
+  disabled,
 }: {
   label: string;
   onClick: () => void;
   subtext?: string;
   icon?: boolean;
+  /** Spec 1a — honest advance: the CTA is held (dimmed, non-interactive) while
+   *  the current hole's scores aren't CONFIRMED saved. `subtext` names the reason. */
+  disabled?: boolean;
 }) {
   return (
     <div
@@ -105,18 +109,20 @@ export function BottomCTA({
       }}
     >
       <button
-        onClick={onClick}
-        className="flex w-full items-center justify-center gap-2 transition-transform active:scale-[0.98]"
+        onClick={disabled ? undefined : onClick}
+        disabled={disabled}
+        className="flex w-full items-center justify-center gap-2 transition-transform active:scale-[0.98] disabled:cursor-default"
         style={{
           height: 54,
           borderRadius: 12,
-          background: "var(--color-bt-accent)",
-          color: "#0d1f1a",
+          background: disabled ? "var(--color-bt-card-raised)" : "var(--color-bt-accent)",
+          color: disabled ? "var(--color-bt-text-dim)" : "#0d1f1a",
           fontSize: 17,
           fontWeight: 600,
+          opacity: disabled ? 0.75 : 1,
         }}
       >
-        {icon && <Check size={20} strokeWidth={2.2} />}
+        {icon && !disabled && <Check size={20} strokeWidth={2.2} />}
         {label}
       </button>
       {subtext && (

--- a/src/components/games/scoreGate.test.ts
+++ b/src/components/games/scoreGate.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { unconfirmedOnHole, unconfirmedCount, scoreCellKey, type SaveStatusMap } from "./types";
+
+/**
+ * Confirmation-gate helpers (Spec 1a — honest advance). The rule: advance/finish
+ * is blocked only by `saving`/`error` cells; a cell with NO status entry is a
+ * server-loaded / already-confirmed value and must NOT block (the resume-seed
+ * case — server scores are seeded without a status).
+ */
+
+const key = scoreCellKey;
+
+describe("unconfirmedOnHole", () => {
+  const pids = ["a", "b", "c"];
+
+  it("not blocked when all current-hole cells are saved or have no status", () => {
+    const s: SaveStatusMap = { [key("a", "3")]: "saved" }; // b, c server-loaded (no status)
+    expect(unconfirmedOnHole(s, pids, "3")).toEqual({ blocked: false, saving: 0, errored: 0 });
+  });
+
+  it("blocked while a cell is still saving", () => {
+    const s: SaveStatusMap = { [key("a", "3")]: "saved", [key("b", "3")]: "saving" };
+    expect(unconfirmedOnHole(s, pids, "3")).toEqual({ blocked: true, saving: 1, errored: 0 });
+  });
+
+  it("blocked when a cell errored", () => {
+    const s: SaveStatusMap = { [key("a", "3")]: "error" };
+    expect(unconfirmedOnHole(s, pids, "3")).toEqual({ blocked: true, saving: 0, errored: 1 });
+  });
+
+  it("only considers the given hole (a saving cell on another hole doesn't block)", () => {
+    const s: SaveStatusMap = { [key("a", "4")]: "saving" };
+    expect(unconfirmedOnHole(s, pids, "3").blocked).toBe(false);
+  });
+
+  it("empty status → not blocked (nothing entered this session / all server-loaded)", () => {
+    expect(unconfirmedOnHole({}, pids, "3").blocked).toBe(false);
+  });
+});
+
+describe("unconfirmedCount (pre-Finish gate)", () => {
+  it("counts saving + errored across the whole game", () => {
+    const s: SaveStatusMap = {
+      [key("a", "1")]: "saved",
+      [key("b", "1")]: "saving",
+      [key("a", "2")]: "error",
+      [key("b", "2")]: "error",
+    };
+    expect(unconfirmedCount(s)).toEqual({ saving: 1, errored: 2, total: 3 });
+  });
+
+  it("all saved / empty → nothing blocks finish", () => {
+    expect(unconfirmedCount({}).total).toBe(0);
+    expect(unconfirmedCount({ [key("a", "1")]: "saved" }).total).toBe(0);
+  });
+});

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -64,3 +64,45 @@ export function parseScoreCellKey(key: string): {
   const i = key.indexOf(":");
   return { participantId: key.slice(0, i), unitLabel: key.slice(i + 1) };
 }
+
+/**
+ * Confirmation gate (Spec 1a — honest advance). A hole is safe to advance/finish
+ * PAST only when none of its cells is mid-save (`saving`) or failed (`error`) —
+ * i.e. every entered value is CONFIRMED on the server, not merely optimistic in
+ * local state. A cell with NO status entry is a server-loaded / already-confirmed
+ * value (seeded via `setValues` without a status), so it does NOT block — only
+ * `saving` and `error` block. Pure + unit-tested; both entry views gate on it.
+ */
+export function unconfirmedOnHole(
+  saveStatus: SaveStatusMap,
+  participantIds: string[],
+  unitLabel: string,
+): { blocked: boolean; saving: number; errored: number } {
+  let saving = 0;
+  let errored = 0;
+  for (const pid of participantIds) {
+    const s = saveStatus[scoreCellKey(pid, unitLabel)];
+    if (s === "saving") saving++;
+    else if (s === "error") errored++;
+  }
+  return { blocked: saving > 0 || errored > 0, saving, errored };
+}
+
+/**
+ * Game-wide unconfirmed tally (Spec 1a) — the pre-Finish gate. `finish` computes
+ * results from server `score_entries`, so ANY cell still `saving`/`error` would be
+ * silently omitted from standings — block Finish until all are confirmed.
+ */
+export function unconfirmedCount(saveStatus: SaveStatusMap): {
+  saving: number;
+  errored: number;
+  total: number;
+} {
+  let saving = 0;
+  let errored = 0;
+  for (const s of Object.values(saveStatus)) {
+    if (s === "saving") saving++;
+    else if (s === "error") errored++;
+  }
+  return { saving, errored, total: saving + errored };
+}

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -177,9 +177,15 @@ export function useScoreSaver(
     if (!tripId || !gameId) return;
     if (recoveredForGame.current === gameId) return;
     recoveredForGame.current = gameId;
-    for (const e of outboxEntries(gameId)) {
-      onChange(e.participantId, e.unitLabel, e.value);
-    }
+    const pending = outboxEntries(gameId);
+    if (pending.length === 0) return;
+    // Defer the re-send out of the effect body (each onChange setStates; a
+    // microtask keeps it off the synchronous effect path). One tick's delay is
+    // immaterial for recovering already-unconfirmed writes.
+    const t = setTimeout(() => {
+      for (const e of pending) onChange(e.participantId, e.unitLabel, e.value);
+    }, 0);
+    return () => clearTimeout(t);
   }, [tripId, gameId, onChange]);
 
   const errorCount = Object.values(saveStatus).filter(

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { trpc } from "@/lib/trpc-client";
 import { outboxPut, outboxClear, outboxEntries } from "@/lib/scoreOutbox";
+import { showToast } from "@/lib/toast";
 import {
   scoreCellKey,
   type CellSaveState,
@@ -184,6 +185,11 @@ export function useScoreSaver(
     // immaterial for recovering already-unconfirmed writes.
     const t = setTimeout(() => {
       for (const e of pending) onChange(e.participantId, e.unitLabel, e.value);
+      // Honest UI: tell the user their scores survived and are being re-sent.
+      showToast(
+        `Recovered ${pending.length} unsaved score${pending.length > 1 ? "s" : ""} — retrying`,
+        "info",
+      );
     }, 0);
     return () => clearTimeout(t);
   }, [tripId, gameId, onChange]);

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { trpc } from "@/lib/trpc-client";
+import { outboxPut, outboxClear, outboxEntries } from "@/lib/scoreOutbox";
 import {
   scoreCellKey,
   type CellSaveState,
@@ -34,9 +35,13 @@ import {
  * agnostic scorecard components — they receive `values` + `saveStatus` as props
  * and emit through `onChange`/`onClear`/`onRetryCell`.
  *
- * This is Layer 1 (visibility + retry). It deliberately does NOT persist the
- * mutation across an app-kill or flush a queue on reconnect — that is Layer 2
- * (the persisted write-queue), a separate follow-on.
+ * Layer 2 (Spec 1a — durability): every entry is ALSO written to a small
+ * localStorage `scoreOutbox` (keyed by the SAME idempotent id) BEFORE the write
+ * settles, and cleared ONLY when the server confirms it (`saved`). So a nav /
+ * reload / app-kill between "typed" and "confirmed" can't drop the score: on the
+ * next mount `outboxEntries` is re-sent through this same idempotent path and
+ * reflected in the UI as recovering. Scores only, cleared-on-confirm — not a
+ * long-running offline queue.
  */
 
 const MAX_RETRIES = 4;
@@ -89,6 +94,9 @@ export function useScoreSaver(
         [participantId]: { ...(v[participantId] ?? {}), [unitLabel]: value },
       }));
       mark(key, "saving");
+      // Layer 2: persist to the durable outbox BEFORE the write settles, so a
+      // nav/reload/kill in the gap can't lose it. Cleared on confirmation below.
+      outboxPut(gameId, participantId, unitLabel, value);
       // mutateAsync — NOT mutate. Concurrent saves share ONE mutation observer,
       // and the inline mutate() callbacks fire only for the observer's CURRENT
       // (latest) mutation: a rapid foursome left every cell but the last
@@ -100,8 +108,13 @@ export function useScoreSaver(
       // STATUS only.
       upsertEntry
         .mutateAsync({ tripId, gameId, participantId, unitLabel, value, participantType })
-        .then(() => mark(key, "saved"))
-        // KEEP the optimistic value on failure — flag it, never roll back.
+        // Confirmed on the server → safe to drop the durable copy.
+        .then(() => {
+          mark(key, "saved");
+          outboxClear(gameId, participantId, unitLabel);
+        })
+        // KEEP the optimistic value AND the outbox entry on failure — flag it,
+        // never roll back; the outbox re-sends it on the next mount.
         .catch(() => mark(key, "error"));
     },
     [tripId, gameId, upsertEntry, mark, participantType],
@@ -119,6 +132,8 @@ export function useScoreSaver(
         return { ...v, [participantId]: row };
       });
       mark(key, null);
+      // A cleared cell has no pending upsert to recover — drop any outbox entry.
+      outboxClear(gameId, participantId, unitLabel);
       // mutateAsync per call (see onChange): concurrent clears must each resolve
       // their own outcome, never be orphaned by a later one on the shared observer.
       deleteEntry
@@ -150,6 +165,22 @@ export function useScoreSaver(
     },
     [values, onChange],
   );
+
+  // Recover-on-mount (Layer 2): any entries still in the outbox are unconfirmed
+  // (a prior nav/reload/kill left them un-acked). Re-send each through the same
+  // idempotent path — which re-marks it `saving`, re-optimistically shows the
+  // value, and clears the outbox on confirmation. Runs ONCE per game (the ref
+  // guards against re-runs when onChange's identity churns). This is what makes a
+  // dropped-on-the-course score come BACK on return instead of vanishing.
+  const recoveredForGame = useRef<string | null>(null);
+  useEffect(() => {
+    if (!tripId || !gameId) return;
+    if (recoveredForGame.current === gameId) return;
+    recoveredForGame.current = gameId;
+    for (const e of outboxEntries(gameId)) {
+      onChange(e.participantId, e.unitLabel, e.value);
+    }
+  }, [tripId, gameId, onChange]);
 
   const errorCount = Object.values(saveStatus).filter(
     (s) => s === "error",

--- a/src/lib/scoreOutbox.test.ts
+++ b/src/lib/scoreOutbox.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  putIn,
+  clearIn,
+  entriesOf,
+  outboxPut,
+  outboxClear,
+  outboxEntries,
+  type OutboxMap,
+} from "./scoreOutbox";
+
+/**
+ * scoreOutbox (Spec 1a — durable WAL). Pure map ops are tested directly; the
+ * localStorage wrappers are tested against an in-memory localStorage polyfill so
+ * persist → read → clear round-trips and the per-game namespacing hold.
+ */
+
+describe("scoreOutbox — pure map ops", () => {
+  it("putIn adds a keyed entry (idempotent id gameId-agnostic key = pid:unit)", () => {
+    const m = putIn({}, "p1", "3", 4);
+    expect(m).toEqual({ "p1:3": 4 });
+  });
+
+  it("putIn overwrites the same cell (last-write-wins)", () => {
+    let m: OutboxMap = putIn({}, "p1", "3", 4);
+    m = putIn(m, "p1", "3", 5);
+    expect(m).toEqual({ "p1:3": 5 });
+  });
+
+  it("clearIn removes only the target cell; no-ops when absent", () => {
+    const m = { "p1:3": 4, "p2:3": 5 };
+    expect(clearIn(m, "p1", "3")).toEqual({ "p2:3": 5 });
+    expect(clearIn(m, "pX", "9")).toBe(m); // unchanged reference when absent
+  });
+
+  it("entriesOf round-trips keys back to {participantId, unitLabel, value}", () => {
+    const m = { "p1:3": 4, "p2:12": 6 };
+    expect(entriesOf(m).sort((a, b) => a.participantId.localeCompare(b.participantId))).toEqual([
+      { participantId: "p1", unitLabel: "3", value: 4 },
+      { participantId: "p2", unitLabel: "12", value: 6 },
+    ]);
+  });
+});
+
+describe("scoreOutbox — localStorage wrappers", () => {
+  beforeEach(() => {
+    // Minimal in-memory localStorage polyfill for the node test env.
+    const store = new Map<string, string>();
+    (globalThis as unknown as { window: unknown; localStorage: unknown }).window = globalThis;
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } as Storage;
+  });
+
+  it("persist → read an unconfirmed score", () => {
+    outboxPut("g1", "p1", "3", 4);
+    expect(outboxEntries("g1")).toEqual([{ participantId: "p1", unitLabel: "3", value: 4 }]);
+  });
+
+  it("clear-on-confirm removes the entry; emptied game clears its key", () => {
+    outboxPut("g1", "p1", "3", 4);
+    outboxClear("g1", "p1", "3");
+    expect(outboxEntries("g1")).toEqual([]);
+  });
+
+  it("is per-game namespaced (one game's outbox never leaks into another)", () => {
+    outboxPut("g1", "p1", "3", 4);
+    outboxPut("g2", "p9", "1", 7);
+    expect(outboxEntries("g1")).toEqual([{ participantId: "p1", unitLabel: "3", value: 4 }]);
+    expect(outboxEntries("g2")).toEqual([{ participantId: "p9", unitLabel: "1", value: 7 }]);
+  });
+
+  it("survives a simulated reload (same backing store, fresh reads)", () => {
+    outboxPut("g1", "p1", "3", 4);
+    outboxPut("g1", "p2", "3", 5);
+    // A 'reload' is just another read of the same store.
+    expect(outboxEntries("g1")).toHaveLength(2);
+  });
+});

--- a/src/lib/scoreOutbox.ts
+++ b/src/lib/scoreOutbox.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { scoreCellKey, parseScoreCellKey } from "@/components/games/types";
+
+/**
+ * scoreOutbox — a tiny write-ahead log for score entries (Spec 1a, the missing
+ * "Layer 2"). DURABILITY, not offline-first: it covers only the gap between "the
+ * score was typed" and "the server confirmed the write", so a nav / reload /
+ * app-kill on poor signal can't silently drop an unconfirmed score.
+ *
+ * Shape: localStorage, one entry-map per game (namespaced key), entries keyed by
+ * the SAME idempotent `scoreCellKey(participantId, unitLabel)` the saver + server
+ * upsert already use — one id scheme, one home. An entry is written on score
+ * entry and cleared ONLY when the server CONFIRMS that write (`saved`); on failure
+ * it stays, so on the next mount it's re-sent (idempotent upsert → safe). If the
+ * same cell is re-entered before confirmation the map holds the latest value
+ * (last-write-wins locally, matching the idempotent upsert). Scores only,
+ * cleared-on-confirm — no sync engine, no conflict resolution, no long-running
+ * queue.
+ *
+ * The map operations are pure (testable without a DOM); the localStorage wrappers
+ * are thin and best-effort (a disabled/full store degrades to no-op, never throws
+ * into the score path).
+ */
+
+/** { [scoreCellKey]: value } — the persisted unconfirmed writes for one game. */
+export type OutboxMap = Record<string, number>;
+export interface OutboxEntry {
+  participantId: string;
+  unitLabel: string;
+  value: number;
+}
+
+// ── Pure map ops (unit-tested) ───────────────────────────────────────────────
+export function putIn(map: OutboxMap, participantId: string, unitLabel: string, value: number): OutboxMap {
+  return { ...map, [scoreCellKey(participantId, unitLabel)]: value };
+}
+export function clearIn(map: OutboxMap, participantId: string, unitLabel: string): OutboxMap {
+  const key = scoreCellKey(participantId, unitLabel);
+  if (!(key in map)) return map;
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+export function entriesOf(map: OutboxMap): OutboxEntry[] {
+  return Object.entries(map).map(([key, value]) => ({ ...parseScoreCellKey(key), value }));
+}
+
+// ── localStorage wrappers (best-effort, SSR-safe) ────────────────────────────
+const NS = "bt.scoreOutbox.v1";
+const storeKey = (gameId: string) => `${NS}:${gameId}`;
+
+function read(gameId: string): OutboxMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(storeKey(gameId));
+    return raw ? (JSON.parse(raw) as OutboxMap) : {};
+  } catch {
+    return {};
+  }
+}
+function write(gameId: string, map: OutboxMap): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (Object.keys(map).length === 0) window.localStorage.removeItem(storeKey(gameId));
+    else window.localStorage.setItem(storeKey(gameId), JSON.stringify(map));
+  } catch {
+    /* quota exceeded / storage disabled — best-effort; never throw into scoring. */
+  }
+}
+
+/** Persist an unconfirmed score (on entry). */
+export function outboxPut(gameId: string, participantId: string, unitLabel: string, value: number): void {
+  write(gameId, putIn(read(gameId), participantId, unitLabel, value));
+}
+/** Remove a score from the outbox (on server confirmation, or on clear). */
+export function outboxClear(gameId: string, participantId: string, unitLabel: string): void {
+  write(gameId, clearIn(read(gameId), participantId, unitLabel));
+}
+/** All still-unconfirmed scores for a game (read on mount → re-send + reflect). */
+export function outboxEntries(gameId: string): OutboxEntry[] {
+  return entriesOf(read(gameId));
+}


### PR DESCRIPTION
The correctness fix from the data-layer diagnosis: **stop silently losing scores at the event.** Durability + honesty (NOT offline-first). Ships alone; no navigation/panels (Spec 2) or invalidation cleanup (Spec 1b).

## The bug (confirmed mechanism)
The save layer (`useScoreSaver`) was fine (idempotent upsert, retry, keeps value + flags error). The loss came from around it:
1. **Advance/Finish gated on local completeness, not confirmation** — an optimistic value looked entered, so "Hole N ›"/Finish fired even if the write failed.
2. Failure signal was only a passive banner.
3. **Unconfirmed values lived only in component state** — nav/reload/app-kill dropped them (`useScoreSaver`'s "Layer 2" was never built).
4. **Finish computes from server `score_entries`** — unwritten rows silently omitted from standings.
   Plus: **rack was worst** — a raw fire-and-forget `upsertEntry.mutate()` with no retry, no error handling, no status (fully silent).

## The fix (per-task commits)
- **Durable outbox (`scoreOutbox.ts`, the missing Layer 2):** a small localStorage write-ahead log, per-game, keyed by the existing `scoreCellKey` (one id scheme). Persisted on entry, **cleared only on server confirmation**, **recovered + re-sent on mount** (idempotent). Covers the "typed → confirmed" gap so nav/reload/app-kill can't drop a score. Wired into `useScoreSaver`.
- **Confirmation-gated advance/finish:** pure `unconfirmedOnHole` / `unconfirmedCount` helpers; the "Hole N ›"/Finish CTAs are held (dimmed + a reason: "Saving scores…" / "N didn't save — retry above") while any current-hole cell is `saving`/`error`, and `handleFinish` (stroke/match/rack) blocks on any game-wide unconfirmed cell with a toast. Never finalize from partial server state.
- **Rack migrated onto `useScoreSaver`** — gains retry + outbox + per-cell badges + the banner + the gate (was none). `values` seeded once from server (mirrors stroke).
- **Honest UI:** advance-blocked reason + a recovery toast ("Recovered N unsaved scores — retrying") on return-from-outbox.
- The saver's good parts (idempotent upsert, retry, no-rollback) are unchanged — everything is added around them.

## Verify
- ✅ **Unit tests (15):** `scoreOutbox` (put/clear/recover, per-game namespacing, reload) + the gate helpers (server-loaded cells don't block; only saving/error do).
- ✅ **Vitest full:** 890 passed (0 failures).
- ✅ **Playwright 3/3** (setup + critical-path + match-play) — the gate does NOT regress normal advance/finish (Playwright auto-waits for the CTA to enable once saved).
- ✅ **Browser failure-path (real game, safe):** patched `fetch` to fail the upsert, entered a score → the failed score **persisted to the localStorage outbox**, the **"1 score didn't save · Retry" banner** showed, the value was retained. The patched upsert never reached the server (verified: no `score_entries` leaked), and I cleared the test outbox + restored fetch — the real game is intact.
- ✅ tsc + lint clean.

**Coverage note:** the disabled-advance-CTA and outbox-recovery-on-reload paths are unit-tested + code-wired; the full on-course poor-signal round is the natural human final check. All four entry surfaces (stroke/match/rack + the non-golf placement post — which is a single mutation, not hole-advance) are accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)