### PR TITLE
Fix the pre-existing tripStatus date-flake (freeze the clock)

### DIFF
--- a/src/lib/tripStatus.test.ts
+++ b/src/lib/tripStatus.test.ts
@@ -1,14 +1,36 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { getEffectiveStatus, countdownLabel } from "./tripStatus";
 
-// Helper: ISO date string N days from today.
+/**
+ * Pin "today" to a fixed LOCAL-noon instant so the countdown/status math is
+ * deterministic regardless of when — or in which timezone — the suite runs.
+ * Without this freeze these tests flake: `dayOffset` builds its fixtures from
+ * the UTC calendar date (`toISOString`) while the code-under-test derives
+ * "today" from the LOCAL calendar date (`new Date()` + `setHours(0,0,0,0)` and
+ * `parseLocalDate`'s noon-local parsing). Late in the day in a western timezone
+ * the two disagree by a day, flipping "Tomorrow" → "2 days to go" and crossing
+ * the 3-day now/upcoming boundary. Freezing at local noon keeps the UTC and
+ * local calendar dates aligned (mirrors tripCountdown.test.ts).
+ */
+const FIXED_TODAY = new Date(2026, 3, 26, 12, 0, 0); // April 26, 2026, local noon (month 0-indexed)
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_TODAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Helper: ISO date string N days from the (frozen) today.
 function dayOffset(days: number): string {
   const d = new Date();
   d.setDate(d.getDate() + days);
   return d.toISOString().split("T")[0];
 }
 
-const LOCKED = new Date().toISOString();
+const LOCKED = new Date(2026, 3, 26, 12, 0, 0).toISOString();
 
 describe("getEffectiveStatus", () => {
   it("returns 'idea' when no destination is locked", () => {


### PR DESCRIPTION
## What & why

The `tripStatus` countdown/status boundary tests have flaked all session — the recurring **~3 failures** (`countdownLabel` "Tomorrow" / "2 days to go", and the 3-day now/upcoming boundary) that get correctly isolated as "not a real regression" on nearly every PR. This makes them deterministic so the mental-filtering tax goes away.

## Phase 0 — root cause

The test helper `dayOffset(n)` builds fixtures from the **UTC** calendar date:
```ts
const d = new Date(); d.setDate(d.getDate() + days); return d.toISOString().split("T")[0];
```
…but the code-under-test (`getEffectiveStatus` / `countdownLabel`) derives "today" from the **LOCAL** calendar date (`new Date()` + `setHours(0,0,0,0)`, and `parseLocalDate` parsing `YYYY-MM-DD` as **noon local**). Late in the day in a western timezone (e.g. 20:00 US-Pacific = 03:00 UTC next day), the UTC date is a day ahead of the local date, so `dayOffset(1)` lands two local days out → `"Tomorrow"` reads as `"2 days to go"`, and the 3-day boundary crosses. It's **time-of-day × timezone** dependent, not a code bug — the app is correct.

Proven against the real module at a hostile frozen instant (`2026-07-07T03:00:00Z`, US-Pacific): pre-fix `countdownLabel(...)` returns `"2 days to go"` where the test expects `"Tomorrow"`.

**News:** investigated and **not** in the same root class — the news test orders on *fixed seeded* timestamps; its one timing-sensitive assertion (`unreadCount` bump) depends on DB `now()` vs app markRead ordering, which a JS clock freeze doesn't touch (and it passes reliably). Left untouched per "don't broaden scope."

## Fix (tests only — no app-logic change)

Freeze the clock at a fixed **local-noon** instant with `vi.useFakeTimers()` / `vi.setSystemTime()`, restored in `afterEach` — mirroring the already-stable `tripCountdown.test.ts`. Local-noon keeps the UTC and local calendar dates aligned, so it's timezone-robust. `LOCKED` becomes a fixed literal so it no longer reads the wall clock at module load.

## Verification

- Deterministic **PASS across 7 timezones** (UTC-11 → UTC+14), twice each.
- Pre-fix flake reproduced against the real module; post-fix stable at the same instant.
- Fake timers restored in teardown — **no leakage**: full suite **890/890 green**.
- `tsc --noEmit` clean, `eslint` clean. Playwright unaffected (unit-test hygiene).