### PR TITLE
Scorecard: full-page screen → slide-in overlay over its caller

### DIFF
--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -25,6 +25,7 @@ export function Sheet({
   footer,
   testId,
   maxWidthClass = "max-w-lg",
+  bodyClassName = "p-4",
 }: {
   title: string;
   subtitle?: string;
@@ -35,6 +36,10 @@ export function Sheet({
   testId?: string;
   /** Panel max width (Tailwind class). Default max-w-lg; rosters wants max-w-3xl. */
   maxWidthClass?: string;
+  /** Body padding/utility classes. Default `p-4`; a full-bleed body (e.g. the
+   *  scorecard grid, which manages its own horizontal scroll + sticky column)
+   *  passes `p-0`. Always keeps `flex-1 overflow-y-auto`. */
+  bodyClassName?: string;
 }) {
   return (
     <ScrollLock>
@@ -76,7 +81,7 @@ export function Sheet({
           </div>
 
           {/* Body */}
-          <div className="flex-1 overflow-y-auto p-4">{children}</div>
+          <div className={`flex-1 overflow-y-auto ${bodyClassName}`}>{children}</div>
 
           {/* Footer (optional) */}
           {footer && (

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 import { ChevronLeft, Users } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
@@ -18,6 +18,7 @@ import { RackGameView } from "@/components/games/RackGameView";
 import { NonGolfGameView } from "@/components/games/NonGolfGameView";
 import { StrokeGameView } from "@/components/games/StrokeGameView";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
+import { ScorecardPreviewSheet } from "@/components/games/ScorecardPreviewSheet";
 
 interface Competition {
   id: string;
@@ -111,7 +112,14 @@ export function CompetitionFace({
   // (faceBootstrap-seeded), so a game's format is known synchronously — no fetch
   // just to decide whether (and which view) to panel. ONE host for all formats.
   const search = useSearchParams();
+  const router = useRouter();
   const openGameId = search.get("game");
+  // The scorecard OVERLAY over the board (leaderboard caller): a golf game's
+  // scorecard icon pushes `?scorecard=<id>` (GameRow), and we float the scorecard
+  // Sheet over the still-mounted board. Dismiss (scrim/✕/back) → router.back()
+  // pops the entry. Distinct from the in-game scorecard, which each game view
+  // hosts itself so it can show live scores/save-state.
+  const scorecardGameId = search.get("scorecard");
   const gamesForPanel = trpc.games.listByTrip.useQuery({ tripId }, STRUCTURE_QUERY).data ?? [];
   const openGame = openGameId
     ? (gamesForPanel as { id: string; game_type_id: string | null }[]).find((g) => g.id === openGameId)
@@ -348,6 +356,13 @@ export function CompetitionFace({
         >
           {panelView}
         </div>
+      )}
+
+      {/* Scorecard overlay (leaderboard caller) — floats over the board via
+          `?scorecard=<id>`. Only reachable when no game panel is open (the icon
+          lives on the board), so no panel/scorecard z-fight. */}
+      {scorecardGameId && (
+        <ScorecardPreviewSheet tripId={tripId} gameId={scorecardGameId} onClose={() => router.back()} />
       )}
     </div>
   );

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -2,7 +2,7 @@
 
 import { createElement } from "react";
 import Link from "next/link";
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Radio, Flag, Swords, Layers, Gamepad2, Table2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
@@ -22,6 +22,18 @@ export { gameHref, isGolfFormat } from "@/lib/gameRoutes";
 function openGamePanel(pathname: string, gameId: string, settings: boolean) {
   const q = `?game=${gameId}${settings ? "&settings=1" : ""}`;
   window.history.pushState(null, "", `${pathname}${q}`);
+}
+
+/**
+ * Open the scorecard as an OVERLAY over the board (not a route navigation): push
+ * `?scorecard=<id>` onto the current url via the History API — Next syncs it to
+ * `useSearchParams` with no round-trip, so the board stays warm underneath and
+ * CompetitionFace renders the scorecard Sheet on top. Back pops this entry.
+ * (Mirrors `openGamePanel`; the standalone `/games/scorecard` route stays as the
+ * cold deep-link fallback.)
+ */
+function openScorecardOverlay(pathname: string, gameId: string) {
+  window.history.pushState(null, "", `${pathname}?scorecard=${gameId}`);
 }
 
 // ── Row helpers (own the board-row primitives) ────────────────────────────────
@@ -142,7 +154,6 @@ export function GameRow({
   // Once scoring is on (live/final), everyone gets the scoreboard. Members never
   // get the settings link — they hit the server-walled placeholder.
   const canEditThisGame = !!canEdit || mine;
-  const router = useRouter();
   const pathname = usePathname();
   const setupMode = !(game.status === "complete" || game.status === "active" || game.scoringEnabled === true);
   const href = gameHref(tripId, game.gameTypeId, game.id, {
@@ -305,7 +316,7 @@ export function GameRow({
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              router.push(scorecardHref);
+              openScorecardOverlay(pathname, game.id);
             }}
           >
             <Table2 size={15} />

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -17,6 +17,7 @@ import { GameManagementPanel } from "@/components/games/GameManagementPanel";
 import { ChecklistRow, type ChecklistRowState } from "@/components/games/ChecklistRow";
 import { MatchCard } from "@/components/games/MatchCard";
 import { StandardGrid } from "@/components/games/StandardGrid";
+import { ScorecardSheet } from "@/components/games/ScorecardSheet";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { RelHandicapControl } from "@/components/games/RelHandicapControl";
 import { DragHandle } from "@/components/games/DragHandle";
@@ -166,7 +167,9 @@ export function MatchGameView() {
   // Back-stack: forward transitions push the screen they left; Back pops to it.
   // Empty stack means we arrived directly (derived screen) → leave to trip home.
   const [navStack, setNavStack] = useState<Screen[]>([]);
-  const [view, setView] = useState<"entry" | "grid">("entry");
+  // The scorecard is an OVERLAY over the match entry view (not a third screen), so
+  // the entry stays mounted underneath and dismiss returns with score state intact.
+  const [gridOpen, setGridOpen] = useState(false);
   const [currentHole, setCurrentHole] = useState(1);
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
   // Collapse-on-advance: when teeing off with some slots still unfilled, confirm
@@ -479,10 +482,10 @@ export function MatchGameView() {
   // the leaderboard. Depth: 0 on the hub/overview, 1 in a match's score screen, 2 in
   // its grid (only when not locked — a locked match opens the grid directly, one
   // level). `matchBack()` is the one path the score-entry breadcrumbs use.
-  const inGrid = screen === "score" && !locked && view === "grid";
+  const inGrid = screen === "score" && !locked && gridOpen;
   const matchEntryDepth = (screen === "score" ? 1 : 0) + (inGrid ? 1 : 0);
   const matchBack = useScreenHistory(matchEntryDepth, () => {
-    if (inGrid) setView("entry");
+    if (inGrid) setGridOpen(false);
     else if (screen === "score") goBack();
   });
 
@@ -962,53 +965,59 @@ export function MatchGameView() {
       : selectedGroup.a.id === meId || selectedGroup.b.id === meId);
     const canScoreMatch = canEdit || inThisMatch;
     const readOnly = locked || !canScoreMatch;
+    // The read-only scorecard grid — shared by a read-only/locked viewer's landing
+    // surface and the scorer's overlay. onCellTap (jump to a hole's entry) is
+    // editable-only; back returns to the matches hub (#7).
+    const scorecardGrid = (
+      <StandardGrid
+        units={scUnits}
+        tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+        teeRows={teeRows}
+        participants={entryParticipants}
+        values={values}
+        direction="low_wins"
+        pips={entryPips}
+        saveStatus={saveStatus}
+        onCellTap={readOnly ? undefined : (label) => {
+          setCurrentHole(Number(label) || 1);
+          matchBack();
+        }}
+      />
+    );
     return (
       <div className="fixed inset-0 z-50">
-        {view === "grid" || readOnly ? (
-          <div className="flex h-full flex-col">
-            <div className="flex shrink-0 items-center gap-3" style={{ height: 52, padding: "0 16px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-              {/* Read-only when locked OR the viewer can't score this match — back
-                  returns to the hub and cells don't open editable entry (#7). */}
-              <button onClick={matchBack} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>‹ Back</button>
-              <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{locked ? "Scorecard · Final" : "Scorecard"}</span>
-            </div>
-            <div className="min-h-0 flex-1">
-              <StandardGrid
-                units={scUnits}
-                tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
-                teeRows={teeRows}
-                participants={entryParticipants}
-                values={values}
-                direction="low_wins"
-                pips={entryPips}
-                saveStatus={saveStatus}
-                onCellTap={readOnly ? undefined : (label) => {
-                  setCurrentHole(Number(label) || 1);
-                  matchBack();
-                }}
-              />
-            </div>
-          </div>
+        {readOnly ? (
+          // Read-only when locked OR the viewer can't score this match — the
+          // scorecard IS the surface, now an overlay; dismiss returns to the hub.
+          <ScorecardSheet title={locked ? "Scorecard · Final" : "Scorecard"} onClose={matchBack}>
+            {scorecardGrid}
+          </ScorecardSheet>
         ) : (
-          <MatchEntryView
-            gameName={`${selectedGroup.a.name} v ${selectedGroup.b.name}`}
-            subtitle={sided ? "Doubles match · 2v2" : "Singles match · 1v1"}
-            units={scUnits}
-            matches={[selectedGroup]}
-            values={values}
-            currentHole={currentHole}
-            onHoleChange={setCurrentHole}
-            onChange={onChange}
-            onClear={onClear}
-            saveStatus={saveStatus}
-            onRetryCell={retryCell}
-            onBack={matchBack}
-            onOpenGrid={() => setView("grid")}
-            onFinish={matchBack}
-            finishLabel="Back to matches"
-            finishSubtext="Scores save as you enter"
-            meId={me?.id}
-          />
+          <>
+            <MatchEntryView
+              gameName={`${selectedGroup.a.name} v ${selectedGroup.b.name}`}
+              subtitle={sided ? "Doubles match · 2v2" : "Singles match · 1v1"}
+              units={scUnits}
+              matches={[selectedGroup]}
+              values={values}
+              currentHole={currentHole}
+              onHoleChange={setCurrentHole}
+              onChange={onChange}
+              onClear={onClear}
+              saveStatus={saveStatus}
+              onRetryCell={retryCell}
+              onBack={matchBack}
+              onOpenGrid={() => setGridOpen(true)}
+              onFinish={matchBack}
+              finishLabel="Back to matches"
+              finishSubtext="Scores save as you enter"
+              meId={me?.id}
+            />
+            {/* Scorecard OVERLAY over entry — entry stays mounted (#543 intact). */}
+            {gridOpen && (
+              <ScorecardSheet title="Scorecard" onClose={matchBack}>{scorecardGrid}</ScorecardSheet>
+            )}
+          </>
         )}
       </div>
     );
@@ -1485,8 +1494,9 @@ export function MatchGameView() {
             if (g) setCurrentHole(currentHoleFor(g));
             setSelectedMatchId(matchId);
             setValues((v) => (Object.keys(v).length ? v : loadedValues));
-            // Locked → open the read-only scorecard grid; otherwise editable entry.
-            setView(locked ? "grid" : "entry");
+            // Locked → land on the read-only scorecard overlay; otherwise editable
+            // entry (a non-scorer still resolves to read-only in the score screen).
+            setGridOpen(locked);
             go("score");
           }}
         />

--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -16,6 +16,7 @@ import { RackGroupBuilder, type GroupBuilderTeam } from "@/components/games/rack
 import { toPersist as groupsToPersist } from "@/lib/rackGroupDraft";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
+import { ScorecardSheet } from "@/components/games/ScorecardSheet";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { GameConfigurationView } from "@/components/games/GameConfigurationView";
@@ -79,7 +80,9 @@ export function RackGameView() {
   const [entryGroupId, setEntryGroupId] = useState<string | null>(null);
   // The tapped group's scorecard: "entry" (score keypad) vs "grid" (the read grid,
   // opened by the top-right scorecard icon).
-  const [entryView, setEntryView] = useState<"entry" | "grid">("entry");
+  // The scorecard is an OVERLAY over a group's entry view (not a third screen), so
+  // the entry stays mounted underneath and dismiss returns with score state intact.
+  const [gridOpen, setGridOpen] = useState(false);
   // Rack settings: both GROUPINGS and HANDICAPS are inline accordions (the rack
   // equivalents of the 2v2 Matches/Handicaps rows), single-open. `groupDraft` = one
   // user-id array per group.
@@ -485,9 +488,9 @@ export function RackGameView() {
   // instead of jumping to the leaderboard. Depth: 0 = play screen, 1 = a group's
   // card, 2 = its grid view (only when not locked — a locked group shows the grid
   // directly, one level). `back()` is the one path every breadcrumb/finish uses.
-  const entryDepth = entryGroupId ? (!locked && entryView === "grid" ? 2 : 1) : 0;
+  const entryDepth = entryGroupId ? (!locked && gridOpen ? 2 : 1) : 0;
   const back = useScreenHistory(entryDepth, () => {
-    if (!locked && entryView === "grid") setEntryView("entry");
+    if (!locked && gridOpen) setGridOpen(false);
     else setEntryGroupId(null);
   });
 
@@ -586,47 +589,54 @@ export function RackGameView() {
     // Read-only scorecard when the card is locked/posted, the grid is toggled on,
     // OR the viewer can't score this cart (Task 2) — no tap-to-edit in any of those.
     const readOnly = locked || !canScoreGroup;
-    if (readOnly || entryView === "grid") {
+    // The read-only scorecard grid — shared by a locked/read-only viewer's landing
+    // surface and the scorer's overlay. onCellTap (jump to a hole's entry) is
+    // editable-only.
+    const scorecardGrid = (
+      <StandardGrid
+        units={scUnits}
+        tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+        teeRows={teeRows}
+        participants={ps}
+        values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
+        direction="low_wins"
+        pips={groupPips}
+        onCellTap={readOnly ? undefined : (label) => { setCurrentHole(Number(label) || 1); back(); }}
+      />
+    );
+    const scorecardTitle = `${groupName ?? "Group"}${locked ? " · Final" : " · Scorecard"}`;
+    if (readOnly) {
+      // Locked/posted OR a viewer who can't score this cart lands on the read-only
+      // scorecard — now an overlay; dismiss returns to the rack hub (#7).
       return (
-        <div className="flex flex-col" style={{ height: "100vh" }}>
-          <div className="flex shrink-0 items-center gap-3" style={{ height: 52, padding: "0 16px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-            <button onClick={back} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>‹ Back</button>
-            <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>{(groupName ?? "Group")}{locked ? " · Final" : " · Scorecard"}</span>
-          </div>
-          <div className="min-h-0 flex-1">
-            <StandardGrid
-              units={scUnits}
-              tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
-              teeRows={teeRows}
-              participants={ps}
-              values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
-              direction="low_wins"
-              pips={groupPips}
-              onCellTap={readOnly ? undefined : (label) => { setCurrentHole(Number(label) || 1); back(); }}
-            />
-          </div>
+        <div className="fixed inset-0 z-50">
+          <ScorecardSheet title={scorecardTitle} onClose={back}>{scorecardGrid}</ScorecardSheet>
         </div>
       );
     }
     return (
-      <div className="flex flex-col" style={{ height: "100vh" }}>
-        <ScoreEntryView
-          gameName={groupName ?? "Group"}
-          units={scUnits}
-          participants={ps}
-          values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
-          direction="low_wins"
-          currentHole={currentHole}
-          onHoleChange={setCurrentHole}
-          onChange={onChange}
-          onClear={onClear}
-          saveStatus={saveStatus}
-          onRetryCell={retryCell}
-          onBack={back}
-          onOpenGrid={() => setEntryView("grid")}
-          onFinish={back}
-          pips={groupPips}
-        />
+      <div className="fixed inset-0 z-50">
+        <div className="flex flex-col" style={{ height: "100vh" }}>
+          <ScoreEntryView
+            gameName={groupName ?? "Group"}
+            units={scUnits}
+            participants={ps}
+            values={Object.fromEntries(ps.map((p) => [p.id, mergedFor(p.id)]))}
+            direction="low_wins"
+            currentHole={currentHole}
+            onHoleChange={setCurrentHole}
+            onChange={onChange}
+            onClear={onClear}
+            saveStatus={saveStatus}
+            onRetryCell={retryCell}
+            onBack={back}
+            onOpenGrid={() => setGridOpen(true)}
+            onFinish={back}
+            pips={groupPips}
+          />
+        </div>
+        {/* Scorecard OVERLAY over entry — entry stays mounted (#543 intact). */}
+        {gridOpen && <ScorecardSheet title={scorecardTitle} onClose={back}>{scorecardGrid}</ScorecardSheet>}
       </div>
     );
   }
@@ -828,7 +838,7 @@ export function RackGameView() {
             : undefined
         }
       />
-      <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); setEntryView("entry"); }} />
+      <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); setGridOpen(false); }} />
       {/* #501 Part 3: the scoring board is read-and-score only — "Edit handicaps"
           (config) is gone. Edit handicaps in Setup mode (gear → Who's playing ·
           Handicaps), where mid-game config is deliberate. */}

--- a/src/components/games/ScorecardPreviewSheet.tsx
+++ b/src/components/games/ScorecardPreviewSheet.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo } from "react";
+import { trpc } from "@/lib/trpc-client";
+import { STRUCTURE_QUERY } from "@/lib/queryConfig";
+import { StandardGrid } from "@/components/games/StandardGrid";
+import { ScorecardSheet } from "@/components/games/ScorecardSheet";
+import { unitsFromSchema, teeFromSchema } from "@/lib/strokePlayConfig";
+import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
+
+/**
+ * ScorecardPreviewSheet — the leaderboard's scorecard, as a Sheet overlay over the
+ * board. It shows the game's PERSISTED course structure (par / yardage / stroke
+ * index, front + back) with NO scores — the same empty course-setup preview the
+ * standalone `/games/scorecard` route renders (Spec 5a), just floated over the
+ * board instead of being a full page. Reads `games.getById` (the snapshotted
+ * `scorecard_schema`, the source of truth); format-agnostic (only needs the
+ * schema). Dismiss returns to the board.
+ */
+export function ScorecardPreviewSheet({
+  tripId,
+  gameId,
+  onClose,
+}: {
+  tripId: string;
+  gameId: string;
+  onClose: () => void;
+}) {
+  const gameQ = trpc.games.getById.useQuery(
+    { tripId, gameId },
+    { ...STRUCTURE_QUERY },
+  );
+
+  const schema = gameQ.data?.scorecard_schema as Parameters<typeof unitsFromSchema>[0];
+  const units = useMemo(() => unitsFromSchema(schema), [schema]);
+  const tee = useMemo(
+    () => teeFromSchema(schema as Parameters<typeof teeFromSchema>[0]),
+    [schema],
+  );
+  const teeRows = useScorecardTeeRows(tripId, gameQ.data);
+  const name = (gameQ.data?.name as string | undefined) ?? undefined;
+  const hasCourse = !!(gameQ.data as { course_id?: string | null } | undefined)?.course_id;
+
+  return (
+    <ScorecardSheet title="Scorecard" subtitle={name} onClose={onClose}>
+      {gameQ.isLoading ? (
+        <div className="flex items-center justify-center p-10">
+          <div
+            className="h-7 w-7 animate-spin rounded-full border-2"
+            style={{ borderColor: "var(--color-bt-accent)", borderTopColor: "transparent" }}
+          />
+        </div>
+      ) : hasCourse && units.length > 0 ? (
+        <StandardGrid units={units} tee={tee} participants={[]} values={{}} direction="low_wins" teeRows={teeRows} />
+      ) : (
+        <p className="px-6 py-10 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
+          No course set for this game yet — apply a course in game settings to preview its scorecard.
+        </p>
+      )}
+    </ScorecardSheet>
+  );
+}

--- a/src/components/games/ScorecardSheet.tsx
+++ b/src/components/games/ScorecardSheet.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Sheet } from "@/components/Sheet";
+
+/**
+ * ScorecardSheet — the golf scorecard as a slide-in overlay (composing the shared
+ * `Sheet` primitive, NOT a new overlay). The scorecard "floats": it's a layer
+ * reachable from the leaderboard, the game scoreboard, and score entry, and it
+ * dismisses back to whichever called it — never a rung in the nav spine.
+ *
+ * It's narrower than a full page on purpose: the `StandardGrid` inside owns its
+ * own horizontal scroll + sticky first column (and the #562 opaque-fill fix), so
+ * it scrolls left-right within the sheet rather than needing full-page width. The
+ * body is full-bleed (`p-0`) so the grid runs edge-to-edge; the sheet's title +
+ * ✕ header replaces the old bespoke 52px "‹ Back / Scorecard" bar. Dismiss = tap
+ * the scrim, the ✕, or (where the caller wires it) browser back.
+ *
+ * The caller passes the already-built `<StandardGrid>` as children so each format
+ * keeps ownership of its own grid props (values / saveStatus / onCellTap live in
+ * the caller's useScoreSaver — that locality is what preserves in-progress entry,
+ * #543).
+ */
+export function ScorecardSheet({
+  title = "Scorecard",
+  subtitle,
+  onClose,
+  children,
+}: {
+  title?: string;
+  subtitle?: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Sheet
+      title={title}
+      subtitle={subtitle}
+      onClose={onClose}
+      maxWidthClass="max-w-2xl"
+      bodyClassName="p-0"
+      testId="scorecard-sheet"
+    >
+      {children}
+    </Sheet>
+  );
+}

--- a/src/components/games/StrokeGameView.tsx
+++ b/src/components/games/StrokeGameView.tsx
@@ -9,6 +9,7 @@ import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
+import { ScorecardSheet } from "@/components/games/ScorecardSheet";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { FinalStandings } from "@/components/games/FinalStandings";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
@@ -96,10 +97,14 @@ export function StrokeGameView() {
   // A game created or joined in THIS session (the standalone new flow, or after
   // adding players to a competition game we opened with ?game).
   const [createdGame, setCreatedGame] = useState<{ id: string; participants: Participant[] } | null>(null);
-  const [view, setView] = useState<"entry" | "grid" | "final">("entry");
+  const [view, setView] = useState<"entry" | "final">("entry");
+  // The scorecard is an OVERLAY over the current view (entry or final), not a
+  // third base view — so the caller stays mounted underneath and dismiss returns
+  // to it with score state intact (#543).
+  const [gridOpen, setGridOpen] = useState(false);
   // Browser/OS back steps out of the scorecard grid back to entry (not the
   // leaderboard). The grid is the one history-tracked sub-screen over entry.
-  const backFromGrid = useScreenHistory(view === "grid" ? 1 : 0, () => setView("entry"));
+  const backFromGrid = useScreenHistory(gridOpen ? 1 : 0, () => setGridOpen(false));
   const [currentHole, setCurrentHole] = useState(1);
   const [standings, setStandings] = useState<StrokeStanding[]>([]);
   // The ONE settings overlay — owns open/close/back + the leaderboard deep link
@@ -388,6 +393,7 @@ export function StrokeGameView() {
     setSelected([]);
     setCurrentHole(1);
     setView("entry");
+    setGridOpen(false);
     // Drop ?game so "Play again" starts a fresh game instead of resuming this one.
     if (urlGameId) router.replace(`/trips/${param}/games/new`);
   }
@@ -521,62 +527,66 @@ export function StrokeGameView() {
 
   // ── Play ──
   if (game) {
+    // The read-only scorecard grid — shared by a non-scorer's landing surface and
+    // the scorer's overlay. onCellTap (jump to a hole's entry) is scorer-only.
+    const scorecardGrid = (
+      <StandardGrid
+        units={scUnits}
+        tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+        teeRows={teeRows}
+        participants={game.participants}
+        values={values}
+        direction="low_wins"
+        pips={entryPips}
+        saveStatus={saveStatus}
+        onCellTap={canScoreStroke ? (label) => {
+          setCurrentHole(Number(label) || 1);
+          backFromGrid();
+        } : undefined}
+      />
+    );
     return (
       <div className="fixed inset-0 z-50">
-        {view === "final" ? (
-          <FinalStandings
-            participants={game.participants}
-            standings={standings}
-            unitCount={scUnits.length}
-            dateLabel={new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
-            onScorecard={() => setView("grid")}
-            onPlayAgain={playAgain}
-          />
-        ) : view === "grid" || !canScoreStroke ? (
-          // Read-only scorecard when the grid is toggled on OR the viewer can't
-          // score this game (Task 2 — a non-participant, non-owner/delegate member
-          // lands here instead of a dead entry screen; the SERVER is the real gate).
-          <div className="flex h-full flex-col">
-            <div className="flex shrink-0 items-center gap-3" style={{ height: 52, padding: "0 16px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-              <button onClick={canScoreStroke ? backFromGrid : () => router.back()} style={{ color: "var(--color-bt-accent)", fontSize: 14, fontWeight: 600 }}>‹ Back</button>
-              <span style={{ fontSize: 15, fontWeight: 600, color: "var(--color-bt-text)" }}>Scorecard</span>
-            </div>
-            <div className="min-h-0 flex-1">
-              <StandardGrid
+        {!canScoreStroke ? (
+          // #557: a viewer who can't score this game lands on the read-only
+          // scorecard — now as an overlay; dismissing leaves the game (back to the
+          // board), consistent with the "scorecard floats" model.
+          <ScorecardSheet onClose={() => router.back()}>{scorecardGrid}</ScorecardSheet>
+        ) : (
+          <>
+            {view === "final" ? (
+              <FinalStandings
+                participants={game.participants}
+                standings={standings}
+                unitCount={scUnits.length}
+                dateLabel={new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+                onScorecard={() => setGridOpen(true)}
+                onPlayAgain={playAgain}
+              />
+            ) : (
+              <ScoreEntryView
+                gameName="Stroke Play"
                 units={scUnits}
-                tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
-                teeRows={teeRows}
                 participants={game.participants}
                 values={values}
                 direction="low_wins"
-                pips={entryPips}
+                currentHole={currentHole}
+                onHoleChange={setCurrentHole}
+                onChange={onChange}
+                onClear={onClear}
                 saveStatus={saveStatus}
-                onCellTap={canScoreStroke ? (label) => {
-                  setCurrentHole(Number(label) || 1);
-                  backFromGrid();
-                } : undefined}
+                onRetryCell={retryCell}
+                pips={entryPips}
+                onBack={() => router.back()}
+                onOpenGrid={() => setGridOpen(true)}
+                onConfig={canEdit ? openConfig : undefined}
+                onFinish={handleFinish}
               />
-            </div>
-          </div>
-        ) : (
-          <ScoreEntryView
-            gameName="Stroke Play"
-            units={scUnits}
-            participants={game.participants}
-            values={values}
-            direction="low_wins"
-            currentHole={currentHole}
-            onHoleChange={setCurrentHole}
-            onChange={onChange}
-            onClear={onClear}
-            saveStatus={saveStatus}
-            onRetryCell={retryCell}
-            pips={entryPips}
-            onBack={() => router.back()}
-            onOpenGrid={() => setView("grid")}
-            onConfig={canEdit ? openConfig : undefined}
-            onFinish={handleFinish}
-          />
+            )}
+            {/* Scorecard OVERLAY over entry/final — the base stays mounted so
+                dismiss returns with in-progress entry intact (#543). */}
+            {gridOpen && <ScorecardSheet onClose={backFromGrid}>{scorecardGrid}</ScorecardSheet>}
+          </>
         )}
       </div>
     );


### PR DESCRIPTION
Split out of #550. Converts the golf scorecard from a full-page screen into a slide-in **Sheet overlay with a darkened backdrop**, layered over whatever called it — the settled "scorecard floats" design. Reachable from all three callers, dismissing back to each.

## Phase 0 (map)
The scorecard had two full-bleed forms: the **`/games/scorecard` route** (full-page empty course preview, from the leaderboard icon) and the in-panel **`view === "grid"` sub-view** (scored grid, from scoreboard/entry). The scored one *must* stay hosted in the game view — it needs that view's live `values`/`saveStatus`/outbox (#543). Reuse target: the **`Sheet`** primitive (its docstring literally names "leaderboard → game → scorecard" as its model). `StandardGrid` owns its own horizontal scroll + sticky column, so a narrower sheet is correct.

## What changed
- **Task 1** — `ScorecardSheet` (composes `Sheet`, full-bleed body via a new optional `Sheet` `bodyClassName`) + `ScorecardPreviewSheet` (the leaderboard's empty preview in a sheet). No new overlay built.
- **Task 2 (in-game)** — Stroke/Match/Rack render the scorecard as a Sheet **over** the entry/scoreboard: split the coupled `view === "grid"` into a base view + a `gridOpen` boolean so the entry stays mounted and dismiss returns with score state intact (#543). Browser-back still dismisses via the existing `useScreenHistory`; scrim/✕ route through the same. Read-only/#557/locked viewers land on the same overlay.
- **Task 2 (leaderboard)** — the scorecard icon pushes `?scorecard=<id>` (History API, board stays warm) and `CompetitionFace` floats the preview sheet over the board; dismiss → `router.back()`. The `/games/scorecard` route stays as the cold deep-link fallback.
- **Task 3 (stacking)** — falls out of reusing `Sheet` (z-50 over its caller); leaderboard scorecard only opens when no panel is present, so no panel/scorecard z-fight.

## Verified on preview (all three callers)
- **Leaderboard:** icon → scorecard bottom-sheet over the dimmed board; browser-back → board (`?scorecard=` popped). ✅
- **Score entry:** Table2 icon → scorecard sheet over the dimmed entry (entry mounted underneath, live player scores + save-status dots shown); ✕ → back on entry, scores intact. ✅
- **Locked/read-only match:** lands on the read-only scorecard overlay. ✅
- Horizontal scroll + sticky first column mask correctly inside the narrower sheet — no #562 regression (chosen row keeps its opaque `linear-gradient(accent-faint), base` fill at full scroll). ✅
- No bottom nav on the overlay; backdrop dims the caller; no console errors.
- `tsc` + eslint clean · full Vitest **956 passed** (92 files) · Playwright critical-path **2 passed** (its `…→ scorecard` step exercises the overlay directly).

## For your eyeball
- **App bar (when #550 lands):** the sheet at `fixed inset-0 z-50` covers the app bar — standard modal. Recommend leaving it covered; easy to inset if you prefer it visible.
- **Non-scorer / stroke:** with no scoring base behind, the scorecard sheet floats over the panel background. Reasonable as "lands as an overlay," but say the word if you'd rather it be a full-bleed base there.
- **Leaderboard scorecard data:** still the empty course preview (no scores), unchanged — presentation-only conversion. If you want scores there, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)