### PR TITLE
Team-color text contrast (one shared helper) + scorecard icon → Table2

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -3,6 +3,7 @@
 import { Mail } from "lucide-react";
 import { AVATAR_ICON_COMPONENTS } from "@/lib/avatarIconComponents";
 import { initialsFor } from "@/lib/initials";
+import { teamTextColor } from "@/lib/teamTextColor";
 
 /**
  * Avatar — renders a user's chosen Tabler icon (if `avatarIcon` is set)
@@ -99,9 +100,10 @@ export function Avatar({
     : SIZE_MAP[size];
   const isResponsive = size === "sm" && fixedPx === null;
 
-  // Competition context (team color set) → white foreground on team-color bg.
-  // Accent ("filled") → dark foreground on a solid teal circle.
-  // Default → teal (or muted grey) foreground on a neutral raised surface.
+  // Competition context (team color set) → readable foreground computed for the
+  // team color (dark on light team colors, light on dark — teamTextColor is the
+  // one shared contrast helper). Accent ("filled") → dark foreground on a solid
+  // teal circle. Default → teal (or muted grey) foreground on a neutral raised surface.
   const competitionMode = !!teamColor;
   const background = competitionMode
     ? (teamColor as string)
@@ -109,7 +111,7 @@ export function Avatar({
       ? "var(--color-bt-accent)"
       : "var(--color-bt-card-raised)";
   const foreground = competitionMode
-    ? "#ffffff"
+    ? teamTextColor(teamColor)
     : accent
       ? "#0d1f1a"
       : muted

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -3,7 +3,7 @@
 import { createElement } from "react";
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
-import { Radio, Flag, Swords, Layers, Gamepad2, ClipboardList } from "lucide-react";
+import { Radio, Flag, Swords, Layers, Gamepad2, Table2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
 import { gameHref, isGolfFormat, opensAsPanel } from "@/lib/gameRoutes";
@@ -308,7 +308,7 @@ export function GameRow({
               router.push(scorecardHref);
             }}
           >
-            <ClipboardList size={15} />
+            <Table2 size={15} />
           </span>
         ) : (
           <span
@@ -322,7 +322,7 @@ export function GameRow({
             }}
             title="No course set"
           >
-            <ClipboardList size={15} />
+            <Table2 size={15} />
           </span>
         ))}
 

--- a/src/components/games/MatchCard.tsx
+++ b/src/components/games/MatchCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { matchState, type HoleResult } from "@/lib/matchPlay";
+import { teamTextColor } from "@/lib/teamTextColor";
 import type { Participant } from "./types";
 
 /**
@@ -128,7 +129,7 @@ function Margin({ active, square, text, color, closed }: { active: boolean; squa
   return (
     <div className="flex items-center justify-center" style={{ width: 56, flexShrink: 0, background: active ? color : "transparent" }}>
       {(active || square) && (
-        <span style={{ fontSize: closed && active ? 14 : 15, fontWeight: 800, color: active ? "#fff" : NEU_HALF, whiteSpace: "nowrap" }}>
+        <span style={{ fontSize: closed && active ? 14 : 15, fontWeight: 800, color: active ? teamTextColor(color) : NEU_HALF, whiteSpace: "nowrap" }}>
           {text}
         </span>
       )}

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronLeft, Grid3x3 } from "lucide-react";
+import { ChevronLeft, Table2 } from "lucide-react";
 import { buildDecided, matchState, strokeHoles } from "@/lib/matchPlay";
 import { StrokeKeypad } from "./StrokeKeypad";
 import { MatchCard } from "./MatchCard";
@@ -245,7 +245,7 @@ export function MatchEntryView({
           </div>
         </div>
         <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
-          <Grid3x3 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+          <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
         </button>
       </header>
 

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronLeft, Grid3x3, Settings } from "lucide-react";
+import { ChevronLeft, Table2, Settings } from "lucide-react";
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import { Avatar } from "@/components/Avatar";
 import { StrokeKeypad } from "./StrokeKeypad";
@@ -217,7 +217,7 @@ export function ScoreEntryView({
             </button>
           )}
           <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
-            <Grid3x3 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+            <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
           </button>
         </div>
       </header>

--- a/src/components/games/course/CourseRowContent.tsx
+++ b/src/components/games/course/CourseRowContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, X, ClipboardList, ChevronRight } from "lucide-react";
+import { Check, X, Table2, ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
 import { gameHref } from "@/lib/gameRoutes";
@@ -141,7 +141,7 @@ function ScorecardPreviewButton({ onClick }: { onClick: () => void }) {
       className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left"
       style={{ background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
     >
-      <ClipboardList size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+      <Table2 size={16} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
       <span className="flex-1 text-sm" style={{ color: "var(--color-bt-text)" }}>Preview scorecard</span>
       <ChevronRight size={16} style={{ color: "var(--color-bt-text-dim)" }} />
     </button>

--- a/src/components/games/rack/RackBoard.tsx
+++ b/src/components/games/rack/RackBoard.tsx
@@ -2,6 +2,7 @@
 
 import { TrendingUp } from "lucide-react";
 import { fmtToPar, type RackMode, type RackSlot, type RackSlotPlayer } from "@/lib/rackNStack";
+import { teamTextColor } from "@/lib/teamTextColor";
 
 /**
  * Rack-n-Stack display board (Slice C part 3 + addendum). PURE / display-only —
@@ -166,12 +167,14 @@ function ScoreBlock({ value, thru, lead, color }: { value: number; thru: number;
   return (
     <div className="flex shrink-0 flex-col" style={{ width: 60, paddingTop: TOP_PAD, background: lead ? color : "transparent" }}>
       <div className="flex items-center justify-center" style={{ height: PRIMARY }}>
-        <span style={{ fontSize: 22, fontWeight: 800, color: lead ? "#fff" : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
+        <span style={{ fontSize: 22, fontWeight: 800, color: lead ? teamTextColor(color) : "var(--color-bt-text)", fontVariantNumeric: "tabular-nums", lineHeight: 1 }}>
           {fmtToPar(value)}
         </span>
       </div>
       <div className="flex items-center justify-center" style={{ height: SECONDARY }}>
-        <span style={{ fontSize: 9.5, fontWeight: 600, letterSpacing: "0.06em", color: lead ? "rgba(255,255,255,0.85)" : "var(--color-bt-text-dim)" }}>
+        {/* Secondary label on the leader's team color — same computed contrast
+            color, slightly muted so it reads as a sub-label (not full-strength). */}
+        <span style={{ fontSize: 9.5, fontWeight: 600, letterSpacing: "0.06em", color: lead ? teamTextColor(color) : "var(--color-bt-text-dim)", opacity: lead ? 0.85 : undefined }}>
           THRU {thru}
         </span>
       </div>

