### PR TITLE
Scorecard tee-display pass: wrap-bug fix, custom checkbox, collapsible selector

### DIFF
--- a/src/components/games/Checkbox.tsx
+++ b/src/components/games/Checkbox.tsx
@@ -1,0 +1,41 @@
+import { Check } from "lucide-react";
+
+/**
+ * Checkbox — the app's custom checkbox: a teal-filled box with a dark check when
+ * on, a bordered empty box when off. Renders only the box (the `label` is the
+ * a11y name); callers place their own visible label alongside it. Extracted from
+ * ModifierCards so game modifiers and the scorecard tee legend share one control
+ * instead of a native `<input type="checkbox">`.
+ */
+export function Checkbox({
+  on,
+  onClick,
+  label,
+  disabled,
+  className = "",
+}: {
+  on: boolean;
+  onClick: () => void;
+  label: string;
+  disabled?: boolean;
+  /** Extra classes for caller-specific alignment (e.g. `mt-0.5`). */
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md transition-colors disabled:opacity-40 ${className}`}
+      style={{
+        background: on ? "var(--color-bt-accent)" : "transparent",
+        border: `1px solid ${on ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
+      }}
+    >
+      {on && <Check size={13} strokeWidth={3} style={{ color: "var(--color-bt-on-accent)" }} />}
+    </button>
+  );
+}

