### PR TITLE
Standardize padding across all game settings (all formats)

### DIFF
--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -9,6 +9,7 @@ import { GameRulesNote } from "@/components/games/GameRulesNote";
 import { GameFormatExplainer } from "@/components/games/GameFormatExplainer";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import { ZoneHeader } from "@/components/games/ZoneHeader";
+import { SettingsColumn } from "@/components/games/SettingsColumn";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 
 /**
@@ -112,35 +113,38 @@ export function GameConfigurationView({
             (top) → Game Management → grouped Settings / Options → Danger Zone. Each
             format keeps its real rows (stroke's teamless net-total; rack's
             HandicapRoster + course); only the ordering + ZoneHeader grouping change.
-            Section grouping reuses the shared ZoneHeader (Spec 6). */}
+            Section grouping reuses the shared ZoneHeader (Spec 6).
 
-        {/* IDENTITY (W-EDITMODAL-01): name (tap-to-edit) + assigned-to. */}
-        {competitionId && (
-          <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
-        )}
+            Spacing is owned by SettingsColumn (one home): a uniform gap between
+            every header + row, so no section is cramped and no rows sit flush —
+            the SAME rule the match checklist uses. Rows carry NO margin of their
+            own. */}
+        <SettingsColumn>
+          {/* IDENTITY (W-EDITMODAL-01): name (tap-to-edit) + assigned-to. */}
+          {competitionId && (
+            <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
+          )}
 
