### PR TITLE
Rack: remove the redundant team-totals band (correct #551 Task 5)

### DIFF
--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -19,7 +19,7 @@ import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
-import { RsDayScore, RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
+import { RackBoard, type RackTeam } from "@/components/games/rack/RackBoard";
 import { GamePageHeader } from "@/components/competition/GamePageHeader";
 import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/FoursomeEntry";
 import { HandicapList, type HandicapPlayer } from "@/components/games/HandicapRoster";
@@ -750,10 +750,12 @@ export function RackGameView() {
         ) : undefined
       }
     >
-      {/* Standard game header — row 1 (the collapsed cup hero) + row 2 (this
-          game's projected/final per-team contribution), sticky over the
-          scoreboard. Competition games only. RsDayScore below stays as rack's own
-          in-context day-score readout. */}
+      {/* Standard game header — row 1 (the collapsed cup hero, team names +
+          cup totals) + row 2 (this game's projected/final per-team
+          contribution), sticky over the scoreboard. Competition games only.
+          The team standing comes ONLY from this hero now — the old RsDayScore
+          team-totals band ("CENTURIONS 4 · matches won · MANHATTANS 2") was a
+          redundant restatement of the hero + projection row, so it's gone. */}
       <GamePageHeader
         tripId={tripId}
         competitionId={competitionId}
@@ -767,7 +769,6 @@ export function RackGameView() {
             : undefined
         }
       />
-      <RsDayScore teamA={teamMeta.A} teamB={teamMeta.B} pointsA={rack.points.A} pointsB={rack.points.B} final={final} projected={mode === "projected"} />
       <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); setEntryView("entry"); }} />
       {/* #501 Part 3: the scoring board is read-and-score only — "Edit handicaps"
           (config) is gone. Edit handicaps in Setup mode (gear → Who's playing ·

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TrendingUp } from "lucide-react";
-import { fmtToPar, fmtPoints, type RackMode, type RackSlot, type RackSlotPlayer } from "@/lib/rackNStack";
+import { fmtToPar, type RackMode, type RackSlot, type RackSlotPlayer } from "@/lib/rackNStack";
 
 /**
  * Rack-n-Stack display board (Slice C part 3 + addendum). PURE / display-only —
@@ -10,9 +10,11 @@ import { fmtToPar, fmtPoints, type RackMode, type RackSlot, type RackSlotPlayer 
  * margin. Reuses the match-board's outer-edge layout but is a readout, not a
  * control — tapping a slot does nothing.
  *
- * Composed onto the rack page below the team header (`RsDayScore`) and the
- * Groups entry; the board itself is just the toggle + rack + sit-out so it can
- * be reused as the competition leaderboard later.
+ * Composed onto the rack page below the Groups entry; the board itself is the
+ * "Standings · the rack" label + toggle + rack + sit-out, so it can be reused
+ * as the competition leaderboard later. (The old `RsDayScore` team-totals band
+ * was removed — the persistent leaderboard hero is the single source of the
+ * team standing; the rack body no longer restates it.)
  */
 
 export interface RackTeam {
@@ -33,59 +35,7 @@ interface RackBoardProps {
   final?: boolean;
 }
 
-// ── Team-score header (RsDayScore) — pinned above Groups ─────────────────────
-export function RsDayScore({
-  teamA,
-  teamB,
-  pointsA,
-  pointsB,
-  final,
-  projected,
-}: {
-  teamA: RackTeam;
-  teamB: RackTeam;
-  pointsA: number;
-  pointsB: number;
-  final?: boolean;
-  projected?: boolean;
-}) {
-  return (
-    <div
-      className="flex items-stretch"
-      style={{ background: "var(--color-bt-card)", borderBottom: "1px solid var(--color-bt-border)", padding: "14px 16px" }}
-    >
-      <TeamTotal team={teamA} points={pointsA} align="left" />
-      <div className="flex flex-col items-center justify-center" style={{ padding: "0 14px" }}>
-        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: "0.12em", color: "var(--color-bt-text-dim)" }}>
-          {final ? "FINAL" : "RACK"}
-        </span>
-        <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)" }}>
-          matches won{projected && !final ? " · proj" : ""}
-        </span>
-      </div>
-      <TeamTotal team={teamB} points={pointsB} align="right" />
-    </div>
-  );
-}
-
-function TeamTotal({ team, points, align }: { team: RackTeam; points: number; align: "left" | "right" }) {
-  return (
-    <div className="flex flex-1 flex-col" style={{ alignItems: align === "left" ? "flex-start" : "flex-end" }}>
-      <span className="flex items-center gap-1.5">
-        {align === "left" && <Dot color={team.color} />}
-        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--color-bt-text-dim)" }}>
-          {team.name}
-        </span>
-        {align === "right" && <Dot color={team.color} />}
-      </span>
-      <span style={{ fontSize: 34, fontWeight: 800, color: "var(--color-bt-text)", lineHeight: 1.05, fontVariantNumeric: "tabular-nums" }}>
-        {fmtPoints(points)}
-      </span>
-    </div>
-  );
-}
-
-// ── The board (toggle + rack + sit-out) ──────────────────────────────────────
+// ── The board (label + toggle + rack + sit-out) ──────────────────────────────
 export function RackBoard({
   teamA,
   teamB,
@@ -101,15 +51,17 @@ export function RackBoard({
   const colorOf = (t: "A" | "B") => (t === "A" ? teamA.color : teamB.color);
   return (
     <div style={{ padding: "12px 12px 20px" }}>
-      {/* Standard structure: hero → groupings → the rack. The old
-          "Standings · the rack" section header was pre-standardization chrome —
-          removed so the rack presents as content, like the other formats. Only
-          the Current/Projected toggle (a live control the user needs) stays. */}
-      {showProjectedToggle && !final && (
-        <div className="mb-2 flex justify-end">
-          <RsToggle mode={mode} onMode={onMode} />
-        </div>
-      )}
+      {/* Rack uniquely has two body sub-sections — the Groups entry above and
+          this standings ladder — so the ladder keeps its own section label to
+          orient it against the groups (the redundant element was the team-totals
+          band, now removed, not this label). The Current/Projected toggle sits
+          on the same row. */}
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+          Standings · the rack
+        </span>
+        {showProjectedToggle && !final && <RsToggle mode={mode} onMode={onMode} />}
+      </div>
 
       {final && (
         <div className="mb-2 flex items-center justify-center rounded-lg" style={{ height: 30, background: "var(--color-bt-accent-faint)", border: "1px solid var(--color-bt-accent-border)" }}>


### PR DESCRIPTION
Corrects the rack part of #551 (Task 5). Zach's screenshot clarified which element is the redundant "old scoreboard": the **team-totals band** — "CENTURIONS 4 · RACK / matches won · MANHATTANS 2" — not the "Standings · the rack" label #551 removed.

## Phase 0 (identified before building)
1. **The band is `RsDayScore`** (`rack/RackBoard.tsx`), rendered standalone in `RackGameView` between the header and the groupings. Zach's "not even part of the right component" is apt — it's defined in the ladder/display file but rendered as its own header band. This is the element #551 mistakenly **kept**.
2. **Redundancy confirmed on the preview.** The persistent header already shows everything the band restates:
   - Hero row 1: **Manhattans 12 · Centurions 4** (team names + cup totals).
   - Projection row 2: **+2 · +4** (this game's per-team contribution).
   - The band: **CENTURIONS 4 · MANHATTANS 2** — same names (dup of hero) + same per-team tally (dup of the projection row).
   - Nuance (not a blocker): the band read `rack.points` (current toggle mode) while the projection row reads `projectedPoints`; they coincide here and the per-slot current detail is in the ladder — so removing it loses nothing the header+ladder don't already show.
3. **"Standings · the rack"** — #551 removed it; Zach said it "was fine." Restored, because rack uniquely has **two** body sub-sections (Groups entry + standings ladder), so the ladder keeps a label to orient it against the groups.

## Change
- Remove `RsDayScore` from `RackGameView`; delete the now-unused `RsDayScore` + `TeamTotal` (and the `fmtPoints` import) from `RackBoard`.
- Restore the "Standings · the rack" label above the ladder (toggle on the same row).
- Rack scoring content (groups, ladder, projected/current toggle) untouched.

Result: rack reads **hero → groupings → ladder**, with the team standing coming only from the persistent hero — consistent with the other formats.

## Verification
- tsc clean, eslint clean.
- Preview (screenshot): band gone, "Standings · the rack" restored, groups + ladder + toggle intact, body order hero → GROUPS → ladder.
- Critical-path Playwright E2E: **2 passed**.
- Full Vitest: **890/891**. The one failure — `news.test.ts > unreadCount — a newer post bumps the count` — is a **pre-existing local-only clock-skew artifact** (verified: fails identically with my changes stashed; the test stamps `last_read_at` with the runner clock vs the post's DB `now()`, and my local machine is ~5s ahead of the Supabase DB). It's green in CI, where the runner and DB are NTP-synced — which is why `main` and #548/#551 are green. Not touched (out of scope; see #553).

🤖 Generated with [Claude Code](https://claude.com/claude-code)