### PR TITLE
Leaderboard typography + projection display pass

### DIFF
--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -392,11 +392,16 @@ export function CollapsedHero({
  */
 export function ProjectionRow({
   teams,
+  teamTotals,
   perTeam,
   gameName,
   final,
 }: {
   teams: LBTeam[];
+  /** Current realized cup totals per team — the projected TOTAL = this + the
+   *  game's projected delta (perTeam). In-progress games aren't yet in the
+   *  totals, so total = realized + projected reads correctly. */
+  teamTotals: Record<string, number>;
   perTeam: Record<string, number>;
   gameName: string;
   final: boolean;
@@ -404,15 +409,20 @@ export function ProjectionRow({
   const contrib = (t: LBTeam | undefined, align: "left" | "right", key?: string) => {
     if (!t) return <div key={key} style={{ minWidth: 88 }} />;
     const p = perTeam[t.id] ?? 0;
+    // Projected TOTAL = current realized total + this game's projected delta.
+    // Only while live: once final, the game's points are ALREADY in teamTotals
+    // (adding would double-count), so keep the final display as the solid delta.
+    const projectedTotal = (teamTotals[t.id] ?? 0) + p;
     return (
       <div key={key} className="min-w-0 flex-1" style={{ textAlign: align, minWidth: 88 }}>
         <span
           className="tabular-nums"
-          // Team color = data; reduced opacity = "provisional / not final" (no new
-          // hex — the desaturation is opacity over the team's identity color).
-          style={{ fontSize: 18, fontWeight: 600, color: t.color, opacity: final ? 1 : 0.5, lineHeight: 1 }}
+          // A distinguishable SUB-header under the official score: SAME size as
+          // the mini-bar's official scores (26), but NON-BOLD (600 vs 800) and
+          // FAINT (team color at 0.5 while live) so it doesn't compete with it.
+          style={{ fontSize: 26, fontWeight: 600, color: t.color, opacity: final ? 1 : 0.5, lineHeight: 1 }}
         >
-          {p > 0 ? `+${fmtPts(p)}` : fmtPts(p)}
+          {final ? (p > 0 ? `+${fmtPts(p)}` : fmtPts(p)) : `${fmtPts(projectedTotal)} (+${fmtPts(p)})`}
         </span>
       </div>
     );
@@ -421,7 +431,9 @@ export function ProjectionRow({
     <div className="flex-1 text-center">
       <div className="truncate" style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text)", lineHeight: 1.2 }}>{gameName}</div>
       {!final && (
-        <div style={{ fontSize: 10, fontStyle: "italic", color: "var(--color-bt-text-dim)", marginTop: 1 }}>projected</div>
+        // Matches the "First to X wins" target size/style (13, dim) — a peer,
+        // not a tiny afterthought (Task 4).
+        <div style={{ fontSize: 13, fontStyle: "italic", color: "var(--color-bt-text-dim)", marginTop: 1 }}>projected</div>
       )}
     </div>
   );

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -209,8 +209,9 @@ export function CompetitionHero({
               />
             </div>
 
-            {/* Below the bar: ONLY the win target (Task 2). */}
-            <p className="mt-2 text-center" style={{ fontSize: 12, color: "var(--color-bt-text-dim)" }}>
+            {/* Below the bar: ONLY the win target. Sized as a peer of the
+                mini-bar's labels (13/600), not a tiny afterthought. */}
+            <p className="mt-2 text-center" style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>
               {clincher
                 ? `Final · ${clincher.name} wins`
                 : pointsAvailable > 0
@@ -342,9 +343,10 @@ export function CollapsedHero({
     padding: "11px 18px",
   };
   const target = (
+    // Normal-case (Task 2 — no all-caps) + bumped to 13/600 so it reads as a
+    // peer of the team-name labels, matching the expanded hero's target line.
     <span
-      className="uppercase"
-      style={{ fontSize: 10, fontWeight: 600, letterSpacing: ".04em", color: "var(--color-bt-text-dim)" }}
+      style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-text-dim)" }}
     >
       {targetLabel}
     </span>

--- a/src/components/competition/GamePageHeader.tsx
+++ b/src/components/competition/GamePageHeader.tsx
@@ -65,6 +65,7 @@ export function GamePageHeader({
           projection ? (
             <ProjectionRow
               teams={d.teams}
+              teamTotals={d.teamTotals}
               perTeam={projection.perTeam}
               gameName={projection.gameName}
               final={projection.final}

--- a/src/components/competition/ProjectionRow.test.tsx
+++ b/src/components/competition/ProjectionRow.test.tsx
@@ -17,21 +17,23 @@ const team = (id: string, name: string, short: string, color: string): LBTeam =>
 describe("ProjectionRow — two-team (match-play) row", () => {
   const teams = [team("a", "Hammer", "HAM", "#f87171"), team("b", "Whack", "WHK", "#c084fc")];
 
-  it("shows each team's signed contribution and, while live, the 'projected' label", () => {
+  it("shows the projected TOTAL (realized + delta) with the delta in parens, while live", () => {
     const html = renderToStaticMarkup(
-      <ProjectionRow teams={teams} perTeam={{ a: 4, b: 0 }} gameName="Front Nine" final={false} />
+      <ProjectionRow teams={teams} teamTotals={{ a: 12, b: 4 }} perTeam={{ a: 4, b: 0 }} gameName="Front Nine" final={false} />
     );
-    expect(html).toContain("+4"); // a's positive contribution gets a leading +
-    expect(html).toContain(">0<"); // b contributes nothing (no +)
+    expect(html).toContain("16 (+4)"); // a: 12 realized + 4 projected → 16, up 4
+    expect(html).toContain("4 (+0)"); // b: 4 + 0 → 4, up 0 (delta always signed)
     expect(html).toContain("Front Nine");
     expect(html).toContain("projected");
     // desaturated while live — team color at reduced opacity, not full
     expect(html).toContain("opacity:0.5");
   });
 
-  it("drops the 'projected' label and goes solid once the game is complete", () => {
+  it("drops the 'projected' label and goes solid (delta only) once the game is complete", () => {
+    // Final: the game's points are already in teamTotals, so it stays the solid
+    // contribution (no total — adding would double-count).
     const html = renderToStaticMarkup(
-      <ProjectionRow teams={teams} perTeam={{ a: 4, b: 2 }} gameName="Front Nine" final />
+      <ProjectionRow teams={teams} teamTotals={{ a: 12, b: 4 }} perTeam={{ a: 4, b: 2 }} gameName="Front Nine" final />
     );
     expect(html).not.toContain("projected");
     expect(html).toContain("opacity:1");
@@ -41,7 +43,7 @@ describe("ProjectionRow — two-team (match-play) row", () => {
 
   it("colors the numbers with the team color (data, not chrome)", () => {
     const html = renderToStaticMarkup(
-      <ProjectionRow teams={teams} perTeam={{ a: 4, b: 0 }} gameName="Front Nine" final={false} />
+      <ProjectionRow teams={teams} teamTotals={{ a: 0, b: 0 }} perTeam={{ a: 4, b: 0 }} gameName="Front Nine" final={false} />
     );
     expect(html).toContain("#f87171");
     expect(html).toContain("#c084fc");
@@ -55,12 +57,13 @@ describe("ProjectionRow — N-team (points cup) row, not 2-hardcoded", () => {
     team("c", "Charlies", "CHR", "#34d399"),
   ];
 
-  it("renders a contribution for every team", () => {
+  it("renders a projected total (+delta) for every team", () => {
     const html = renderToStaticMarkup(
-      <ProjectionRow teams={teams} perTeam={{ a: 3, b: 1.5, c: 0 }} gameName="Skins" final={false} />
+      <ProjectionRow teams={teams} teamTotals={{ a: 10, b: 5, c: 0 }} perTeam={{ a: 3, b: 1.5, c: 0 }} gameName="Skins" final={false} />
     );
-    expect(html).toContain("+3");
-    expect(html).toContain("+1½"); // fmtPts renders a half as ½
+    expect(html).toContain("13 (+3)"); // a: 10 + 3
+    expect(html).toContain("6½ (+1½)"); // b: 5 + 1.5 → 6½ (fmtPts renders a half as ½)
+    expect(html).toContain("0 (+0)"); // c: 0 + 0
     for (const c of ["#f87171", "#c084fc", "#34d399"]) expect(html).toContain(c);
   });
 });


### PR DESCRIPTION
Four display-only typography/projection items on the competition leaderboard hero + collapsed mini-bar + game-page projection. **No scoring/projection MATH changes.** Separate from the rack ladder's "Projected" toggle (#554) — different surface.

## Phase 0
- **"First to X wins"** lived in two places: the expanded hero (`12px/400`) and the collapsed mini-bar (`10px/uppercase`) — both too small/thin.
- The mini-bar's only all-caps element was that target; its **official scores** are `26px/800`.
- The **projection** (`ProjectionRow`, row 2 of `GamePageHeader`) showed only the delta (`+4`) at `18px/0.5`; the **"projected"** italic label was `10px`. `GamePageHeader` already has `d.teamTotals`, so projected total = `teamTotals + perTeam`.

## Task 1 — bump "First to X wins" (commit 1)
Both instances → `13px / 600 / dim / normal-case`, a peer of the mini-bar's labels.

## Task 2 — de-caps the mini-leaderboard (commit 1)
Dropped `uppercase` + caps tracking on the mini-bar target — normal-case now.

## Task 3 — projection shows total (+delta) (commit 2)
`ProjectionRow` now takes `teamTotals` and, while live, renders the projected **total with the delta in parens** per team — **"16 (+4)"**, **"4 (+0)"** (total = realized 12 + projected 4). Sized like the official scores (`26px`) but **non-bold (600)** and **faint (0.5)** — a distinguishable sub-header under the official score. Final games keep the solid delta-only display (their points are already in `teamTotals` — adding would double-count). The projection MATH is unchanged; this only shows total = current + delta instead of just delta.

## Task 4 — bump the "projected" italic (commit 2)
`10px → 13px`, matching "First to X wins" so the two read as peers.

## Verification
- Eyeballed on the preview: "First to 40½ wins" is readable + normal-case (expanded + collapsed); projection reads **"16 (+4)" / "4 (+0)"** as faint 26px sub-headers under the official 12/4; "projected" bumped. Collapse behavior (#551) and panel restructure unaffected.
- `tsc` clean, `eslint` clean.
- `ProjectionRow.test.tsx` updated + green; all competition component tests pass (14).
- Critical-path Playwright E2E: **2 passed**.
- Full Vitest: green except `news.test.ts > unreadCount`, the known local clock-skew artifact ([#553](https://github.com/zgrether/buddytrip/issues/553)) — green in CI, unrelated to these display-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)