### PR TITLE
Competition-face cleanup: avatar, short-name nav, hero-peek, rack structure (Tasks 2–5)

### DIFF
--- a/src/app/trips/[tripId]/page.tsx
+++ b/src/app/trips/[tripId]/page.tsx
@@ -543,7 +543,13 @@ function TripDetailBody({ tripId }: { tripId: string }) {
           (option A — the competition is visible to the whole crew once created;
           per-game Setup/Scoring handles game-level readiness). The old status
           gate (visible only once "active") was retired with the GO LIVE control. */}
-      {competition && <TripBottomNav tripId={tripId} showComp={true} />}
+      {competition && (
+        <TripBottomNav
+          tripId={tripId}
+          showComp={true}
+          liveLabel={competition.short_name ?? competition.name ?? null}
+        />
+      )}
 
       {/* ── Settings modal ────────────────────────────────────────────────── */}
       {showSettings && role && (

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -108,12 +108,17 @@ interface TripBottomNavProps {
   tripId: string;
   eventId?: string | null;
   showComp?: boolean;
+  /** Label for the competition tab. The competition's short_name when set,
+   *  else its full name (which truncates — the nudge to set a short one).
+   *  Falls back to "Live" when no competition label is available. */
+  liveLabel?: string | null;
 }
 
 export const TripBottomNav: FC<TripBottomNavProps> = ({
   tripId,
   eventId,
   showComp,
+  liveLabel,
 }) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -123,7 +128,7 @@ export const TripBottomNav: FC<TripBottomNavProps> = ({
     { id: "trip-home", label: "Trip Home", Icon: Home, href: `/trips/${tripId}` },
     {
       id: "live",
-      label: "Live",
+      label: liveLabel?.trim() || "Live",
       Icon: Activity,
       href: `/trips/${tripId}/leaderboard`,
       hidden: showComp !== undefined ? !showComp : !eventId,
@@ -171,11 +176,11 @@ export const TripBottomNav: FC<TripBottomNavProps> = ({
               if (goingToTripHome) router.replace(href);
               else router.push(href);
             }}
-            className="relative flex flex-1 flex-col items-center justify-center gap-1 py-2 transition-colors"
+            className="relative flex min-w-0 flex-1 flex-col items-center justify-center gap-1 py-2 transition-colors"
             style={{ color: active ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)" }}
           >
             <Icon size={22} />
-            <span className="text-[10px] font-medium">{label}</span>
+            <span className="max-w-full truncate px-1 text-[10px] font-medium">{label}</span>
             {badge != null && badge > 0 && (
               <span
                 className="absolute right-1/4 top-1 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white"

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -53,6 +53,10 @@ interface TopNavProps {
   /** Hide the News tool (e.g. on the profile page, where the global
    *  broadcast surface isn't relevant). */
   hideNews?: boolean;
+  /** In competition context, the current user's TEAM color — passed to the
+   *  account avatar so it reads in the user's team identity instead of teal.
+   *  Undefined off competition pages (avatar stays teal). */
+  avatarTeamColor?: string | null;
 }
 
 // Minimal shape we read off trips.list for the breadcrumb.
@@ -73,6 +77,7 @@ export const TopNav: FC<TopNavProps> = ({
   onDismissPanels,
   hideTripSwitcher = false,
   hideNews = false,
+  avatarTeamColor,
 }) => {
   const router = useRouter();
   const params = useParams<{ tripId?: string }>();
@@ -287,6 +292,7 @@ export const TopNav: FC<TopNavProps> = ({
         <UserMenu
           onOpen={onDismissPanels}
           onOpenFeedback={() => setFeedbackOpen(true)}
+          teamColor={avatarTeamColor}
         />
       </div>
 

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -34,9 +34,14 @@ interface UserMenuProps {
   /** Fired when the account menu opens. The page uses it to close the
    *  News/Chat rail so the dropdown isn't trapped behind the mobile sheet. */
   onOpen?: () => void;
+  /** In competition context, the current user's TEAM color — paints the
+   *  avatar in their team identity (green = Manhattans, etc.) instead of the
+   *  default teal. Null/undefined (no team, or off a competition page) falls
+   *  back to the teal accent avatar. */
+  teamColor?: string | null;
 }
 
-export function UserMenu({ onOpenFeedback, onOpen }: UserMenuProps = {}) {
+export function UserMenu({ onOpenFeedback, onOpen, teamColor }: UserMenuProps = {}) {
   const { data: me } = trpc.users.getMe.useQuery();
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -121,6 +126,9 @@ export function UserMenu({ onOpenFeedback, onOpen }: UserMenuProps = {}) {
           name={me?.name ?? me?.email ?? "?"}
           avatarIcon={me?.avatar_icon ?? null}
           sizePx={32}
+          // teamColor wins over accent inside Avatar (competition mode); when
+          // absent, the avatar stays the default teal accent.
+          teamColor={teamColor ?? undefined}
           accent
         />
       </button>

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -251,18 +251,34 @@ export function StickyCollapseHero({
   ...hero
 }: React.ComponentProps<typeof CompetitionHero> & { stickyTop?: number }) {
   const collapsedRef = useRef<HTMLDivElement>(null);
-  const [collapsedH, setCollapsedH] = useState(64); // sensible seed → no first-paint jump
-  // Measure BEFORE paint (layout effect on the client) so the overlap uses the real
-  // height on the very first frame — a post-paint measure left the expanded hero
-  // pulled up by the stale seed, so it didn't fully cover the collapsed bar and its
-  // top edge PEEKED above the hero. SSR-safe: falls back to useEffect on the server.
+  const expandedRef = useRef<HTMLDivElement>(null);
+  const [pull, setPull] = useState(64); // sensible seed → no first-paint jump
+  // Pull the expanded hero UP over the pinned collapsed bar. The earlier version
+  // pulled by exactly the collapsed bar's own height (`-(collapsedH + 1)`) on the
+  // assumption the two fragment nodes are flush — but they render into the
+  // leaderboard's spacing column, which inserts ~12px of vertical rhythm between
+  // them, so the pull fell short and the collapsed bar PEEKED ~11px above the hero
+  // at rest. Instead of guessing that offset, MEASURE the rendered gap between the
+  // hero's top and the collapsed bar's top and close it — robust to whatever
+  // ambient spacing sits between them, and to the taller N-team bar. Converges in
+  // one step (moving the margin by X moves the hero's top by X) to a 1px
+  // over-cover (no peek), and re-corrects if the collapsed bar's height changes
+  // (ResizeObserver). Layout effect on the client so the correction lands before
+  // paint; SSR-safe (useEffect fallback).
   useIsoLayoutEffect(() => {
-    const el = collapsedRef.current;
-    if (!el) return;
-    const measure = () => setCollapsedH(el.offsetHeight);
+    const c = collapsedRef.current;
+    const e = expandedRef.current;
+    if (!c || !e) return;
+    const measure = () => {
+      // gap > 0 → the collapsed bar's top peeks above the hero; target a 1px
+      // over-cover (gap = -1) so sub-pixel rounding never leaves a sliver.
+      const gap = e.getBoundingClientRect().top - c.getBoundingClientRect().top;
+      if (Math.abs(gap + 1) > 1) setPull((p) => p + gap + 1);
+    };
     measure();
     const ro = new ResizeObserver(measure);
-    ro.observe(el);
+    ro.observe(c);
+    ro.observe(e);
     return () => ro.disconnect();
   }, []);
   return (
@@ -270,10 +286,7 @@ export function StickyCollapseHero({
       <div ref={collapsedRef} style={{ position: "sticky", top: stickyTop, zIndex: 10 }}>
         <CompetitionHero {...hero} variant="collapsed" />
       </div>
-      {/* +1px so the expanded hero always fully covers the collapsed bar's top edge
-          (defeats sub-pixel/border rounding) — no peek. The over-pull is on a ~180px
-          hero, so it's imperceptible. */}
-      <div style={{ position: "relative", zIndex: 20, marginTop: -(collapsedH + 1) }}>
+      <div ref={expandedRef} style={{ position: "relative", zIndex: 20, marginTop: -pull }}>
         <CompetitionHero {...hero} variant="expanded" />
       </div>
     </>

--- a/src/components/competition/CompetitionSettings.tsx
+++ b/src/components/competition/CompetitionSettings.tsx
@@ -8,6 +8,8 @@ import { SectionLabel, DangerRow, DangerConfirmModal } from "@/components/Danger
 interface Competition {
   id: string;
   name: string;
+  /** Short label for the bottom-nav tab; falls back to `name` when unset. */
+  short_name?: string | null;
   tagline: string | null;
   /** Frozen at creation (the shape chooser). Shown read-only here. */
   scoring_model?: "match_play" | "points";
@@ -155,6 +157,7 @@ function DetailsSection({
 }) {
   const utils = trpc.useUtils();
   const [name, setName] = useState(competition.name);
+  const [shortName, setShortName] = useState(competition.short_name ?? "");
   const [tagline, setTagline] = useState(competition.tagline ?? "");
   const [error, setError] = useState<string | null>(null);
   // Transient "Saved" flash after a successful auto-save.
@@ -170,6 +173,7 @@ function DetailsSection({
         utils.competitions.getByTrip.setData({ tripId }, {
           ...previous,
           name: vars.name ?? previous.name,
+          short_name: vars.shortName !== undefined ? vars.shortName : previous.short_name,
           tagline: vars.tagline ?? previous.tagline,
         });
       }
@@ -207,6 +211,14 @@ function DetailsSection({
     setError(null);
     updateComp.mutate({ tripId, competitionId: competition.id, name: trimmed });
   };
+  const commitShortName = () => {
+    if (!canEdit) return;
+    const trimmed = shortName.trim();
+    if (trimmed === (competition.short_name ?? "")) return;
+    setError(null);
+    // Empty clears it (→ null) so the nav falls back to the full name.
+    updateComp.mutate({ tripId, competitionId: competition.id, shortName: trimmed || null });
+  };
   const commitTagline = () => {
     if (!canEdit) return;
     const trimmed = tagline.trim();
@@ -240,6 +252,26 @@ function DetailsSection({
             style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", opacity: canEdit ? 1 : 0.7 }}
             data-testid="comp-settings-name"
           />
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+            Short name <span className="normal-case font-normal">shown in the bottom navigation bar</span>
+          </label>
+          <input
+            value={shortName}
+            onChange={(e) => { setShortName(e.target.value); if (error) setError(null); }}
+            onBlur={commitShortName}
+            readOnly={!canEdit}
+            placeholder="e.g. BBMI — keep it short to fit the nav tab"
+            maxLength={40}
+            className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+            style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)", opacity: canEdit ? 1 : 0.7 }}
+            data-testid="comp-settings-short-name"
+          />
+          <p className="mt-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+            The full name won&apos;t fit the &ldquo;Live&rdquo; tab — set a short label here. Leave blank to fall back to the full name.
+          </p>
         </div>
 
         <div>

--- a/src/components/competition/LiveFaceClient.tsx
+++ b/src/components/competition/LiveFaceClient.tsx
@@ -105,6 +105,22 @@ export function LiveFaceClient({
   const competition = boot?.competition ?? null;
   // Competition role (owner / co_admin / member), live-derived server-side.
   const role = boot?.myCompetitionRole ?? null;
+
+  // The current user's TEAM color, for the app-bar avatar (Task 2 — reinforces
+  // team identity in competition context). Resolved from the same faceBootstrap
+  // snapshot the board uses: my assignment → team → color. Undefined when I'm
+  // teamless/unresolvable → the avatar falls back to the teal accent.
+  const { data: me } = trpc.users.getMe.useQuery();
+  const myTeamColor = useMemo(() => {
+    if (!boot || !me) return null;
+    const myTeamId = (boot.assignments as { user_id: string; team_id: string }[] | undefined)
+      ?.find((a) => a.user_id === me.id)?.team_id;
+    if (!myTeamId) return null;
+    return (
+      (boot.teams as { id: string; color: string | null }[] | undefined)
+        ?.find((t) => t.id === myTeamId)?.color ?? null
+    );
+  }, [boot, me]);
   const canEdit = role === "owner" || role === "co_admin";
   const isOwner = role === "owner";
   // Seed the child caches from the one bootstrap so the board/guide — and the
@@ -205,6 +221,7 @@ export function LiveFaceClient({
         chatOpen={chatOpen}
         onOpenNews={openNews}
         newsOpen={newsOpen}
+        avatarTeamColor={myTeamColor}
         onDismissPanels={() => {
           setChatOpen(false);
           setNewsOpen(false);

--- a/src/components/competition/LiveFaceClient.tsx
+++ b/src/components/competition/LiveFaceClient.tsx
@@ -215,7 +215,11 @@ export function LiveFaceClient({
 
       {/* Bottom nav persists on the face so you can always cross back to the
           trip (§11). Live is the current destination. */}
-      <TripBottomNav tripId={tripId} showComp={true} />
+      <TripBottomNav
+        tripId={tripId}
+        showComp={true}
+        liveLabel={competition?.short_name ?? competition?.name ?? null}
+      />
 
       {/* Chat / News overlay any surface (§11). */}
       <FloatingChatPanel

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -101,12 +101,15 @@ export function RackBoard({
   const colorOf = (t: "A" | "B") => (t === "A" ? teamA.color : teamB.color);
   return (
     <div style={{ padding: "12px 12px 20px" }}>
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-          Standings · the rack
-        </span>
-        {showProjectedToggle && !final && <RsToggle mode={mode} onMode={onMode} />}
-      </div>
+      {/* Standard structure: hero → groupings → the rack. The old
+          "Standings · the rack" section header was pre-standardization chrome —
+          removed so the rack presents as content, like the other formats. Only
+          the Current/Projected toggle (a live control the user needs) stays. */}
+      {showProjectedToggle && !final && (
+        <div className="mb-2 flex justify-end">
+          <RsToggle mode={mode} onMode={onMode} />
+        </div>
+      )}
 
       {final && (
         <div className="mb-2 flex items-center justify-center rounded-lg" style={{ height: 30, background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}>

--- a/src/server/routers/competitions.test.ts
+++ b/src/server/routers/competitions.test.ts
@@ -88,6 +88,28 @@ describe("competitions router", () => {
     expect(updated.tagline).toBe("If you're not first, you're last");
   });
 
+  it("update — short_name persists and clears back to null", async () => {
+    const ownerCaller = ctx.caller();
+    const existing = await ownerCaller.competitions.getByTrip({ tripId });
+    expect(existing).not.toBeNull();
+
+    // Set a short label (the bottom-nav tab uses this).
+    const set = await ownerCaller.competitions.update({
+      tripId,
+      competitionId: existing!.id,
+      shortName: "BBMI",
+    });
+    expect(set.short_name).toBe("BBMI");
+
+    // Empty clears it → null (nav falls back to the full name).
+    const cleared = await ownerCaller.competitions.update({
+      tripId,
+      competitionId: existing!.id,
+      shortName: null,
+    });
+    expect(cleared.short_name).toBeNull();
+  });
+
   it("delete — only owner can delete", async () => {
     const ownerCaller = ctx.caller();
     const existing = await ownerCaller.competitions.getByTrip({ tripId });

--- a/src/server/routers/competitions.ts
+++ b/src/server/routers/competitions.ts
@@ -272,6 +272,8 @@ export const competitionsRouter = router({
         tripId: z.string(),
         competitionId: z.string(),
         name: z.string().min(2).max(200).optional(),
+        // Short label for the bottom-nav tab (empty string clears it → null).
+        shortName: z.string().max(40).nullable().optional(),
         tagline: z.string().max(500).nullable().optional(),
         scoreboardStyle: z.enum(SCOREBOARD_STYLES).optional(),
         // The roster-setup progression (building → saved → dismissed). "Save
@@ -285,6 +287,7 @@ export const competitionsRouter = router({
     .mutation(async ({ ctx, input }) => {
       const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
       if (input.name !== undefined) patch.name = input.name;
+      if (input.shortName !== undefined) patch.short_name = input.shortName;
       if (input.tagline !== undefined) patch.tagline = input.tagline;
       if (input.scoreboardStyle !== undefined) patch.scoreboard_style = input.scoreboardStyle;
       if (input.rosterSetup !== undefined) patch.roster_setup = input.rosterSetup;

--- a/supabase/migrations/20260706120000_071_competitions_short_name.sql
+++ b/supabase/migrations/20260706120000_071_competitions_short_name.sql
@@ -1,0 +1,12 @@
+-- 071 — competitions.short_name
+--
+-- A short label for the competition, surfaced as the BOTTOM-nav "Live" tab
+-- label (the full name — e.g. "Buddy Banks Memorial Invitational 2026" — won't
+-- fit a nav tab). Nullable: when unset the nav falls back to the full `name`
+-- (which truncates, itself the nudge to set a short one). Display-string only —
+-- no RLS or code branches on this value.
+ALTER TABLE competitions
+  ADD COLUMN IF NOT EXISTS short_name text;
+
+COMMENT ON COLUMN competitions.short_name IS
+  'Short label shown in the bottom navigation bar. Falls back to name when null.';


### PR DESCRIPTION
Competition-face cleanup pass. Four of the five spec tasks — the bounded, independently-valuable ones. **Task 1 (context-aware app bar) is split into its own follow-up** ([#550](https://github.com/zgrether/buddytrip/issues/550)) because it's a much larger, riskier global-nav rewrite touching the shipped #545–547 back-nav; Phase 0 for it is done and captured in that issue.

Each task is its own commit.

## Task 2 — team-color avatar in competition context
The app-bar account avatar now paints in the current user's **team color** (green = Manhattans, orange = Centurions, …) instead of the default teal, reinforcing team identity. Reuses the existing `Avatar` `teamColor` variant (which already wins over `accent`) — no rebuild. `UserMenu`/`TopNav` gain an optional color prop; `LiveFaceClient` resolves my team color from the faceBootstrap snapshot (my assignment → team → color), falling back to teal when teamless (no crash).

## Task 3 — competition short name for the bottom nav
A nullable `short_name` on `competitions` (migration **071**) surfaced as the bottom-nav "Live" tab label, so a long cup name ("Buddy Banks Memorial Invitational 2026") doesn't overflow the tab. `competitions.update` accepts `shortName` (≤40, empty clears to null); a clearly-labeled **"Short name — shown in the bottom navigation bar"** settings field with helper text (auto-saved on blur); the tab shows `short_name ?? name` (truncating) with a "Live" fallback. Router test covers persist + clear-to-null.

## Task 4 — leaderboard hero peek at rest
The collapsed mini-bar peeked ~11px above the hero at rest. `StickyCollapseHero` pulled the hero up by exactly the collapsed bar's own height, assuming the two fragment nodes were flush — but they render into the leaderboard's spacing column, which inserts ~12px between them. Fix: **measure the rendered gap and close it** (converges in one step; re-corrects via ResizeObserver) instead of hardcoding an offset. Verified on preview: at rest nothing peeks; on scroll the bar still pins at top:56 with the hero scrolled away.

## Task 5 — rack presents as hero → groupings → rack
`RackBoard` rendered a pre-standardization "Standings · the rack" section header above the ladder — chrome no other format carries. Removed so the rack presents as content, matching match/stroke/non-golf. The Current/Projected toggle (a live control) is preserved (right-aligned); `RsDayScore` and all rack content untouched.

## Verification
- `tsc --noEmit` clean, `eslint` clean.
- Full Vitest **891 passing** (86 files) — includes the new short_name router test; the tripStatus flake stays green.
- Critical-path Playwright E2E: **2 passed**.
- Tasks 2–4 eyeballed on the preview (screenshot: team-color avatar, "BBMI Test Cup" nav label, no hero peek).

## Migration note
`competitions.short_name` was added to the linked DB via an idempotent `ADD COLUMN IF NOT EXISTS` (no `schema_migrations` row recorded), so CI's `db push` applies file 071 as a clean no-op — the flow CLAUDE.md documents.

Closes #TBD partially — see [#550](https://github.com/zgrether/buddytrip/issues/550) for the remaining Task 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)