### PR TITLE
#550 game-chrome pass: context-aware app bar + panel reposition + match play (Phase 1)

### DIFF
--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,7 +3,7 @@
 import type { FC } from "react";
 import { Suspense, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { Pin, MessageCircle, Megaphone, ChevronDown } from "lucide-react";
+import { Pin, MessageCircle, Megaphone, ChevronDown, ChevronLeft, Settings, Table2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { UserMenu } from "./UserMenu";
 import { TripSwitcher } from "./TripSwitcher";
@@ -11,6 +11,7 @@ import { FeedbackModal } from "./FeedbackModal";
 import { trpc } from "@/lib/trpc-client";
 import { useChatUnreadCount } from "./FloatingChatPanel";
 import { useNewsUnreadCount } from "./NewsPanel";
+import { useGameChrome } from "./games/GameChrome";
 
 /**
  * App title bar — two zones:
@@ -106,6 +107,14 @@ export const TopNav: FC<TopNavProps> = ({
     ) ?? null;
   const showSwitcher = !hideTripSwitcher && currentTrip != null;
 
+  // Game context (#550): when a game panel is open, a game view publishes its
+  // chrome here and the bar SWAPS its left zone to a back affordance + single-
+  // line game title (and adds the scorecard/settings actions on the right). Chat,
+  // news, feedback, and the team avatar persist in BOTH modes — the whole point
+  // is that chat stays reachable from inside a game. Back is history.back(): the
+  // game views' own popstate listeners make it correct at every level.
+  const gameChrome = useGameChrome();
+
   return (
     <header
       className="@container sticky top-0 z-40 flex h-14 items-center justify-between"
@@ -117,7 +126,27 @@ export const TopNav: FC<TopNavProps> = ({
         padding: "0 16px",
       }}
     >
-      {/* ── LEFT: identity / scope ─────────────────────────────────────── */}
+      {/* ── LEFT: identity / scope — OR game back + title (#550) ─────────── */}
+      {gameChrome ? (
+        <div className="flex min-w-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            aria-label="Back"
+            data-testid="game-back"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[9px] transition-colors hover:bg-[var(--color-bt-hover)]"
+          >
+            <ChevronLeft size={22} style={{ color: "var(--color-bt-text)" }} />
+          </button>
+          <span
+            className="truncate"
+            style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}
+            data-testid="game-title"
+          >
+            {gameChrome.title}
+          </span>
+        </div>
+      ) : (
       <div className="flex min-w-0 items-center">
         {/* Home anchor — flag + wordmark navigate to the dashboard. */}
         <button
@@ -223,9 +252,34 @@ export const TopNav: FC<TopNavProps> = ({
           </div>
         )}
       </div>
+      )}
 
       {/* ── RIGHT: global tools + me ───────────────────────────────────── */}
       <div className="flex flex-shrink-0 items-center gap-1">
