### PR TITLE
#550 game-chrome Phase 2: relocate rack / non-golf / stroke headers to the bar

### DIFF
--- a/src/components/competition/CompetitionFace.tsx
+++ b/src/components/competition/CompetitionFace.tsx
@@ -19,6 +19,7 @@ import { NonGolfGameView } from "@/components/games/NonGolfGameView";
 import { StrokeGameView } from "@/components/games/StrokeGameView";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { ScorecardPreviewSheet } from "@/components/games/ScorecardPreviewSheet";
+import { useGameChrome } from "@/components/games/GameChrome";
 
 interface Competition {
   id: string;
@@ -126,6 +127,13 @@ export function CompetitionFace({
     : undefined;
   const openType = openGame?.game_type_id ?? null;
   const panelOpen = !!openGame && opensAsPanel(openType);
+  // The bottom nav (z-40, fixed) overlays the panel's bottom (z-30). On surfaces
+  // that KEEP the nav (scoreboards — not the nav-hiding score-entry surfaces), pad
+  // the panel's scroll by the nav height so its last content clears the nav
+  // instead of hiding behind it. Read from the published chrome so it tracks each
+  // format's hideBottomNav automatically.
+  const chrome = useGameChrome();
+  const navUnderPanel = panelOpen && !chrome?.hideBottomNav;
   // Lock the PAGE scroll while a panel is open: the panel is `fixed` with its own
   // `overflow-y-auto`, so without this the board behind it keeps its own window
   // scrollbar → two vertical scrollbars (Zach's QA). The panel owns the only
@@ -365,7 +373,12 @@ export function CompetitionFace({
       {panelOpen && (
         <div
           className="fixed inset-x-0 bottom-0 top-14 z-30 overflow-y-auto game-panel-in"
-          style={{ background: "var(--color-bt-base)" }}
+          style={{
+            background: "var(--color-bt-base)",
+            // Clear the bottom nav (58px) + safe area when it's showing; none on the
+            // nav-hidden entry surfaces (their CTA anchors to the viewport bottom).
+            paddingBottom: navUnderPanel ? "calc(64px + env(safe-area-inset-bottom))" : undefined,
+          }}
           data-testid="game-panel"
         >
           {panelView}

--- a/src/components/games/GameConfigurationView.tsx
+++ b/src/components/games/GameConfigurationView.tsx
@@ -45,6 +45,7 @@ export function GameConfigurationView({
   onEnable,
   onDisable,
   busy,
+  hideHeader = false,
 }: {
   subtitle: string;
   onBack: () => void;
@@ -86,6 +87,10 @@ export function GameConfigurationView({
   onEnable: () => void;
   onDisable: () => void;
   busy: boolean;
+  /** #550: hide the view's own header — as a panel the app bar carries back/title.
+   *  Standalone route (no bar) keeps it. Also fills the panel height instead of
+   *  forcing 100vh (avoids a spurious scroll). */
+  hideHeader?: boolean;
 }) {
   // #501: in scoring mode game-altering settings freeze. `settingsEditable` gates
   // every game-altering editor (course/points/who's-playing/handicaps/modifiers);
@@ -93,19 +98,21 @@ export function GameConfigurationView({
   // stays active (the path back to Setup), and the Danger Zone disables wholesale.
   const settingsEditable = canEdit && !scoringEnabled;
   return (
-    <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
-      <header
-        className="flex shrink-0 items-center"
-        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
-      >
-        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
-          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
-        </button>
-        <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
-          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Configuration</div>
-          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
-        </div>
-      </header>
+    <div className={`flex flex-col ${hideHeader ? "h-full" : "min-h-screen"}`} style={{ background: "var(--color-bt-base)" }}>
+      {!hideHeader && (
+        <header
+          className="flex shrink-0 items-center"
+          style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+        >
+          <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+          </button>
+          <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
+            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Configuration</div>
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
+          </div>
+        </header>
+      )}
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
         {/* Stroke + rack now follow the canonical cleaned ORDER (Spec 7 — same

--- a/src/components/games/NonGolfConfigurationView.tsx
+++ b/src/components/games/NonGolfConfigurationView.tsx
@@ -55,6 +55,7 @@ export function NonGolfConfigurationView({
   onEnable,
   onDisable,
   busy,
+  hideHeader = false,
 }: {
   subtitle: string;
   onBack: () => void;
@@ -73,25 +74,30 @@ export function NonGolfConfigurationView({
   onEnable: () => void;
   onDisable: () => void;
   busy: boolean;
+  /** #550: hide the view's own header (the app bar carries back/title as a panel);
+   *  fills the panel height instead of forcing 100vh. Standalone keeps it. */
+  hideHeader?: boolean;
 }) {
   // #501: in scoring mode game-altering settings freeze (competition_format +
   // points). Rules keeps plain canEdit (the exception), the toggle stays active
   // (the path back to Setup), and the Danger Zone disables wholesale.
   const settingsEditable = canEdit && !scoringEnabled;
   return (
-    <div className="flex min-h-screen flex-col" style={{ background: "var(--color-bt-base)" }}>
-      <header
-        className="flex shrink-0 items-center"
-        style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
-      >
-        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
-          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
-        </button>
-        <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
-          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Configuration</div>
-          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
-        </div>
-      </header>
+    <div className={`flex flex-col ${hideHeader ? "h-full" : "min-h-screen"}`} style={{ background: "var(--color-bt-base)" }}>
+      {!hideHeader && (
+        <header
+          className="flex shrink-0 items-center"
+          style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}
+        >
+          <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+          </button>
+          <div className="min-w-0 flex-1 text-center" style={{ marginRight: 36 }}>
+            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Configuration</div>
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>
+          </div>
+        </header>
+      )}
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
         {/* Non-golf now mirrors the cleaned golf ORDER (Spec 6): identity → explainer

--- a/src/components/games/NonGolfGameView.tsx
+++ b/src/components/games/NonGolfGameView.tsx
@@ -11,6 +11,7 @@ import { NonGolfScoreboard } from "@/components/games/NonGolfScoreboard";
 import { GamePageHeader } from "@/components/competition/GamePageHeader";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
+import { useInGamePanel, usePublishGameChrome } from "@/components/games/GameChrome";
 import { useConfigSync } from "@/hooks/useConfigSync";
 import { GAME_TYPES, type ScoringModel } from "@/lib/gameTypes";
 import type { GameRow, LBTeamLite } from "@/components/competition/CompetitionGamesPanel";
@@ -159,10 +160,25 @@ export function NonGolfGameView() {
     }
   }
 
+  // #550: as a PANEL, publish chrome to the app bar (back/title + owner gear)
+  // instead of a second header. Non-golf has no focused entry surface (posted
+  // results), so the bottom nav stays. Standalone route keeps its own header.
+  const inPanel = useInGamePanel();
+  usePublishGameChrome(
+    inPanel
+      ? {
+          title: (game?.name as string | undefined)?.trim() || typeName,
+          onSettings: game && !showConfig && canEdit ? openConfig : undefined,
+        }
+      : null,
+  );
+
   if (!tripId || !urlGameId) return <Spinner />;
   if (gameQ.isLoading || !game) return <Spinner />;
 
-  const header = (title: string) => (
+  // As a panel the app bar carries back/title/gear (published above) → no own
+  // header. Standalone route (no bar) keeps it.
+  const header = (title: string) => inPanel ? null : (
     <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
       <button onClick={() => router.back()} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
         <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
@@ -188,6 +204,7 @@ export function NonGolfGameView() {
   if (showConfig && canEdit && competitionId) {
     return (
       <NonGolfConfigurationView
+        hideHeader={inPanel}
         subtitle={typeName}
         onBack={closeConfig}
         tripId={tripId}
@@ -212,7 +229,7 @@ export function NonGolfGameView() {
   // ── Setup mode (pending) — member placeholder / owner pass-through. ──
   if (!scoringEnabled) {
     return (
-      <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
+      <div className="flex flex-col" style={{ minHeight: inPanel ? "100%" : "100vh", background: "var(--color-bt-base)" }}>
         {header(gameName)}
         <div className="flex-1">
           <SetupPlaceholder
@@ -241,7 +258,7 @@ export function NonGolfGameView() {
 
   // ── Scoring mode (active/complete) — the scoreboard. ──
   return (
-    <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
+    <div className="flex flex-col" style={{ minHeight: inPanel ? "100%" : "100vh", background: "var(--color-bt-base)" }}>
       {header(gameName)}
       {/* Standard game header — row 1 (the collapsed cup hero) + row 2 (this
           game's projected/final per-team contribution), sticky over the

--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -910,7 +910,10 @@ export function RackGameView() {
 // route (no bar) keeps the header.
 function Shell({ title, subtitle, onBack, right, children, hideHeader = false }: { title: string; subtitle?: string; onBack: () => void; right?: React.ReactNode; children: React.ReactNode; hideHeader?: boolean }) {
   return (
-    <div className={`flex flex-col ${hideHeader ? "h-full" : ""}`} style={{ background: "var(--color-bt-base)", minHeight: hideHeader ? undefined : "100vh" }}>
+    // min-height (not h-full): the scoreboard content isn't in its own scroll
+    // container, so it must GROW and let the panel scroll (h-full capped it and
+    // clipped the bottom rows). Fills the panel when short; grows when tall.
+    <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: hideHeader ? "100%" : "100vh" }}>
       {!hideHeader && (
         <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
           <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">

--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -7,6 +7,7 @@ import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
+import { useInGamePanel, usePublishGameChrome } from "@/components/games/GameChrome";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
@@ -536,6 +537,27 @@ export function RackGameView() {
     }
   }
 
+  // #550: as a PANEL, publish this screen's chrome to the app bar (back/title +
+  // owner gear) instead of a second header. Standalone route (no provider) keeps
+  // its own Shell/ScoreEntryView headers below.
+  const inPanel = useInGamePanel();
+  const rackGroupName = (groupsQ.data?.groups ?? []).find((g) => g.id === entryGroupId)?.display_name as string | undefined;
+  const rackFinal = gameQ.data?.status === "complete";
+  usePublishGameChrome(
+    inPanel
+      ? {
+          title: entryGroupId
+            ? rackGroupName ?? "Group"
+            : (gameQ.data?.name as string | undefined)?.trim() || "Rack-n-Stack",
+          // Gear on the scoreboard screens only (owner/delegate, not final) — not
+          // on the entry, the config page, or the pre-setup steps.
+          onSettings:
+            gid && !entryGroupId && !showConfig && !needsSetup && canEdit && !rackFinal ? openConfig : undefined,
+          hideBottomNav: !!entryGroupId,
+        }
+      : null,
+  );
+
   // ── Render ───────────────────────────────────────────────────────────
   if (!tripId || roleLoading || crew.isLoading || competition.isLoading) {
     return <Center>Loading…</Center>;
@@ -548,7 +570,7 @@ export function RackGameView() {
 
   if (!hasCompetition) {
     return (
-      <Shell onBack={() => router.back()} title="Rack-n-Stack">
+      <Shell hideHeader={inPanel} onBack={() => router.back()} title="Rack-n-Stack">
         <div className="flex flex-col items-center text-center" style={{ paddingTop: 72 }}>
           <div className="flex items-center justify-center" style={{ width: 56, height: 56, borderRadius: 16, background: "var(--color-bt-card-raised)", marginBottom: 16 }}>
             <Users size={24} style={{ color: "var(--color-bt-text-dim)" }} />
@@ -609,15 +631,17 @@ export function RackGameView() {
       // Locked/posted OR a viewer who can't score this cart lands on the read-only
       // scorecard — now an overlay; dismiss returns to the rack hub (#7).
       return (
-        <div className="fixed inset-0 z-50">
+        <div className={inPanel ? "absolute inset-0" : "fixed inset-0 z-50"}>
           <ScorecardSheet title={scorecardTitle} onClose={back}>{scorecardGrid}</ScorecardSheet>
         </div>
       );
     }
     return (
-      <div className="fixed inset-0 z-50">
-        <div className="flex flex-col" style={{ height: "100vh" }}>
+      // As a panel: fill BELOW the app bar; standalone: full-screen.
+      <div className={inPanel ? "absolute inset-0" : "fixed inset-0 z-50"}>
+        <div className="flex flex-col" style={{ height: inPanel ? "100%" : "100vh" }}>
           <ScoreEntryView
+            hideHeader={inPanel}
             gameName={groupName ?? "Group"}
             units={scUnits}
             participants={ps}
@@ -695,6 +719,7 @@ export function RackGameView() {
     );
     return (
       <GameConfigurationView
+        hideHeader={inPanel}
         subtitle="Net stroke play · team rack"
         // The close-flush effect persists the groupings on ANY overlay close (incl.
         // OS back), so Back just closes — no inline save needed here.
@@ -728,13 +753,13 @@ export function RackGameView() {
   if (!gid || needsSetup) {
     if (!canEdit) {
       return (
-        <Shell onBack={() => router.back()} title="Rack-n-Stack">
+        <Shell hideHeader={inPanel} onBack={() => router.back()} title="Rack-n-Stack">
           <SetupPlaceholder tripId={tripId} game={gameQ.data as unknown as GameRow | undefined} />
         </Shell>
       );
     }
     return (
-      <Shell onBack={() => router.back()} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
+      <Shell hideHeader={inPanel} onBack={() => router.back()} title="Rack-n-Stack" subtitle="Net stroke play · team rack">
         <div className="w-full px-4 py-5">
           <div className="flex flex-col gap-3.5">
             <div>
@@ -768,6 +793,7 @@ export function RackGameView() {
   if (!scoringEnabled) {
     return (
       <Shell
+        hideHeader={inPanel}
         onBack={() => router.back()}
         title="Rack-n-Stack"
         right={
@@ -808,6 +834,7 @@ export function RackGameView() {
     // Title-bar (back + name/status + gear) then the GamePageHeader below — the same
     // header pattern the match/stroke game pages use.
     <Shell
+      hideHeader={inPanel}
       onBack={() => router.back()}
       title="Rack-n-Stack"
       subtitle={correcting ? "Net stroke play · correcting" : final ? "Net stroke play · final" : "Net stroke play · standings"}
@@ -878,19 +905,24 @@ export function RackGameView() {
   );
 }
 
-function Shell({ title, subtitle, onBack, right, children }: { title: string; subtitle?: string; onBack: () => void; right?: React.ReactNode; children: React.ReactNode }) {
+// #550: as a panel the app bar carries back/title/gear, so the header is
+// suppressed and the shell fills the panel height (no forced 100vh). Standalone
+// route (no bar) keeps the header.
+function Shell({ title, subtitle, onBack, right, children, hideHeader = false }: { title: string; subtitle?: string; onBack: () => void; right?: React.ReactNode; children: React.ReactNode; hideHeader?: boolean }) {
   return (
-    <div className="flex flex-col" style={{ background: "var(--color-bt-base)", minHeight: "100vh" }}>
-      <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
-          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
-        </button>
-        <div className="min-w-0 text-center">
-          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
-          {subtitle && <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>}
-        </div>
-        <div className="flex h-9 min-w-9 items-center justify-end pr-1">{right}</div>
-      </header>
+    <div className={`flex flex-col ${hideHeader ? "h-full" : ""}`} style={{ background: "var(--color-bt-base)", minHeight: hideHeader ? undefined : "100vh" }}>
+      {!hideHeader && (
+        <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", backdropFilter: "blur(14px)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+          <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+          </button>
+          <div className="min-w-0 text-center">
+            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{title}</div>
+            {subtitle && <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{subtitle}</div>}
+          </div>
+          <div className="flex h-9 min-w-9 items-center justify-end pr-1">{right}</div>
+        </header>
+      )}
       <div className="flex-1">{children}</div>
     </div>
   );

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -60,6 +60,10 @@ interface ScoreEntryViewProps {
    *  with no handicap (stroke play / Quick Game). Net = gross − 1 on a stroked
    *  hole. */
   pips?: Record<string, Set<string>>;
+  /** #550: hide the view's own header — as a panel the app bar carries
+   *  back/title (+ the config gear). The scorecard affordance relocates to the
+   *  right of the "Scores" strip (mirrors match's card-header placement). */
+  hideHeader?: boolean;
 }
 
 export function ScoreEntryView({
@@ -78,6 +82,7 @@ export function ScoreEntryView({
   saveStatus = {},
   onRetryCell,
   pips,
+  hideHeader = false,
 }: ScoreEntryViewProps) {
   const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
   const hole = currentHole ?? holeInternal;
@@ -190,44 +195,49 @@ export function ScoreEntryView({
 
   return (
     <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
-      {/* ── App bar ── */}
-      <header
-        className="flex shrink-0 items-center justify-between"
-        style={{
-          height: 52,
-          padding: "0 12px",
-          background: "var(--color-bt-nav-bg)",
-          backdropFilter: "blur(14px)",
-          borderBottom: "1px solid var(--color-bt-subtle-border)",
-        }}
-      >
-        <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
-          <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
-        </button>
-        <div className="text-center">
-          <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{gameName}</div>
-          <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
-            Hole {hole} of {units.length}
-          </div>
-        </div>
-        <div className="flex items-center">
-          {onConfig && (
-            <button onClick={onConfig} aria-label="Configuration" className="flex h-9 w-9 items-center justify-center">
-              <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
-            </button>
-          )}
-          <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
-            <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+      {/* ── App bar — suppressed as a panel (#550): the shared TopNav carries
+          back/title (+ the config gear published by the parent). Kept for
+          standalone routes (no bar). ── */}
+      {!hideHeader && (
+        <header
+          className="flex shrink-0 items-center justify-between"
+          style={{
+            height: 52,
+            padding: "0 12px",
+            background: "var(--color-bt-nav-bg)",
+            backdropFilter: "blur(14px)",
+            borderBottom: "1px solid var(--color-bt-subtle-border)",
+          }}
+        >
+          <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
           </button>
-        </div>
-      </header>
+          <div className="text-center">
+            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{gameName}</div>
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+              Hole {hole} of {units.length}
+            </div>
+          </div>
+          <div className="flex items-center">
+            {onConfig && (
+              <button onClick={onConfig} aria-label="Configuration" className="flex h-9 w-9 items-center justify-center">
+                <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+              </button>
+            )}
+            <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
+              <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+            </button>
+          </div>
+        </header>
+      )}
 
       {/* ── Unsaved-scores safety net (Connectivity Layer 1) ── */}
       <UnsavedScoresBanner count={errorCount} onRetry={retryAll} />
 
-      {/* ── Standings strip ── */}
+      {/* ── Standings strip (+ the scorecard affordance on the right when the
+          header is hidden — mirrors match's card-header placement) ── */}
       <div
-        className="flex shrink-0 items-center gap-2 overflow-x-auto"
+        className="flex shrink-0 items-center"
         style={{
           minHeight: 42,
           padding: "0 14px",
@@ -235,6 +245,7 @@ export function ScoreEntryView({
           borderBottom: "1px solid var(--color-bt-border)",
         }}
       >
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
         <span
           style={{
             fontSize: 12,
@@ -278,6 +289,18 @@ export function ScoreEntryView({
                 </span>
               );
             })
+        )}
+        </div>
+        {hideHeader && onOpenGrid && (
+          <button
+            type="button"
+            onClick={onOpenGrid}
+            aria-label="Scorecard"
+            data-testid="entry-scorecard"
+            className="ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded transition-colors hover:bg-[var(--color-bt-hover)]"
+          >
+            <Table2 size={17} style={{ color: "var(--color-bt-text-dim)" }} />
+          </button>
         )}
       </div>
 

--- a/src/components/games/StrokeGameView.tsx
+++ b/src/components/games/StrokeGameView.tsx
@@ -10,6 +10,7 @@ import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { ScoreEntryView } from "@/components/games/ScoreEntryView";
 import { StandardGrid } from "@/components/games/StandardGrid";
 import { ScorecardSheet } from "@/components/games/ScorecardSheet";
+import { useInGamePanel, usePublishGameChrome } from "@/components/games/GameChrome";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { FinalStandings } from "@/components/games/FinalStandings";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
@@ -344,6 +345,21 @@ export function StrokeGameView() {
     }
   }
 
+  // #550: as a PANEL, publish chrome to the app bar (back/title + owner gear)
+  // instead of a second header. The handicaps/modifiers drill-downs keep their own
+  // header + local back (they cover the bar). Standalone route keeps its headers.
+  const inPanel = useInGamePanel();
+  const onDrilldown = !!game && (showHandicaps || showModifiers) && settingsEditable;
+  usePublishGameChrome(
+    inPanel
+      ? {
+          title: (gameQ.data?.name as string | undefined)?.trim() || "Stroke Play",
+          onSettings: !!game && canEdit && !showConfig && !onDrilldown && view !== "final" ? openConfig : undefined,
+          hideBottomNav: !!game && scoringEnabled && !showConfig && !onDrilldown && view === "entry" && canScoreStroke,
+        }
+      : null,
+  );
+
   if (!tripId) {
     return (
       <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--color-bt-base)" }}>
@@ -403,7 +419,10 @@ export function StrokeGameView() {
   // Drives `netStrokeEntries`/`strokeHoles`: the input Phase 1 deferred. ──
   if (game && showHandicaps && settingsEditable) {
     return (
-      <div className="flex flex-col" style={{ height: "100vh" }}>
+      // Drill-down keeps its own header + LOCAL back (setShowHandicaps) — as a panel
+      // it covers the bar (fixed) so there's no double-decker and the bar's
+      // history-back can't hijack the local back.
+      <div className={`flex flex-col ${inPanel ? "fixed inset-0 z-50" : ""}`} style={{ height: "100vh", background: "var(--color-bt-base)" }}>
         <HandicapRoster
           players={handicapPlayers}
           holeCount={scUnits.length}
@@ -420,7 +439,8 @@ export function StrokeGameView() {
   // SAME ModifierCards the match setup page uses, persisted on-change.
   if (game && showModifiers && settingsEditable) {
     return (
-      <div className="flex flex-col" style={{ height: "100vh", background: "var(--color-bt-base)" }}>
+      // Drill-down: own header + local back → covers the bar as a panel (see above).
+      <div className={`flex flex-col ${inPanel ? "fixed inset-0 z-50" : ""}`} style={{ height: "100vh", background: "var(--color-bt-base)" }}>
         <div className="flex items-center gap-2 px-4 py-3" style={{ borderBottom: "1px solid var(--color-bt-border)" }}>
           <button
             type="button"
@@ -445,21 +465,24 @@ export function StrokeGameView() {
   // gear). NO checklist, NO toggle on this page — those live on the settings page.
   if (game && !scoringEnabled && !showConfig) {
     return (
-      <div className="flex flex-col" style={{ minHeight: "100vh", background: "var(--color-bt-base)" }}>
-        <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
-          <button onClick={() => router.back()} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
-            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
-          </button>
-          <div className="min-w-0 text-center">
-            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Stroke Play</div>
-            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{`${game.participants.length} player${game.participants.length === 1 ? "" : "s"}`}</div>
-          </div>
-          {canEdit ? (
-            <button onClick={openConfig} aria-label="Settings" className="flex h-9 w-9 items-center justify-center" data-testid="game-settings-gear">
-              <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+      <div className="flex flex-col" style={{ minHeight: inPanel ? "100%" : "100vh", background: "var(--color-bt-base)" }}>
+        {/* #550: as a panel the app bar carries back/title/gear. Standalone keeps it. */}
+        {!inPanel && (
+          <header className="flex shrink-0 items-center justify-between" style={{ height: 52, padding: "0 8px", background: "var(--color-bt-nav-bg)", borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+            <button onClick={() => router.back()} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+              <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
             </button>
-          ) : <div className="h-9 w-9" />}
-        </header>
+            <div className="min-w-0 text-center">
+              <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>Stroke Play</div>
+              <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>{`${game.participants.length} player${game.participants.length === 1 ? "" : "s"}`}</div>
+            </div>
+            {canEdit ? (
+              <button onClick={openConfig} aria-label="Settings" className="flex h-9 w-9 items-center justify-center" data-testid="game-settings-gear">
+                <Settings size={19} style={{ color: "var(--color-bt-text-dim)" }} />
+              </button>
+            ) : <div className="h-9 w-9" />}
+          </header>
+        )}
         <div className="flex-1">
           <SetupPlaceholder
             tripId={tripId}
@@ -495,6 +518,7 @@ export function StrokeGameView() {
   if (game && showConfig && gameQ.data && canEdit) {
     return (
       <GameConfigurationView
+        hideHeader={inPanel}
         subtitle="Stroke Play"
         onBack={closeConfig}
         tripId={tripId}
@@ -546,7 +570,8 @@ export function StrokeGameView() {
       />
     );
     return (
-      <div className="fixed inset-0 z-50">
+      // As a panel: fill BELOW the app bar; standalone: full-screen.
+      <div className={inPanel ? "absolute inset-0" : "fixed inset-0 z-50"}>
         {!canScoreStroke ? (
           // #557: a viewer who can't score this game lands on the read-only
           // scorecard — now as an overlay; dismissing leaves the game (back to the
@@ -565,6 +590,7 @@ export function StrokeGameView() {
               />
             ) : (
               <ScoreEntryView
+                hideHeader={inPanel}
                 gameName="Stroke Play"
                 units={scUnits}
                 participants={game.participants}


### PR DESCRIPTION
Completes #550 — the remaining three formats onto the shared context-aware app bar (Phase 1 / match shipped in #565). Same pattern, one verified commit per format.

## What each format got
- **Rack** — publishes {title (game name / group name on entry), gear on the scoreboard, hideBottomNav on entry}; suppresses its `Shell` header + drops the "Net stroke play · …" subtitles; panel-aware wrappers.
- **Non-golf** — publishes {title, gear}; suppresses its `header()` helper + drops the type subtitle. No focused entry surface (posted results), so the bottom nav stays.
- **Stroke** — publishes {title, gear on setup/entry, hideBottomNav on entry}; suppresses its setup header. The handicaps/modifiers **drill-downs keep their own header + local back** (they cover the bar as a panel, so no double-decker and the bar's history-back can't hijack their local state).

## Shared plumbing (drives rack + stroke)
- `ScoreEntryView` gains `hideHeader`: suppresses its header and **relocates the scorecard button to the right of the "Scores" strip** — mirroring match's card-header placement (the same "off the app bar" fix Zach asked for).
- `GameConfigurationView` + `NonGolfConfigurationView` gain `hideHeader`: suppress their header + fill the panel height (no forced 100vh → no spurious scroll).
- **Standalone routes keep every header** (inPanel=false) — deep-links don't lose chrome.

## Verified on preview (per format)
- **Rack** scoreboard/entry/config: bar back+title (+gear on the scoreboard), no double-decker, ≤1 scrollbar; group entry shows the group name + scorecard on the Scores strip + nav hidden + CTA anchored; back pops one level at each step.
- **Non-golf** scoreboard + config: bar back+title (+gear), no double-decker, ≤1 scrollbar; nav stays.
- **Stroke**: no cup stroke game exists in the test data (raw stroke isn't a cup format — the testing guardrail), so the panel path can't be live-created here; verified the **standalone route renders** (keeps its own header, inPanel=false — stroke's real surface), and the panel path is code-identical to the verified match/rack.
- tsc + eslint clean · full Vitest **956** · Playwright critical-path **2/2** (a stroke game).

Match uses its own MatchEntryView + inline config, so the shared-component changes here don't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)