### PR TITLE
ci: cancel superseded in-flight runs (concurrency group)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+# A new commit on the same ref supersedes the in-flight run — cancel it instead of
+# letting both compete for (sometimes scarce) hosted runners. Keyed by ref so PR
+# branches and main are independent; a canceled run just re-runs on the new SHA.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a per-ref `concurrency` group with `cancel-in-progress: true` to the CI workflow.

**Why:** when two pushes land close together on a branch, both runs queue for hosted runners independently — which is exactly what made #566's `e2e` sit behind a stale run during GitHub's "Delays starting Actions runs" incident. With this, a new commit on the same ref cancels the older in-flight run instead of competing with it.

Keyed by `github.ref` so PR branches and `main` stay independent; a canceled run just re-runs on the new SHA. No job logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)