--- a/src/lib/teamTextColor.test.ts
+++ b/src/lib/teamTextColor.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { teamTextColor, TEAM_TEXT_DARK, TEAM_TEXT_LIGHT } from "./teamTextColor";
+
+// The full team palette (TeamsPanel TEAM_COLORS). Max-contrast crossover picks
+// dark on every one of these vibrant colors (dark beats white on all — the
+// bright green/cyan/amber/orange were the failing-on-white culprits).
+describe("teamTextColor — the team palette", () => {
+  const palette = [
+    ["#3b82f6", "Blue"],
+    ["#22c55e", "Green"],
+    ["#a855f7", "Purple"],
+    ["#06b6d4", "Cyan"],
+    ["#ef4444", "Red"],
+    ["#f59e0b", "Amber"],
+    ["#ec4899", "Pink"],
+    ["#f97316", "Orange"],
+  ] as const;
+
+  for (const [hex, name] of palette) {
+    it(`${name} (${hex}) → dark text (higher contrast)`, () => {
+      expect(teamTextColor(hex)).toBe(TEAM_TEXT_DARK);
+    });
+  }
+});
+
+describe("teamTextColor — light vs dark boundary", () => {
+  it("a very dark background → light (white) text", () => {
+    expect(teamTextColor("#0a1a2a")).toBe(TEAM_TEXT_LIGHT); // a dim variant
+    expect(teamTextColor("#000000")).toBe(TEAM_TEXT_LIGHT);
+  });
+  it("a very light background → dark text", () => {
+    expect(teamTextColor("#ffffff")).toBe(TEAM_TEXT_DARK);
+    expect(teamTextColor("#eeeeee")).toBe(TEAM_TEXT_DARK);
+  });
+  it("accepts shorthand hex and a missing #", () => {
+    expect(teamTextColor("#fff")).toBe(TEAM_TEXT_DARK);
+    expect(teamTextColor("3b82f6")).toBe(TEAM_TEXT_DARK);
+  });
+});
+
+describe("teamTextColor — safe fallback", () => {
+  it("unparseable input → light (safe on dark surfaces), never throws", () => {
+    expect(teamTextColor("var(--color-bt-accent)")).toBe(TEAM_TEXT_LIGHT);
+    expect(teamTextColor("rebeccapurple")).toBe(TEAM_TEXT_LIGHT);
+    expect(teamTextColor("")).toBe(TEAM_TEXT_LIGHT);
+    expect(teamTextColor(null)).toBe(TEAM_TEXT_LIGHT);
+    expect(teamTextColor(undefined)).toBe(TEAM_TEXT_LIGHT);
+  });
+});

