### PR TITLE
Relocate Quick Game: app header → dashboard strip (Tasks 1+2; picker deferred)

### DIFF
--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Zap } from "lucide-react";
 import Link from "next/link";
 import { HelperCards } from "@/components/HelperCards";
 import { FeaturesSection } from "@/components/marketing/FeaturesSection";
@@ -96,7 +96,7 @@ export default function DashboardClient() {
       <TopNav title="BuddyTrip" hideNews />
 
       <main
-        className={`mx-auto max-w-[896px] px-4 pb-24 ${hasAnyTrips ? "pt-4" : ""}`}
+        className="mx-auto max-w-[896px] px-4 pb-24 pt-4"
       >
         {/* ── Header — hidden when the user has no trips. The empty
             state has its own centered "New trip" CTA, so the welcome
@@ -120,6 +120,33 @@ export default function DashboardClient() {
             </button>
           </div>
         )}
+
+        {/* Quick Game — a user-level scratch game, relocated here from the app
+            header (which is trip/competition-scoped). Always available on the
+            dashboard, regardless of trip context. Opens the local stroke-play
+            Quick Game; a format picker is deferred to the standalone-game work. */}
+        <button
+          onClick={() => router.push("/quick-game")}
+          data-testid="quick-game-strip"
+          className="mb-6 flex w-full items-center gap-3 rounded-xl px-4 py-3.5 text-left transition-opacity hover:opacity-90"
+          style={{ background: "var(--color-bt-card)", border: "1px solid var(--color-bt-border)" }}
+        >
+          <span
+            className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl"
+            style={{ background: "var(--color-bt-accent-faint)", color: "var(--color-bt-accent)" }}
+          >
+            <Zap size={20} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-[15px] font-semibold" style={{ color: "var(--color-bt-text)" }}>
+              Quick Game
+            </div>
+            <div className="text-[13px]" style={{ color: "var(--color-bt-text-dim)" }}>
+              Keep score right now — no trip needed
+            </div>
+          </div>
+          <ChevronRight size={18} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+        </button>
 
         {!hasAnyTrips ? (
           /* ── Empty state ─────────────────────────────────────────────────

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,7 +3,7 @@
 import type { FC } from "react";
 import { Suspense, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { Pin, MessageCircle, Megaphone, ChevronDown, Zap } from "lucide-react";
+import { Pin, MessageCircle, Megaphone, ChevronDown } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { UserMenu } from "./UserMenu";
 import { TripSwitcher } from "./TripSwitcher";
@@ -240,20 +240,9 @@ export const TopNav: FC<TopNavProps> = ({
           />
         )}
 
-        {/* Quick Game ⚡ — context-free stroke-play, fire from anywhere.
-            Global (no trip needed); local-storage backed (Slice A2). */}
-        <ToolButton
-          icon={Zap}
-          label="Quick Game"
-          count={0}
-          badgeBg="var(--color-bt-accent)"
-          onClick={() => {
-            onDismissPanels?.();
-            router.push("/quick-game");
-          }}
-          ariaLabel="Quick game"
-          testId="quick-game-button"
-        />
+        {/* Quick Game moved OUT of the app header (trip/competition-scoped chrome)
+            to the user's dashboard, where a scratch game belongs — it's a
+            user-level action, not trip context. See the dashboard strip. */}
 
         {/* Feedback — beta-only outbound channel. Slight teal resting bg
             so it reads as a distinct CTA in the tool cluster without


### PR DESCRIPTION
Move Quick Game out of the app header (trip/competition-scoped chrome) to an independent strip on the user's dashboard, where a scratch game belongs. Per Phase 0's STOP + your call, this ships the **relocation only** (Tasks 1+2); the format→game picker (Tasks 3+4) is deferred — see below.

## Phase 0 (reported, hit the spec's STOP)
1. **Current Quick Game** (`/quick-game`) is **local-storage-only stroke play** — no DB, no tRPC, no trip. Entered via the ⚡ button in `TopNav`. Already fully trip-less.
2. **Add-game modal** (`GameSheet`) creates **real DB games**, entirely trip+competition scoped (`games.create` needs `tripId` + Organizer; team formats need a competition).
3. **Dashboard** (`DashboardClient`) — natural strip spot is the top of `<main>`, under the header.
4. **⛔ Trip-less creation — the STOP.** `games.trip_id` is NOT NULL, `games.create` requires a `tripId` + Organizer, RLS is `is_trip_member(trip_id)`. There's no trip-less DB-game path; the standalone-game/Circle work is explicitly deferred (DEFERRED.md). A format picker that creates match/rack/non-golf games trip-lessly needs that schema work — beyond a UI relocation, which the spec's DO-NOT scoped out.

## Task 1 — remove Quick Game from the app header
Removed the ⚡ ToolButton (+ unused `Zap` import). The tool cluster closes up cleanly (chat/news/feedback/avatar unaffected).

## Task 2 — Quick Game strip on the dashboard
A ⚡ card at the top of the dashboard — **"Quick Game · Keep score right now — no trip needed"** — always visible (empty state + has-trips; `<main>` now always `pt-4`). Opens the existing local stroke-play `/quick-game` (functionality preserved). Verified on preview: header ⚡ gone, strip present + navigates.

## Tasks 3 + 4 — deferred → [#558](https://github.com/zgrether/buddytrip/issues/558)
The format→game picker needs trip-less DB creation (the deferred standalone-game/Circle work). Filed with the Phase 0 findings + options; nothing built here, per the spec's DO-NOT.

## Verification
- `tsc` + `eslint` clean.
- Preview: header decluttered, strip in a natural spot, taps through to `/quick-game`.
- Critical-path Playwright E2E: **2 passed**.
- **Full Vitest: 887/892.** ⚠️ The 5 failures (`scores.test.ts` + `rackNStack.test.ts`, all score-**write** tests) are **NOT from this PR** — it's UI-only (2 files: `DashboardClient` + `TopNav`, no server/test code). They fail because #557's tightened `score_entries` RLS is **already live on the shared test DB** (migration 072 applied out-of-band during #557) while `origin/main` still has the pre-#557 tests. **They clear when #557 merges** (which brings the updated tests). Suggest merging #557 first, then this rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)