-        {/* Format explainer — the compact "how you compete" block that pairs
-            directly ABOVE Rules (the slot reserved for it). */}
-        {competitionId && (
-          <div className="mt-6">
-            <GameFormatExplainer gameTypeId={game.game_type_id} variant="settings" />
-          </div>
-        )}
-
-        {/* RULES OF THE DAY — at the TOP (matching canonical). Saves on blur (no
-            Save&exit — the back arrow navigates; the blur commit is the flush); the
-            carved-out exception keeps it editable in scoring mode (plain canEdit). */}
-        {competitionId && <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />}
-
-        {/* GAME MANAGEMENT — a labeled peer section + the single Setup/Scoring toggle
-            (owner/delegate only). The ZoneHeader supplies the caption, so the panel's
-            own caption is suppressed (hideLabel) — matching canonical. */}
-        {canEdit && (
-          <>
+          {/* Format explainer — the compact "how you compete" block that pairs
+              directly ABOVE Rules (the slot reserved for it). The extra mt-6 gives
+              it a larger break under the identity header (matches the match page). */}
+          {competitionId && (
             <div className="mt-6">
-              <ZoneHeader>Game Management</ZoneHeader>
+              <GameFormatExplainer gameTypeId={game.game_type_id} variant="settings" />
             </div>
-            <div className="mt-2.5">
+          )}
+
+          {/* RULES OF THE DAY — at the TOP (matching canonical). Saves on blur (no
+              Save&exit — the back arrow navigates; the blur commit is the flush); the
+              carved-out exception keeps it editable in scoring mode (plain canEdit). */}
+          {competitionId && <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />}
+
+          {/* GAME MANAGEMENT — a labeled peer section + the single Setup/Scoring toggle
+              (owner/delegate only). The ZoneHeader supplies the caption, so the panel's
+              own caption is suppressed (hideLabel) — matching canonical. */}
+          {canEdit && (
+            <>
+              <ZoneHeader>Game Management</ZoneHeader>
               <GameManagementPanel
                 mode={scoringEnabled ? "scoring" : "setup"}
                 ready={ready}
@@ -149,72 +153,67 @@ export function GameConfigurationView({
                 pending={busy}
                 hideLabel
               />
-            </div>
-          </>
-        )}
+            </>
+          )}
 
-        {/* #501: live-game lock banner — the settings below freeze until the owner/
-            delegate flips the toggle above back to Setup (after the toggle, canonical). */}
-        {scoringEnabled && canEdit && <ScoringLockBanner />}
+          {/* #501: live-game lock banner — the settings below freeze until the owner/
+              delegate flips the toggle above back to Setup (after the toggle, canonical). */}
+          {scoringEnabled && canEdit && <ScoringLockBanner />}
 
-        {/* SETTINGS — the required spine: Course + Format·Points (GameSetupRows).
-            Same editors as the setup hull, reused (never rebuilt); the accordion
-            drill-downs inherit the continuous-panel / no-under-header-divider /
-            scroll-into-view treatment from the shared ChecklistRow. */}
-        <div className="mt-6">
+          {/* SETTINGS — the required spine: Course + Format·Points (GameSetupRows).
+              Same editors as the setup hull, reused (never rebuilt); the accordion
+              drill-downs inherit the continuous-panel / no-under-header-divider /
+              scroll-into-view treatment from the shared ChecklistRow. */}
           <ZoneHeader>Settings</ZoneHeader>
-        </div>
-        {/* Format-specific leading rows (rack's GROUPINGS + Handicaps) sit ABOVE the
-            shared Course/Points spine as the first Settings items. */}
-        {leadingSettingsRows && <div className="mt-2 mb-2.5 flex flex-col gap-2.5">{leadingSettingsRows}</div>}
-        <GameSetupRows
-          tripId={tripId}
-          competitionId={competitionId}
-          game={game}
-          canEdit={settingsEditable}
-          locked={scoringEnabled}
-          onChanged={onChanged}
-          matchCount={matchCount}
-          pointsTitle={pointsRowTitle}
-        />
+          {/* Format-specific leading rows (rack's GROUPINGS) sit ABOVE the shared
+              Course/Points spine as the first Settings items — a plain fragment so
+              its rows join the column's uniform gap. */}
+          {leadingSettingsRows}
+          <GameSetupRows
+            tripId={tripId}
+            competitionId={competitionId}
+            game={game}
+            canEdit={settingsEditable}
+            locked={scoringEnabled}
+            onChanged={onChanged}
+            matchCount={matchCount}
+            pointsTitle={pointsRowTitle}
+          />
 
-        {/* OPTIONS — the optional layer: Who's playing · Handicaps (stroke's
-            per-player strokes / rack's HandicapRoster) + any extra rows (stroke's
-            Modifiers). Rendered only when the format supplies one of them. */}
-        {(onEditWhosPlaying || extraRows) && (
-          <>
-            <div className="mt-6">
+          {/* OPTIONS — the optional layer: Who's playing · Handicaps (stroke's
+              per-player strokes / rack's HandicapRoster) + any extra rows (stroke's
+              Modifiers). Rendered only when the format supplies one of them. */}
+          {(onEditWhosPlaying || extraRows) && (
+            <>
               <ZoneHeader>Options</ZoneHeader>
-            </div>
-            {onEditWhosPlaying && (
-              <button
-                type="button"
-                onClick={onEditWhosPlaying}
-                disabled={!settingsEditable}
-                // #512 Option B: when live-locked, dim + swap the chevron for a lock icon.
-                className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
-                style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: scoringEnabled ? 0.55 : undefined }}
-              >
-                <div className="flex min-w-0 flex-col">
-                  <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
-                    Who&rsquo;s playing · Handicaps
-                  </span>
-                  <span className="truncate text-sm" style={{ color: "var(--color-bt-text)", marginTop: 2 }}>{whosPlayingLabel}</span>
-                </div>
-                {scoringEnabled
-                  ? <Lock size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
-                  : <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />}
-              </button>
-            )}
-            {extraRows}
-          </>
-        )}
+              {onEditWhosPlaying && (
+                <button
+                  type="button"
+                  onClick={onEditWhosPlaying}
+                  disabled={!settingsEditable}
+                  // #512 Option B: when live-locked, dim + swap the chevron for a lock icon.
+                  className="flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
+                  style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: scoringEnabled ? 0.55 : undefined }}
+                >
+                  <div className="flex min-w-0 flex-col">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+                      Who&rsquo;s playing · Handicaps
+                    </span>
+                    <span className="truncate text-sm" style={{ color: "var(--color-bt-text)", marginTop: 2 }}>{whosPlayingLabel}</span>
+                  </div>
+                  {scoringEnabled
+                    ? <Lock size={15} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+                    : <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />}
+                </button>
+              )}
+              {extraRows}
+            </>
+          )}
 