--- a/src/lib/teamTextColor.ts
+++ b/src/lib/teamTextColor.ts
@@ -1,0 +1,62 @@
+/**
+ * teamTextColor — the ONE source of truth for "what text/icon color is readable
+ * on this team-color background?" Every place that paints text or an icon ON a
+ * team color (the #551 avatars, the match-status margin, the rack score block, …)
+ * reads this, so contrast can't be re-decided (or forgotten) per site.
+ *
+ * COMPUTED, not per-color: it picks whichever of the dark or light foreground has
+ * the higher WCAG contrast ratio against the given background (max-contrast — the
+ * standard crossover). Robust to any hex, including future team colors. Some team
+ * colors are light (bright green / cyan / amber / orange) where white fails; this
+ * flips them to dark automatically. Unparseable input → white (safe on the app's
+ * dark surfaces).
+ *
+ * The two foregrounds are the app's tokens: dark = `--color-bt-on-accent`
+ * (#0d1f1a, the same dark used on teal fills), light = white.
+ */
+
+/** Dark foreground for LIGHT team colors (the app's on-accent dark). */
+export const TEAM_TEXT_DARK = "var(--color-bt-on-accent)";
+/** Light foreground for DARK team colors. */
+export const TEAM_TEXT_LIGHT = "#ffffff";
+/** Relative luminance of TEAM_TEXT_DARK (#0d1f1a) — precomputed for the ratio. */
+const DARK_LUMINANCE = 0.0114;
+
+/** Parse a #rgb / #rrggbb hex into [r,g,b] (0–255), or null if unparseable. */
+function parseHex(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  let h = m[1];
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/** sRGB relative luminance (WCAG): linearize each channel, then weight. */
+export function relativeLuminance(r: number, g: number, b: number): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** WCAG contrast ratio between two relative luminances (order-independent). */
+function contrast(l1: number, l2: number): number {
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * The readable text/icon color for text placed ON `bgColor` (a team color).
+ * Returns TEAM_TEXT_DARK or TEAM_TEXT_LIGHT — whichever contrasts more.
+ */
+export function teamTextColor(bgColor: string | null | undefined): string {
+  if (!bgColor) return TEAM_TEXT_LIGHT;
+  const rgb = parseHex(bgColor);
+  if (!rgb) return TEAM_TEXT_LIGHT; // safe fallback (e.g. a CSS var / named color)
+  const bgL = relativeLuminance(rgb[0], rgb[1], rgb[2]);
+  const darkContrast = contrast(DARK_LUMINANCE, bgL);
+  const whiteContrast = contrast(1, bgL); // white luminance = 1
+  return darkContrast >= whiteContrast ? TEAM_TEXT_DARK : TEAM_TEXT_LIGHT;
+}


### PR DESCRIPTION
Two consistency fixes. Task 1 generalized per Zach: the white-text-on-team-color problem isn't just avatars — it's anywhere text sits on a team color (the game scoreboards especially). Fix the CLASS with one shared, computed helper + an audit.

## Task 1 — team-color text contrast (one helper, applied everywhere)

**Phase 0 audit** — every place text/icon sits on a **solid** team-color background (all others with `background:<team color>` are color dots/bars with no text on them; non-golf uses tokens):
- `Avatar` competition-mode foreground — the #551 team-color avatars + the FinalStandings podium avatar (white `#ffffff`).
- `MatchCard` status margin ("2 UP" / "3&2") — white on `active ? color`.
- `RackBoard` ScoreBlock net-to-par **and** the THRU label — white on `lead ? color`.

**The helper** — `src/lib/teamTextColor.ts`: `teamTextColor(bg)` picks the higher-WCAG-contrast foreground (dark `var(--color-bt-on-accent)` vs white) from the background's sRGB relative luminance. Computed → robust to any/future team color; unparseable → white (safe on dark surfaces). **12 unit tests** lock the palette + fallback.

**Threshold — your call: WCAG max-contrast crossover.** Every team color gets its highest-contrast text. For the 8-color palette that means **all flip to dark** (dark beats white on every one, including blue/red at ~3.7:1); white stays only for genuinely dark backgrounds. The bright green/cyan/amber/orange that failed on white are the biggest wins.

Applied at all three usages (all avatars route through the one `Avatar` component, so every avatar site is covered).

## Task 2 — scorecard icon → `Table2`
The scorecard icon was inconsistent — `ClipboardList` (leaderboard rows + "Preview scorecard" course-panel button), `Grid3x3` (score-entry pages). Standardized all to lucide `Table2` (confirmed present): `GameRow` (2 usages), `CourseRowContent`, `ScoreEntryView`, `MatchEntryView`. Left `PointsMatrix`'s `Table2` (a points matrix, not a scorecard) and the idea-zone `LayoutGrid` untouched.

## Verification
- `tsc` + `eslint` clean.
- Full **Vitest 933/933** (incl. the 12 new `teamTextColor` tests).
- Critical-path Playwright E2E **2 passed**.
- Preview: the rack scoreboard's Centurions (orange, a light color) scores now render **dark on orange** (readable — were white before); the leaderboard scorecard icon is `lucide-table-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)