### PR TITLE
Game-state sync: reconcile scores AND config across devices (hash-poll)

### DIFF
--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight, Plus, X, Swords, SlidersHorizontal, Sparkles, Users, Settings } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
+import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -184,7 +185,25 @@ export function MatchGameView() {
   // Multi-tee scorecard yardage rows (Spec 5b) — reads the persisted course record(s).
   const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const matchesQ = trpc.matches.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gameId });
-  const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gameId! }, { enabled: !!tripId && !!gameId });
+  // Scores are STATE — poll (~20s, paused when tab hidden) so remote entries
+  // reflect on this open board (game-state sync). `loadedValues` is a memo of
+  // this query merged UNDER the local `values` (mergedFor), so the poll refreshes
+  // others' scores while the active enterer's local edits still win.
+  const scoresQ = trpc.scores.listByGame.useQuery(
+    { tripId: tripId!, gameId: gameId! },
+    { enabled: !!tripId && !!gameId, refetchInterval: GAME_SYNC_INTERVAL_MS, refetchIntervalInBackground: false },
+  );
+
+  // Config sync: on a config change from another device (matchups reassigned,
+  // side handicaps, modifiers/rules, course, go-live, finish), silently refetch
+  // this game's config so members converge. Match config spans the game row +
+  // the matches table → invalidate both.
+  const onConfigChanged = useCallback(() => {
+    if (!tripId || !gameId) return;
+    void utils.games.getById.invalidate({ tripId, gameId });
+    void utils.matches.listByGame.invalidate({ tripId, gameId });
+  }, [utils, tripId, gameId]);
+  useConfigSync(tripId, gameId, !!gameId, onConfigChanged);
 
   // Format: the resumed game's type is authoritative; a brand-new game (no game
   // yet) reads the `?format=doubles` hint. `sided` switches the whole flow

--- a/src/components/games/NonGolfGameView.tsx
+++ b/src/components/games/NonGolfGameView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ChevronLeft, Settings } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
@@ -11,6 +11,7 @@ import { NonGolfScoreboard } from "@/components/games/NonGolfScoreboard";
 import { GamePageHeader } from "@/components/competition/GamePageHeader";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
+import { useConfigSync } from "@/hooks/useConfigSync";
 import { GAME_TYPES, type ScoringModel } from "@/lib/gameTypes";
 import type { GameRow, LBTeamLite } from "@/components/competition/CompetitionGamesPanel";
 
@@ -75,6 +76,17 @@ export function NonGolfGameView() {
     { tripId: tripId!, competitionId: competitionId! },
     { enabled: !!tripId && !!competitionId }
   );
+
+  // Config sync: on a config change from another device (modifiers/rules, run
+  // config, name, go-live, finish) silently refetch this game's config so members
+  // converge. Non-golf "scores" are posted RESULTS (score-derived, not in the
+  // config hash) — those already reflect via the board's shared leaderboard poll,
+  // so here we invalidate the config (getById) + the leaderboard read.
+  const onConfigChanged = useCallback(() => {
+    if (tripId && urlGameId) void utils.games.getById.invalidate({ tripId, gameId: urlGameId });
+    if (tripId && competitionId) void utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+  }, [utils, tripId, urlGameId, competitionId]);
+  useConfigSync(tripId, urlGameId, !!urlGameId, onConfigChanged);
   const teams = useMemo(() => ((lbQ.data?.teams ?? []) as LBTeamLite[]), [lbQ.data]);
   const gameCells = useMemo(
     () => ((lbQ.data?.cells ?? []) as { gameId: string; teamId: string; place: number; points: number }[])

--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, Users, Settings, SlidersHorizontal } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
@@ -9,6 +9,7 @@ import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
+import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { showToast } from "@/lib/toast";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { RackGroupBuilder, type GroupBuilderTeam } from "@/components/games/rack/RackGroupBuilder";
@@ -105,7 +106,7 @@ export function RackGameView() {
   // same idempotent upsert + retry + outbox + per-cell status as stroke/match
   // (was a raw fire-and-forget mutate with no retry/status). Per-user entries, so
   // no participantType. `values` is seeded once from the server below.
-  const { values, setValues, saveStatus, onChange, onClear, retryCell } = useScoreSaver(tripId, gid);
+  const { values, saveStatus, onChange, onClear, retryCell, reconcile } = useScoreSaver(tripId, gid);
 
   const crew = trpc.tripMembers.list.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
   const competition = trpc.competitions.getByTrip.useQuery({ tripId: tripId! }, { ...STRUCTURE_QUERY, enabled: !!tripId });
@@ -119,7 +120,13 @@ export function RackGameView() {
   // Multi-tee scorecard yardage rows (Spec 5b) — reads the persisted course record(s).
   const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const groupsQ = trpc.playGroups.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { ...STRUCTURE_QUERY, enabled: !!tripId && !!gid });
-  const scoresQ = trpc.scores.listByGame.useQuery({ tripId: tripId!, gameId: gid! }, { enabled: !!tripId && !!gid });
+  // Scores are STATE — poll (~20s, paused when tab hidden) so remote entries
+  // reflect on this open board (game-state sync); reconcile below merges them in
+  // without clobbering the active enterer.
+  const scoresQ = trpc.scores.listByGame.useQuery(
+    { tripId: tripId!, gameId: gid! },
+    { enabled: !!tripId && !!gid, refetchInterval: GAME_SYNC_INTERVAL_MS, refetchIntervalInBackground: false },
+  );
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
@@ -217,16 +224,28 @@ export function RackGameView() {
     }
     return v;
   }, [scoresQ.data]);