+        {/* Game-context actions (#550) — scorecard + owner/delegate settings gear,
+            ahead of the persistent chat/news/feedback/avatar cluster. */}
+        {gameChrome?.onScorecard && (
+          <button
+            type="button"
+            onClick={gameChrome.onScorecard}
+            aria-label="Scorecard"
+            data-testid="game-scorecard"
+            className="flex h-9 w-9 items-center justify-center rounded-[9px] transition-colors hover:bg-[var(--color-bt-hover)]"
+          >
+            <Table2 size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+          </button>
+        )}
+        {gameChrome?.onSettings && (
+          <button
+            type="button"
+            onClick={gameChrome.onSettings}
+            aria-label="Settings"
+            data-testid="game-settings-gear"
+            className="flex h-9 w-9 items-center justify-center rounded-[9px] transition-colors hover:bg-[var(--color-bt-hover)]"
+          >
+            <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+          </button>
+        )}
         {/* News — owner/organizer announcements. Trip-scoped, same as Chat:
             only renders when a trip is in scope and the page wires onOpenNews. */}
         {!hideNews && tripId && onOpenNews && (

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -126,6 +126,19 @@ export function CompetitionFace({
     : undefined;
   const openType = openGame?.game_type_id ?? null;
   const panelOpen = !!openGame && opensAsPanel(openType);
+  // Lock the PAGE scroll while a panel is open: the panel is `fixed` with its own
+  // `overflow-y-auto`, so without this the board behind it keeps its own window
+  // scrollbar → two vertical scrollbars (Zach's QA). The panel owns the only
+  // scroll while it's up; restored on close.
+  useEffect(() => {
+    if (!panelOpen) return;
+    const el = document.documentElement;
+    const prev = el.style.overflow;
+    el.style.overflow = "hidden";
+    return () => {
+      el.style.overflow = prev;
+    };
+  }, [panelOpen]);
   // Pick the format's view — each reads its own tripId + `?game=`, so the host just
   // selects which component to mount. Explicit per format (non-golf is the only
   // fall-through, and only after opensAsPanel already vetted the type).

--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -343,14 +343,15 @@ export function CompetitionFace({
         />
       )}
 
-      {/* Game panel (Spec 2) — the format's scoreboard as a slide-in layer over the
-          persistent board. Each view reads its own tripId + `?game=`, so the host
-          just mounts the right one; the board stays MOUNTED underneath (warm cache,
-          no route teardown). The view's own back arrow (→ router.back) pops the
-          `?game=` history entry, closing the panel and revealing the board. */}
+      {/* Game panel (Spec 2 + #550) — the format's scoreboard as a slide-in layer.
+          Positioned BELOW the 56px app bar (`top-14 z-30`, under the bar's z-40) so
+          TopNav stays visible + interactive — chat/news/avatar reachable, and the
+          bar carries the game's back/title/gear (GameChrome). The board stays
+          MOUNTED underneath. A game view's inner surfaces fill this wrapper (they
+          switch off `fixed inset-0` in panel mode via useInGamePanel). */}
       {panelOpen && (
         <div
-          className="fixed inset-0 z-50 overflow-y-auto game-panel-in"
+          className="fixed inset-x-0 bottom-0 top-14 z-30 overflow-y-auto game-panel-in"
           style={{ background: "var(--color-bt-base)" }}
           data-testid="game-panel"
         >

--- a/src/components/competition/LiveFaceClient.tsx
+++ b/src/components/competition/LiveFaceClient.tsx
@@ -16,6 +16,7 @@ import { FloatingChatPanel } from "@/components/FloatingChatPanel";
 import { NewsPanel, type NewsAuthorMeta } from "@/components/NewsPanel";
 import { CompetitionFace } from "@/components/competition/CompetitionFace";
 import { CompetitionSetupPanel } from "@/components/competition/CompetitionSetupPanel";
+import { GameChromeProvider, useGameChrome } from "@/components/games/GameChrome";
 
 /**
  * The Live face — the competition face's client root (the "Live" bottom-nav
@@ -210,6 +211,7 @@ export function LiveFaceClient({
   }
 
   return (
+    <GameChromeProvider>
     <div
       className="min-h-screen"
       style={{ background: "var(--color-bt-base)", color: "var(--color-bt-text)" }}
@@ -230,11 +232,11 @@ export function LiveFaceClient({
 
       <main className="mx-auto max-w-[1024px] px-3 pt-4 pb-32">{body}</main>
 
-      {/* Bottom nav persists on the face so you can always cross back to the
-          trip (§11). Live is the current destination. */}
-      <TripBottomNav
+      {/* Bottom nav persists on the face so you can always cross back to the trip
+          (§11) — EXCEPT on the focused score-entry surface (#550 Task 5), where a
+          game view publishes hideBottomNav. Live is the current destination. */}
+      <FaceBottomNav
         tripId={tripId}
-        showComp={true}
         liveLabel={competition?.short_name ?? competition?.name ?? null}
       />
 
@@ -278,7 +280,17 @@ export function LiveFaceClient({
         )}
       />
     </div>
+    </GameChromeProvider>
   );
+}
+
+// ── Bottom nav (game-aware) ──────────────────────────────────────────────────
+// A consumer INSIDE the provider so it can read the published chrome; the score-
+// entry surface hides it (Task 5). Kept on the scoreboard + everywhere else.
+function FaceBottomNav({ tripId, liveLabel }: { tripId: string; liveLabel: string | null }) {
+  const chrome = useGameChrome();
+  if (chrome?.hideBottomNav) return null;
+  return <TripBottomNav tripId={tripId} showComp={true} liveLabel={liveLabel} />;
 }
 
 // ── Empty states ────────────────────────────────────────────────────────────

--- a/src/components/games/GameChrome.tsx
+++ b/src/components/games/GameChrome.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+
+/**
+ * GameChrome — a tiny context so a game view can publish its bar chrome (title +
+ * the owner/delegate settings gear + the scorecard affordance + a hide-bottom-nav
+ * flag) UP to the shared app bar (TopNav), instead of rendering its own second
+ * header on the panel (the double-decker #550 removes). The bar's BACK is always
+ * `history.back()` — the game views' existing popstate listeners (useScreenHistory
+ * for score/grid, useGameSettingsOverlay for config, router.back for the panel)
+ * make that correct at every level, so no per-screen back handler is published
+ * (Phase 0 finding).
+ *
+ * Provider presence ALSO tells a game view it's hosted as a PANEL (under TopNav)
+ * vs. on its own standalone route (no TopNav): `useInGamePanel()`. In a panel the
+ * view suppresses its own header and publishes here; on a standalone route (no
+ * provider) it keeps rendering its header as before, so deep-links don't lose
+ * their chrome.
+ *
+ * Two contexts on purpose: the VALUE (re-renders TopNav) and the SETTER (stable,
+ * so a publisher's effect doesn't loop when the value changes).
+ */
+export interface GameChromeData {
+  /** Single-line game title shown in the bar (NO format subtitle — dropped). */
+  title: string;
+  /** Owner/delegate-only settings gear. Present ⇒ the bar shows it. The VIEW
+   *  gates on `useGameEditAccess`, so a member simply never passes it. */
+  onSettings?: () => void;
+  /** Opens the scorecard overlay (the entry surface's Table2 affordance, moved
+   *  into the bar when the entry header is removed). Present ⇒ the bar shows it. */
+  onScorecard?: () => void;
+  /** Hide the trip bottom nav (#550 Task 5) — true on the focused SCORE-ENTRY
+   *  surface (exit is the app-bar back), false on the scoreboard (a viewing
+   *  surface where trip nav stays useful). */
+  hideBottomNav?: boolean;
+}
+
+type SetChrome = (c: GameChromeData | null) => void;
+
+const ChromeValueCtx = createContext<GameChromeData | null>(null);
+const SetChromeCtx = createContext<SetChrome | null>(null);
+
+export function GameChromeProvider({ children }: { children: React.ReactNode }) {
+  const [chrome, setChrome] = useState<GameChromeData | null>(null);
+  return (
+    <SetChromeCtx.Provider value={setChrome}>
+      <ChromeValueCtx.Provider value={chrome}>{children}</ChromeValueCtx.Provider>
+    </SetChromeCtx.Provider>
+  );
+}
+
+/** TopNav reads this to render game-context chrome. Null when no game is open (or
+ *  outside a provider) → the bar renders its normal board mode. */
+export function useGameChrome(): GameChromeData | null {
+  return useContext(ChromeValueCtx);
+}
+
+/** True when rendered inside a GameChromeProvider — i.e. hosted as a panel under
+ *  TopNav. A game view uses this to suppress its own header + reposition below the
+ *  bar; false (standalone route) keeps its self-hosted header. */
+export function useInGamePanel(): boolean {
+  return useContext(SetChromeCtx) != null;
+}
+
+/**
+ * A game view publishes its current-screen chrome. No-op outside a provider
+ * (standalone route). Re-publishes only when the RENDERED shape changes (title,
+ * or gear/scorecard/nav presence) — the callbacks are read through a ref so their
+ * per-render identity churn doesn't thrash the bar; the bar always invokes the
+ * latest. Clears on unmount so closing the panel restores board mode. Depends on
+ * the STABLE setter (not the value) so it never loops.
+ */
+export function usePublishGameChrome(data: GameChromeData | null) {
+  const setChrome = useContext(SetChromeCtx);
+  // Keep the latest data (with its fresh callbacks) in a ref the published proxy
+  // reads at invoke time — updated post-commit so it never lags a tap.
+  const ref = useRef(data);
+  useEffect(() => {
+    ref.current = data;
+  });
+  const key = data
+    ? `${data.title}|${!!data.onSettings}|${!!data.onScorecard}|${!!data.hideBottomNav}`
+    : "";
+  useEffect(() => {
+    if (!setChrome) return;
+    if (!ref.current) {
+      setChrome(null);
+      return;
+    }
+    setChrome({
+      title: ref.current.title,
+      onSettings: ref.current.onSettings ? () => ref.current?.onSettings?.() : undefined,
+      onScorecard: ref.current.onScorecard ? () => ref.current?.onScorecard?.() : undefined,
+      hideBottomNav: ref.current.hideBottomNav,
+    });
+    return () => setChrome(null);
+  }, [setChrome, key]);
+}

--- a/src/components/games/MatchCard.tsx
+++ b/src/components/games/MatchCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Table2 } from "lucide-react";
 import { matchState, type HoleResult } from "@/lib/matchPlay";
 import { teamTextColor } from "@/lib/teamTextColor";
 import type { Participant } from "./types";
@@ -38,6 +39,10 @@ interface MatchCardProps {
   youId?: string;
   /** Hide the "· 1v1" suffix in the header (entry page shows just "MATCH #"). */
   hideFormat?: boolean;
+  /** Opens this match's scorecard — renders a compact button on the RIGHT of the
+   *  header row (the MATCH # · THRU/FINAL row). Only pass when the card itself is
+   *  NOT a tap target (no `onClick`) — nesting a button in a button is invalid. */
+  onScorecard?: () => void;
 }
 
 export function MatchCard({
@@ -51,6 +56,7 @@ export function MatchCard({
   onClick,
   youId,
   hideFormat,
+  onScorecard,
 }: MatchCardProps) {
   const st = matchState(results, holeCount);
   const teams = !!(leftColor && rightColor);
@@ -88,7 +94,20 @@ export function MatchCard({
         >
           {headerWord}
         </span>
-        <span className="flex-1" />
+        {/* Scorecard affordance — right of the header row (moved off the app bar). */}
+        <span className="flex flex-1 items-center justify-end">
+          {onScorecard && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onScorecard(); }}
+              aria-label="Scorecard"
+              data-testid="match-scorecard"
+              className="flex h-5 w-5 items-center justify-center rounded transition-colors hover:bg-[var(--color-bt-hover)]"
+            >
+              <Table2 size={14} style={{ color: "var(--color-bt-text-dim)" }} />
+            </button>
+          )}
+        </span>
       </div>
 
       {/* 2 · Row */}

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -74,6 +74,9 @@ interface MatchEntryViewProps {
   saveStatus?: SaveStatusMap;
   /** Re-fire the save for a flagged cell. */
   onRetryCell?: (participantId: string, unitLabel: string) => void;
+  /** #550: hide the view's own header — as a panel the app bar carries
+   *  back/title + the scorecard action, so this second header is dropped. */
+  hideHeader?: boolean;
 }
 
 export function MatchEntryView({
@@ -94,6 +97,7 @@ export function MatchEntryView({
   meId,
   saveStatus = {},
   onRetryCell,
+  hideHeader = false,
 }: MatchEntryViewProps) {
   const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
   const hole = currentHole ?? holeInternal;
@@ -224,30 +228,33 @@ export function MatchEntryView({
 
   return (
     <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
-      {/* App bar */}
-      <header
-        className="flex shrink-0 items-center justify-between"
-        style={{
-          height: 52,
-          padding: "0 12px",
-          background: "var(--color-bt-nav-bg)",
-          backdropFilter: "blur(14px)",
-          borderBottom: "1px solid var(--color-bt-subtle-border)",
-        }}
-      >
-        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
-          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
-        </button>
-        <div className="text-center">
-          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{gameName}</div>
-          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
-            {subtitle ?? `Hole ${hole} of ${units.length}`}
+      {/* App bar — suppressed as a panel (#550): the shared TopNav carries
+          back/title + the scorecard action. Kept for standalone routes (no bar). */}
+      {!hideHeader && (
+        <header
+          className="flex shrink-0 items-center justify-between"
+          style={{
+            height: 52,
+            padding: "0 12px",
+            background: "var(--color-bt-nav-bg)",
+            backdropFilter: "blur(14px)",
+            borderBottom: "1px solid var(--color-bt-subtle-border)",
+          }}
+        >
+          <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+          </button>
+          <div className="text-center">
+            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{gameName}</div>
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+              {subtitle ?? `Hole ${hole} of ${units.length}`}
+            </div>
           </div>
-        </div>
-        <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
-          <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
-        </button>
-      </header>
+          <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
+            <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+          </button>
+        </header>
+      )}
 
       {/* Unsaved-scores safety net (Connectivity Layer 1) */}
       <UnsavedScoresBanner count={errorCount} onRetry={retryAll} />

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -280,6 +280,7 @@ export function MatchEntryView({
                 leftColor={m.leftColor}
                 rightColor={m.rightColor}
                 hideFormat
+                onScorecard={onOpenGrid}
               />
 
               {/* Closed-out result banner (§4) */}

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -933,7 +933,8 @@ export function MatchGameView() {
             !cfgOpen && (screen === "overview" || screen === "setup") && canEdit && status !== "complete"
               ? openConfig
               : undefined,
-          onScorecard: screen === "score" ? () => setGridOpen(true) : undefined,
+          // Scorecard affordance now lives ON the match card's header row (Zach's
+          // QA), not the app bar — so no onScorecard published here.
           // Focused score-entry surface → hide the trip bottom nav (Task 5).
           hideBottomNav: screen === "score",
         }
@@ -1061,7 +1062,7 @@ export function MatchGameView() {
   const headerTitle =
     cfgOpen ? "Configuration" : screen === "new" ? "New game" : screen === "setup" ? "Game Setup" : "Matches";
   return (
-    <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: "100vh" }}>
+    <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: inPanel ? "100%" : "100vh" }}>
       {/* #550: as a panel the app bar carries back/title/gear (published above), so
           the view's own header is suppressed. Standalone route (no bar) keeps it. */}
       {!inPanel && (

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -9,6 +9,7 @@ import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
+import { useInGamePanel, usePublishGameChrome } from "@/components/games/GameChrome";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
@@ -834,7 +835,11 @@ export function MatchGameView() {
         // too, or a re-locked correction reads stale until the 30s poll.
         utils.competitions.faceBootstrap.invalidate({ tripId });
       }
-      go("overview");
+      // #550 Task 4: Finish is tapped ON the overview (the "Finish round" /
+      // "Re-lock" CTAs). The old `go("overview")` PUSHED another overview onto the
+      // nav stack — the two-backs-to-leave bug the unified app-bar back would
+      // inherit. We're already on the overview; the refetch above re-renders it as
+      // Final · locked. No navigation — stay put (pop-not-push).
     } catch {
       // Stay put (no silent advance). The global error toast surfaces the
       // failure; Finish stays tappable to retry (the recompute is idempotent).
@@ -912,6 +917,29 @@ export function MatchGameView() {
   );
   const entryParticipants = selectedGroup ? [selectedGroup.a, selectedGroup.b] : [];
 
+  // #550: as a PANEL, publish this screen's chrome to the app bar (back/title +
+  // owner gear + scorecard) instead of rendering our own header. On a standalone
+  // route (no provider) `inPanel` is false → we keep our own headers below.
+  const inPanel = useInGamePanel();
+  const chromeTitle =
+    screen === "score" && selectedGroup
+      ? `${selectedGroup.a.name} v ${selectedGroup.b.name}`
+      : (gameQ.data?.name as string | undefined)?.trim() || (sided ? "2v2 Match Play" : "1v1 Match Play");
+  usePublishGameChrome(
+    inPanel
+      ? {
+          title: chromeTitle,
+          onSettings:
+            !cfgOpen && (screen === "overview" || screen === "setup") && canEdit && status !== "complete"
+              ? openConfig
+              : undefined,
+          onScorecard: screen === "score" ? () => setGridOpen(true) : undefined,
+          // Focused score-entry surface → hide the trip bottom nav (Task 5).
+          hideBottomNav: screen === "score",
+        }
+      : null,
+  );
+
   // #533 header projection (row 2) — a presentation rollup of the match strips
   // ALREADY on this page: "if the game ended now, what does each team get?" Each
   // match's CURRENT standing (up → its team wins the match's points; all-square
@@ -985,7 +1013,9 @@ export function MatchGameView() {
       />
     );
     return (
-      <div className="fixed inset-0 z-50">
+      // As a panel: fill BELOW the app bar (absolute inset-0 of the top-14 panel),
+      // not fixed inset-0 (which would cover the bar). Standalone: full-screen.
+      <div className={inPanel ? "absolute inset-0" : "fixed inset-0 z-50"}>
         {readOnly ? (
           // Read-only when locked OR the viewer can't score this match — the
           // scorecard IS the surface, now an overlay; dismiss returns to the hub.
@@ -995,6 +1025,7 @@ export function MatchGameView() {
         ) : (
           <>
             <MatchEntryView
+              hideHeader={inPanel}
               gameName={`${selectedGroup.a.name} v ${selectedGroup.b.name}`}
               subtitle={sided ? "Doubles match · 2v2" : "Singles match · 1v1"}
               units={scUnits}
@@ -1031,25 +1062,24 @@ export function MatchGameView() {
     cfgOpen ? "Configuration" : screen === "new" ? "New game" : screen === "setup" ? "Game Setup" : "Matches";
   return (
     <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: "100vh" }}>
-      <SetupHeader
-        title={headerTitle}
-        subtitle={sided ? "Doubles · 2v2 Match Play" : "Singles · 1v1 Match Play"}
-        // Settings back routes through history.back() so it's the SAME action as the
-        // browser/OS back — both return to the game page.
-        onBack={cfgOpen ? closeConfig : goBack}
-        right={
-          // The settings GEAR (A2-ux correction) — owner/delegate access to the ONE
-          // settings page, reachable in BOTH modes (the setup-mode pass-through AND
-          // the scoring-mode overview). A gear, not a text link: one affordance, no
-          // per-format wording to drift. (On the settings page itself → no gear, the
-          // back arrow handles it.)
-          !cfgOpen && (screen === "overview" || screen === "setup") && canEdit && status !== "complete" ? (
-            <button onClick={openConfig} aria-label="Settings" className="flex h-9 w-9 items-center justify-center" data-testid="game-settings-gear">
-              <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
-            </button>
-          ) : null
-        }
-      />
+      {/* #550: as a panel the app bar carries back/title/gear (published above), so
+          the view's own header is suppressed. Standalone route (no bar) keeps it. */}
+      {!inPanel && (
+        <SetupHeader
+          title={headerTitle}
+          subtitle={sided ? "Doubles · 2v2 Match Play" : "Singles · 1v1 Match Play"}
+          // Settings back routes through history.back() so it's the SAME action as the
+          // browser/OS back — both return to the game page.
+          onBack={cfgOpen ? closeConfig : goBack}
+          right={
+            !cfgOpen && (screen === "overview" || screen === "setup") && canEdit && status !== "complete" ? (
+              <button onClick={openConfig} aria-label="Settings" className="flex h-9 w-9 items-center justify-center" data-testid="game-settings-gear">
+                <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+              </button>
+            ) : null
+          }
+        />
+      )}
 
       {/* Standard game header — row 1 (the collapsed cup hero) + row 2 (this
           game's projected/final per-team contribution), sticky while the match


### PR DESCRIPTION
Builds #550 (Task 1 deferred from #551). Per the spec's **"phase it, do one format first, verify on preview, no big-bang"** mandate, this is **Phase 1: the foundation (Tasks 1–2) + match play (Tasks 3-match, 4, 5, 6), fully verified.** Rack / non-golf / stroke are the mechanical repeats to follow (see "Remaining" below).

## What's in this PR
**Tasks 1+2 — foundation (format-agnostic):**
- `GameChrome` — a tiny two-context store (value + a *stable* setter, so a publisher's effect never loops). A game view publishes `{title, onSettings?, onScorecard?, hideBottomNav?}` UP to `TopNav`.
- `TopNav` game mode: left = back + single-line game title; right = scorecard + owner/delegate gear, then the persistent **chat · pinned news · feedback · team avatar** (reachable from inside a game — the gap this closes). Back = `history.back()` (correct at every level via the views' existing popstate listeners — no per-screen rewiring).
- Panel repositioned `fixed inset-0 z-50` → `top-14 z-30` (below the 56px bar, under its z-40) so the bar stays visible + tappable. Bottom nav becomes game-aware (`FaceBottomNav`).

**Match play (Task 3-match + 4 + 5 + 6):**
- Publishes its chrome and suppresses its own `SetupHeader` + `MatchEntryView` header (no double-decker); **format subtitle dropped**. Standalone route (no provider) keeps its own header — deep-links don't lose chrome.
- **Task 4:** removed `handleFinish`'s `go("overview")` self-push (finish is tapped *on* the overview) — the two-backs bug the unified back would inherit. One back per level now.
- **Task 5:** score-entry publishes `hideBottomNav` → nav hidden there, kept on the scoreboard.
- **Task 6:** the panel now anchors to the real viewport bottom (`fixed …bottom-0`), giving the entry's flex column a definite height so the Finish/next-hole CTA + keypad anchor to the viewport bottom regardless of hole height (the off-screen-CTA fix). #543's gated disabled states are untouched — positioning only.

## Verified on the preview (match play)
- Board: flag/wordmark + chat/news/feedback/avatar. Panel open: **back + "2v2 Match Scoring Test" (no subtitle) + gear + scorecard**, chat/news/avatar present & tappable, panel top = 56px (below the bar), **no second header**.
- Single app-bar back pops one level at every step: **entry → overview → board** (url `?game=` cleared at the end). Bottom nav **hidden on entry, restored on the scoreboard**. "Back to matches"/Finish CTA sits at the **true viewport bottom**.
- tsc + eslint clean · full Vitest **956 passed** · Playwright critical-path **2 passed**.

## Remaining (Phase 2 — same pattern, one commit each, verified on preview)
Rack (`Shell` + shared `ScoreEntryView` header), non-golf (`header()` helper), stroke (inline header + shared `ScoreEntryView` + `FinalStandings`). Until then those three render as today (their `fixed inset-0 z-50` still covers the bar) — **no regression**, just not-yet-on-the-bar. The foundation is inert for them.

I stopped at the verified match-play checkpoint rather than push an unverified 4-format change (which the spec forbids). Happy to continue Phase 2 on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)