### PR TITLE
Glorious Finishing Holes — scoring engine (last N holes 2×, match play)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,20 @@ These patterns have been established through prior work. Follow them exactly —
     the board is still stale until a hard refresh / the poll." (History: the
     team-color audit established this for setup-data mutations; the rack/1v1
     finalize + correction lag was the same class on the result path.)
+11. **Glorious Finishing Holes weight is DERIVED, never snapshotted.** The "last N
+    holes worth 2×" modifier (`games.modifiers.glorious_holes: { holes: N }`) is
+    applied at COMPUTE time by `holeWeight`/`remainingSwing` (`src/lib/gloriousHoles.ts`),
+    never stored on a hole result — flip the flag or change N mid-round and the tally
+    just recomputes (nothing migrates). It weights the match tally (a won glorious
+    hole is ±2) and, critically, close-out/dormie compare the lead to the WEIGHTED
+    `remainingSwing`, NOT raw holes left (a 4-up lead with 3 glorious holes / swing 6
+    is still live). Match SINGLES/DOUBLES only, **guarded on `game_type_id`** (via
+    `isMatchPlayFormat`) — NOT the competition `scoring_model` (rack is `match_play`
+    by scoring_model but is net-stroke entry, excluded). The ONE weighted `matchState`
+    (`src/lib/matchPlay.ts`, `buildDecided` now emits `{hole, result}[]`) feeds the
+    live client strip AND the server `computeMatchPlayResults`, so they can't diverge.
+    The margin string keeps X = weighted lead, Y = raw holes-to-play (so "4&2" is a
+    legal, correct glorious margin — do not "fix" it).
 
 ## Guest → real-user conversion (auth)
 

--- a/src/components/games/MatchCard.tsx
+++ b/src/components/games/MatchCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Table2 } from "lucide-react";
-import { matchState, type HoleResult } from "@/lib/matchPlay";
+import { matchState, type DecidedHole } from "@/lib/matchPlay";
+import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
 import { teamTextColor } from "@/lib/teamTextColor";
 import type { Participant } from "./types";
 