-  // Seed the saver's values from the server ONCE on resume (mirrors stroke) — the
-  // saver's `values` is then the single source (server seed + live edits), so a
-  // clear removes from it cleanly and the outbox recovery re-populates it.
-  const seededRef = useRef(false);
+  // Reflect scores from OTHER devices: reconcile server truth into the saver each
+  // time the poll returns changed data, merged so the active enterer's unsaved
+  // cells win (game-state sync). The saver's `values` stays the single source
+  // (server-reconciled + live edits), so a clear removes from it cleanly and the
+  // outbox recovery re-populates it. Handles the initial load too (empty local →
+  // takes the server scores), so no separate seed-once is needed.
   useEffect(() => {
-    if (seededRef.current || !gid || !scoresQ.data) return;
-    setValues((v) => (Object.keys(v).length ? v : loadedValues));
-    seededRef.current = true;
-  }, [gid, scoresQ.data, loadedValues, setValues]);
+    if (!gid || !scoresQ.data) return;
+    reconcile(loadedValues);
+  }, [gid, scoresQ.data, loadedValues, reconcile]);
   const mergedFor = (pid: string) => values[pid] ?? {};
+
+  // Config sync: on a config change from another device (foursomes reshuffled,
+  // participant handicaps, modifiers/rules, course, go-live, finish), silently
+  // refetch this game's config so members converge. Rack config spans the game
+  // row + the play_groups/participants → invalidate both.
+  const onConfigChanged = useCallback(() => {
+    if (!tripId || !gid) return;
+    void utils.games.getById.invalidate({ tripId, gameId: gid });
+    void utils.playGroups.listByGame.invalidate({ tripId, gameId: gid });
+  }, [utils, tripId, gid]);
+  useConfigSync(tripId, gid, !!gid, onConfigChanged);
 
   // ── Rack read-model (the spec's novelty) ─────────────────────────────
   const participants = useMemo(() => groupsQ.data?.participants ?? [], [groupsQ.data]);

--- a/src/components/games/StrokeGameView.tsx
+++ b/src/components/games/StrokeGameView.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight, Lock, Settings } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
+import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
@@ -78,9 +79,17 @@ export function StrokeGameView() {
   );
   // Multi-tee scorecard yardage rows (Spec 5b) — reads the persisted course record.
   const teeRows = useScorecardTeeRows(tripId, gameQ.data);
+  // Scores are STATE — poll them (~20s) so a remote device's entries reflect on
+  // this open board (game-state sync). refetchIntervalInBackground:false pauses
+  // the poll when the tab is hidden. The reconcile below merges fresh server
+  // scores in without clobbering the active enterer.
   const scoresQ = trpc.scores.listByGame.useQuery(
     { tripId: tripId!, gameId: urlGameId! },
-    { enabled: !!tripId && !!urlGameId }
+    {
+      enabled: !!tripId && !!urlGameId,
+      refetchInterval: GAME_SYNC_INTERVAL_MS,
+      refetchIntervalInBackground: false,
+    }
   );
 
   const [selected, setSelected] = useState<string[]>([]);
@@ -269,7 +278,7 @@ export function StrokeGameView() {
   // Score writes go through the connectivity-resilient saver: optimistic value,
   // retry-with-backoff, per-cell save status, kept-and-flagged (never rolled
   // back) on failure. Owns `values` + `saveStatus` for this game.
-  const { values, setValues, saveStatus, onChange, onClear, retryCell } =
+  const { values, setValues, saveStatus, onChange, onClear, retryCell, reconcile } =
     useScoreSaver(tripId, activeGameId);
   // Finishing also retries (idempotent — recomputes from the same scores); a
   // failure stays on the entry view and surfaces via the global error toast,
@@ -279,19 +288,30 @@ export function StrokeGameView() {
     retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 8000),
   });
 
