### PR TITLE
Score-entry permissions: scope who can enter scores (SERVER-first)

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -153,9 +153,33 @@ who's in, what they're called, what role they hold — is the Owner's.
 | **Edit / configure a game** (status incl. drop, points distribution, course, participants) | ✓ | ✓ | **game organizer of *that* game** | `games.update` / `setStatus` / `setPointsDistribution` / `applyCourse` / `addParticipants` |
 | **Enter a game's results** (manual placement; finish/compute) | ✓ | ✓ | **game organizer of *that* game** | `games.setManualResults` / `finish` |
 | **RUN: post results / open score correction** | ✓ | **—** | **game organizer of *that* game** | `games.post` / `openCorrection` *(Owner or game-delegate only — **not** a plain Organizer)* |
-| Enter a per-hole score (until posted) | ✓ | ✓ | ✓ | `scores.upsertEntry` / `deleteEntry` *(any member; **blocked** once the game is posted & not in correction)* |
+| Enter a per-hole score (until posted) | ✓ (any unit) | ✓ (any unit) | ✓ (any unit in *their* game) | `scores.upsertEntry` / `deleteEntry` — **scoped** (see below); **blocked** once the game is posted & not in correction |
+| ↳ a plain **Member** | their own **unit** only | — | — | member scores only the match/group they play in; a non-participant scores nothing |
 | Delegate / revoke a game organizer | ✓ | ✓ | — | `games.addOrganizer` / `removeOrganizer` *(trip staff only — a delegate can't sub-delegate)* |
 | View who runs a game | ✓ | ✓ | ✓ | `games.listOrganizers` |
+
+> **Score-entry is SCOPED (mig 072 — this SUPERSEDES the old "any member" rule).**
+> Entering/clearing a per-hole score (`scores.upsertEntry`/`deleteEntry`) is gated
+> to a three-tier model, enforced **server-side** (the tRPC guard `canWriteScore`
+> **and** the `score_entries` write RLS via `can_score_unit()` — hiding the button
+> is not enough, anyone can call the API directly):
+> - **Owner / Organizer (comp owner/co-admin)** → any unit, any game (`canEditGame`).
+> - **Delegate of *that* game** → any unit in that game (game-isolated).
+> - **Member** → only the **unit they participate in**; a **non-participant** member
+>   scores nothing.
+>
+> The "unit" is resolved per format from `game_matches` + `game_participants`
+> (`src/lib/scoreUnit.ts::memberCanScoreUnit`, mirrored by the SQL `can_score_unit`):
+> **stroke** = the individual player (own row only) · **1v1 match** = the match's
+> two players · **rack** = the play_group (cart) · **2v2 match** = the match's two
+> side groups. The UI reflects this: a unit you can't score taps through to the
+> read-only **scorecard**, not a dead entry screen (owner/delegate keep entry).
+>
+> **Deferred (needs a data link that doesn't exist):** singles (1v1) matches imply
+> a foursome (~2 matches per cart), but there's no `match ↔ foursome` link, so we
+> can't yet let one cart-mate keep BOTH matches' cards. For now a 1v1 member scores
+> **only their own match**. Building it needs a "which matches form a foursome"
+> link; the unit check is already the clean boundary to widen.
 
 > **Roster-removal lock once scoring starts (team-identity).** Once a competition
 > has **any entered score** (`score_entries` exists for any of its games), its team
@@ -203,9 +227,11 @@ who's in, what they're called, what role they hold — is the Owner's.
 > return FORBIDDEN) until the owner/delegate opens correction; results stay
 > visible to everyone throughout.
 
-> **Scoring is Organizer+ today** (`setPlacements`). There is no member-facing
-> "enter your own score" path yet — the intent (see Resolved notes) is for any
-> member to score games they're in, once the scoring engine is rebuilt.
+> **Per-hole scoring is member-facing and SCOPED** (`scores.upsertEntry`/
+> `deleteEntry`, mig 072): a member enters scores for the match/group they play
+> in; owner/organizer/delegate score more broadly. See the scoped-model note under
+> the competition table above. (Non-golf placement scoring — `games.post` /
+> `setManualResults` — stays owner/organizer/delegate.)
 
 ### News / trip board — `news`
 
@@ -288,11 +314,13 @@ only listed view + add).
   planned. `trip_members.status` stays purely as Owner-managed membership state
   (in / invited / out); the only "RSVP" left in the code is comments noting its
   removal. No action.