-        {/* Per-game danger zone — owner-only (reset scores → reset settings →
-            delete), reusing the shared confirm vocabulary + the Phase A resets.
-            Dimmed-header + disabled wholesale in scoring mode (shared treatment). */}
-        {isOwner && (
-          <div className="mt-6">
+          {/* Per-game danger zone — owner-only (reset scores → reset settings →
+              delete), reusing the shared confirm vocabulary + the Phase A resets.
+              Dimmed-header + disabled wholesale in scoring mode (shared treatment). */}
+          {isOwner && (
             <GameDangerZone
               tripId={tripId}
               gameId={game.id}
@@ -223,8 +222,8 @@ export function GameConfigurationView({
               onDeleted={onDeleted}
               disabled={scoringEnabled}
             />
-          </div>
-        )}
+          )}
+        </SettingsColumn>
       </div>
     </div>
   );

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -25,6 +25,7 @@ import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { SettingsColumn } from "@/components/games/SettingsColumn";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote } from "@/components/games/GameRulesNote";
 import { GameFormatExplainer } from "@/components/games/GameFormatExplainer";
@@ -1191,7 +1192,7 @@ export function MatchGameView() {
           }
         };
         return (
-          <div className="flex flex-col gap-2.5 pb-4">
+          <SettingsColumn className="pb-4">
             {/* Zone 1 — IDENTITY header (W-EDITMODAL-01): name (tap-to-edit) +
                 "Assigned to" frame. Display-first, above the checklist. Competition
                 games only — it re-homes the modal's name/delegate, which were
@@ -1437,7 +1438,7 @@ export function MatchGameView() {
                 disabled={scoringEnabled}
               />
             )}
-          </div>
+          </SettingsColumn>
         );
       })()}
 

--- a/src/components/games/NonGolfConfigurationView.tsx
+++ b/src/components/games/NonGolfConfigurationView.tsx
@@ -11,6 +11,7 @@ import { GameFormatExplainer } from "@/components/games/GameFormatExplainer";
 import { FormatPointsPanel } from "@/components/games/FormatPointsPanel";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import { ZoneHeader } from "@/components/games/ZoneHeader";
+import { SettingsColumn } from "@/components/games/SettingsColumn";
 import {
   PointStepper,
   FormatSheet,
@@ -98,31 +99,33 @@ export function NonGolfConfigurationView({
             differ (no course/handicaps/matches; it HAS Competition Format + Game
             Value), but the grouping + treatment match golf so they read as one page
             family. Shared primitives (identity, Rules, toggle, Danger Zone, explainer,
-            ZoneHeader) inherit the golf treatment — nothing re-implemented. */}
+            ZoneHeader) inherit the golf treatment — nothing re-implemented.
 
-        {/* Identity — name (tap-to-edit) + assigned-to (same as golf). */}
-        <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
+            Spacing is owned by SettingsColumn (one home) — the SAME uniform-gap rule
+            golf + match use, so no format's settings look different. Rows carry NO
+            margin of their own. */}
+        <SettingsColumn>
+          {/* Identity — name (tap-to-edit) + assigned-to (same as golf). */}
+          <GameIdentityHeader tripId={tripId} game={game} canEdit={canEdit} isOwner={isOwner} />
 
-        {/* Format explainer — the compact "how you compete" block that pairs directly
-            ABOVE Rules (this is the slot reserved for it). */}
-        <div className="mt-6">
-          <GameFormatExplainer gameTypeId={game.game_type_id} variant="settings" />
-        </div>
+          {/* Format explainer — the compact "how you compete" block that pairs directly
+              ABOVE Rules (this is the slot reserved for it). Extra mt-6 for a larger
+              break under the identity header (matches golf + match). */}
+          <div className="mt-6">
+            <GameFormatExplainer gameTypeId={game.game_type_id} variant="settings" />
+          </div>
 
-        {/* RULES OF THE DAY — at the TOP (matching golf). Saves on blur; the
-            carved-out exception stays editable in scoring mode (notes, not
-            game-altering) — so it keeps plain canEdit. */}
-        <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />
+          {/* RULES OF THE DAY — at the TOP (matching golf). Saves on blur; the
+              carved-out exception stays editable in scoring mode (notes, not
+              game-altering) — so it keeps plain canEdit. */}
+          <GameRulesNote tripId={tripId} game={game} canEdit={canEdit} />
 