-  // Seed the saved scores into the entry view ONCE on resume — never clobber an
-  // edit already made in this session (mirrors the match page).
-  const seededRef = useRef(false);
+  // Reflect scores from OTHER devices: reconcile server truth into the view each
+  // time the poll returns changed data, merged so the active enterer's unsaved
+  // cells win (game-state sync). This also handles the initial load — an empty
+  // local view simply takes the server's scores — so no separate seed-once is
+  // needed. (Structural sharing means this only fires when scores actually
+  // change.)
   useEffect(() => {
-    if (seededRef.current || !urlGameId || !scoresQ.data) return;
+    if (!urlGameId || !scoresQ.data) return;
     const loaded: ScoreValues = {};
     for (const e of scoresQ.data as { participant_id: string; unit_label: string; value: number | null }[]) {
       if (e.value == null) continue;
       (loaded[e.participant_id] ??= {})[e.unit_label] = e.value;
     }
-    setValues((v) => (Object.keys(v).length ? v : loaded));
-    seededRef.current = true;
-  }, [urlGameId, scoresQ.data, setValues]);
+    reconcile(loaded);
+  }, [urlGameId, scoresQ.data, reconcile]);
+
+  // Config sync: poll the cheap config hash on the same tick (batched with the
+  // score poll) and, when it changes on another device, silently refetch THIS
+  // game's config so groupings/modifiers/rules/course/status converge. Stroke's
+  // config lives entirely on the game row → invalidate getById.
+  const onConfigChanged = useCallback(() => {
+    if (tripId && activeGameId) void utils.games.getById.invalidate({ tripId, gameId: activeGameId });
+  }, [utils, tripId, activeGameId]);
+  useConfigSync(tripId, activeGameId, !!activeGameId, onConfigChanged);
 
   function toggle(userId: string) {
     setSelected((prev) =>
@@ -368,7 +388,6 @@ export function StrokeGameView() {
     setSelected([]);
     setCurrentHole(1);
     setView("entry");
-    seededRef.current = false;
     // Drop ?game so "Play again" starts a fresh game instead of resuming this one.
     if (urlGameId) router.replace(`/trips/${param}/games/new`);
   }

--- a/src/hooks/useConfigSync.ts
+++ b/src/hooks/useConfigSync.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { trpc } from "@/lib/trpc-client";
+
+/**
+ * The game-state sync poll cadence. Zach's spec: scores/config reconcile within
+ * ~15–30s ("delayed-a-bit is fine; not a live broadcast"). 20s sits in the
+ * middle. Used for BOTH the score poll (refetchInterval on scores.listByGame in
+ * each view) and this config-hash poll, so — because the tRPC client batches —
+ * the two fire on the same tick and coalesce into ONE HTTP round-trip.
+ */
+export const GAME_SYNC_INTERVAL_MS = 20_000;
+
+/**
+ * useConfigSync — the CHEAP half of cross-device game-state reconcile.
+ *
+ * The stale-state root: a game's CONFIG (modifiers/rules/settings/course/status +
+ * groupings + matchups + handicaps) is cached as STRUCTURE (staleTime: Infinity)
+ * and only refetched on an explicit invalidation — which is LOCAL to the device
+ * that made the change. A second device never hears about it (the reproduced
+ * grouping-swap; the danger case of an unseen mid-round modifier/rule change).
+ *
+ * The fix, per Zach's design: poll a cheap server-computed CONFIG HASH
+ * (`games.configHash` — a short string, NOT the heavy config) on the same tick as
+ * the score poll. Hold the last hash; when the server's differs, the config
+ * actually changed, so invalidate the full-config queries (getById + the format's
+ * matchups/groupings) to converge. When it MATCHES, do nothing — no heavy config
+ * refetch when nothing changed (the efficiency win). Convergence is SILENT — the
+ * caller's invalidations quietly re-render; no toast/notification.
+ *
+ * Scoped: pass `enabled` = the game panel is open + showing the board, so the
+ * poll only runs where it's needed (paused when the tab is hidden via
+ * refetchIntervalInBackground: false — matches the leaderboard poll).
+ *
+ * Baseline: the FIRST observed hash is the baseline (no refetch) — it represents
+ * the config the view just fetched on open. Every change AFTER that is caught.
+ * (A config change that lands in the &lt;20s window between panel-open and the first
+ * poll on a WARM-cached reopen isn't detected until the next real change — the
+ * same warm-cache staleness that exists today; the continuous-open danger case
+ * this targets is fully covered.)
+ *
+ * @param onConfigChanged the view's structure invalidations. Wrap in useCallback
+ *   so it's identity-stable; it's fine if it changes, the effect only ACTS on a
+ *   genuine hash change.
+ */
+export function useConfigSync(
+  tripId: string | undefined,
+  gameId: string | null | undefined,
+  enabled: boolean,
+  onConfigChanged: () => void,
+) {
+  const lastHash = useRef<string | null>(null);
+  const active = enabled && !!tripId && !!gameId;
+
+  const hashQ = trpc.games.configHash.useQuery(
+    { tripId: tripId!, gameId: gameId! },
+    {
+      enabled: active,
+      refetchInterval: GAME_SYNC_INTERVAL_MS,
+      refetchIntervalInBackground: false,
+    },
+  );
+
+  // Reset the baseline when the watched game changes, so reopening a different
+  // game doesn't compare against the previous game's hash.
+  useEffect(() => {
+    lastHash.current = null;
+  }, [gameId]);
+
+  const serverHash = hashQ.data?.hash;
+  useEffect(() => {
+    if (!serverHash) return;
+    if (lastHash.current === null) {
+      lastHash.current = serverHash; // first observation = baseline, don't refetch
+      return;
+    }
+    if (serverHash !== lastHash.current) {
+      lastHash.current = serverHash;
+      onConfigChanged(); // silent convergence — invalidate full config
+    }
+  }, [serverHash, onConfigChanged]);
+}

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { trpc } from "@/lib/trpc-client";
 import { outboxPut, outboxClear, outboxEntries } from "@/lib/scoreOutbox";
+import { reconcileScores } from "@/lib/scoreReconcile";
 import { showToast } from "@/lib/toast";
 import {
   scoreCellKey,
@@ -58,6 +59,15 @@ export function useScoreSaver(
 ) {
   const [values, setValues] = useState<ScoreValues>({});
   const [saveStatus, setSaveStatus] = useState<SaveStatusMap>({});
+  // A live mirror of saveStatus so `reconcile` can read the latest without being
+  // recreated on every status change (it must stay identity-stable — a view polls
+  // scores and calls it in an effect keyed on the fetched data, not on this hook).
+  // reconcile always runs from a post-commit effect, so the committed value is
+  // current by then.
+  const saveStatusRef = useRef(saveStatus);
+  useEffect(() => {
+    saveStatusRef.current = saveStatus;
+  }, [saveStatus]);
 
   // suppressErrorToast: these own per-cell save UI (badge + banner), so the
   // global connectivity toast would double-signal — opt out of it.
@@ -157,6 +167,47 @@ export function useScoreSaver(
     [tripId, gameId, values, deleteEntry, mark, participantType],
   );
 
+  /**
+   * Reconcile incoming SERVER score truth into the local view so a remote
+   * device's entries reflect here (game-state sync), WITHOUT ever clobbering the
+   * person actively entering (the #543 durable-outbox writes win locally).
+   *
+   * Semantics: keep every local cell, then OVERLAY the server's value for each
+   * cell the server has — EXCEPT cells with an unconfirmed local write (flagged
+   * `saving`/`error`, or still in the durable outbox), which keep their local
+   * value. So a teammate's new/corrected score appears; a value the enterer just
+   * saved is never overwritten by a poll that raced the save (a server response
+   * lacking that cell can't drop it — overlay only SETS server-present cells).
+   *
+   * Deliberate gap: a score DELETED on another device isn't removed here (its
+   * cell is simply absent from the server payload, and we never drop a local
+   * cell). Reflecting adds/edits is the requirement; never-clobber-the-enterer is
+   * the hard rule, and full drop-to-server-truth couldn't guarantee both. Remote
+   * clears are rare and self-correct on the next real edit or a reopen.
+   *
+   * Idempotent + safe every poll tick; with TanStack's structural sharing the
+   * caller's effect only fires when the fetched scores actually change.
+   */
+  const reconcile = useCallback(
+    (server: ScoreValues) => {
+      setValues((cur) => {
+        // Protect cells with an unconfirmed local write — flagged saving/error, or
+        // still in the durable outbox (#543) — so the active enterer always wins.
+        const protectedKeys = new Set<string>();
+        for (const [k, st] of Object.entries(saveStatusRef.current)) {
+          if (st === "saving" || st === "error") protectedKeys.add(k);
+        }
+        if (gameId) {
+          for (const e of outboxEntries(gameId)) {
+            protectedKeys.add(scoreCellKey(e.participantId, e.unitLabel));
+          }
+        }
+        return reconcileScores(cur, server, protectedKeys);
+      });
+    },
+    [gameId],
+  );
+
   /** Re-fire the save for a flagged cell using its current value. */
   const retryCell = useCallback(
     (participantId: string, unitLabel: string) => {
@@ -206,5 +257,6 @@ export function useScoreSaver(
     onChange,
     onClear,
     retryCell,
+    reconcile,
   };
 }

--- a/src/lib/configHash.test.ts
+++ b/src/lib/configHash.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { computeConfigHash, canonicalize } from "./configHash";
+
+describe("computeConfigHash — deterministic fingerprint", () => {
+  it("is stable across object key ordering (jsonb/JS key order must not churn it)", () => {
+    expect(computeConfigHash({ a: 1, b: 2 })).toBe(computeConfigHash({ b: 2, a: 1 }));
+    expect(computeConfigHash({ x: { p: 1, q: 2 } })).toBe(computeConfigHash({ x: { q: 2, p: 1 } }));
+  });
+
+  it("returns the SAME hash for identical config (no false 'changed')", () => {
+    const cfg = { modifiers: { glorious: true }, groups: [{ id: "g1", members: ["u1", "u2"] }] };
+    expect(computeConfigHash(cfg)).toBe(computeConfigHash(structuredClone(cfg)));
+  });
+
+  it("CHANGES when a modifier toggles (the danger case)", () => {
+    const before = { modifiers: { glorious: false } };
+    const after = { modifiers: { glorious: true } };
+    expect(computeConfigHash(before)).not.toBe(computeConfigHash(after));
+  });
+
+  it("CHANGES when a grouping swaps players (the reproduced bug)", () => {
+    const before = { groups: [{ id: "g1", members: ["u1", "u2"] }, { id: "g2", members: ["u3", "u4"] }] };
+    const after = { groups: [{ id: "g1", members: ["u1", "u3"] }, { id: "g2", members: ["u2", "u4"] }] };
+    expect(computeConfigHash(before)).not.toBe(computeConfigHash(after));
+  });
+
+  it("CHANGES when a matchup handicap changes", () => {
+    const before = { matches: [{ id: "m1", sideA: "u1", sideB: "u2", handicap: 0 }] };
+    const after = { matches: [{ id: "m1", sideA: "u1", sideB: "u2", handicap: 3 }] };
+    expect(computeConfigHash(before)).not.toBe(computeConfigHash(after));
+  });
+
+  it("CHANGES when rules / status / scoring_enabled change", () => {
+    const base = { rules: "std", status: "active", scoringEnabled: true };
+    expect(computeConfigHash(base)).not.toBe(computeConfigHash({ ...base, rules: "double last 3" }));
+    expect(computeConfigHash(base)).not.toBe(computeConfigHash({ ...base, status: "complete" }));
+    expect(computeConfigHash(base)).not.toBe(computeConfigHash({ ...base, scoringEnabled: false }));
+  });
+
+  it("distinguishes null / absent / falsey (a dropped field must move the hash)", () => {
+    expect(computeConfigHash({ course: null })).not.toBe(computeConfigHash({ course: "c1" }));
+    expect(computeConfigHash({ course: null })).not.toBe(computeConfigHash({}));
+    expect(computeConfigHash({ a: 0 })).not.toBe(computeConfigHash({ a: false }));
+  });
+
+  it("produces an 8-char hex string", () => {
+    expect(computeConfigHash({ any: "thing" })).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+describe("canonicalize", () => {
+  it("sorts keys recursively and preserves array order", () => {
+    expect(canonicalize({ b: 1, a: [3, 1, 2] })).toBe('{"a":[3,1,2],"b":1}');
+  });
+});

--- a/src/lib/configHash.ts
+++ b/src/lib/configHash.ts
@@ -1,0 +1,54 @@
+/**
+ * computeConfigHash — a cheap, deterministic fingerprint of a game's CONFIG so a
+ * remote device can detect "did the config change?" without refetching the whole
+ * config every tick (game-state sync, Spec).
+ *
+ * The problem it solves: a game's config (modifiers, rules, settings, course,
+ * status, groupings, matchups, handicaps) is cached client-side as STRUCTURE
+ * (staleTime: Infinity) and only refetched on an explicit invalidation — which is
+ * LOCAL to the device that made the change. A second device never hears about it
+ * and plays under stale rules/groupings. The fix is a cheap change-signal: the
+ * server hashes the config, the client polls just the hash alongside the score
+ * poll, and refetches the full config ONLY when the hash it holds differs.
+ *
+ * Why a hash (not a version bump): it's derived from the ACTUAL config, so it
+ * changes automatically whenever any config field changes — it can't be forgotten
+ * the way a manual `version++` on some-but-not-all mutations can (and this app's
+ * config mutations invalidate inconsistently — exactly the kind of gap a hash is
+ * immune to).
+ *
+ * This is client-safe and dependency-free (no node `crypto`): the fingerprint
+ * only needs to change iff the input changes — it is NOT a security primitive, so
+ * a fast non-cryptographic hash (FNV-1a over canonical JSON) is the right tool.
+ * Keeping it pure + client-safe makes it unit-testable and reusable either side.
+ */
+
+/**
+ * Canonical JSON — stable across object key ordering so `{a:1,b:2}` and
+ * `{b:2,a:1}` hash identically (Postgres jsonb / JS object key order must not
+ * flip the fingerprint). Arrays keep their order — callers pass config arrays
+ * pre-sorted by a stable key (e.g. row id) so a reorder that doesn't change
+ * meaning doesn't churn the hash, and a reorder that DOES (e.g. slot order) does.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalize(obj[k])}`).join(",")}}`;
+}
+
+/**
+ * FNV-1a 32-bit over the canonical string → an 8-char hex fingerprint. Fast,
+ * deterministic, and collision-resistant enough for change-detection (we only
+ * ever compare equality of two hashes of the same small config object).
+ */
+export function computeConfigHash(config: unknown): string {
+  const s = canonicalize(config);
+  let h = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193); // FNV prime, 32-bit via imul
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}

--- a/src/lib/scoreReconcile.test.ts
+++ b/src/lib/scoreReconcile.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { reconcileScores } from "./scoreReconcile";
+import { scoreCellKey, type ScoreValues } from "@/components/games/types";
+
+const NONE = new Set<string>();
+
+describe("reconcileScores — merge server truth without clobbering the enterer", () => {
+  it("adds a teammate's new score from the server", () => {
+    const local: ScoreValues = { u1: { "1": 4 } };
+    const server: ScoreValues = { u1: { "1": 4 }, u2: { "1": 5 } };
+    expect(reconcileScores(local, server, NONE)).toEqual({ u1: { "1": 4 }, u2: { "1": 5 } });
+  });
+
+  it("reflects a remote EDIT to a confirmed cell (server value wins when not protected)", () => {
+    const local: ScoreValues = { u1: { "1": 4 } };
+    const server: ScoreValues = { u1: { "1": 5 } }; // corrected elsewhere
+    expect(reconcileScores(local, server, NONE)).toEqual({ u1: { "1": 5 } });
+  });
+
+  it("does NOT overwrite an unconfirmed local cell (the enterer wins)", () => {
+    const local: ScoreValues = { u1: { "1": 7 } }; // just typed, still saving
+    const server: ScoreValues = { u1: { "1": 4 } }; // stale server value
+    const prot = new Set([scoreCellKey("u1", "1")]);
+    expect(reconcileScores(local, server, prot)).toEqual({ u1: { "1": 7 } });
+  });
+
+  it("never drops a local cell the server payload lacks (poll racing a fresh save)", () => {
+    const local: ScoreValues = { u1: { "1": 4, "2": 6 } }; // hole 2 just saved
+    const server: ScoreValues = { u1: { "1": 4 } }; // response predates hole 2
+    // Even unprotected, the missing cell is kept — overlay only SETS server cells.
+    expect(reconcileScores(local, server, NONE)).toEqual({ u1: { "1": 4, "2": 6 } });
+  });
+
+  it("protects an unconfirmed cell but still applies server truth to OTHER cells", () => {
+    const local: ScoreValues = { u1: { "1": 7 }, u2: { "1": 3 } };
+    const server: ScoreValues = { u1: { "1": 4 }, u2: { "1": 5 }, u3: { "1": 2 } };
+    const prot = new Set([scoreCellKey("u1", "1")]); // u1/1 is mid-save locally
+    expect(reconcileScores(local, server, prot)).toEqual({
+      u1: { "1": 7 }, // kept (protected)
+      u2: { "1": 5 }, // updated to server
+      u3: { "1": 2 }, // added from server
+    });
+  });
+
+  it("seeds from empty local (initial load takes the server scores)", () => {
+    const server: ScoreValues = { u1: { "1": 4, "2": 5 } };
+    expect(reconcileScores({}, server, NONE)).toEqual({ u1: { "1": 4, "2": 5 } });
+  });
+
+  it("does not mutate the inputs", () => {
+    const local: ScoreValues = { u1: { "1": 4 } };
+    const server: ScoreValues = { u1: { "1": 5 } };
+    reconcileScores(local, server, NONE);
+    expect(local).toEqual({ u1: { "1": 4 } });
+    expect(server).toEqual({ u1: { "1": 5 } });
+  });
+});

--- a/src/lib/scoreReconcile.ts
+++ b/src/lib/scoreReconcile.ts
@@ -1,0 +1,35 @@
+import { scoreCellKey, type ScoreValues } from "@/components/games/types";
+
+/**
+ * reconcileScores — the pure merge behind useScoreSaver.reconcile (game-state
+ * sync). Reflects a remote device's scores into the local view WITHOUT clobbering
+ * the person actively entering.
+ *
+ * Rule: keep every local cell, then overlay the server's value for each cell the
+ * server has, EXCEPT cells in `protectedKeys` (an unconfirmed local write —
+ * flagged `saving`/`error` or still in the durable outbox, #543), which keep
+ * their local value. So a teammate's new/corrected score appears, while a value
+ * the enterer just saved is never overwritten by a poll that raced the save (a
+ * server payload lacking that cell can't drop it — overlay only SETS
+ * server-present cells).
+ *
+ * Deliberate gap: a score DELETED elsewhere isn't removed here — reflecting
+ * adds/edits is the requirement, never-clobber-the-enterer is the hard rule, and
+ * dropping-to-exact-server-truth can't guarantee both. Remote clears are rare and
+ * self-correct on the next real edit or reopen.
+ */
+export function reconcileScores(
+  local: ScoreValues,
+  server: ScoreValues,
+  protectedKeys: ReadonlySet<string>,
+): ScoreValues {
+  const next: ScoreValues = {};
+  for (const pid of Object.keys(local)) next[pid] = { ...local[pid] };
+  for (const pid of Object.keys(server)) {
+    for (const ul of Object.keys(server[pid])) {
+      if (protectedKeys.has(scoreCellKey(pid, ul))) continue;
+      (next[pid] ??= {})[ul] = server[pid][ul];
+    }
+  }
+  return next;
+}

--- a/src/server/routers/games.configHash.test.ts
+++ b/src/server/routers/games.configHash.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+const STROKE_PLAY = "gtt_stroke_play";
+
+/**
+ * games.configHash — the cheap cross-device change-signal (game-state sync). The
+ * load-bearing properties: a CONFIG change moves the hash (so remote devices
+ * refetch and converge), a SCORE entry does NOT (so scoring never triggers a
+ * pointless full-config refetch), and any trip member can read it.
+ */
+let ctx: TestContext;
+let tripId: string;
+let gameId: string;
+let ownerId: string;
+let memberId: string;
+
+describe("games.configHash — config change-signal", () => {
+  beforeAll(async () => {
+    ctx = await TestContext.create();
+    tripId = await ctx.createTrip("Config Hash Trip");
+    await ctx.addTripMember(tripId, "member", "Member");
+    ownerId = ctx.user.id;
+    memberId = ctx.getUser("member").id;
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: STROKE_PLAY, name: "Round" });
+    gameId = game.id;
+    await ctx.caller().games.addParticipants({ tripId, gameId, userIds: [ownerId, memberId] });
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it("any trip member can read the hash (a short string)", async () => {
+    const { hash } = await ctx.callerAs("member").games.configHash({ tripId, gameId });
+    expect(typeof hash).toBe("string");
+    expect(hash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("is STABLE when nothing changes (no false 'changed')", async () => {
+    const a = await ctx.caller().games.configHash({ tripId, gameId });
+    const b = await ctx.caller().games.configHash({ tripId, gameId });
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it("CHANGES when config changes — go-live (enableScoring)", async () => {
+    const before = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+    const after = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    expect(after).not.toBe(before);
+  });
+
+  it("does NOT change when only SCORES change (the efficiency guarantee)", async () => {
+    // Scoring is enabled by the prior test. A score write touches score_entries
+    // only — the config hash must not move, or every entry would trigger a
+    // needless full-config refetch on every device.
+    const before = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    await ctx.caller().scores.upsertEntry({ tripId, gameId, participantId: ownerId, unitLabel: "1", value: 4 });
+    await ctx.caller().scores.upsertEntry({ tripId, gameId, participantId: memberId, unitLabel: "1", value: 5 });
+    const after = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    expect(after).toBe(before);
+  });
+
+  it("CHANGES when a modifier / rule changes (the danger case)", async () => {
+    const before = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    await ctx.caller().games.update({ tripId, gameId, rulesForToday: "Double the last 3 holes" });
+    const after = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    expect(after).not.toBe(before);
+  });
+
+  it("CHANGES when a participant's handicap changes (setParticipantStrokes)", async () => {
+    const before = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    await ctx.caller().playGroups.setParticipantStrokes({ tripId, gameId, userId: memberId, strokes: 6 });
+    const after = (await ctx.caller().games.configHash({ tripId, gameId })).hash;
+    expect(after).not.toBe(before);
+  });
+
+  it("a non-member cannot read the hash", async () => {
+    // `planner` was never added to this trip → not a trip member.
+    await expect(
+      ctx.callerAs("planner").games.configHash({ tripId, gameId }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -13,6 +13,17 @@ import { buildScorecardSchema, composeTwoNines, validateStrokeIndex, type Snapsh
 import { validatePlacement } from "@/lib/gameConfig";
 import { GAME_TYPES, getGameTypeDefinition } from "@/lib/gameTypes";
 import { assertGameReady } from "../lib/gameReadiness";
+import { computeConfigHash } from "@/lib/configHash";
+
+/**
+ * The game-row columns that constitute CONFIG (fingerprinted by `configHash`).
+ * Deliberately EXCLUDES `created_at` (immutable) and anything score-derived, so
+ * entering a score never churns the hash. Groupings/matchups/handicaps live in
+ * child tables (game_participants / play_groups / matches) and are folded in
+ * alongside these — see `configHash` below.
+ */
+const GAME_CONFIG_COLS =
+  "name, status, game_type_id, config, modifiers, rules_for_today, scorecard_schema, tee_time, points_distribution, points_total, competition_format, scoring_enabled, course_id, back_course_id, corrections_open, pairings_published_at";
 
 /**
  * games — the competition-engine spine (Slice A: individual stroke play).
@@ -184,6 +195,66 @@ export const gamesRouter = router({
           ).data ?? [];
 
       return { ...game, participants };
+    }),
+
+  // configHash — any trip member. A CHEAP change-signal for game-state sync: a
+  // deterministic fingerprint of the game's CONFIG (modifiers/rules/settings/
+  // course/status + groupings + matchups + handicaps), read on the score-poll
+  // tick so a remote device can tell "did the config change?" without refetching
+  // the whole config every poll. It refetches the full config (getById + matches/
+  // playGroups) ONLY when this hash differs from the one it holds — the efficiency
+  // win. Returns just the short hash string (the heavy config is never shipped
+  // here). See src/lib/configHash.ts for why a hash beats a manual version bump.
+  //
+  // The child-table config lives in game_participants (roster + play_group_id +
+  // handicap_strokes), play_groups (2v2 side containers + handicaps), and matches
+  // (matchup structure). Score-DERIVED fields — score_entries, matches.result/
+  // margin/status — are excluded on purpose so entering scores never churns the
+  // config hash (that would defeat the "refetch only when config changed" goal).
+  // All reads run under the caller's RLS context, so the fingerprint reflects
+  // exactly the config that getById would return to THIS member.
+  configHash: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx, input }) => {
+      const [gameRes, partsRes, groupsRes, matchesRes] = await Promise.all([
+        ctx.supabase
+          .from("games")
+          .select(GAME_CONFIG_COLS)
+          .eq("id", input.gameId)
+          .eq("trip_id", ctx.tripId)
+          .maybeSingle(),
+        ctx.supabase
+          .from("game_participants")
+          .select("user_id, play_group_id, team_id, handicap_strokes")
+          .eq("game_id", input.gameId)
+          .order("user_id", { ascending: true }),
+        ctx.supabase
+          .from("play_groups")
+          .select("id, display_name, handicap_strokes")
+          .eq("game_id", input.gameId)
+          .order("id", { ascending: true }),
+        ctx.supabase
+          .from("matches")
+          .select("id, play_group_id, match_number, display_order, side_a, side_b")
+          .eq("game_id", input.gameId)
+          .order("id", { ascending: true }),
+      ]);
+      if (gameRes.error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to read config: ${gameRes.error.message}` });
+      }
+      if (!gameRes.data) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+      // Ordered arrays (by id/user_id) + canonical (sorted-key) hashing make the
+      // fingerprint stable regardless of DB row-return order.
+      const hash = computeConfigHash({
+        game: gameRes.data,
+        participants: partsRes.data ?? [],
+        groups: groupsRes.data ?? [],
+        matches: matchesRes.data ?? [],
+      });
+      return { hash };
     }),
 
   // addParticipants — Owner/Organizer. 2–4 users, individual (no side/team).


### PR DESCRIPTION
Two people on the course, two devices: Device A changes something, Device B never saw it. This makes B converge on server truth — scores AND config (groupings / modifiers / rules / settings / matchups) — silently, within ~15–30s.

## Phase 0 diagnosis (the root)
Every cache invalidation in the app is **device-LOCAL** (fired in the mutating device's component). The competition structure/state split is otherwise sound, but it never accounted for multi-device:
- **Config** (`games.getById`, `matches`/`playGroups.listByGame`) is `STRUCTURE_QUERY` = `staleTime: Infinity`, refetched **only on invalidation** → a remote device is frozen forever (the reproduced grouping-swap; the danger case of an unseen mid-round modifier change).
- **Scores** (`scores.listByGame`) were mount-once, no poll, seeded into local state once → remote scores never appeared.
- The `games` table has **no `updated_at`/version/hash** — nothing to detect drift.

**Plumbing chosen: hash-poll** (Zach's default), decisively cleaner than Realtime here — Realtime would need a publication + `REPLICA IDENTITY` migration on the shared DB for `games`/`score_entries`, new hooks, and would over-deliver scores as a live broadcast. Hash-poll needs **zero schema changes** (compute-on-read), is scoped to the open panel, and — because the tRPC client batches — the score poll + hash query **coalesce into one HTTP round-trip per tick**.

## What changed
- **`computeConfigHash` + `reconcileScores`** — pure, client-safe, unit-tested primitives.
- **`games.configHash`** — a cheap per-tick fingerprint of the game's config (game row + groupings + matchups + handicaps), score-derived fields excluded so scoring never churns it. No migration.
- **`useScoreSaver.reconcile`** (Task 1) — merges polled server scores in without clobbering the active enterer (unsaved / outbox cells win, #543).
- **`useConfigSync`** (Task 2) — polls the hash, and on a mismatch silently refetches the full config so members converge. First hash = baseline; no toast.
- **All 4 views wired**: scores poll at ~20s (golf) / board's shared leaderboard poll (non-golf); config sync everywhere.
- **Task 3 (strain)**: the diagnosis found no pre-existing over-fetch to remove; net new cost is one batched round-trip per tick per *open* panel, full config only on a hash mismatch.
- **Task 4 (leaderboard)**: completions already ride the board's existing 30s leaderboard poll — verified, left alone (no new aggressive polling).

## Verification
- **End-to-end convergence proven in the preview**: a simulated remote config change (direct DB write to `rules_for_today`) was detected on the next poll tick and triggered a silent `games.getById,matches.listByGame` refetch (~700ms later), then returned to cheap ticks. Resource timeline captured.
- **Efficiency proven**: steady state is only `scores.listByGame,games.configHash` batched every ~20s; the full config is **not** refetched when the hash matches.
- Unit tests: hash (changes iff config changes) + reconcile (never clobbers the enterer). Integration test: `games.configHash` moves on config change, **not** on score change; member-gated.
- `tsc` + eslint clean · full Vitest **956 passed** (92 files, +23) · Playwright critical-path **2 passed** · no console errors.

## Notes / judgment calls
- **Deliberate reconcile gap**: a score DELETED on another device isn't removed locally (overlay only sets server-present cells — the price of never-clobber-the-enterer). Remote clears are rare and self-correct on the next edit/reopen.
- **Warm-reopen edge**: a config change that lands in the &lt;20s window between a warm-cached panel reopen and its first hash poll isn't caught until the next real change — the same warm-cache staleness that exists today; the continuous-open danger case is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)