-- **Score entry — intent: any member.** A member should be able to enter/edit
-  the score of any game they're in. This is **not built yet** — there's no
-  scores router; today's only scoring path is `events.setPlacements`
-  (Organizer+). Captured here as the target permission for the scoring engine
-  when it ships (member-scoped to games they belong to).
+- **Score entry — SHIPPED and scoped (mig 072).** The `scores` router
+  (`upsertEntry`/`deleteEntry`) is live and SERVER-scoped: owner/organizer/
+  delegate score broadly; a member scores only the match/group they play in; a
+  non-participant scores nothing. This SUPERSEDED the earlier "intent: any member"
+  target (which was intentionally tightened — anyone-scores-anything was a score-
+  integrity risk at the real event). See the scoped-model note under the
+  competition table.
 - **Add expense — any member.** Confirmed; matches `expenses.create`
   (`requireTripMember`).
 

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -941,13 +941,24 @@ export function MatchGameView() {
 
   // ── Single-match scoring (one match at a time) ──
   if (screen === "score" && selectedGroup) {
+    // Score-entry access (Task 2 — reflect the server rule): owner/delegate score
+    // any match; a member scores only THEIR OWN match (both players/sides).
+    // Tapping a match you can't score lands on the read-only scorecard (like a
+    // locked/posted match), never a dead entry screen. SERVER is the real gate.
+    const meId = me?.id;
+    const inThisMatch = !!meId && (sided
+      ? (membersOfSide.get(selectedGroup.a.id) ?? []).includes(meId) ||
+        (membersOfSide.get(selectedGroup.b.id) ?? []).includes(meId)
+      : selectedGroup.a.id === meId || selectedGroup.b.id === meId);
+    const canScoreMatch = canEdit || inThisMatch;
+    const readOnly = locked || !canScoreMatch;
     return (
       <div className="fixed inset-0 z-50">
-        {view === "grid" ? (
+        {view === "grid" || readOnly ? (
           <div className="flex h-full flex-col">
             <div className="flex shrink-0 items-center gap-3" style={{ height: 52, padding: "0 16px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-              {/* When locked, the grid is the read-only result — back returns to
-                  the hub and cells don't open editable entry (#7). */}
+              {/* Read-only when locked OR the viewer can't score this match — back
+                  returns to the hub and cells don't open editable entry (#7). */}
               <button onClick={matchBack} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>‹ Back</button>
               <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{locked ? "Scorecard · Final" : "Scorecard"}</span>
             </div>
@@ -961,7 +972,7 @@ export function MatchGameView() {
                 direction="low_wins"
                 pips={entryPips}
                 saveStatus={saveStatus}
-                onCellTap={locked ? undefined : (label) => {
+                onCellTap={readOnly ? undefined : (label) => {
                   setCurrentHole(Number(label) || 1);
                   matchBack();
                 }}

--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -543,6 +543,11 @@ export function RackGameView() {
   // Entry: the tapped foursome's stroke-play card.
   if (entryGroupId && gid) {
     const members = participants.filter((p) => p.play_group_id === entryGroupId);
+    // Score-entry access (Task 2 — reflect the server rule): owner/delegate score
+    // any cart; a member scores only THEIR OWN cart. Tapping a cart you can't
+    // score lands on the read-only scorecard (like a locked/posted card), never a
+    // dead entry screen. The SERVER (canWriteScore + RLS) is the real gate.
+    const canScoreGroup = canEdit || (!!me && members.some((m) => (m.user_id as string) === me.id));
     const groupName = (groupsQ.data?.groups ?? []).find((g) => g.id === entryGroupId)?.display_name as string | undefined;
     const ps: Participant[] = members.map((p) => {
       const id = p.user_id as string;
@@ -559,7 +564,10 @@ export function RackGameView() {
     // Locked (posted) → the read-only scorecard grid (#7). Otherwise the editable
     // entry, with a grid view toggled by the top-right scorecard icon (onOpenGrid).
     // Correcting re-opens editing (locked=false).
-    if (locked || entryView === "grid") {
+    // Read-only scorecard when the card is locked/posted, the grid is toggled on,
+    // OR the viewer can't score this cart (Task 2) — no tap-to-edit in any of those.
+    const readOnly = locked || !canScoreGroup;
+    if (readOnly || entryView === "grid") {
       return (
         <div className="flex flex-col" style={{ height: "100vh" }}>
           <div className="flex shrink-0 items-center gap-3" style={{ height: 52, padding: "0 16px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
@@ -575,7 +583,7 @@ export function RackGameView() {
               values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
               direction="low_wins"
               pips={groupPips}
-              onCellTap={locked ? undefined : (label) => { setCurrentHole(Number(label) || 1); back(); }}
+              onCellTap={readOnly ? undefined : (label) => { setCurrentHole(Number(label) || 1); back(); }}
             />
           </div>
         </div>

--- a/src/components/games/StrokeGameView.tsx
+++ b/src/components/games/StrokeGameView.tsx
@@ -18,6 +18,7 @@ import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useScreenHistory } from "@/hooks/useScreenHistory";
 import type { StrokeStanding } from "@/lib/strokePlay";
@@ -62,6 +63,7 @@ export function StrokeGameView() {
   // #501 Part 1: delegate-aware — a game-delegate (even a plain Member) edits this
   // game, mirroring the server's `canEditGame`. `isOwner` stays trip-Owner-only.
   const { canEdit, isOwner } = useGameEditAccess(tripId, urlGameId);
+  const me = useCurrentUser();
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
 
@@ -142,6 +144,14 @@ export function StrokeGameView() {
     }
     return null;
   }, [createdGame, urlGameId, resumeRoster, memberById]);
+
+  // Score-entry access (Task 2 — reflect the server rule). Stroke's unit is the
+  // individual player, so a plain member scores only if they're a participant
+  // (their own row); owner/delegate score everyone. A non-participant lands on the
+  // read-only scorecard, never a dead entry screen. The SERVER (canWriteScore +
+  // RLS) is the real gate; this is UX. (Finer per-row gating so a member can't tap
+  // a co-player's cell in the shared card is a follow-up — the server rejects it.)
+  const canScoreStroke = canEdit || (!!me && resumeRoster.includes(me.id));
 
   // §3: the COURSE-aware scorecard — par + stroke index from the applied course
   // snapshot (falls back to the 18-hole template default when no course). The
@@ -503,10 +513,13 @@ export function StrokeGameView() {
             onScorecard={() => setView("grid")}
             onPlayAgain={playAgain}
           />
-        ) : view === "grid" ? (
+        ) : view === "grid" || !canScoreStroke ? (
+          // Read-only scorecard when the grid is toggled on OR the viewer can't
+          // score this game (Task 2 — a non-participant, non-owner/delegate member
+          // lands here instead of a dead entry screen; the SERVER is the real gate).
           <div className="flex h-full flex-col">
             <div className="flex shrink-0 items-center gap-3" style={{ height: 52, padding: "0 16px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-              <button onClick={backFromGrid} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>‹ Back</button>
+              <button onClick={canScoreStroke ? backFromGrid : () => router.back()} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>‹ Back</button>
               <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>Scorecard</span>
             </div>
             <div className="min-h-0 flex-1">
@@ -519,10 +532,10 @@ export function StrokeGameView() {
                 direction="low_wins"
                 pips={entryPips}
                 saveStatus={saveStatus}
-                onCellTap={(label) => {
+                onCellTap={canScoreStroke ? (label) => {
                   setCurrentHole(Number(label) || 1);
                   backFromGrid();
-                }}
+                } : undefined}
               />
             </div>
           </div>

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -138,7 +138,7 @@ export function useScoreSaver(
       // mutateAsync per call (see onChange): concurrent clears must each resolve
       // their own outcome, never be orphaned by a later one on the shared observer.
       deleteEntry
-        .mutateAsync({ tripId, gameId, participantId, unitLabel })
+        .mutateAsync({ tripId, gameId, participantId, unitLabel, participantType })
         // A failed delete means the value is still on the server — restore it
         // (accurate) and flag it so the user knows the clear didn't take.
         .catch(() => {
@@ -154,7 +154,7 @@ export function useScoreSaver(
           }
         });
     },
-    [tripId, gameId, values, deleteEntry, mark],
+    [tripId, gameId, values, deleteEntry, mark, participantType],
   );
 
   /** Re-fire the save for a flagged cell using its current value. */

--- a/src/lib/scoreUnit.test.ts
+++ b/src/lib/scoreUnit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { memberCanScoreUnit, type ScoreUnitMatch } from "./scoreUnit";
+
+// The MEMBER tier only — owner/co-admin/delegate bypass this via canEditGame.
+// Covers each format × in-unit / out-of-unit / non-participant.
+
+const userSide = (id: string) => ({ type: "user" as const, id });
+const pgSide = (id: string) => ({ type: "play_group" as const, id });
+
+describe("memberCanScoreUnit — stroke (unit = the individual)", () => {
+  const base = { matches: [] as ScoreUnitMatch[], myPlayGroupId: null, targetPlayGroupId: null };
+
+  it("a member scores their OWN row", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u1", participantId: "u1", participantType: "user", meIsParticipant: true }),
+    ).toBe(true);
+  });
+
+  it("a member CANNOT score another player's row", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u1", participantId: "u2", participantType: "user", meIsParticipant: true }),
+    ).toBe(false);
+  });
+
+  it("a non-participant cannot score even their own id", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u1", participantId: "u1", participantType: "user", meIsParticipant: false }),
+    ).toBe(false);
+  });
+});
+
+describe("memberCanScoreUnit — 1v1 match (unit = the match's two players)", () => {
+  // Two separate 1v1 matches (a cart, but no data link between them).
+  const matches: ScoreUnitMatch[] = [
+    { side_a: userSide("u1"), side_b: userSide("u2") }, // my match
+    { side_a: userSide("u3"), side_b: userSide("u4") }, // cart-mate's match
+  ];
+  const base = { matches, myPlayGroupId: null, targetPlayGroupId: null, meIsParticipant: true };
+
+  it("a player scores their OWN score in their match", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "u1", participantType: "user" })).toBe(true);
+  });
+
+  it("a player scores their OPPONENT in the same match (one card per match)", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "u2", participantType: "user" })).toBe(true);
+  });
+
+  it("DEFERRED: a player CANNOT score the other 1v1 match in the cart", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "u3", participantType: "user" })).toBe(false);
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "u4", participantType: "user" })).toBe(false);
+  });
+
+  it("a non-participant of any match cannot score", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u9", participantId: "u1", participantType: "user" })).toBe(false);
+  });
+});
+
+describe("memberCanScoreUnit — rack (unit = the play_group / cart)", () => {
+  // Rack has no game_matches; grouping is via play_group_id.
+  const base = { matches: [] as ScoreUnitMatch[] };
+
+  it("a member scores a cart-mate in the SAME group", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u1", participantId: "u2", participantType: "user", myPlayGroupId: "g1", targetPlayGroupId: "g1", meIsParticipant: true }),
+    ).toBe(true);
+  });
+
+  it("a member scores their OWN row in their group", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u1", participantId: "u1", participantType: "user", myPlayGroupId: "g1", targetPlayGroupId: "g1", meIsParticipant: true }),
+    ).toBe(true);
+  });
+
+  it("a member CANNOT score a player in a DIFFERENT group", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u1", participantId: "u3", participantType: "user", myPlayGroupId: "g1", targetPlayGroupId: "g2", meIsParticipant: true }),
+    ).toBe(false);
+  });
+
+  it("a member with no group cannot score a grouped player", () => {
+    expect(
+      memberCanScoreUnit({ ...base, meId: "u9", participantId: "u2", participantType: "user", myPlayGroupId: null, targetPlayGroupId: "g1", meIsParticipant: false }),
+    ).toBe(false);
+  });
+});
+
+describe("memberCanScoreUnit — 2v2 match (unit = the match's two side groups)", () => {
+  // side_a = group ga (u1,u2), side_b = group gb (u3,u4). Score entries are per side (play_group).
+  const matches: ScoreUnitMatch[] = [
+    { side_a: pgSide("ga"), side_b: pgSide("gb") },
+    { side_a: pgSide("gc"), side_b: pgSide("gd") }, // another match
+  ];
+  const base = { matches, targetPlayGroupId: null, meIsParticipant: true };
+
+  it("a member scores their OWN side", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "ga", participantType: "play_group", myPlayGroupId: "ga" })).toBe(true);
+  });
+
+  it("a member scores the OPPONENT side of their match (one card per match)", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "gb", participantType: "play_group", myPlayGroupId: "ga" })).toBe(true);
+  });
+
+  it("a member CANNOT score a side in a DIFFERENT match", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "gc", participantType: "play_group", myPlayGroupId: "ga" })).toBe(false);
+  });
+
+  it("a non-participant (no side group) cannot score", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u9", participantId: "ga", participantType: "play_group", myPlayGroupId: null })).toBe(false);
+  });
+
+  it("an unknown play_group id is rejected", () => {
+    expect(memberCanScoreUnit({ ...base, meId: "u1", participantId: "gZ", participantType: "play_group", myPlayGroupId: "ga" })).toBe(false);
+  });
+});