-        {/* GAME MANAGEMENT — a labeled peer section + the single Setup/Scoring toggle
-            (owner/delegate only). ZoneHeader supplies the caption, so the panel's own
-            caption is suppressed (hideLabel) to avoid a double label — matching golf. */}
-        {canEdit && (
-          <>
-            <div className="mt-6">
+          {/* GAME MANAGEMENT — a labeled peer section + the single Setup/Scoring toggle
+              (owner/delegate only). ZoneHeader supplies the caption, so the panel's own
+              caption is suppressed (hideLabel) to avoid a double label — matching golf. */}
+          {canEdit && (
+            <>
               <ZoneHeader>Game Management</ZoneHeader>
-            </div>
-            <div className="mt-2.5">
               <GameManagementPanel
                 mode={scoringEnabled ? "scoring" : "setup"}
                 ready={ready}
@@ -131,38 +134,34 @@ export function NonGolfConfigurationView({
                 pending={busy}
                 hideLabel
               />
-            </div>
-          </>
-        )}
+            </>
+          )}
 
-        {/* #501: live-game lock banner — the settings below are frozen until the
-            owner/delegate flips the toggle above back to Setup (after the toggle,
-            matching golf). */}
-        {scoringEnabled && canEdit && <ScoringLockBanner />}
+          {/* #501: live-game lock banner — the settings below are frozen until the
+              owner/delegate flips the toggle above back to Setup (after the toggle,
+              matching golf). */}
+          {scoringEnabled && canEdit && <ScoringLockBanner />}
 
-        {/* SETTINGS — non-golf's real, different content: Competition Format ("how
-            it's played") + Game Value (points-for-the-match). Locked in scoring mode. */}
-        <div className="mt-6">
+          {/* SETTINGS — non-golf's real, different content: Competition Format ("how
+              it's played") + Game Value (points-for-the-match). Locked in scoring mode. */}
           <ZoneHeader>Settings</ZoneHeader>
-        </div>
-        <CompetitionFormatRow tripId={tripId} game={game} canEdit={settingsEditable} locked={scoringEnabled} onChanged={onChanged} />
-        {/* The points payload, by the competition's scoring model. Locked in scoring —
-            #512 Option B: dim the read-only panel so it reads as frozen. */}
-        {scoringModel === "match_play" ? (
-          <div className="mt-2" style={{ opacity: scoringEnabled ? 0.55 : undefined }}>
-            <MatchValueStepper tripId={tripId} game={game} canEdit={settingsEditable} onChanged={onChanged} />
-          </div>
-        ) : (
-          <div className="mt-2" style={{ opacity: scoringEnabled ? 0.55 : undefined }}>
-            <FormatPointsPanel tripId={tripId} game={game} canEdit={settingsEditable} />
-          </div>
-        )}
+          <CompetitionFormatRow tripId={tripId} game={game} canEdit={settingsEditable} locked={scoringEnabled} onChanged={onChanged} />
+          {/* The points payload, by the competition's scoring model. Locked in scoring —
+              #512 Option B: dim the read-only panel so it reads as frozen. */}
+          {scoringModel === "match_play" ? (
+            <div style={{ opacity: scoringEnabled ? 0.55 : undefined }}>
+              <MatchValueStepper tripId={tripId} game={game} canEdit={settingsEditable} onChanged={onChanged} />
+            </div>
+          ) : (
+            <div style={{ opacity: scoringEnabled ? 0.55 : undefined }}>
+              <FormatPointsPanel tripId={tripId} game={game} canEdit={settingsEditable} />
+            </div>
+          )}
 
-        {/* Per-game danger zone — owner-only (reset scores / reset settings / delete).
-            Dimmed-header + disabled wholesale in scoring mode (#501, shared treatment)
-            — switch to Setup to manage it. */}
-        {isOwner && (
-          <div className="mt-6">
+          {/* Per-game danger zone — owner-only (reset scores / reset settings / delete).
+              Dimmed-header + disabled wholesale in scoring mode (#501, shared treatment)
+              — switch to Setup to manage it. */}
+          {isOwner && (
             <GameDangerZone
               tripId={tripId}
               gameId={game.id}
@@ -171,8 +170,8 @@ export function NonGolfConfigurationView({
               onDeleted={onDeleted}
               disabled={scoringEnabled}
             />
-          </div>
-        )}
+          )}
+        </SettingsColumn>
       </div>
     </div>
   );
@@ -212,7 +211,7 @@ function CompetitionFormatRow({
         onClick={() => canEdit && setOpen(true)}
         disabled={!canEdit}
         // #512 Option B: live-locked → dim + a lock icon in place of the chevron.
-        className="mt-3 flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
+        className="flex w-full items-center justify-between gap-3 rounded-xl px-3.5 py-3 text-left disabled:opacity-60"
         style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)", opacity: locked ? 0.55 : undefined }}
         data-testid="row-competition-format"
       >

--- a/src/components/games/SettingsColumn.tsx
+++ b/src/components/games/SettingsColumn.tsx
@@ -1,0 +1,27 @@
+/**
+ * SettingsColumn — the ONE spacing home for every game-settings surface
+ * (rack/stroke via GameConfigurationView, non-golf via NonGolfConfigurationView,
+ * and match 1v1/2v2's inline checklist). A single uniform gap between every
+ * section header (ZoneHeader) and every row (ChecklistRow / panel / button), so
+ * no section is cramped and no two rows sit flush. `ZoneHeader`'s own `pt-2`
+ * gives section breaks a touch more air on top of the gap.
+ *
+ * This replaces the ad-hoc per-item margins (mt-6 / mt-2.5 / mt-2 / mt-3) that
+ * had drifted apart across the layouts and left the reported 0px gaps
+ * (Options→Handicaps, Course→Points). Rows carry NO margin of their own — the
+ * gap is owned HERE, in one place, so the spacing can't diverge per format again.
+ */
+export function SettingsColumn({
+  className,
+  children,
+}: {
+  /** Extra classes merged onto the column (e.g. a page's bottom padding). */
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`flex flex-col gap-2.5${className ? ` ${className}` : ""}`}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Generalized from Zach's QA pass: he found two padding gaps in rack settings (OPTIONS→Handicaps and around Points per Slot) and correctly generalized — standardize the spacing rule across ALL formats, not just patch the two. Rebased on current main (after #554). **Spacing only** — no content/order/behavior change.

## Phase 0
**Root cause:** the settings row/section spacing was never systematized. `ZoneHeader` has no bottom margin and `ChecklistRow` has no external margin (rows must be gapped by a parent), so each layout added ad-hoc per-item margins that drifted apart:
- **`GameConfigurationView`** (rack/stroke): `mt-6`/`mt-2.5` wrappers + an **unwrapped `GameSetupRows`** (Course/Points flush = **0px**) + unwrapped `extraRows` (OPTIONS→Handicaps flush = **0px**).
- **`NonGolfConfigurationView`**: its own `mt-6`/`mt-2.5`/`mt-3`/`mt-2`.
- **`MatchGameView`** inline: a uniform `flex flex-col gap-2.5` column — the **best-spaced** one, used as the reference.

Measured rack gaps before: Settings→Groupings 8px, Groupings→Course 10px, **Course→Points 0px**, **Options→Handicaps 0px**.

## Fix — one home
A shared **`SettingsColumn`** (`flex flex-col gap-2.5`) owns the spacing: every header + row is a flex item with a uniform gap, so nothing sits flush and no section is cramped. All three layouts now use it; the ad-hoc per-item margins are removed (only the format explainer keeps its larger `mt-6` break — as the match page already did). Rows carry **no margin of their own**, so the spacing can't diverge per format again. The reported gaps are fixed as a consequence of the general rule, not one-offs.

## Verify (eyeballed on the preview, across formats)
Every header→row and row→row gap is a **uniform 10px**:
- **Rack**: course→points and options→handicaps were 0px → now 10px; whole page even (screenshot).
- **Match (1v1/2v2)**: uniform 10px (reference, unchanged); the 44px between Points and Handicaps is just the OPTIONS section break.
- **Non-golf**: Settings→format-row was ad-hoc (12/8px) → 10px.
- **Stroke**: shares the golf `GameConfigurationView` path → same rule.

No regression to #554 (rack content/order) or settings behavior. `tsc` + `eslint` clean; full **Vitest 892/892**; critical-path Playwright **2 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)