--- a/src/components/games/ModifierCards.tsx
+++ b/src/components/games/ModifierCards.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { Checkbox } from "@/components/games/Checkbox";
 import { Stepper } from "@/components/games/Stepper";
 import {
   modifierDef,
@@ -57,6 +57,7 @@ export function ModifierCards({
                 disabled={readOnly}
                 onClick={() => onChange(setModifierEnabled(modifiers, key, !on))}
                 label={def.label}
+                className="mt-0.5"
               />
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium" style={{ color: "var(--color-bt-text)" }}>{def.label}</p>
@@ -100,25 +101,3 @@ function HoleStepper({ value, onChange, disabled }: { value: number; onChange: (
   );
 }
 
-/** The on/off CHECKBOX (§10): teal fill + dark check glyph when on, transparent +
- *  bordered when off. Toggles the modifier's presence in the jsonb exactly as the
- *  old Switch did — appearance change only. */
-function Checkbox({ on, onClick, label, disabled }: { on: boolean; onClick: () => void; label: string; disabled?: boolean }) {
-  return (
-    <button
-      type="button"
-      role="checkbox"
-      aria-checked={on}
-      aria-label={label}
-      onClick={onClick}
-      disabled={disabled}
-      className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md transition-colors disabled:opacity-40"
-      style={{
-        background: on ? "var(--color-bt-accent)" : "transparent",
-        border: `1px solid ${on ? "var(--color-bt-accent)" : "var(--color-bt-border)"}`,
-      }}
-    >
-      {on && <Check size={13} strokeWidth={3} style={{ color: "var(--color-bt-on-accent)" }} />}
-    </button>
-  );
-}

--- a/src/components/games/StandardGrid.test.tsx
+++ b/src/components/games/StandardGrid.test.tsx
@@ -46,9 +46,10 @@ describe("StandardGrid — empty (scores-off) preview", () => {
   });
 });
 
-// Spec 5b — multi-tee yardage rows. When teeRows is supplied, the grid renders a
-// checkbox legend + one yardage row per VISIBLE tee (default = chosen + neighbors),
-// replacing the single snapshot Yards row; the chosen tee is highlighted + in play.
+// Spec 5b — multi-tee yardage rows. When teeRows is supplied, the grid renders one
+// yardage row per VISIBLE tee (default = chosen + neighbors), replacing the single
+// snapshot Yards row; the chosen tee is highlighted + in play. The tee SELECTION
+// controls live behind a collapsed-by-default disclosure (tee-display pass).
 describe("StandardGrid — multi-tee yardage rows (5b)", () => {
   const teeRows: TeeRow[] = [
     { name: "Blue", color: "#3b82f6", yards: [410, 165, 540, 430], total: 1545, isChosen: false, defaultVisible: true },
@@ -59,11 +60,14 @@ describe("StandardGrid — multi-tee yardage rows (5b)", () => {
     <StandardGrid units={units} participants={[]} values={{}} direction="low_wins" teeRows={teeRows} />
   );
 
-  it("renders the checkbox legend listing every tee (even hidden ones)", () => {
-    expect(html).toContain("tee-legend");
-    expect(html).toContain("Blue");
-    expect(html).toContain("White");
-    expect(html).toContain("Red"); // in the legend even though its row is hidden by default
+  it("collapses the tee selector behind a disclosure, summarizing the chosen tee", () => {
+    expect(html).toContain("tee-legend-toggle"); // the disclosure trigger (collapsed by default)
+    expect(html).toContain("Tees"); // the trigger label
+    expect(html).toContain("White · in play"); // chosen tee shown in the trigger summary
+    // The full per-tee selection is behind the collapsed disclosure — a tee that is
+    // neither chosen nor rendered in the grid (Red, default-hidden) is absent from
+    // the initial static markup until the disclosure is expanded.
+    expect(html).not.toContain("Red");
   });
 
   it("renders a yardage row for each DEFAULT-VISIBLE tee, and hides the rest", () => {

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronDown, Flag } from "lucide-react";
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import type { TeeRow } from "@/lib/teeRows";
 import { Avatar } from "@/components/Avatar";
+import { Checkbox } from "./Checkbox";
 import { GolfChip } from "./GolfChip";
 import {
   scoreCellKey,
@@ -80,8 +82,12 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
   // Multi-tee rows (Spec 5b): user overrides on top of each row's default
   // visibility; the CHOSEN tee is always shown (non-hidable — it's in play).
   const multiTee = teeRows.length > 0;
+  // The tee selector is collapsed by default (it's setup busy-ness, not scoring);
+  // the chosen tee still shows in the trigger summary and in the grid below.
+  const [teePanelOpen, setTeePanelOpen] = useState(false);
   const [teeOverrides, setTeeOverrides] = useState<Record<string, boolean>>({});
   const teeVisible = (row: TeeRow) => row.isChosen || (teeOverrides[row.name] ?? row.defaultVisible);
+  const chosenTee = teeRows.find((r) => r.isChosen);
   const toggleTee = (row: TeeRow) =>
     setTeeOverrides((o) => ({ ...o, [row.name]: !(o[row.name] ?? row.defaultVisible) }));
   // A tee's front/back/total yardage — its yards align with `units` by index.
@@ -160,33 +166,64 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
 
   return (
     <div className="h-full" style={{ background: "var(--color-bt-base)" }}>
-      {/* Multi-tee checkbox legend (Spec 5b) — reveal/hide each tee's yardage row.
-          The chosen tee is checked + disabled (in play, never hidable). Replaces the
-          single-tee header when tee rows are present. */}
+      {/* Multi-tee selector (Spec 5b) — reveal/hide each tee's yardage row.
+          Collapsed behind a disclosure (mirrors the leaderboard's "Game by game"
+          PointsMatrix toggle) so the selection controls aren't always taking up
+          space; the chosen tee shows in the trigger and always renders in the grid.
+          The chosen tee is checked + disabled (in play, never hidable). */}
       {multiTee ? (
-        <div
-          className="flex flex-wrap items-center gap-x-3 gap-y-1.5"
-          style={{ padding: "8px 12px", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
-          data-testid="tee-legend"
-        >
-          {teeRows.map((row) => {
-            const on = teeVisible(row);
-            return (
-              <label key={row.name} className="flex items-center gap-1.5" style={{ cursor: row.isChosen ? "default" : "pointer" }}>
-                <input
-                  type="checkbox"
-                  checked={on}
-                  disabled={row.isChosen}
-                  onChange={() => toggleTee(row)}
-                  style={{ accentColor: "var(--color-bt-accent)" }}
-                />
-                <span style={{ width: 9, height: 9, borderRadius: "50%", background: row.color, border: "1px solid var(--color-bt-subtle-border)", flexShrink: 0 }} />
-                <span style={{ fontSize: 12, fontWeight: row.isChosen ? 700 : 500, color: on ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>
-                  {row.name}{row.isChosen ? " · in play" : ""}
+        <div style={{ borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+          <button
+            type="button"
+            onClick={() => setTeePanelOpen((o) => !o)}
+            aria-expanded={teePanelOpen}
+            className="flex w-full items-center gap-2"
+            style={{ padding: "8px 12px" }}
+            data-testid="tee-legend-toggle"
+          >
+            <Flag size={13} style={{ color: "var(--color-bt-text-dim)", flexShrink: 0 }} />
+            <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>
+              Tees
+            </span>
+            {chosenTee && (
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span style={{ width: 8, height: 8, borderRadius: "50%", background: chosenTee.color, border: "1px solid var(--color-bt-subtle-border)", flexShrink: 0 }} />
+                <span className="truncate" style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text)" }}>
+                  {chosenTee.name} · in play
                 </span>
-              </label>
-            );
-          })}
+              </span>
+            )}
+            <ChevronDown
+              size={16}
+              className="ml-auto transition-transform"
+              style={{ color: "var(--color-bt-text-dim)", transform: teePanelOpen ? "rotate(180deg)" : undefined, flexShrink: 0 }}
+            />
+          </button>
+          {teePanelOpen && (
+            <div
+              className="flex flex-wrap items-center gap-x-4 gap-y-2.5"
+              style={{ padding: "2px 12px 10px" }}
+              data-testid="tee-legend"
+            >
+              {teeRows.map((row) => {
+                const on = teeVisible(row);
+                return (
+                  <div key={row.name} className="flex items-center gap-1.5">
+                    <Checkbox
+                      on={on}
+                      disabled={row.isChosen}
+                      onClick={() => toggleTee(row)}
+                      label={`Show ${row.name} tee yardages`}
+                    />
+                    <span style={{ width: 9, height: 9, borderRadius: "50%", background: row.color, border: "1px solid var(--color-bt-subtle-border)", flexShrink: 0 }} />
+                    <span style={{ fontSize: 12, fontWeight: row.isChosen ? 700 : 500, color: on ? "var(--color-bt-text)" : "var(--color-bt-text-dim)" }}>
+                      {row.name}{row.isChosen ? " · in play" : ""}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       ) : tee ? (
         <div className="flex items-center gap-2" style={{ padding: "8px 12px", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -241,11 +241,22 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                 const valColor = row.isChosen ? "var(--color-bt-text)" : "var(--color-bt-text-dim)";
                 // The chosen row gets a left accent rail on the sticky name cell
                 // (inset shadow — no layout shift), so it's unmistakable at a glance.
+                // Its fill (accent-faint) is TRANSLUCENT, so the sticky column must
+                // composite it over an OPAQUE surface — otherwise the yardage cells
+                // scrolling underneath bleed through the frozen tee-name cell. Layer
+                // the tint over base (matches the row, which sits on base) so it
+                // masks cleanly at every scroll position.
                 const nameStyle = {
                   ...nameCell,
                   background: zebraBg,
                   padding: "0 10px",
-                  ...(row.isChosen ? { boxShadow: "inset 3px 0 0 var(--color-bt-accent)" } : {}),
+                  ...(row.isChosen
+                    ? {
+                        background:
+                          "linear-gradient(var(--color-bt-accent-faint), var(--color-bt-accent-faint)), var(--color-bt-base)",
+                        boxShadow: "inset 3px 0 0 var(--color-bt-accent)",
+                      }
+                    : {}),
                 } as React.CSSProperties;
                 return (
                   <div key={row.name} className="flex" style={{ height: 26, background: zebraBg, borderBottom: "1px solid var(--color-bt-subtle-border)" }} data-testid={`tee-row-${row.name}`}>


### PR DESCRIPTION
Three related fixes to the scorecard's multi-tee display (Spec 5b), from Zach's QA pass. All one surface — the scorecard tee selector + yardage grid. Per-task commits.

## Phase 0 findings
- **Wrap bug root cause:** the sticky first column masks scrolling content only when opaque. The **chosen** tee row set its sticky name cell to `--color-bt-accent-faint`, a **translucent** token (`rgba .08/.12`), so yardage cells scrolling underneath showed *through* the frozen tee-name cell. Non-chosen zebra rows use opaque surfaces → never bled (chosen-only, as reported).
- **Checkbox:** the tee legend used a native `<input type="checkbox">` with `accentColor`; the game-modifiers checkbox is a local `Checkbox` in `ModifierCards.tsx` (not exported, no shared UI checkbox).
- **Collapse pattern:** reused the leaderboard's "Game by game" `PointsMatrix` disclosure idiom (`button` + `aria-expanded` + `ChevronDown` rotate + `{open && panel}`).

## Task 1 — wrap-behind-tee-name fix
Composite the accent tint over an opaque surface — `linear-gradient(accent-faint, accent-faint), var(--color-bt-base)` — so the chosen cell looks identical (accent-faint over the grid base the row already sits on) but masks the scrolling yardages. Verified at scrollLeft 0 / 90 / full-right.

## Task 2 — shared custom checkbox
Extracted the modifiers checkbox into `src/components/games/Checkbox.tsx` (teal fill + dark check on, bordered off) and used it in both ModifierCards and the tee legend. ModifierCards keeps its `mt-0.5` via a new optional `className` prop. No native checkbox restyle.

## Task 3 — collapse the tee selector
The always-exposed per-tee checkboxes now sit behind a collapsed-by-default disclosure: a Flag-iconed `TEES · <chosen> in play` trigger that expands to the full selection. Only the SELECTION controls collapse — the chosen tee still summarizes in the trigger and always renders in the grid; chosen-tee highlighting and per-tee yardage rows are unchanged.

## Verification
- Preview (2v2 Match Scoring Test scorecard, real multi-tee course): disclosure collapsed by default with chosen-tee summary; expands to custom checkboxes matching modifiers; scrolled right at multiple positions — frozen column masks cleanly, no bleed-through; chosen-tee accent-faint fill + rail intact; zebra + per-tee rows unaffected.
- `tsc --noEmit` clean · eslint clean · full Vitest **933 passed** (89 files) · Playwright critical-path **2 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)