--- a/src/lib/scoreUnit.ts
+++ b/src/lib/scoreUnit.ts
@@ -1,0 +1,102 @@
+/**
+ * scoreUnit — the PURE, client-safe core of "can a plain MEMBER enter this score?"
+ *
+ * Score-entry is scoped (SERVER-enforced; this is the shared truth the mutation
+ * guard AND the UI tap-routing both read so they can't diverge):
+ *   - Owner / co-admin / delegate-of-this-game → any unit (handled by
+ *     `canEditGame`, NOT here — this function is only the MEMBER tier).
+ *   - Member → only the unit they participate in.
+ *   - Non-participant member → nothing.
+ *
+ * The "unit" differs per format (all resolved from `game_matches` +
+ * `game_participants`, no format literal):
+ *   - stroke: the individual player — a member scores only THEIR OWN row.
+ *   - 1v1 match: the match (its two user-sides) — a member scores either player
+ *     in the match they're in.
+ *   - rack: the play_group (cart) — a member scores anyone in their group.
+ *   - 2v2 match: the match (its two side play_groups) — a member scores either
+ *     side of the match they're in.
+ *
+ * Deferred (needs a match↔foursome data link that doesn't exist): letting one
+ * cart-mate score the OTHER 1v1 match in the same foursome. For now a 1v1 member
+ * scores only their own match — this function's match check is already the clean
+ * boundary to widen later.
+ */
+
+/** A match side as stored on `game_matches.side_a/side_b` (jsonb). */
+export interface ScoreUnitSide {
+  type: "user" | "play_group";
+  id: string;
+}
+
+/** One row of `game_matches` — only the two sides matter for unit membership. */
+export interface ScoreUnitMatch {
+  side_a: ScoreUnitSide | null;
+  side_b: ScoreUnitSide | null;
+}
+
+export interface MemberScoreAccessInput {
+  /** The scorer's user id. */
+  meId: string;
+  /** The score's participant id — a user_id ("user") or play_group_id ("play_group"). */
+  participantId: string;
+  participantType: "user" | "play_group";
+  /** This game's matches (empty for stroke + rack — they have no game_matches). */
+  matches: ScoreUnitMatch[];
+  /** The scorer's own `game_participants.play_group_id` (null if none / not a participant). */
+  myPlayGroupId: string | null;
+  /** The TARGET user's play_group_id — only meaningful for participantType "user"
+   *  (rack). Null for stroke / 1v1 / when the target isn't a grouped participant. */
+  targetPlayGroupId: string | null;
+  /** Whether the scorer is a participant of this game at all (gates stroke self-scoring). */
+  meIsParticipant: boolean;
+}
+
+/**
+ * Can a plain MEMBER enter this score? (Owner/co-admin/delegate bypass this — they
+ * are allowed by `canEditGame` before this is ever consulted.)
+ */
+export function memberCanScoreUnit(input: MemberScoreAccessInput): boolean {
+  const { meId, participantId, participantType, matches } = input;
+
+  // 2v2: participantId is a SIDE (play_group). The unit is the whole match, so a
+  // member on EITHER side may keep the match card. Find the match this side
+  // belongs to, then require the scorer to be in one of that match's side groups.
+  if (participantType === "play_group") {
+    const match = matches.find(
+      (m) => m.side_a?.id === participantId || m.side_b?.id === participantId,
+    );
+    if (!match) return false;
+    const sideGroupIds = [match.side_a, match.side_b]
+      .filter((s): s is ScoreUnitSide => s?.type === "play_group")
+      .map((s) => s.id);
+    return input.myPlayGroupId != null && sideGroupIds.includes(input.myPlayGroupId);
+  }
+
+  // participantType === "user":
+
+  // 1v1 match — participantId is a user-side. The unit is the match (both
+  // players), so a member in the match scores either player. Deferred: this is
+  // scoped to THEIR match, not the other 1v1 in the same cart.
+  const singlesMatch = matches.find(
+    (m) =>
+      (m.side_a?.type === "user" && m.side_a.id === participantId) ||
+      (m.side_b?.type === "user" && m.side_b.id === participantId),
+  );
+  if (singlesMatch) {
+    const users = [singlesMatch.side_a, singlesMatch.side_b]
+      .filter((s): s is ScoreUnitSide => s?.type === "user")
+      .map((s) => s.id);
+    return users.includes(meId);
+  }
+
+  // rack — participantId (a user) is in a play_group (cart). The unit is the
+  // group, so a member scores anyone in the SAME group.
+  if (input.targetPlayGroupId != null) {
+    return input.myPlayGroupId != null && input.myPlayGroupId === input.targetPlayGroupId;
+  }
+
+  // stroke — no group, no match. The unit is the individual: a member scores
+  // only their own row (and must actually be a participant).
+  return participantId === meId && input.meIsParticipant;
+}