@@ -27,8 +28,10 @@ const NEU_HALF = "#8c97a8"; // halved — mid
 interface MatchCardProps {
   a: Participant;
   b: Participant;
-  /** Decided holes, A's perspective (W/L/H), in play order. */
-  results: HoleResult[];
+  /** Decided holes, A's perspective — {hole, W/L/H}, in play order. */
+  results: DecidedHole[];
+  /** Glorious Finishing Holes weight (2× the last N). Omit for standard match play. */
+  glorious?: GloriousConfig;
   label?: string;
   /** Team colors (Slice D). Omit for the neutral standalone default. */
   leftColor?: string;
@@ -49,6 +52,7 @@ export function MatchCard({
   a,
   b,
   results,
+  glorious = NO_GLORIOUS,
   label = "Match",
   leftColor,
   rightColor,
@@ -58,7 +62,7 @@ export function MatchCard({
   hideFormat,
   onScorecard,
 }: MatchCardProps) {
-  const st = matchState(results, holeCount);
+  const st = matchState(results, holeCount, glorious);
   const teams = !!(leftColor && rightColor);
   const lc = leftColor || WIN_GREEN; // left emphasis color
   const rc = rightColor || WIN_GREEN; // right emphasis color
@@ -129,7 +133,7 @@ export function MatchCard({
           let bg = "var(--color-bt-card-raised)";
           let op = 0.5;
           if (i < st.thru) {
-            const r = results[i];
+            const r = results[i]?.result;
             bg = r === "W" ? wonL : r === "L" ? wonR : halfC;
             op = 1;
           } else if (st.closed) {

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronLeft, Table2 } from "lucide-react";
 import { buildDecided, matchState, strokeHoles } from "@/lib/matchPlay";
+import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
 import { StrokeKeypad } from "./StrokeKeypad";
 import { MatchCard } from "./MatchCard";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
@@ -77,6 +78,9 @@ interface MatchEntryViewProps {
   /** #550: hide the view's own header — as a panel the app bar carries
    *  back/title + the scorecard action, so this second header is dropped. */
   hideHeader?: boolean;
+  /** Glorious Finishing Holes weight (2× the last N) for the live match state.
+   *  Omit for standard match play. */
+  glorious?: GloriousConfig;
 }
 
 export function MatchEntryView({
@@ -98,6 +102,7 @@ export function MatchEntryView({
   saveStatus = {},
   onRetryCell,
   hideHeader = false,
+  glorious = NO_GLORIOUS,
 }: MatchEntryViewProps) {
   const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
   const hole = currentHole ?? holeInternal;
@@ -126,7 +131,7 @@ export function MatchEntryView({
   // Per-match derived state (from the SHARED frozen matchState).
   const groups = matches.map((m) => {
     const decided = buildDecided(values[m.a.id] ?? {}, values[m.b.id] ?? {}, m.strokesA, m.strokesB, scIndex, units.length);
-    const st = matchState(decided, units.length);
+    const st = matchState(decided, units.length, glorious);
     const strokeHolesA = strokeHoles(m.strokesA, scIndex);
     const strokeHolesB = strokeHoles(m.strokesB, scIndex);
     // A hole is "dead" for a decided match once it's past the close-out hole.
@@ -265,7 +270,7 @@ export function MatchEntryView({
           const { m } = g;
           // Board state excludes the in-progress hole (computes on ✓, not on tap).
           const boardDecided = buildDecided(committedGross(m.a.id), committedGross(m.b.id), m.strokesA, m.strokesB, scIndex, units.length);
-          const st = matchState(boardDecided, units.length);
+          const st = matchState(boardDecided, units.length, glorious);
           const winner = st.leader === "A" ? m.a : st.leader === "B" ? m.b : null;
           const loser = st.leader === "A" ? m.b : st.leader === "B" ? m.a : null;
           return (
@@ -274,6 +279,7 @@ export function MatchEntryView({
                 a={m.a}
                 b={m.b}
                 results={boardDecided}
+                glorious={glorious}
                 label={m.label}
                 holeCount={units.length}
                 youId={meId}

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -38,7 +38,8 @@ import { useScreenHistory } from "@/hooks/useScreenHistory";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
-import { buildDecided, matchState, strokeHoles, type HoleResult } from "@/lib/matchPlay";
+import { buildDecided, matchState, strokeHoles, type DecidedHole } from "@/lib/matchPlay";
+import { gloriousConfig, type GloriousConfig } from "@/lib/gloriousHoles";
 import { rollupMatchPlay, type ProjMatch } from "@/lib/gameProjection";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
@@ -434,6 +435,15 @@ export function MatchGameView() {
     [gameQ.data]
   );
   const scIndex = useMemo(() => strokeIndexOf(scUnits), [scUnits]);
+
+  // Glorious Finishing Holes weight — the LIVE 2×-last-N config off this game
+  // (derived at compute time; format-guarded to match singles/doubles). Feeds every
+  // matchState on this page + the entry view, the SAME weight the server scores on,
+  // so the live strips and the finished record can't diverge.
+  const glorious = useMemo<GloriousConfig>(
+    () => gloriousConfig(gameQ.data?.game_type_id as string | null, gameQ.data?.modifiers as ModifiersMap | null),
+    [gameQ.data]
+  );
 
   // Decided holes (A's perspective) for an overview strip — the shared builder.
   const decidedFor = (g: MatchGroupData) =>
@@ -949,7 +959,7 @@ export function MatchGameView() {
   const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
   const projectionPerTeam = useMemo(() => {
     const projMatches: ProjMatch[] = groups.map((g) => {
-      const st = matchState(decidedFor(g), scUnits.length);
+      const st = matchState(decidedFor(g), scUnits.length, glorious);
       return {
         aTeamId: teamOfSide(g.a.id)?.id ?? null,
         bTeamId: teamOfSide(g.b.id)?.id ?? null,
@@ -961,7 +971,7 @@ export function MatchGameView() {
     // decidedFor/teamOfSide are per-render closures; we depend on the DATA they
     // read (scores via loadedValues/values, handicaps, roster→team, scorecard).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groups, loadedValues, values, handicapOf, scIndex, scUnits, twoTeams, teamOfUser, teamById, membersOfSide, pointsPerMatch]);
+  }, [groups, loadedValues, values, handicapOf, scIndex, scUnits, twoTeams, teamOfUser, teamById, membersOfSide, pointsPerMatch, glorious]);
 
   const entryPips = useMemo(() => {
     const m: Record<string, Set<string>> = {};
@@ -1044,6 +1054,7 @@ export function MatchGameView() {
               finishLabel="Back to matches"
               finishSubtext="Scores save as you enter"
               meId={me?.id}
+              glorious={glorious}
             />
             {/* Scorecard OVERLAY over entry — entry stays mounted (#543 intact). */}
             {gridOpen && (
@@ -1513,6 +1524,7 @@ export function MatchGameView() {
           complete={status === "complete"}
           canEdit={canEdit}
           decidedFor={decidedFor}
+          glorious={glorious}
           holeCount={scUnits.length}
           onFinish={handleFinish}
           finishing={finishGame.isPending}
@@ -2054,6 +2066,7 @@ function Overview({
   complete,
   canEdit,
   decidedFor,
+  glorious,
   holeCount,
   onFinish,
   finishing,
@@ -2070,7 +2083,9 @@ function Overview({
   published: boolean;
   complete: boolean;
   canEdit: boolean;
-  decidedFor: (g: MatchGroupData) => HoleResult[];
+  decidedFor: (g: MatchGroupData) => DecidedHole[];
+  /** Glorious Finishing Holes weight (2× the last N) for the match state. */
+  glorious: GloriousConfig;
   /** The round's hole count (from the scorecard schema) — feeds matchState so
    *  close-out/over derive against 9 vs 18, not a hardcoded 18. */
   holeCount: number;
@@ -2086,7 +2101,7 @@ function Overview({
 }) {
   if (!published) return <MemberNotReady tripId={tripId} game={game} />;
   const decideds = groups.map(decidedFor);
-  const allOver = groups.length > 0 && decideds.every((d) => matchState(d, holeCount).over);
+  const allOver = groups.length > 0 && decideds.every((d) => matchState(d, holeCount, glorious).over);
   const matchWord = groups.length === 1 ? "Match" : "Matches";
   return (
     <div>
@@ -2114,6 +2129,7 @@ function Overview({
             a={g.a}
             b={g.b}
             results={decideds[i]}
+            glorious={glorious}
             label={`Match ${i + 1}`}
             youId={myId}
             leftColor={g.leftColor}

--- a/src/lib/gameTypes.ts
+++ b/src/lib/gameTypes.ts
@@ -155,12 +155,12 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "user_holes",
     resultStrategy: "stroke_total",
     scorecardSchema: strokeSchema,
-    // ⚠ TESTABILITY VALUES, NOT real-world applicability. Crossed deliberately so each
-    // golf format exercises one Modifiers render branch (hide / checkbox / stepper / both).
-    // Real applicability is different (e.g. glorious_holes doubles a hole's MATCH value, so it
-    // does NOT apply to stroke play). Reconcile to real applicability when modifier scoring
-    // logic is built — see W-GAMEPAGE-01 §6.5. Tracked in DEFERRED.md.
-    compatibleModifiers: ["moving_tees", "glorious_holes"], // BOTH cards branch
+    // glorious_holes is MATCH-PLAY ONLY (it doubles a hole's match value) — removed
+    // from stroke play when the scoring engine landed (it was inert here). moving_tees
+    // applicability is still provisional (not yet reconciled — a separate call). The
+    // golf formats still happen to exercise all four Modifiers render branches
+    // (hide / checkbox / stepper / both) — locked by modifiers.test.ts.
+    compatibleModifiers: ["moving_tees"], // checkbox-only branch
     supportsFreeForAll: true,
     supportsSides: false,
     requiresSides: false,
@@ -177,7 +177,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "user_holes",
     resultStrategy: "match_play",
     scorecardSchema: singlesSchema,
-    compatibleModifiers: ["moving_tees"], // ⚠ test-matrix value (CHECKBOX-only branch) — see note on gtt_stroke_play
+    compatibleModifiers: ["moving_tees", "glorious_holes"], // BOTH branch — glorious applies to match play (scoring engine)
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,
@@ -194,7 +194,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "group_holes",
     resultStrategy: "match_play",
     scorecardSchema: doublesSchema,
-    compatibleModifiers: ["glorious_holes"], // ⚠ test-matrix value (STEPPER-only branch) — see note on gtt_stroke_play
+    compatibleModifiers: ["glorious_holes"], // stepper-only branch — glorious applies to match play (scoring engine)
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,
@@ -211,7 +211,7 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     entrySchema: "user_holes",
     resultStrategy: "rack_n_stack",
     scorecardSchema: rackSchema,
-    compatibleModifiers: [], // ⚠ test-matrix value (HIDE-the-row branch: a golf format with none) — see note on gtt_stroke_play
+    compatibleModifiers: [], // hide-the-row branch — no modifiers apply (glorious is match-play hole-win only)
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,

--- a/src/lib/gloriousHoles.test.ts
+++ b/src/lib/gloriousHoles.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { gloriousConfig, holeWeight, remainingSwing, NO_GLORIOUS } from "./gloriousHoles";
+
+// The pure weight helper. The tally/close-out consequences (comeback, weighted
+// close-out, margin string) are gated in matchPlay.test.ts; this file pins the
+// primitives + the format guard (§6 gate d).
+
+describe("gloriousConfig — read + format guard", () => {
+  const on = { glorious_holes: { holes: 3 } };
+
+  it("reads enabled + N off a match-play game's modifiers", () => {
+    expect(gloriousConfig("gtt_match_play_singles", on)).toEqual({ enabled: true, n: 3 });
+    expect(gloriousConfig("gtt_match_play_doubles", { glorious_holes: { holes: 5 } })).toEqual({ enabled: true, n: 5 });
+  });
+
+  it("legacy `{}` shape reads as the default N=3 (existing rows don't break)", () => {
+    expect(gloriousConfig("gtt_match_play_singles", { glorious_holes: {} })).toEqual({ enabled: true, n: 3 });
+  });
+
+  it("absent key = disabled (presence-model)", () => {
+    expect(gloriousConfig("gtt_match_play_singles", {})).toBe(NO_GLORIOUS);
+    expect(gloriousConfig("gtt_match_play_singles", null)).toBe(NO_GLORIOUS);
+  });
+
+  it("FORMAT GUARD: inert for stroke / rack / manual even with the flag forced on", () => {
+    // Rack is match_play by COMPETITION scoring_model — the trap. Guard is on the id.
+    expect(gloriousConfig("gtt_rack_n_stack", on)).toBe(NO_GLORIOUS);
+    expect(gloriousConfig("gtt_stroke_play", on)).toBe(NO_GLORIOUS);
+    expect(gloriousConfig("gtt_generic_bar", on)).toBe(NO_GLORIOUS);
+    expect(gloriousConfig(null, on)).toBe(NO_GLORIOUS);
+  });
+});
+
+describe("holeWeight", () => {
+  const cfg = { enabled: true, n: 3 }; // last 3 → holes 16,17,18 double
+
+  it("2× on the last N holes, 1× elsewhere", () => {
+    expect(holeWeight(15, cfg)).toBe(1);
+    expect(holeWeight(16, cfg)).toBe(2);
+    expect(holeWeight(17, cfg)).toBe(2);
+    expect(holeWeight(18, cfg)).toBe(2);
+  });
+
+  it("N=1 doubles only the 18th", () => {
+    expect(holeWeight(17, { enabled: true, n: 1 })).toBe(1);
+    expect(holeWeight(18, { enabled: true, n: 1 })).toBe(2);
+  });
+
+  it("disabled → always 1", () => {
+    for (const h of [16, 17, 18]) expect(holeWeight(h, NO_GLORIOUS)).toBe(1);
+  });
+});
+
+describe("remainingSwing — over the actual unplayed-hole set", () => {
+  const cfg = { enabled: true, n: 3 };
+
+  it("sums each unplayed hole's weight (not a scalar count)", () => {
+    // holes 16,17,18 left → 2+2+2 = 6 weighted swing
+    expect(remainingSwing([16, 17, 18], cfg)).toBe(6);
+    // holes 14,15 left → 1+1 = 2
+    expect(remainingSwing([14, 15], cfg)).toBe(2);
+  });
+
+  it("counts a GAP correctly — an unplayed glorious hole mid-set keeps its 2×", () => {
+    // 16 undecided while 17,18 are decided → remaining unplayed {16} = weight 2,
+    // NOT 1 (a scalar 'one hole left' would undercount the swing).
+    expect(remainingSwing([16], cfg)).toBe(2);
+    // mixed gap: holes 15 and 18 unplayed → 1 + 2 = 3
+    expect(remainingSwing([15, 18], cfg)).toBe(3);
+  });
+
+  it("with no glorious, weighted swing == raw hole count", () => {
+    expect(remainingSwing([16, 17, 18], NO_GLORIOUS)).toBe(3);
+  });
+});

--- a/src/lib/gloriousHoles.ts
+++ b/src/lib/gloriousHoles.ts
@@ -1,0 +1,83 @@
+/**
+ * Glorious Finishing Holes — the per-hole 2× weight for match play.
+ *
+ * The mechanic (frozen): the last N holes of a match are worth DOUBLE. A won
+ * glorious hole is a ±2 swing; a halved hole is still 0. The multiplier is a fixed
+ * 2× — there is no 3× and no owner-set multiplier; the only config inputs are
+ * `enabled` (presence of `glorious_holes` in `games.modifiers`) and `N` (its
+ * `holes` count).
+ *
+ * DERIVED, never snapshotted. The weight is a pure function of the LIVE config read
+ * at compute time — flip the flag or change N mid-round and the tally simply
+ * recomputes; nothing is stored on a hole result and nothing migrates. Raw per-hole
+ * outcomes stay raw in `score_entries` (engine decision #16); the weight lives only
+ * in the compute path.
+ *
+ * Applies to match SINGLES/DOUBLES only. Stroke play has no per-hole win to double;
+ * rack-n-stack is net-stroke ENTRY (it is `match_play` by COMPETITION scoring_model,
+ * but that is NOT this — guard on the game_type_id, NEVER the scoring model);
+ * manual/non-golf has no per-hole entry. The format guard lives in `gloriousConfig`
+ * so the weight stays inert for every excluded format no matter what the modifiers
+ * jsonb says — belt-and-suspenders on top of the fact that only singles/doubles ever
+ * reach `matchState`.
+ *
+ * Pure + client-safe: the SAME helper feeds the live client strip and the server
+ * result compute, so they can't diverge (CLAUDE.md pattern #8). When Skins ships it
+ * reuses `holeWeight` unchanged.
+ */
+import { isMatchPlayFormat } from "./gameRoutes";
+import { isModifierEnabled, gloriousHolesCount, type ModifiersMap } from "./modifiers";
+
+/**
+ * The mechanic is frozen as "last N of an 18-hole match" → a hole is glorious when
+ * its number is > 18 − N. This is deliberately the literal 18 from the spec, not the
+ * round's own hole count: match play is 18-hole, and on a shorter round no hole
+ * clears `18 − N` so glorious is simply inert (revisit only if 9-hole match play +
+ * glorious ever becomes a real case).
+ */
+const ROUND_HOLES = 18;
+
+export interface GloriousConfig {
+  enabled: boolean;
+  /** Trailing holes worth 2×. Meaningless (0) when `!enabled`. */
+  n: number;
+}
+
+/** The inert config — every hole weighs 1. Default for callers with no glorious. */
+export const NO_GLORIOUS: GloriousConfig = { enabled: false, n: 0 };
+
+/**
+ * Read the LIVE glorious config off a game, FORMAT-GUARDED. Returns `NO_GLORIOUS`
+ * for any game_type_id outside match singles/doubles (via `isMatchPlayFormat`) — so
+ * stroke/rack/manual stay inert even if their `modifiers` jsonb somehow carries
+ * `glorious_holes`. Guarded on the id, NEVER the competition `scoring_model`: rack is
+ * `match_play` by scoring_model yet is excluded here, by design (the §2 trap).
+ */
+export function gloriousConfig(
+  gameTypeId: string | null | undefined,
+  modifiers: ModifiersMap | null | undefined
+): GloriousConfig {
+  if (!isMatchPlayFormat(gameTypeId ?? null)) return NO_GLORIOUS;
+  const m = modifiers ?? {};
+  if (!isModifierEnabled(m, "glorious_holes")) return NO_GLORIOUS;
+  return { enabled: true, n: gloriousHolesCount(m) };
+}
+
+/** Per-hole weight: `(enabled && hole > 18 − n) ? 2 : 1`. The ONE home of the
+ *  mechanic; Skins will reuse it. */
+export function holeWeight(hole: number, cfg: GloriousConfig): 1 | 2 {
+  return cfg.enabled && hole > ROUND_HOLES - cfg.n ? 2 : 1;
+}
+
+/**
+ * Weighted swing still on the table = Σ weight over the UNPLAYED holes. Takes the
+ * actual unplayed-hole SET (not a scalar count) so a mid-round gap — match play
+ * allows partial / out-of-order entry — is counted with each unplayed hole's real
+ * weight, not "holes 1..k done, the rest remaining". This is the value close-out and
+ * dormie compare against (§4): `matchClosed = holesUp > remainingSwing`.
+ */
+export function remainingSwing(unplayedHoles: Iterable<number>, cfg: GloriousConfig): number {
+  let sum = 0;
+  for (const h of unplayedHoles) sum += holeWeight(h, cfg);
+  return sum;
+}

--- a/src/lib/matchPlay.test.ts
+++ b/src/lib/matchPlay.test.ts
@@ -1,16 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { strokeHoles, buildDecided, matchState, matchHasScores, type HoleResult } from "./matchPlay";
+import { strokeHoles, buildDecided, matchState, matchHasScores, type HoleResult, type DecidedHole } from "./matchPlay";
+import { NO_GLORIOUS, type GloriousConfig } from "./gloriousHoles";
 
-// W-GAMEPAGE-01 §11 — the destructive-edit guard's "scores exist" signal. A hole
-// is decided only when both sides' grosses are in, so a non-empty decided list IS
-// "this match has entered scores" (removing it must confirm first).
+// Compact builder: a sequential run of outcomes on holes 1..n (no gaps) — the shape
+// buildDecided emits for an in-order match. Glorious cases that need specific hole
+// numbers build DecidedHole[] explicitly.
+const seq = (rs: HoleResult[]): DecidedHole[] => rs.map((result, i) => ({ hole: i + 1, result }));
+const GLOR3: GloriousConfig = { enabled: true, n: 3 }; // last 3 holes (16,17,18) worth 2×
+
+// W-GAMEPAGE-01 §11 — the destructive-edit guard's "scores exist" signal.
 describe("matchHasScores", () => {
   it("is false for a match with no decided holes (nothing to lose → no confirm)", () => {
     expect(matchHasScores([])).toBe(false);
   });
   it("is true once any hole is decided (scores entered → confirm before removal)", () => {
-    expect(matchHasScores(["W"])).toBe(true);
-    expect(matchHasScores(["H", "L", "W"])).toBe(true);
+    expect(matchHasScores(seq(["W"]))).toBe(true);
+    expect(matchHasScores(seq(["H", "L", "W"]))).toBe(true);
   });
 });
 
@@ -29,132 +34,170 @@ describe("strokeHoles", () => {
   });
 
   it("with a stroke index: the n hardest holes (index <= n) get a stroke", () => {
-    // hole:        1  2  3  4 ... where the value is its difficulty rank (1 = hardest)
     const index = [10, 2, 18, 4, 14, 6, 16, 8, 12, 1, 11, 3, 17, 5, 15, 7, 13, 9];
-    // n=3 → holes whose rank is 1,2,3 → hole 10 (1), hole 2 (2), hole 12 (3)
     expect([...strokeHoles(3, index)].sort((a, b) => a - b)).toEqual([2, 10, 12]);
   });
 
   it("a 9-hole index is honored — not rejected as 'not 18' and fed board-order", () => {
-    // The real 9-hole course index [2,3,1,9,5,4,6,7,8]. n=6 → the 6 hardest by
-    // index (rank ≤ 6) = holes 1(2), 2(3), 3(1), 5(5), 6(4), 7(6) → {1,2,3,5,6,7}.
-    // The pre-fix `length === 18` gate fell back to board-order {1,2,3,4,5,6}.
     const index = [2, 3, 1, 9, 5, 4, 6, 7, 8];
     expect([...strokeHoles(6, index)].sort((a, b) => a - b)).toEqual([1, 2, 3, 5, 6, 7]);
   });
 
   it("no-index fallback respects a passed holeCount (won't strike beyond the round)", () => {
-    // 12 strokes on a 9-hole round with no index → every hole, capped at 9.
     expect([...strokeHoles(12, undefined, 9)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 });
 
-describe("buildDecided", () => {
-  it("emits a result only when BOTH grosses exist, in hole order", () => {
+describe("buildDecided — emits {hole, result}", () => {
+  it("emits a result only when BOTH grosses exist, tagged with the hole number", () => {
     const decided = buildDecided(
       { "1": 4, "2": 5, "3": 4 },
       { "1": 5, "2": 5 /* hole 3 missing */ },
       0,
       0
     );
-    expect(decided).toEqual(["W", "H"]); // hole 1 A wins, hole 2 halved, hole 3 undecided
+    // hole 1 A wins, hole 2 halved, hole 3 undecided (absent — NOT a positional gap)
+    expect(decided).toEqual([{ hole: 1, result: "W" }, { hole: 2, result: "H" }]);
+  });
+
+  it("carries the true hole number across a gap (undecided hole simply absent)", () => {
+    const decided = buildDecided({ "1": 4, "3": 4 }, { "1": 5, "3": 5 }, 0, 0);
+    expect(decided).toEqual([{ hole: 1, result: "W" }, { hole: 3, result: "W" }]);
   });
 
   it("compares on NET — a received stroke can flip the hole", () => {
-    // A gross 5, B gross 4 on hole 1; A receives 1 stroke (fallback → hole 1) → net 4 vs 4 → halve
-    expect(buildDecided({ "1": 5 }, { "1": 4 }, 1, 0)).toEqual(["H"]);
-    // without the stroke, B wins
-    expect(buildDecided({ "1": 5 }, { "1": 4 }, 0, 0)).toEqual(["L"]);
+    expect(buildDecided({ "1": 5 }, { "1": 4 }, 1, 0)).toEqual([{ hole: 1, result: "H" }]);
+    expect(buildDecided({ "1": 5 }, { "1": 4 }, 0, 0)).toEqual([{ hole: 1, result: "L" }]);
   });
 });
 
-describe("matchState — in progress", () => {
+describe("matchState — in progress (standard, no glorious)", () => {
   it("all square", () => {
-    const s = matchState(["W", "L", "H"]);
-    expect(s).toMatchObject({ up: 0, leader: null, over: false, margin: null });
+    expect(matchState(seq(["W", "L", "H"]))).toMatchObject({ up: 0, leader: null, over: false, margin: null });
   });
 
   it("one side up", () => {
-    const s = matchState(["W", "H", "W", "L"]); // diff +1
-    expect(s).toMatchObject({ up: 1, leader: "A", over: false, dormie: false, margin: null });
+    expect(matchState(seq(["W", "H", "W", "L"]))).toMatchObject({ up: 1, leader: "A", over: false, dormie: false, margin: null });
   });
 
   it("dormie — up by exactly the holes remaining (3 up / 3 to play)", () => {
-    // 15 decided holes, A +3 → holesLeft 3, up 3 → dormie, not over
-    const decided: HoleResult[] = [
-      "W", "W", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H",
-    ];
-    const s = matchState(decided);
-    expect(s).toMatchObject({ thru: 15, up: 3, holesLeft: 3, dormie: true, over: false, closed: false });
+    const decided = seq(["W", "W", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H"]);
+    expect(matchState(decided)).toMatchObject({ thru: 15, up: 3, holesLeft: 3, dormie: true, over: false, closed: false });
   });
 });
 
-describe("matchState — decided", () => {
+describe("matchState — decided (standard, no glorious)", () => {
   it("closed early → {up}&{holesLeft} (3&2)", () => {
-    // A reaches +3 at hole 16 → holesLeft 2, up 3 > 2 → close as 3&2
-    const decided: HoleResult[] = [
-      "W", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "W",
-    ];
-    const s = matchState(decided);
-    expect(s).toMatchObject({ closed: true, over: true, margin: "3&2", thru: 16, leader: "A" });
+    const decided = seq(["W", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "W"]);
+    expect(matchState(decided)).toMatchObject({ closed: true, over: true, margin: "3&2", thru: 16, leader: "A" });
   });
 
   it("FREEZES at close-out — losing holes appended after 3&2 do not change it", () => {
-    const closed3and2: HoleResult[] = [
-      "W", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "W",
-    ];
-    const withPlayItOut = [...closed3and2, "L", "L"] as HoleResult[]; // holes 17, 18 played out
+    const closed3and2 = seq(["W", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "W"]);
+    const withPlayItOut: DecidedHole[] = [...closed3and2, { hole: 17, result: "L" }, { hole: 18, result: "L" }];
     expect(matchState(withPlayItOut).margin).toBe("3&2");
     expect(matchState(withPlayItOut).thru).toBe(16);
   });
 
   it("won through 18 → {up} UP", () => {
-    // 18 decided, A +2, never decided early
-    const decided: HoleResult[] = [
-      "W", "L", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "W",
-    ];
-    const s = matchState(decided);
-    expect(s).toMatchObject({ over: true, closed: false, margin: "2 UP", thru: 18 });
+    const decided = seq(["W", "L", "W", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "W"]);
+    expect(matchState(decided)).toMatchObject({ over: true, closed: false, margin: "2 UP", thru: 18 });
   });
 
   it("halved through 18 → AS", () => {
-    const decided: HoleResult[] = [
-      "W", "L", "W", "L", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H",
-    ];
-    const s = matchState(decided);
-    expect(s).toMatchObject({ over: true, closed: false, margin: "AS", up: 0 });
+    const decided = seq(["W", "L", "W", "L", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H", "H"]);
+    expect(matchState(decided)).toMatchObject({ over: true, closed: false, margin: "AS", up: 0 });
   });
 });
 
-// 9-hole games: every case here computes WRONG under the old hardcoded-18
-// matchState (close-out never fires, a finished match never goes `over`). The
-// hole count comes from the round's scorecard schema, threaded by the caller.
 describe("matchState — 9-hole rounds", () => {
-  it("closed early 3&2 — A +3 at hole 7 of 9 → holesLeft 2 (would stay open under 18)", () => {
-    // 7 decided holes, A reaches +3 on the 7th → holesLeft 9-7=2, up 3 > 2 → closed
-    const decided: HoleResult[] = ["W", "W", "H", "H", "H", "H", "W"];
-    const s = matchState(decided, 9);
-    expect(s).toMatchObject({ closed: true, over: true, margin: "3&2", thru: 7, leader: "A" });
-    // Regression guard: the same holes under 18 are NOT closed (the bug).
+  it("closed early 3&2 — A +3 at hole 7 of 9 (would stay open under 18)", () => {
+    const decided = seq(["W", "W", "H", "H", "H", "H", "W"]);
+    expect(matchState(decided, 9)).toMatchObject({ closed: true, over: true, margin: "3&2", thru: 7, leader: "A" });
     expect(matchState(decided, 18)).toMatchObject({ closed: false, over: false });
   });
 
-  it("halved through 9 → AS, and over=true (the bug: never finalized under 18)", () => {
-    const decided: HoleResult[] = ["W", "L", "H", "H", "H", "H", "H", "H", "H"];
-    const s = matchState(decided, 9);
-    expect(s).toMatchObject({ over: true, closed: false, margin: "AS", up: 0, holesLeft: 0, thru: 9 });
-    expect(matchState(decided, 18).over).toBe(false); // would never finalize under 18
+  it("halved through 9 → AS, over=true", () => {
+    const decided = seq(["W", "L", "H", "H", "H", "H", "H", "H", "H"]);
+    expect(matchState(decided, 9)).toMatchObject({ over: true, closed: false, margin: "AS", up: 0, holesLeft: 0, thru: 9 });
+    expect(matchState(decided, 18).over).toBe(false);
   });
 
   it("won through 9 → 2 UP", () => {
-    const decided: HoleResult[] = ["W", "L", "W", "H", "H", "H", "H", "H", "W"];
-    const s = matchState(decided, 9);
-    expect(s).toMatchObject({ over: true, closed: false, margin: "2 UP", thru: 9 });
+    expect(matchState(seq(["W", "L", "W", "H", "H", "H", "H", "H", "W"]), 9)).toMatchObject({ over: true, margin: "2 UP", thru: 9 });
   });
 
-  it("dormie on 9 — A +2 at hole 7 → holesLeft 2, up 2 → dormie, not over", () => {
-    const decided: HoleResult[] = ["W", "W", "H", "H", "H", "H", "H"];
-    const s = matchState(decided, 9);
-    expect(s).toMatchObject({ thru: 7, up: 2, holesLeft: 2, dormie: true, over: false, closed: false });
+  it("dormie on 9 — A +2 at hole 7 → holesLeft 2, up 2", () => {
+    expect(matchState(seq(["W", "W", "H", "H", "H", "H", "H"]), 9)).toMatchObject({ thru: 7, up: 2, holesLeft: 2, dormie: true, over: false });
+  });
+});
+
+// ── Glorious Finishing Holes — the acceptance gates (§6) ───────────────────────
+//
+// Scenarios: `downSix` = 6 down through hole 15 (6 losses on 1–6, halves 7–15).
+
+const downSix: DecidedHole[] = [
+  ...Array.from({ length: 6 }, (_, i) => ({ hole: i + 1, result: "L" as HoleResult })), // holes 1–6 lost
+  ...Array.from({ length: 9 }, (_, i) => ({ hole: i + 7, result: "H" as HoleResult })), // holes 7–15 halved
+];
+const upN = (n: number): DecidedHole[] => [
+  ...Array.from({ length: n }, (_, i) => ({ hole: i + 1, result: "W" as HoleResult })),
+  ...Array.from({ length: 15 - n }, (_, i) => ({ hole: n + i + 1, result: "H" as HoleResult })),
+]; // A is `n` up through hole 15
+
+describe("§6a — comeback squares: down 6 thru 15, win 16/17/18 → all square", () => {
+  it("glorious N=3 ON: the three ±2 swings pull a 6-down match back to AS (emerges from the weighted sum)", () => {
+    const comeback: DecidedHole[] = [...downSix, { hole: 16, result: "W" }, { hole: 17, result: "W" }, { hole: 18, result: "W" }];
+    expect(matchState(comeback, 18, GLOR3)).toMatchObject({ over: true, up: 0, leader: null, margin: "AS" });
+  });
+
+  it("glorious OFF: the same player is eliminated — closed out at hole 13 (6 down, only 5 raw swing left)", () => {
+    const comeback: DecidedHole[] = [...downSix, { hole: 16, result: "W" }, { hole: 17, result: "W" }, { hole: 18, result: "W" }];
+    // Under raw rules the match is already dead at hole 13 (6 up > 5 holes left) —
+    // frozen there, so the 16/17/18 comeback wins are never even counted.
+    expect(matchState(comeback, 18, NO_GLORIOUS)).toMatchObject({ over: true, closed: true, thru: 13, leader: "B", margin: "6&5" });
+  });
+});
+
+describe("§6b — close-out respects WEIGHTED swing (N=3, glorious ON)", () => {
+  it("4 up thru 15 is NOT closed and NOT dormie (lead 4 ≤ remaining swing 6)", () => {
+    expect(matchState(upN(4), 18, GLOR3)).toMatchObject({ up: 4, over: false, closed: false, dormie: false, margin: null });
+  });
+  it("6 up thru 15 IS dormie (lead 6 === remaining swing 6)", () => {
+    expect(matchState(upN(6), 18, GLOR3)).toMatchObject({ up: 6, over: false, closed: false, dormie: true });
+  });
+  it("7 up thru 15 IS closed / won (lead 7 > remaining swing 6)", () => {
+    expect(matchState(upN(7), 18, GLOR3)).toMatchObject({ up: 7, over: true, closed: true, leader: "A" });
+  });
+  it("regression: a raw holesUp>holesRemaining impl would wrongly close the 4-up case (4 > 3)", () => {
+    // Under NO glorious the SAME 4-up-thru-15 IS closed (4 > 3 raw) — proving the
+    // weighted swing is what keeps the glorious game live.
+    expect(matchState(upN(4), 18, NO_GLORIOUS)).toMatchObject({ over: true, closed: true });
+  });
+});
+
+describe("§6c — derive, don't snapshot: same stored outcomes, flip the flag → tally changes", () => {
+  it("flipping glorious ON (no re-entry) flips the SAME 6-down match from a B win to a halve", () => {
+    const comeback: DecidedHole[] = [...downSix, { hole: 16, result: "W" }, { hole: 17, result: "W" }, { hole: 18, result: "W" }];
+    const before = JSON.stringify(comeback); // the stored raw outcomes
+    const off = matchState(comeback, 18, NO_GLORIOUS);
+    const on = matchState(comeback, 18, GLOR3);
+    expect(off.leader).toBe("B"); // eliminated under raw rules
+    expect(on.leader).toBe(null); // all square once the last 3 count double
+    // Read-side only: the flip touched no stored data (the input is byte-identical).
+    expect(JSON.stringify(comeback)).toBe(before);
+  });
+});
+
+describe("§6e — weighted margin string: X = weighted lead, Y = raw holes-to-play", () => {
+  it("no premature close-out string — 4 up thru 15 shows null, not '4&3'", () => {
+    expect(matchState(upN(4), 18, GLOR3).margin).toBeNull();
+  });
+  it("a glorious close-out carries the WEIGHTED lead as X and RAW holes as Y (X can exceed Y)", () => {
+    // 3 up thru 15 (swing 6, still live), then win hole 16 (2×) → lead 5, holes-left 2
+    // → closed "5&2". Raw rules would read the same close as "4&2" (hole 16 counts 1).
+    const win16 = [...upN(3), { hole: 16, result: "W" as HoleResult }];
+    expect(matchState(win16, 18, GLOR3)).toMatchObject({ closed: true, margin: "5&2", holesLeft: 2, up: 5 });
+    expect(matchState(win16, 18, NO_GLORIOUS).margin).toBe("4&2");
   });
 });

--- a/src/lib/matchPlay.ts
+++ b/src/lib/matchPlay.ts
@@ -5,9 +5,26 @@
  *
  * No React, no DB. Net is DERIVED here; gross (`score_entries.value`) is never
  * overwritten (engine decision #16).
+ *
+ * Glorious Finishing Holes: `matchState` weights each hole's win/loss by
+ * `holeWeight` (2× on the last N holes) and compares the lead to the WEIGHTED
+ * remaining swing (`remainingSwing`) for close-out/dormie — see `gloriousHoles.ts`.
+ * With no glorious config every weight is 1 and this is exactly standard match play.
  */
+import { holeWeight, remainingSwing, NO_GLORIOUS, type GloriousConfig } from "./gloriousHoles";
 
 export type HoleResult = "W" | "L" | "H"; // A vs B on NET; decided holes only, play order
+
+/**
+ * A decided hole = its NUMBER + the A-perspective outcome. The number is
+ * load-bearing for glorious weighting (the weight depends on WHICH hole it is), so
+ * `buildDecided` carries it rather than emitting bare outcomes in play order — a
+ * gap-tolerant shape (undecided holes are simply absent, so position ≠ hole number).
+ */
+export interface DecidedHole {
+  hole: number;
+  result: HoleResult;
+}
 
 /**
  * Has this match had any scores entered? (W-GAMEPAGE-01 §11.) A hole is decided
@@ -16,7 +33,7 @@ export type HoleResult = "W" | "L" | "H"; // A vs B on NET; decided holes only, 
  * — removing a scored match clears entered scores, so it must confirm first.
  * Pure + named so the guard and its test share one definition.
  */
-export function matchHasScores(decided: HoleResult[]): boolean {
+export function matchHasScores(decided: DecidedHole[]): boolean {
   return decided.length > 0;
 }
 
@@ -71,18 +88,26 @@ export function buildDecided(
   strokesB: number,
   strokeIndex?: number[],
   holeCount = HOLES
-): HoleResult[] {
+): DecidedHole[] {
   const setA = strokeHoles(strokesA, strokeIndex, holeCount);
   const setB = strokeHoles(strokesB, strokeIndex, holeCount);
-  const out: HoleResult[] = [];
+  const out: DecidedHole[] = [];
   for (let h = 1; h <= holeCount; h++) {
     const ga = grossA[String(h)];
     const gb = grossB[String(h)];
     if (ga == null || gb == null) continue; // undecided — still to play
     const na = ga - (setA.has(h) ? 1 : 0);
     const nb = gb - (setB.has(h) ? 1 : 0);
-    out.push(na < nb ? "W" : na > nb ? "L" : "H");
+    out.push({ hole: h, result: na < nb ? "W" : na > nb ? "L" : "H" });
   }
+  return out;
+}
+
+/** Hole numbers 1..holeCount not present in the decided set — the genuinely
+ *  unplayed holes (gap-tolerant: an undecided mid-round hole counts as unplayed). */
+function unplayedHoles(holeCount: number, played: Set<number>): number[] {
+  const out: number[] = [];
+  for (let h = 1; h <= holeCount; h++) if (!played.has(h)) out.push(h);
   return out;
 }
 
@@ -90,41 +115,59 @@ export function buildDecided(
  * Walk decided holes and FREEZE the official result at the close-out hole —
  * anything after (a "Play it out" hole) is ignored, so a closed 3&2 can't
  * recompute to nonsense when the trailing player wins 17 & 18.
+ *
+ * WEIGHTED for Glorious Finishing Holes: each hole's win/loss counts for
+ * `holeWeight(hole, cfg)` (2× on the last N holes), and close-out/dormie compare the
+ * lead to the WEIGHTED `remainingSwing` over the unplayed holes — NOT raw holes left
+ * (§4). So a 4-up lead with 3 glorious holes (swing 6) stays live; 7-up is closed.
+ * With `NO_GLORIOUS` every weight is 1 and this is byte-for-byte standard match play.
  */
-export function matchState(decided: HoleResult[], holeCount = HOLES): MatchState {
+export function matchState(decided: DecidedHole[], holeCount = HOLES, cfg: GloriousConfig = NO_GLORIOUS): MatchState {
+  const played = new Set<number>();
   let diff = 0;
-  let played = 0;
-  for (const r of decided) {
-    played++;
-    if (r === "W") diff++;
-    else if (r === "L") diff--;
-    const holesLeft = holeCount - played;
+  let count = 0;
+  for (const { hole, result } of decided) {
+    count++;
+    played.add(hole);
+    const w = holeWeight(hole, cfg);
+    if (result === "W") diff += w;
+    else if (result === "L") diff -= w;
+    const holesLeftRaw = holeCount - count; // raw holes still to play (margin Y)
+    const swingLeft = remainingSwing(unplayedHoles(holeCount, played), cfg); // weighted (§4)
     const up = Math.abs(diff);
-    if (holesLeft > 0 && up > holesLeft) return finalize(played, diff, holesLeft, true, true);
-    if (holesLeft === 0) break;
+    if (holesLeftRaw > 0 && up > swingLeft) return finalize(count, diff, holesLeftRaw, swingLeft, true, true);
+    if (holesLeftRaw === 0) break;
   }
-  const holesLeft = holeCount - played;
-  return finalize(played, diff, holesLeft, holesLeft === 0, false);
+  const holesLeftRaw = holeCount - count;
+  const swingLeft = remainingSwing(unplayedHoles(holeCount, played), cfg);
+  return finalize(count, diff, holesLeftRaw, swingLeft, holesLeftRaw === 0, false);
 }
 
 function finalize(
   played: number,
   diff: number,
-  holesLeft: number,
+  holesLeftRaw: number,
+  swingLeft: number,
   over: boolean,
   closedEarly: boolean
 ): MatchState {
   const up = Math.abs(diff);
-  const dormie = !over && up === holesLeft && diff !== 0; // up by exactly the holes remaining
+  // Dormie / close-out are against the WEIGHTED remaining swing (§4), not raw holes.
+  const dormie = !over && up === swingLeft && diff !== 0; // up by exactly the swing left
   let margin: string | null = null;
-  if (closedEarly) margin = `${up}&${holesLeft}`; // "3&2"
-  else if (over && up) margin = `${up} UP`; // won through 18
-  else if (over) margin = "AS"; // halved through 18
+  // Margin string: X = the WEIGHTED lead, Y = RAW holes-to-play. Under glorious the
+  // weighted lead can EXCEED the raw holes remaining, so "4&2" (or even "6&2") is a
+  // LEGAL, correct margin — it means 4 up weighted with 2 holes physically left, and
+  // the match closed because the weighted swing left was smaller than the lead. This
+  // "X > Y is legal" is intentional; do NOT "fix" it to look like standard match play.
+  if (closedEarly) margin = `${up}&${holesLeftRaw}`; // "3&2" (raw) / "6&2" (glorious)
+  else if (over && up) margin = `${up} UP`; // won through the last hole
+  else if (over) margin = "AS"; // halved through the last hole
   return {
     thru: played,
     diff,
     up,
-    holesLeft,
+    holesLeft: holesLeftRaw, // raw holes-to-play (kept raw — the margin's Y and the display count)
     over,
     closed: closedEarly,
     dormie,

--- a/src/lib/modifiers.test.ts
+++ b/src/lib/modifiers.test.ts
@@ -44,24 +44,25 @@ describe("registry", () => {
   });
 });
 
-// The four render branches the crossed test-matrix exercises (Task 0). Maps each
-// golf format's compatibleModifiers (from gameTypes.ts) through the registry to
-// the control types it would render — locking the matrix + registry together.
+// Real applicability (glorious_holes is match-play only, reconciled when the scoring
+// engine landed) still exercises all four Modifiers render branches across the golf
+// formats. Maps each format's compatibleModifiers (from gameTypes.ts) through the
+// registry to the control types it renders — locking applicability + registry together.
 describe("render-branch matrix (gameTypes.ts → registry)", () => {
   const controlsFor = (id: string) =>
     (GAME_TYPES.find((t) => t.id === id)?.compatibleModifiers ?? []).map((k) => modifierDef(k).controlType);
 
-  it("rack_n_stack → [] (HIDE branch — golf format with none)", () => {
+  it("rack_n_stack → [] (HIDE branch — no modifiers apply)", () => {
     expect(controlsFor("gtt_rack_n_stack")).toEqual([]);
   });
-  it("match_play_singles → [checkbox] (CHECKBOX-only branch)", () => {
-    expect(controlsFor("gtt_match_play_singles")).toEqual(["checkbox"]);
+  it("stroke_play → [checkbox] (CHECKBOX-only — moving_tees; glorious does NOT apply to stroke)", () => {
+    expect(controlsFor("gtt_stroke_play")).toEqual(["checkbox"]);
   });
-  it("match_play_doubles → [checkbox+stepper] (STEPPER-only branch)", () => {
+  it("match_play_doubles → [checkbox+stepper] (STEPPER-only — glorious applies)", () => {
     expect(controlsFor("gtt_match_play_doubles")).toEqual(["checkbox+stepper"]);
   });
-  it("stroke_play → [checkbox, checkbox+stepper] (BOTH branch)", () => {
-    expect(controlsFor("gtt_stroke_play")).toEqual(["checkbox", "checkbox+stepper"]);
+  it("match_play_singles → [checkbox, checkbox+stepper] (BOTH — moving_tees + glorious)", () => {
+    expect(controlsFor("gtt_match_play_singles")).toEqual(["checkbox", "checkbox+stepper"]);
   });
 });
 

--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -1,5 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { buildDecided, matchState } from "@/lib/matchPlay";
+import { gloriousConfig } from "@/lib/gloriousHoles";
+import type { ModifiersMap } from "@/lib/modifiers";
 import { effectiveStrokes } from "@/lib/handicap";
 import { isPerMatch, type PerMatchDistribution } from "@/lib/pointsDistribution";
 
@@ -64,6 +66,22 @@ export async function computeMatchPlayResults(
   // → `buildDecided` uses the sequential fallback (the no-course path).
   const { strokeIndex, holeCount } = await loadStrokeIndex(supabase, gameId);
 
+  // Glorious Finishing Holes: the LIVE 2×-last-N weight, read from games.modifiers
+  // at compute time — derived, never snapshotted, so a mid-round flag/N flip just
+  // recomputes here. Format-guarded inside gloriousConfig (inert for anything but
+  // match singles/doubles), and this compute is only ever reached by match_play
+  // games anyway — belt and suspenders. Same helper the live client strip uses, so
+  // finish and the live board can't diverge.
+  const { data: gameCfg } = await supabase
+    .from("games")
+    .select("game_type_id, modifiers")
+    .eq("id", gameId)
+    .maybeSingle();
+  const glorious = gloriousConfig(
+    gameCfg?.game_type_id as string | null,
+    gameCfg?.modifiers as ModifiersMap | null
+  );
+
   // Side handicaps, keyed by SIDE id. A 1v1 side is a user (handicap on
   // game_participants); a 2v2 side is a pair = a play_group (handicap on
   // play_groups). Read both so one compute serves both formats — the id spaces
@@ -122,7 +140,7 @@ export async function computeMatchPlayResults(
       strokeIndex,
       holeCount
     );
-    const st = matchState(decided, holeCount);
+    const st = matchState(decided, holeCount, glorious);
 
     const result: MatchOutcome["result"] = st.over
       ? st.up === 0

--- a/src/server/routers/matches.test.ts
+++ b/src/server/routers/matches.test.ts
@@ -280,6 +280,74 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     expect(matches[0]).toMatchObject({ result: "a_win", margin: "3&2" }); // still 3&2, not recomputed
   });
 
+  // ── Glorious Finishing Holes — the weighted last-N result via the SAME finish
+  // path. "Real data": modifiers persisted on the game, scores in score_entries,
+  // computeMatchPlayResults reads the live config. Proves the down-6-comeback and
+  // the 4-up-stays-live cases end-to-end, each against a no-glorious control.
+  async function pairOwnerMember(gameId: string) {
+    await ctx.caller().matches.setPairings({
+      tripId,
+      gameId,
+      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+    });
+  }
+  // A is 6 DOWN thru 15 (loses 1–6, halves 7–15), then A wins 16/17/18.
+  function downSixThenWinLast(): [Record<number, number>, Record<number, number>] {
+    const a: Record<number, number> = {};
+    const b: Record<number, number> = {};
+    for (let h = 1; h <= 6; h++) { a[h] = 5; b[h] = 4; } // A loses 1–6
+    for (let h = 7; h <= 15; h++) { a[h] = 4; b[h] = 4; } // halved 7–15
+    a[16] = 4; a[17] = 4; a[18] = 4; // A wins the last three…
+    b[16] = 5; b[17] = 5; b[18] = 5;
+    return [a, b];
+  }
+  // A is 4 UP thru 15 (wins 1–4, halves 5–15); only 15 holes entered.
+  function fourUpThru15(): [Record<number, number>, Record<number, number>] {
+    const a: Record<number, number> = {};
+    const b: Record<number, number> = {};
+    for (let h = 1; h <= 4; h++) { a[h] = 4; b[h] = 5; }
+    for (let h = 5; h <= 15; h++) { a[h] = 4; b[h] = 4; }
+    return [a, b];
+  }
+
+  it("GLORIOUS N=3 — 6 down thru 15, wins 16/17/18 → HALVE (the three ±2 swings square it)", async () => {
+    const gameId = await freshGame("Glorious comeback");
+    await ctx.caller().games.update({ tripId, gameId, modifiers: { glorious_holes: { holes: 3 } } });
+    await pairOwnerMember(gameId);
+    const [a, b] = downSixThenWinLast();
+    await enter(gameId, owner, member, a, b);
+    const { matches } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(matches[0]).toMatchObject({ result: "halve", status: "complete" });
+  });
+
+  it("CONTROL — same scores, no glorious → b_win (A eliminated at hole 13, comeback never counts)", async () => {
+    const gameId = await freshGame("No-glorious control");
+    await pairOwnerMember(gameId);
+    const [a, b] = downSixThenWinLast();
+    await enter(gameId, owner, member, a, b);
+    const { matches } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(matches[0]).toMatchObject({ result: "b_win", margin: "6&5", status: "complete" });
+  });
+
+  it("GLORIOUS N=3 — 4 up thru 15 stays LIVE (weighted swing 6 ≥ lead 4) → not decided", async () => {
+    const gameId = await freshGame("Glorious four-up live");
+    await ctx.caller().games.update({ tripId, gameId, modifiers: { glorious_holes: { holes: 3 } } });
+    await pairOwnerMember(gameId);
+    const [a, b] = fourUpThru15();
+    await enter(gameId, owner, member, a, b);
+    const { matches } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(matches[0]).toMatchObject({ result: null, status: "active" }); // NOT closed out
+  });
+
+  it("CONTROL — same 4-up-thru-15, no glorious → a_win 4&3 (raw swing 3 < lead 4 → closed)", async () => {
+    const gameId = await freshGame("Four-up closed control");
+    await pairOwnerMember(gameId);
+    const [a, b] = fourUpThru15();
+    await enter(gameId, owner, member, a, b);
+    const { matches } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(matches[0]).toMatchObject({ result: "a_win", margin: "4&3", status: "complete" });
+  });
+
   it("net allocation (fallback) — a received stroke flips a hole", async () => {
     const gameId = await freshGame("Net stroke");
     await ctx.caller().matches.setPairings({


### PR DESCRIPTION
Builds the scoring logic behind the already-persisted **Glorious Finishing Holes** modifier: the last **N** holes of a match are worth **2×** (fixed). Applies to **match singles + doubles only**. The weight is a pure function of live config applied at compute time — **never snapshotted**; flip the flag or change N mid-round and the tally just recomputes.

### What it does
- `holeWeight(hole, cfg)` = `(enabled && hole > 18−N) ? 2 : 1`; a won glorious hole is a ±2 swing.
- Close-out / dormie compare the lead to the **weighted `remainingSwing`** over the actual unplayed holes — not raw holes left (the trap). A 4-up lead with 3 glorious holes (swing 6) stays **live**; 6-up is dormie; 7-up is closed.
- The margin string keeps **X = weighted lead, Y = raw holes-to-play**, so "4&2"/"6&2" is a legal glorious margin (documented inline).
- One weighted `matchState` (`src/lib/matchPlay.ts`; `buildDecided` now emits `{hole, result}[]`) feeds the live client strips **and** the server `computeMatchPlayResults` — finish and live can't diverge.
- **Format-guarded on `game_type_id`** (`gloriousConfig`), never the competition `scoring_model` (rack is `match_play` by scoring_model but is excluded).
- Sync: no code — `modifiers` is already in `configHash`, so a mid-round flip already propagates.
- Reconciled `compatibleModifiers` to real applicability: glorious now offered on singles + doubles, dropped from stroke (was inert there).

### Verification
- **Acceptance gates (pure):** comeback-squares, weighted close-out (4-up live / 6-up dormie / 7-up closed), derive-don't-snapshot, exclusions inert, weighted margin string — all pass.
- **Real data (integration, `matches.test.ts`):** through `score_entries` → `computeMatchPlayResults` → `games.finish`: 6-down-then-win-16/17/18 → **halve** (no-glorious control → b_win 6&5); 4-up-thru-15 → **stays live** (control → a_win 4&3).
- **Live eyeball:** glorious now renders + enables on a singles game (checkbox + N stepper) and re-derives the match through the weighted `matchState`.
- `tsc` clean · `next lint` clean · full Vitest **980 green** · CLAUDE.md pattern #11 added.

Visual/badge layer (×2 column badge, leaderboard chip) is a deliberate follow-up (spec §8), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)