--- a/src/server/lib/scoreAccess.ts
+++ b/src/server/lib/scoreAccess.ts
@@ -1,0 +1,69 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { canEditGame, type TripRole } from "@/server/middleware";
+import { memberCanScoreUnit, type ScoreUnitMatch, type ScoreUnitSide } from "@/lib/scoreUnit";
+
+/**
+ * canWriteScore — the SERVER source of truth for "may this caller write THIS
+ * score?" (score-entry permissions). Owner / co-admin / delegate-of-this-game →
+ * any unit (via `canEditGame`, the reused elevated-tier check). A plain member →
+ * only the unit they participate in, resolved per format by `memberCanScoreUnit`
+ * (the pure, client-safe core the UI also reads).
+ *
+ * Called by both `scores.upsertEntry` and `scores.deleteEntry` so no write path
+ * is left on the old "any member" rule. Defense-in-depth: RLS on `score_entries`
+ * enforces the same rule via `can_score_unit()` for direct (non-tRPC) writes.
+ */
+type ScoreCtx = {
+  supabase: { from: (t: string) => unknown };
+  user: { id: string } | null;
+  membershipCache: Map<string, TripRole>;
+};
+
+export async function canWriteScore(
+  ctx: ScoreCtx,
+  tripId: string,
+  gameId: string,
+  participantId: string,
+  participantType: "user" | "play_group",
+): Promise<boolean> {
+  // Owner / co-admin / delegate of THIS game → any unit. Reuses the same helper
+  // the rest of the game-edit surface uses (Phase 0 #3/#4), so the elevated tier
+  // can't drift from the config/run gates.
+  if (await canEditGame(ctx, tripId, gameId)) return true;
+
+  const meId = ctx.user?.id;
+  if (!meId) return false;
+
+  const db = ctx.supabase as unknown as SupabaseClient;
+
+  // This game's matches (empty for stroke + rack). side_a/side_b are jsonb
+  // {type,id}; an empty slot stays null.
+  const { data: matchRows } = await db
+    .from("game_matches")
+    .select("side_a, side_b")
+    .eq("game_id", gameId);
+  const matches: ScoreUnitMatch[] = ((matchRows as { side_a: ScoreUnitSide | null; side_b: ScoreUnitSide | null }[] | null) ?? []).map(
+    (r) => ({ side_a: r.side_a, side_b: r.side_b }),
+  );
+
+  // The scorer's own participant row (+ the target user's, for rack) — one query.
+  const wantUsers = participantType === "user" ? [meId, participantId] : [meId];
+  const { data: partRows } = await db
+    .from("game_participants")
+    .select("user_id, play_group_id")
+    .eq("game_id", gameId)
+    .in("user_id", wantUsers);
+  const parts = (partRows as { user_id: string; play_group_id: string | null }[] | null) ?? [];
+  const meRow = parts.find((p) => p.user_id === meId);
+  const targetRow = parts.find((p) => p.user_id === participantId);
+
+  return memberCanScoreUnit({
+    meId,
+    participantId,
+    participantType,
+    matches,
+    myPlayGroupId: meRow?.play_group_id ?? null,
+    targetPlayGroupId: participantType === "user" ? targetRow?.play_group_id ?? null : null,
+    meIsParticipant: !!meRow,
+  });
+}

--- a/src/server/routers/scores.permissions.test.ts
+++ b/src/server/routers/scores.permissions.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Score-entry permissions (SERVER) — the scoped model, DB-backed (exercises the
+ * tRPC guard in scores.upsertEntry/deleteEntry AND the score_entries RLS, since
+ * the caller writes through its own RLS-bound client):
+ *   Owner / Organizer (co-admin) / delegate-of-this-game → any unit.
+ *   Member → only the match/group they play in.
+ *   Non-participant member → nothing.
+ * The exhaustive per-format in/out-of-unit matrix is in src/lib/scoreUnit.test.ts
+ * (pure); this proves the guard is WIRED on every format's write path.
+ */
+const STROKE = "gtt_stroke_play";
+const SINGLES = "gtt_match_play_singles";
+const DOUBLES = "gtt_match_play_doubles";
+const RACK = "gtt_rack_n_stack";
+
+let ctx: TestContext;
+let tripId: string;
+let owner: string, planner: string, member: string, outsider: string;
+
+type MatchRow = { id: string; side_a: { type: string; id: string } | null; side_b: { type: string; id: string } | null };
+
+const FORBIDDEN = { code: "FORBIDDEN" };
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Score Perms Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer"); // co-admin (elevated)
+  await ctx.addTripMember(tripId, "member", "Member"); // plain member
+  await ctx.addTripMember(tripId, "outsider", "Member"); // plain member
+  owner = ctx.user.id;
+  planner = ctx.getUser("planner").id;
+  member = ctx.getUser("member").id;
+  outsider = ctx.getUser("outsider").id;
+});
+
+afterAll(async () => {
+  await ctx.cleanup();
+});
+
+describe("stroke — the unit is the individual player", () => {
+  let gameId: string;
+  beforeAll(async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE, name: "Stroke Perms" });
+    gameId = g.id;
+    await ctx.caller().games.addParticipants({ tripId, gameId, userIds: [member, outsider] });
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+  });
+
+  it("a member enters their OWN score", async () => {
+    const e = await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: member, unitLabel: "1", value: 4 });
+    expect(e.value).toBe(4);
+  });
+
+  it("a member CANNOT enter another player's score", async () => {
+    await expect(
+      ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: outsider, unitLabel: "1", value: 4 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+
+  it("a member CANNOT clear another player's score", async () => {
+    await ctx.caller().scores.upsertEntry({ tripId, gameId, participantId: outsider, unitLabel: "2", value: 5 });
+    await expect(
+      ctx.callerAs("member").scores.deleteEntry({ tripId, gameId, participantId: outsider, unitLabel: "2" }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+
+  it("the owner enters anyone's score; the Organizer (co-admin) too", async () => {
+    expect((await ctx.caller().scores.upsertEntry({ tripId, gameId, participantId: member, unitLabel: "3", value: 4 })).value).toBe(4);
+    expect((await ctx.callerAs("planner").scores.upsertEntry({ tripId, gameId, participantId: outsider, unitLabel: "3", value: 5 })).value).toBe(5);
+  });
+});
+
+describe("stroke — a non-participant member scores nothing", () => {
+  let gameId: string;
+  beforeAll(async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: STROKE, name: "Stroke Solo" });
+    gameId = g.id;
+    // member + planner are the participants; outsider is deliberately NOT in this game.
+    await ctx.caller().games.addParticipants({ tripId, gameId, userIds: [member, planner] });
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+  });
+
+  it("a member not in the game cannot score its participants", async () => {
+    await expect(
+      ctx.callerAs("outsider").scores.upsertEntry({ tripId, gameId, participantId: member, unitLabel: "1", value: 4 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+
+  it("a non-participant cannot score even their own id", async () => {
+    await expect(
+      ctx.callerAs("outsider").scores.upsertEntry({ tripId, gameId, participantId: outsider, unitLabel: "1", value: 4 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+});
+
+describe("1v1 match — the unit is the match (its two players)", () => {
+  let gameId: string;
+  beforeAll(async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: SINGLES, name: "Singles Perms" });
+    gameId = g.id;
+    // Two matches (a cart, but no data link between them): m1 owner v planner, m2 member v outsider.
+    await ctx.caller().matches.setPairings({
+      tripId,
+      gameId,
+      matches: [
+        { sideA: { type: "user", id: owner }, sideB: { type: "user", id: planner }, matchNumber: 1 },
+        { sideA: { type: "user", id: member }, sideB: { type: "user", id: outsider }, matchNumber: 2 },
+      ],
+    });
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+  });
+
+  it("a player scores BOTH players in their own match (one card per match)", async () => {
+    expect((await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: member, unitLabel: "1", value: 4 })).value).toBe(4);
+    expect((await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: outsider, unitLabel: "1", value: 5 })).value).toBe(5);
+  });
+
+  it("DEFERRED: a player CANNOT score the other 1v1 match in the cart", async () => {
+    await expect(
+      ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: owner, unitLabel: "1", value: 3 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+    await expect(
+      ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: planner, unitLabel: "1", value: 3 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+});
+
+describe("2v2 match — the unit is the match (its two side groups)", () => {
+  let gameId: string, pgA: string, pgB: string;
+  beforeAll(async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: DOUBLES, name: "Doubles Perms" });
+    gameId = g.id;
+    const matches = (await ctx.caller().matches.setDoublesPairings({
+      tripId,
+      gameId,
+      matches: [{ sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 }],
+    })) as MatchRow[];
+    pgA = matches[0].side_a!.id; // owner+planner
+    pgB = matches[0].side_b!.id; // member+outsider
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+  });
+
+  it("a member scores BOTH sides of their match (their own + the opponent)", async () => {
+    expect((await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: pgB, unitLabel: "1", value: 4, participantType: "play_group" })).value).toBe(4);
+    expect((await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: pgA, unitLabel: "1", value: 5, participantType: "play_group" })).value).toBe(5);
+  });
+});
+
+describe("rack — the unit is the play_group (cart)", () => {
+  let gameId: string;
+  beforeAll(async () => {
+    const g = await ctx.caller().games.create({ tripId, gameTypeId: RACK, name: "Rack Perms" });
+    gameId = g.id;
+    // Two carts: g1 = member+outsider, g2 = owner+planner.
+    await ctx.caller().playGroups.setFoursomes({
+      tripId,
+      gameId,
+      groups: [{ userIds: [member, outsider] }, { userIds: [owner, planner] }],
+    });
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+  });
+
+  it("a member scores anyone in their OWN cart", async () => {
+    expect((await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: member, unitLabel: "1", value: 4 })).value).toBe(4);
+    expect((await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: outsider, unitLabel: "1", value: 5 })).value).toBe(5);
+  });
+
+  it("a member CANNOT score a player in a DIFFERENT cart", async () => {
+    await expect(
+      ctx.callerAs("member").scores.upsertEntry({ tripId, gameId, participantId: owner, unitLabel: "1", value: 3 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+});
+
+describe("delegate — a game-organizer grant scores any unit, but only in THAT game", () => {
+  let gameA: string, gameB: string;
+  beforeAll(async () => {
+    const a = await ctx.caller().games.create({ tripId, gameTypeId: STROKE, name: "Delegate A" });
+    const b = await ctx.caller().games.create({ tripId, gameTypeId: STROKE, name: "Delegate B" });
+    gameA = a.id;
+    gameB = b.id;
+    await ctx.caller().games.addParticipants({ tripId, gameId: gameA, userIds: [member, planner] });
+    await ctx.caller().games.addParticipants({ tripId, gameId: gameB, userIds: [member, planner] });
+    // outsider (a plain member, NOT a participant of either) is delegated to game A only.
+    await ctx.admin.from("game_delegates").insert({ game_id: gameA, user_id: outsider });
+    await ctx.caller().games.enableScoring({ tripId, gameId: gameA });
+    await ctx.caller().games.enableScoring({ tripId, gameId: gameB });
+  });
+  afterAll(async () => {
+    await ctx.admin.from("game_delegates").delete().eq("game_id", gameA);
+  });
+
+  it("the delegate scores any unit in THEIR game", async () => {
+    expect((await ctx.callerAs("outsider").scores.upsertEntry({ tripId, gameId: gameA, participantId: member, unitLabel: "1", value: 4 })).value).toBe(4);
+  });
+
+  it("the SAME grant does NOT let them score a different game (game-isolated)", async () => {
+    await expect(
+      ctx.callerAs("outsider").scores.upsertEntry({ tripId, gameId: gameB, participantId: member, unitLabel: "1", value: 4 }),
+    ).rejects.toMatchObject(FORBIDDEN);
+  });
+});

--- a/src/server/routers/scores.test.ts
+++ b/src/server/routers/scores.test.ts
@@ -29,22 +29,25 @@ describe("scores router (Slice A — per-hole entry)", () => {
     await ctx.cleanup();
   });
 
-  it("any member can enter a score for any participant; submitted_by is recorded", async () => {
-    // The MEMBER enters a score for the OWNER's card — allowed (engine #7).
+  it("a member enters their OWN score; submitted_by is recorded", async () => {
+    // Scoped model (mig 072): a stroke member scores only their own row. The
+    // exhaustive owner/delegate/member/non-participant matrix is in
+    // scores.permissions.test.ts + scoreUnit.test.ts.
     const entry = await ctx
       .callerAs("member")
-      .scores.upsertEntry({ tripId, gameId, participantId: ownerId, unitLabel: "1", value: 4 });
+      .scores.upsertEntry({ tripId, gameId, participantId: memberId, unitLabel: "1", value: 4 });
     expect(entry.value).toBe(4);
     expect(entry.participant_type).toBe("user");
     expect(entry.submitted_by).toBe(memberId); // audit only — not a gate
   });
 
   it("upsert updates the same cell in place (no duplicate row)", async () => {
+    // The owner may write anyone's card (elevated) — used here for the in-place check.
     await ctx
-      .callerAs("member")
+      .caller()
       .scores.upsertEntry({ tripId, gameId, participantId: ownerId, unitLabel: "1", value: 5 });
     const updated = await ctx
-      .callerAs("member")
+      .caller()
       .scores.upsertEntry({ tripId, gameId, participantId: ownerId, unitLabel: "1", value: 6 });
     expect(updated.value).toBe(6);
 
@@ -113,8 +116,8 @@ describe("scores router (Slice A — per-hole entry)", () => {
     expect(before.data?.status).toBe("active");
 
     // The scores.ts first-score flip is now a documented no-op fallback: scoring
-    // still works and status stays active.
-    await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId: g.id, participantId: ownerId, unitLabel: "1", value: 4 });
+    // still works and status stays active. (Member scores their OWN row.)
+    await ctx.callerAs("member").scores.upsertEntry({ tripId, gameId: g.id, participantId: memberId, unitLabel: "1", value: 4 });
     const after = await ctx.admin.from("games").select("status").eq("id", g.id).single();
     expect(after.data?.status).toBe("active");
   });

--- a/src/server/routers/scores.ts
+++ b/src/server/routers/scores.ts
@@ -2,15 +2,21 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
 import { requireTripMember, canEditGame } from "../middleware";
+import { canWriteScore } from "../lib/scoreAccess";
 import { createAdminClient } from "@/lib/supabase-admin";
 
 /**
  * scores — per-unit score entry for a game (Slice A: per-hole strokes).
  *
- * ANY trip member may enter a score for ANY participant — anyone in the group
- * can keep the card; we don't force everyone phones-out (engine decision #7).
- * `submitted_by` records who typed it for audit only — it is NEVER a permission
- * gate. So this is `requireTripMember`, not Organizer+.
+ * SCOPED score-entry permissions (mig 072 — SERVER-enforced, RLS-backed):
+ *   Owner / Organizer (co-admin) / delegate-of-this-game → any unit.
+ *   Member → only the match/group they participate in (per-format `canWriteScore`
+ *            → `memberCanScoreUnit`).
+ *   Non-participant member → nothing.
+ * Hiding the entry button isn't enough (anyone can call this mutation directly),
+ * so the guard lives here AND in the score_entries RLS. `submitted_by` records who
+ * typed it for audit only. `requireTripMember` gates trip membership; `canWriteScore`
+ * gates the unit.
  */
 export const scoresRouter = router({
   // upsertEntry — set one cell (game × participant × unit). Idempotent on the
@@ -58,6 +64,26 @@ export const scoresRouter = router({
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "Enable scoring before entering scores.",
+        });
+      }
+
+      // Score-entry permissions (SERVER — the real gate; the UI only reflects it).
+      // Owner / co-admin / delegate-of-this-game → any unit; a plain member → only
+      // the match/group they participate in (per-format, `memberCanScoreUnit`).
+      // Anyone else (incl. a non-participant of the game) is rejected — hiding the
+      // button isn't enough, this rejects the raw mutation too.
+      if (
+        !(await canWriteScore(
+          ctx,
+          ctx.tripId!,
+          input.gameId,
+          input.participantId,
+          input.participantType ?? "user",
+        ))
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You can only enter scores for your own match or group.",
         });
       }
 
@@ -126,6 +152,9 @@ export const scoresRouter = router({
         gameId: z.string(),
         participantId: z.string().min(1),
         unitLabel: z.string().min(1).max(16),
+        // Same scoring unit as upsertEntry — needed to resolve unit membership for
+        // the permission check. Defaults to 'user' (singles/stroke/rack).
+        participantType: z.enum(["user", "play_group"]).optional(),
       })
     )
     .use(requireTripMember)
@@ -138,6 +167,23 @@ export const scoresRouter = router({
         .maybeSingle();
       if (!game) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+
+      // Same scoped gate as upsertEntry — clearing a cell is a score write too, so
+      // a member can only clear scores in their own unit (owner/delegate anywhere).
+      if (
+        !(await canWriteScore(
+          ctx,
+          ctx.tripId!,
+          input.gameId,
+          input.participantId,
+          input.participantType ?? "user",
+        ))
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You can only clear scores for your own match or group.",
+        });
       }
 
       const { error } = await ctx.supabase

--- a/supabase/migrations/20260707120000_072_score_entry_permissions.sql
+++ b/supabase/migrations/20260707120000_072_score_entry_permissions.sql
@@ -1,0 +1,132 @@
+-- 072 — Score-entry permissions (scoped, SERVER-enforced) + RLS defense-in-depth
+--
+-- Prior rule (mig 068): ANY trip member could write ANY score once the game had
+-- scoring_enabled — so anyone could POST directly to /rest/v1/score_entries and
+-- overwrite anyone's card, bypassing tRPC. This tightens the write path to the
+-- scoped model (mirrors the tRPC guard in scores.upsertEntry/deleteEntry):
+--   Owner / Organizer (comp owner/co-admin)  → any unit, any time.
+--   Delegate of THIS game                    → any unit, any time.
+--   Member                                   → only the match/group they play in,
+--                                              and only once scoring is enabled.
+--   Non-participant member                   → nothing.
+-- SELECT (reading scores) is unchanged — viewing a card is not the concern.
+
+-- can_score_unit — per-format "is the CALLER in the unit this score belongs to?"
+-- (the MEMBER tier only; owner/organizer/delegate are handled by the policy's
+-- other OR-branches). The unit is resolved from game_matches + game_participants,
+-- never a format literal — mirrors src/lib/scoreUnit.ts::memberCanScoreUnit.
+--   • 2v2  (participant_type 'play_group'): caller is in a side group of the match
+--          containing p_participant_id.
+--   • 1v1  (participant_type 'user', a user-side of a match): caller is the other
+--          (or same) user-side of that match.
+--   • rack (participant_type 'user', target has a play_group): caller shares it.
+--   • stroke (participant_type 'user', no match/group): p_participant_id = caller,
+--          and the caller is a participant.
+-- SECURITY DEFINER + pinned search_path, like is_trip_member / is_game_delegate,
+-- so it's usable inside the RLS policy. Reads only; leaks nothing (a boolean about
+-- the caller's own access), so it is not REVOKEd from authenticated (the policy
+-- needs to execute it).
+CREATE OR REPLACE FUNCTION public.can_score_unit(
+  p_game_id text,
+  p_participant_id text,
+  p_participant_type text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  me text := (auth.uid())::text;
+  v_my_pg text;
+  v_target_pg text;
+BEGIN
+  IF me IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- 2v2: participant is a SIDE (play_group). The caller must be in a play_group
+  -- that is a side of the match containing that side (either side = same card).
+  IF p_participant_type = 'play_group' THEN
+    RETURN EXISTS (
+      SELECT 1
+      FROM game_matches gm
+      JOIN game_participants gp
+        ON gp.game_id = gm.game_id AND gp.user_id = me
+      WHERE gm.game_id = p_game_id
+        AND (gm.side_a->>'id' = p_participant_id OR gm.side_b->>'id' = p_participant_id)
+        AND gp.play_group_id IN (gm.side_a->>'id', gm.side_b->>'id')
+    );
+  END IF;
+
+  -- participant_type = 'user'
+
+  -- 1v1: participant is a user-side of a match → the caller must be a user-side
+  -- of that same match (their own match, both players).
+  IF EXISTS (
+    SELECT 1 FROM game_matches gm
+    WHERE gm.game_id = p_game_id
+      AND ((gm.side_a->>'type' = 'user' AND gm.side_a->>'id' = p_participant_id)
+        OR (gm.side_b->>'type' = 'user' AND gm.side_b->>'id' = p_participant_id))
+  ) THEN
+    RETURN EXISTS (
+      SELECT 1 FROM game_matches gm
+      WHERE gm.game_id = p_game_id
+        AND (gm.side_a->>'id' = p_participant_id OR gm.side_b->>'id' = p_participant_id)
+        AND (gm.side_a->>'id' = me OR gm.side_b->>'id' = me)
+    );
+  END IF;
+
+  -- rack: the target user is in a play_group (cart) → the caller must share it.
+  SELECT play_group_id INTO v_target_pg
+  FROM game_participants
+  WHERE game_id = p_game_id AND user_id = p_participant_id;
+  IF v_target_pg IS NOT NULL THEN
+    SELECT play_group_id INTO v_my_pg
+    FROM game_participants
+    WHERE game_id = p_game_id AND user_id = me;
+    RETURN v_my_pg IS NOT NULL AND v_my_pg = v_target_pg;
+  END IF;
+
+  -- stroke: no match/group → the unit is the individual. The caller scores only
+  -- their own row, and must be a participant.
+  RETURN p_participant_id = me AND EXISTS (
+    SELECT 1 FROM game_participants WHERE game_id = p_game_id AND user_id = me
+  );
+END;
+$$;
+
+-- Tighten the write policy to the scoped model. USING (existing rows: UPDATE/
+-- DELETE) and WITH CHECK (new/updated rows: INSERT/UPDATE) use the SAME
+-- expression, so the unit a member may clear == the unit they may enter.
+DROP POLICY IF EXISTS score_entries_write ON public.score_entries;
+CREATE POLICY score_entries_write ON public.score_entries FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = score_entries.game_id
+        AND is_trip_member(g.trip_id)
+        AND (
+          -- Elevated: owner/organizer or this game's delegate — any unit, any time.
+          has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+          OR is_game_delegate(g.id)
+          -- Member: only their own unit, and only once scoring is enabled.
+          OR (g.scoring_enabled = true
+              AND can_score_unit(score_entries.game_id, score_entries.participant_id, score_entries.participant_type))
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = score_entries.game_id
+        AND is_trip_member(g.trip_id)
+        AND (
+          has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+          OR is_game_delegate(g.id)
+          OR (g.scoring_enabled = true
+              AND can_score_unit(score_entries.game_id, score_entries.participant_id, score_entries.participant_type))
+        )
+    )
+  );


### PR DESCRIPTION
**SECURITY / score-integrity fix (September-relevant).** Score entry was open to ANY trip member for ANY unit — anyone could POST directly to `/rest/v1/score_entries` and overwrite anyone's card, bypassing tRPC. Tighten to a scoped three-tier model, **SERVER-enforced** (mutation guard + RLS); the UI reflects it. **Changes a prior resolved decision** (PERMISSIONS.md updated).

## The model
- **Owner / Organizer** (comp owner/co-admin) → any unit, any game.
- **Delegate of *that* game** → any unit in that game (game-isolated).
- **Member** → only the match/group they participate in.
- **Non-participant member** → nothing.

## Phase 0 (mapped, no STOP — all formats have a clean unit resolution)
Write paths: `scores.upsertEntry`/`deleteEntry` (stroke/1v1/2v2/rack) were `requireTripMember`; `games.post` (non-golf placements) was already `requireGameRunAction` (owner/delegate) — unchanged. Per-format unit (from `game_matches` + `game_participants`, no format literal): stroke = the individual · 1v1 = the match's two players · rack = the play_group (cart) · 2v2 = the match's two side groups. Elevated tier reuses the existing `canEditGame`.

## Task 1 — SERVER (the real fix)
- `src/lib/scoreUnit.ts` — `memberCanScoreUnit()`, the **pure, client-safe** per-format resolver (**16 unit tests**).
- `src/server/lib/scoreAccess.ts` — `canWriteScore()` = `canEditGame` bypass + the member unit check.
- `scores.upsertEntry` + `deleteEntry` guard with it (deleteEntry gains `participantType`; `useScoreSaver.onClear` passes it).
- **Migration 072** — `can_score_unit()` SQL mirror + tightened `score_entries_write` RLS (defense-in-depth for direct/non-tRPC writes). Applied to the linked DB; no stray history row → CI applies file 072 cleanly.
- `scores.permissions.test.ts` — **13 DB-backed tests** across stroke/1v1/2v2/rack + delegate (game-isolated) + owner/organizer + non-participant (exercises the tRPC guard AND RLS, since callers write through their own RLS-bound client). `scores.test.ts` updated off the old rule.

## Task 2 — UI (reflect the rule)
Tapping a unit you can't score lands on the read-only **scorecard** (the existing grid), never a dead entry screen — rack (own cart), match (own match, 1v1 + 2v2), stroke (non-participant → scorecard). Owner/delegate keep full entry (verified on preview). Reuses each view's grid.

## Task 3 — PERMISSIONS.md
Documented the scoped model, per-format unit resolution, and the deferred foursome-shared scorekeeping; refreshed the stale "scoring is Organizer+ / not built yet" notes.

## Deferred (logged)
Singles imply a foursome (~2 matches/cart) but there's no `match ↔ foursome` data link, so one cart-mate can't yet keep BOTH cards. A 1v1 member scores **only their own match**; the unit check is the clean boundary to widen when the link lands.

## Verification
- `tsc` + `eslint` clean.
- Full **Vitest 921/921** (+29 new; other formats green — they score via elevated callers).
- Critical-path Playwright E2E **2 passed**.
- Preview: owner still reaches editable entry (gating doesn't touch owner/delegate).

## Judgment call to flag
**Stroke's "unit" is the individual** — a stroke *member* can enter only their own row (owner/delegate enter everyone). That's the strict, spec-consistent reading of "member scores only their own unit"; trivially loosened to whole-game if you'd rather. Also: finer per-cell gating inside the shared stroke card (so a member can't tap a co-player's cell) is a noted follow-up — the server already rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)