### PR TITLE
Glorious Finishing Holes — visual layer (scorecard diamond/bracket/wash, entry banner)

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -118,6 +118,7 @@ uses this token for its `border-color`.
 | Accent dim | `--color-bt-accent-dim` | `#0f766e` | `#14b8a6` | Hover state for accent text |
 | Owner text | `--color-bt-owner` | `#d97706` | `#fbbf24` | Owner role badge (border + text) |
 | Warning text | `--color-bt-warning` | `#d97706` | `#fbbf24` | Maybe/caution states — STATUS DISPLAY ONLY, not buttons |
+| Glorious text | `--color-bt-glorious` | `#92720f` | `#c9852f` | Glorious Finishing Holes modifier ONLY (scorecard diamond/bracket/label, score-entry banner) — a deliberately different hue from Owner/Warning so the two are never mistaken on the same card (the scorecard's amber stroke pip already uses `--color-bt-warning`). Dark value verified live side-by-side with the pip + a GolfChip eagle ring (an initial `#e2a437` read too close). NOT a warning/amber substitute; NOT a score-value color (keep out of the eagle/birdie/par/bogey/dbl+ palette) |
 | Danger text | `--color-bt-danger` | `#dc2626` | `#f87171` | Errors, Can't/declined, destructive actions |
 | Planning text | `--color-bt-planning` | `#2563eb` | `#60a5fa` | Blue status indicators |
 | Ready text | `--color-bt-ready` | `#7c3aed` | `#a78bfa` | Planner role badge, violet states |
@@ -156,6 +157,7 @@ These apply in **both light and dark mode** — vote colors are semantic and do 
 | `--color-bt-tag-bg` | `#f0fdfa` (teal-50) | `#134e4a` (teal-900) |
 | `--color-bt-accent-faint` | `rgba(13,148,136,0.08)` | `rgba(45,212,191,0.12)` |
 | `--color-bt-warning-faint` | `rgba(217,119,6,0.08)` | `rgba(251,191,36,0.08)` |
+| `--color-bt-glorious-faint` | `rgba(146,114,15,0.08)` | `rgba(201,133,47,0.10)` |
 | `--color-bt-danger-faint` | `rgba(220,38,38,0.08)` | `rgba(248,113,113,0.12)` |
 | `--color-bt-planning-faint` | `rgba(37,99,235,0.08)` | `rgba(96,165,250,0.08)` |
 | `--color-bt-danger-bg` | `#fef2f2` | `#450a0a` |
@@ -168,6 +170,7 @@ These apply in **both light and dark mode** — vote colors are semantic and do 
 |-------|-------|------|
 | `--color-bt-accent-border` | `rgba(13,148,136,0.22)` | `rgba(45,212,191,0.25)` |
 | `--color-bt-warning-border` | `rgba(217,119,6,0.20)` | `rgba(251,191,36,0.20)` |
+| `--color-bt-glorious-border` | `rgba(146,114,15,0.22)` | `rgba(201,133,47,0.35)` |
 | `--color-bt-danger-border` | `rgba(220,38,38,0.20)` | `rgba(248,113,113,0.20)` |
 | `--color-bt-planning-border` | `rgba(37,99,235,0.22)` | `rgba(96,165,250,0.25)` |
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,16 @@
   --color-bt-warning-faint: rgba(217, 119, 6, 0.08);
   --color-bt-warning-border: rgba(217, 119, 6, 0.20);
 
+  /* Glorious Finishing Holes (match play, #569/#571) — a deliberately DIFFERENT
+     hue from warning/owner (orange-amber, ~32° hue): pulled toward yellow-olive
+     (~44° hue) with lower saturation so it never reads as the warning/owner
+     semantic on the scorecard, where the two can appear on the same card (the
+     stroke pip already uses --color-bt-warning). Not a score-value color — keep
+     out of the GolfChip eagle/birdie/par palette too. */
+  --color-bt-glorious: #92720f;
+  --color-bt-glorious-faint: rgba(146, 114, 15, 0.08);
+  --color-bt-glorious-border: rgba(146, 114, 15, 0.22);
+
   --color-bt-danger: #dc2626;        /* red-600 */
   --color-bt-danger-bg: #fef2f2;
   --color-bt-danger-faint: rgba(220, 38, 38, 0.08);
@@ -149,6 +159,17 @@
   --color-bt-warning: #fbbf24;
   --color-bt-warning-faint: rgba(251, 191, 36, 0.08);
   --color-bt-warning-border: rgba(251, 191, 36, 0.20);
+
+  /* Glorious Finishing Holes — a deep bronze-gold, deliberately AWAY from warning's
+     bright yellow (#fbbf24, ~43° hue) so the two never read as the same thing on a
+     card that can show both (the amber stroke pip is --color-bt-warning). Verified
+     live side-by-side with the pip + a GolfChip eagle ring on the actual dark card
+     (not just eyeballed in isolation) — an initial #e2a437 read too close to the
+     pip; #c9852f is the one that visibly separates while still reading as gold, not
+     brown/copper. */
+  --color-bt-glorious: #c9852f;
+  --color-bt-glorious-faint: rgba(201, 133, 47, 0.10);
+  --color-bt-glorious-border: rgba(201, 133, 47, 0.35);
 
   --color-bt-danger: #f87171;        /* red-400 */
   --color-bt-danger-bg: #450a0a;

--- a/src/components/games/MatchEntryView.test.tsx
+++ b/src/components/games/MatchEntryView.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MatchEntryView, type MatchGroupData } from "./MatchEntryView";
+import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
+import type { ScoreUnit } from "./types";
+
+// Glorious Finishing Holes — the score-entry banner (§8/#571 gate c). A full
+// contiguous 18-hole round so `currentHole` (engine position) matches the unit
+// index directly. Rendered via react-dom/server (no RTL, matches StandardGrid's
+// convention) — the component reads `currentHole` from props (no internal state
+// dependency needed for a single static render).
+
+const units: ScoreUnit[] = Array.from({ length: 18 }, (_, i) => ({
+  label: String(i + 1),
+  section: i < 9 ? "front" : "back",
+  par: 4,
+}));
+
+const matches: MatchGroupData[] = [
+  {
+    matchId: "m1",
+    label: "Match 1",
+    a: { id: "a", name: "Alex", color: "#22c55e" },
+    b: { id: "b", name: "Bailey", color: "#f97316" },
+    strokesA: 0,
+    strokesB: 0,
+  },
+];
+
+const glor3: GloriousConfig = { enabled: true, n: 3 }; // last 3 → holes 16,17,18
+
+function renderAt(hole: number, glorious: GloriousConfig) {
+  return renderToStaticMarkup(
+    <MatchEntryView
+      gameName="Test Match"
+      units={units}
+      matches={matches}
+      values={{}}
+      onChange={() => {}}
+      currentHole={hole}
+      glorious={glorious}
+    />
+  );
+}
+
+describe("MatchEntryView — Glorious banner (gate c)", () => {
+  it("shows the banner on a glorious hole (17, within the last 3)", () => {
+    const html = renderAt(17, glor3);
+    expect(html).toContain("glorious-entry-banner");
+    expect(html).toContain("Glorious Finishing Hole · Worth Double");
+  });
+
+  it("hides the banner on a non-glorious hole (12)", () => {
+    const html = renderAt(12, glor3);
+    expect(html).not.toContain("glorious-entry-banner");
+  });
+
+  it("hides the banner everywhere when glorious is off, even on hole 17", () => {
+    const html = renderAt(17, NO_GLORIOUS);
+    expect(html).not.toContain("glorious-entry-banner");
+  });
+
+  it("defaults to NO_GLORIOUS when the prop is omitted (no banner anywhere)", () => {
+    const html = renderToStaticMarkup(
+      <MatchEntryView gameName="Test Match" units={units} matches={matches} values={{}} onChange={() => {}} currentHole={17} />
+    );
+    expect(html).not.toContain("glorious-entry-banner");
+  });
+
+  it("marks exactly the boundary hole correctly — 15 (raw) vs 16 (glorious) for N=3", () => {
+    expect(renderAt(15, glor3)).not.toContain("glorious-entry-banner");
+    expect(renderAt(16, glor3)).toContain("glorious-entry-banner");
+  });
+});

--- a/src/components/games/MatchEntryView.tsx
+++ b/src/components/games/MatchEntryView.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { ChevronLeft, Table2 } from "lucide-react";
 import { buildDecided, matchState, strokeHoles } from "@/lib/matchPlay";
-import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
+import { NO_GLORIOUS, isGloriousHole, type GloriousConfig } from "@/lib/gloriousHoles";
 import { StrokeKeypad } from "./StrokeKeypad";
 import { MatchCard } from "./MatchCard";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
@@ -117,6 +117,9 @@ export function MatchEntryView({
   const unit = units[hole - 1];
   const label = unit?.label ?? String(hole);
   const valueFor = (pid: string, l: string) => values[pid]?.[l];
+  // The ONE predicate — `hole` here IS the engine position (units[hole-1] is the
+  // current unit), so no label-parsing/re-derivation needed.
+  const holeIsGlorious = isGloriousHole(hole, glorious);
 
   // The course's per-hole stroke index (from the snapshot units). Threading it
   // into the live display makes pips + the live net land on the COURSE's
@@ -347,6 +350,26 @@ export function MatchEntryView({
         </div>
         <NavArrow dir="next" disabled={hole >= units.length} onClick={() => goHole(hole + 1)} />
       </div>
+
+      {/* Glorious banner — announces (unlike the scorecard's quiet diamond/wash),
+          shown ONLY on a glorious hole, pure config+format (no score dependency). */}
+      {holeIsGlorious && (
+        <div
+          data-testid="glorious-entry-banner"
+          style={{
+            margin: "0 16px 10px",
+            padding: "8px 12px",
+            borderRadius: 10,
+            textAlign: "center",
+            background: "var(--color-bt-glorious-faint)",
+            border: "1px solid var(--color-bt-glorious-border)",
+          }}
+        >
+          <span style={{ fontSize: 13, fontWeight: 700, color: "var(--color-bt-glorious)" }}>
+            Glorious Finishing Hole · Worth Double
+          </span>
+        </div>
+      )}
 
       {/* Player rows */}
       <div className="flex-1 overflow-y-auto" style={{ padding: "0 12px 8px" }}>

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -1017,6 +1017,7 @@ export function MatchGameView() {
         direction="low_wins"
         pips={entryPips}
         saveStatus={saveStatus}
+        glorious={glorious}
         onCellTap={readOnly ? undefined : (label) => {
           setCurrentHole(Number(label) || 1);
           matchBack();

--- a/src/components/games/ScorecardPreviewSheet.tsx
+++ b/src/components/games/ScorecardPreviewSheet.tsx
@@ -7,6 +7,8 @@ import { StandardGrid } from "@/components/games/StandardGrid";
 import { ScorecardSheet } from "@/components/games/ScorecardSheet";
 import { unitsFromSchema, teeFromSchema } from "@/lib/strokePlayConfig";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
+import { gloriousConfig } from "@/lib/gloriousHoles";
+import type { ModifiersMap } from "@/lib/modifiers";
 
 /**
  * ScorecardPreviewSheet — the leaderboard's scorecard, as a Sheet overlay over the
@@ -40,6 +42,13 @@ export function ScorecardPreviewSheet({
   const teeRows = useScorecardTeeRows(tripId, gameQ.data);
   const name = (gameQ.data?.name as string | undefined) ?? undefined;
   const hasCourse = !!(gameQ.data as { course_id?: string | null } | undefined)?.course_id;
+  // Glorious visibility keys off config + format ONLY — zero participants (this
+  // preview never has any) is NOT a suppression condition (§1). A configured
+  // glorious game shows the treatment here exactly as it does in-game.
+  const glorious = gloriousConfig(
+    (gameQ.data as { game_type_id?: string | null } | undefined)?.game_type_id,
+    (gameQ.data as { modifiers?: ModifiersMap | null } | undefined)?.modifiers
+  );
 
   return (
     <ScorecardSheet title="Scorecard" subtitle={name} onClose={onClose}>
@@ -51,7 +60,7 @@ export function ScorecardPreviewSheet({
           />
         </div>
       ) : hasCourse && units.length > 0 ? (
-        <StandardGrid units={units} tee={tee} participants={[]} values={{}} direction="low_wins" teeRows={teeRows} />
+        <StandardGrid units={units} tee={tee} participants={[]} values={{}} direction="low_wins" teeRows={teeRows} glorious={glorious} />
       ) : (
         <p className="px-6 py-10 text-center text-sm" style={{ color: "var(--color-bt-text-dim)" }}>
           No course set for this game yet — apply a course in game settings to preview its scorecard.

--- a/src/components/games/StandardGrid.test.tsx
+++ b/src/components/games/StandardGrid.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { StandardGrid } from "./StandardGrid";
 import type { ScoreUnit } from "./types";
 import type { TeeRow } from "@/lib/teeRows";
+import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
 
 // Empty scorecard PREVIEW (Spec 5a): the grid renders the course STRUCTURE
 // (par / yardage / stroke-index rows + front/back sections) independently of
@@ -85,5 +86,117 @@ describe("StandardGrid — multi-tee yardage rows (5b)", () => {
   it("shows per-tee yardage values (a display-only reference row)", () => {
     expect(html).toContain("410"); // Blue hole 1
     expect(html).toContain("380"); // White (chosen) hole 1
+  });
+});
+
+// Glorious Finishing Holes visual layer (§8/#571) — a full contiguous 18-hole
+// round so array INDEX (i+1) matches the hole LABEL, keeping the fixture
+// unambiguous re: engine position vs. display label.
+const round18: ScoreUnit[] = Array.from({ length: 18 }, (_, i) => ({
+  label: String(i + 1),
+  section: i < 9 ? "front" : "back",
+  par: 4,
+  strokeIndex: i + 1,
+  yardage: 400,
+}));
+const round9: ScoreUnit[] = Array.from({ length: 9 }, (_, i) => ({
+  label: String(i + 1),
+  section: "front",
+  par: 4,
+  strokeIndex: i + 1,
+  yardage: 400,
+}));
+const g = (n: number): GloriousConfig => ({ enabled: true, n });
+
+describe("StandardGrid — Glorious Finishing Holes (gate a: marks the right holes)", () => {
+  it("N=3: diamond + bracket on holes 16/17/18 only; tees-bar label reads '3 ...'", () => {
+    const html = renderToStaticMarkup(
+      <StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} glorious={g(3)} />
+    );
+    for (const h of [16, 17, 18]) expect(html).toContain(`glorious-diamond-${h}"`);
+    // Quote-terminated match — "glorious-diamond-1" is a PREFIX of
+    // "glorious-diamond-16/17/18", so an unterminated check would false-positive.
+    for (const h of [1, 5, 10, 15]) expect(html).not.toContain(`glorious-diamond-${h}"`);
+    expect(html).toContain("glorious-bracket");
+    expect(html).toContain("glorious-tees-label");
+    expect(html).toContain("3 Glorious Finishing Holes · Worth Double");
+  });
+
+  it("N=4: the marked span shifts to holes 15–18 (not hardcoded to 3)", () => {
+    const html = renderToStaticMarkup(
+      <StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} glorious={g(4)} />
+    );
+    for (const h of [15, 16, 17, 18]) expect(html).toContain(`glorious-diamond-${h}`);
+    expect(html).not.toContain("glorious-diamond-14");
+    expect(html).toContain("4 Glorious Finishing Holes · Worth Double");
+  });
+
+  it("off: none of the treatment renders, and the grid is otherwise unchanged", () => {
+    const html = renderToStaticMarkup(
+      <StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} glorious={NO_GLORIOUS} />
+    );
+    expect(html).not.toContain("glorious-diamond-");
+    expect(html).not.toContain("glorious-bracket");
+    expect(html).not.toContain("glorious-tees-label");
+    expect(html).not.toContain("var(--color-bt-glorious"); // no token referenced anywhere
+    // Untouched structural rendering still present.
+    expect(html).toContain("Par");
+    expect(html).toContain("Blue tees");
+  });
+
+  it("defaults to NO_GLORIOUS when the prop is omitted entirely", () => {
+    const html = renderToStaticMarkup(<StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" />);
+    expect(html).not.toContain("glorious-diamond-");
+  });
+});
+
+describe("StandardGrid — Glorious (gate b: score legend untouched)", () => {
+  it("legend keeps exactly its five score-value chips, unaffected by glorious state", () => {
+    for (const glorious of [NO_GLORIOUS, g(3)]) {
+      const html = renderToStaticMarkup(
+        <StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} glorious={glorious} />
+      );
+      for (const label of ["Eagle", "Birdie", "Par", "Bogey", "Dbl+"]) expect(html).toContain(label);
+      // The tees-bar label (a real string this glorious=g(3) case DOES render) must
+      // never end up folded into the legend — it's a separate DOM region entirely.
+      const legendStart = html.indexOf("Eagle");
+      const legendEnd = html.lastIndexOf("Dbl+");
+      expect(html.slice(legendStart, legendEnd)).not.toContain("Worth Double");
+    }
+  });
+});
+
+describe("StandardGrid — Glorious (gate e: pure-config, not gated on emptiness)", () => {
+  it("zero participants AND zero scores still renders the full treatment (the in-game setup-preview case, #501)", () => {
+    const html = renderToStaticMarkup(
+      <StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} glorious={g(3)} />
+    );
+    expect(html).not.toContain("score-cell-"); // confirms genuinely empty (no participants)
+    expect(html).toContain("glorious-diamond-16");
+    expect(html).toContain("glorious-bracket");
+    expect(html).toContain("glorious-tees-label");
+  });
+});
+
+describe("StandardGrid — Glorious (gate f: no-course degradation)", () => {
+  it("no tee/teeRows → diamond + bracket present, no tees-bar label, no crash", () => {
+    const render = () =>
+      renderToStaticMarkup(<StandardGrid units={round18} participants={[]} values={{}} direction="low_wins" glorious={g(3)} />);
+    expect(render).not.toThrow();
+    const html = render();
+    expect(html).toContain("glorious-diamond-16");
+    expect(html).toContain("glorious-bracket");
+    expect(html).not.toContain("glorious-tees-label"); // accepted degradation — no fallback bar
+  });
+});
+
+describe("StandardGrid — Glorious (9-hole round: the 18−N inertness is inherited, not special-cased)", () => {
+  it("no hole on a 9-hole round ever qualifies, so nothing renders — even with glorious enabled", () => {
+    const html = renderToStaticMarkup(
+      <StandardGrid units={round9} participants={[]} values={{}} direction="low_wins" tee={{ name: "Blue" }} glorious={g(3)} />
+    );
+    expect(html).not.toContain("glorious-diamond-");
+    expect(html).not.toContain("glorious-bracket");
+    expect(html).not.toContain("glorious-tees-label"); // gloriousCols.size === 0 → label gate is also closed
   });
 });

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -83,6 +83,14 @@ const NAME_W = 124;
 const HOLE_W = 30;
 const SUB_W = 44;
 const TOTAL_W = 50;
+// The right-edge fade (below) is NOT scroll-position-aware — it's pinned to the
+// sheet's edge and stays rendered even once the grid is scrolled all the way to
+// its true end, permanently shading the last FADE_W px of CONTENT (not just
+// "more to scroll" — there's nothing more there). At TOTAL_W (50px) that shaded
+// strip covered roughly half the Total column's numbers. Every row ends in a
+// transparent RightGutter of this same width so the fade lands on empty space
+// instead of real content — shared constant so the two can't drift apart.
+const FADE_W = 24;
 
 export function StandardGrid({
   units,
@@ -333,6 +341,7 @@ export function StandardGrid({
             {hasSections && <HeaderSub label="Out" />}
             {hasSections && <HeaderSub label="In" />}
             <HeaderSub label="Total" wide />
+            <RightGutter />
           </div>
 
           {/* Yardage — DISPLAY ONLY. Multi-tee (Spec 5b): one row per VISIBLE tee,
@@ -382,6 +391,7 @@ export function StandardGrid({
                     {hasSections && <ParSub value={teeSum(row.yards, 0, front.length)} />}
                     {hasSections && <ParSub value={teeSum(row.yards, front.length, units.length)} />}
                     <ParSub value={teeSum(row.yards, 0, units.length)} wide />
+                    <RightGutter />
                   </div>
                 );
               })
@@ -400,6 +410,7 @@ export function StandardGrid({
                   {hasSections && <ParSub value={yardSum(front)} />}
                   {hasSections && <ParSub value={yardSum(back)} />}
                   <ParSub value={yardSum(units)} wide />
+                  <RightGutter />
                 </div>
               )}
 
@@ -419,6 +430,7 @@ export function StandardGrid({
               {hasSections && <ParSub value={parSum(front)} />}
               {hasSections && <ParSub value={parSum(back)} />}
               <ParSub value={parSum(units)} wide />
+              <RightGutter />
             </div>
           )}
 
@@ -438,6 +450,7 @@ export function StandardGrid({
               {hasSections && <IndexSub />}
               {hasSections && <IndexSub />}
               <IndexSub wide />
+              <RightGutter />
             </div>
           )}
 
@@ -491,6 +504,7 @@ export function StandardGrid({
                 {hasSections && <SubCell value={sumOf(p.id, front)} vsPar={hasPar ? vsParOf(p.id, front) : undefined} />}
                 {hasSections && <SubCell value={sumOf(p.id, back)} vsPar={hasPar ? vsParOf(p.id, back) : undefined} />}
                 <SubCell value={totalOf(p.id)} vsPar={hasPar ? vsParOf(p.id, units) : undefined} wide bold leader={isLeader} />
+                <RightGutter />
               </div>
             );
           })}
@@ -522,10 +536,13 @@ export function StandardGrid({
           )}
           </div>
         </div>
-        {/* Right-edge fade signalling more columns */}
+        {/* Right-edge fade signalling more columns — NOT scroll-position-aware
+            (always rendered, even at true max scroll), which is exactly why every
+            row ends in a RightGutter of the same FADE_W: the fade always has
+            FADE_W of real spacer to land on instead of the Total column. */}
         <div
           className="pointer-events-none absolute right-0 top-0 h-full"
-          style={{ width: 24, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
+          style={{ width: FADE_W, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
         />
       </div>
       {/* Legend is pinned below the scroller — it does NOT scroll with the grid. */}
@@ -666,6 +683,13 @@ function IndexSub({ wide }: { wide?: boolean }) {
       }}
     />
   );
+}
+
+/** Transparent trailing spacer, the same width as the right-edge fade — so the
+ *  fade always lands on empty space at the true end of the scroll, never on the
+ *  Total column's real numbers (see FADE_W). One per row, after its last cell. */
+function RightGutter() {
+  return <div aria-hidden style={{ width: FADE_W, minWidth: FADE_W, flexShrink: 0 }} />;
 }
 
 function ParSub({ value, wide }: { value: number; wide?: boolean }) {

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -313,9 +313,15 @@ export function StandardGrid({
                     data-testid={`glorious-diamond-${u.label}`}
                     style={{
                       position: "absolute",
-                      width: 16,
-                      height: 16,
-                      background: "var(--color-bt-glorious-faint)",
+                      width: 18,
+                      height: 18,
+                      // -faint (8-10% alpha) reads as almost nothing on the header's
+                      // opaque card-raised surface — bumped to the eagle chip's
+                      // proven-visible fill level (22%) + a border ring, the same
+                      // "fill + ring" grammar GolfChip already uses for its highest
+                      // score tier, so this reads as a deliberate marker, not noise.
+                      background: "color-mix(in srgb, var(--color-bt-glorious) 22%, transparent)",
+                      border: "1px solid var(--color-bt-glorious-border)",
                       transform: "rotate(45deg)",
                     }}
                   />
@@ -492,7 +498,12 @@ export function StandardGrid({
               spanning header through the last row. Border-only (the wash fill is
               per-cell, above); pointerEvents:none so it never blocks a score-cell
               tap. min/max of the glorious index set, not an assumed "last N" span
-              — robust if the predicate ever yields a non-suffix set. */}
+              — robust if the predicate ever yields a non-suffix set.
+              zIndex MUST exceed the header row's (2): the header is `position:
+              sticky` with an OPAQUE background, so at zIndex 1 its top border
+              segment (which sits at the header's own top edge) was fully painted
+              over — the bracket visually "started" below the header instead of
+              enclosing it. At zIndex 3 the thin border renders on top instead. */}
           {gloriousCols.size > 0 && (
             <div
               aria-hidden
@@ -505,7 +516,7 @@ export function StandardGrid({
                 bottom: 0,
                 border: "1px solid var(--color-bt-glorious-border)",
                 pointerEvents: "none",
-                zIndex: 1,
+                zIndex: 3,
               }}
             />
           )}

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ChevronDown, Flag } from "lucide-react";
 import { computeStrokePlayStandings, type StrokeEntry } from "@/lib/strokePlay";
 import type { TeeRow } from "@/lib/teeRows";
+import { isGloriousHole, NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
 import { Avatar } from "@/components/Avatar";
 import { Checkbox } from "./Checkbox";
 import { GolfChip } from "./GolfChip";
@@ -66,6 +67,16 @@ interface StandardGridProps {
    * visibility, chosen flag, color) from `useScorecardTeeRows`.
    */
   teeRows?: TeeRow[];
+  /**
+   * Glorious Finishing Holes (#569/#571) — the LIVE 2×-last-N weight. Purely
+   * config + format driven: a diamond marks each glorious hole number, a gold
+   * bracket + faint column wash mark the glorious columns, and the tees bar gets
+   * one label. Renders identically whether or not scores/participants exist
+   * (never gated on emptiness — only the config+format predicate decides).
+   * Omit (defaults to `NO_GLORIOUS`) for non-match-play grids — the format guard
+   * inside `gloriousConfig`/`isGloriousHole` makes that redundant but explicit.
+   */
+  glorious?: GloriousConfig;
 }
 
 const NAME_W = 124;
@@ -73,7 +84,26 @@ const HOLE_W = 30;
 const SUB_W = 44;
 const TOTAL_W = 50;
 
-export function StandardGrid({ units, participants, values, onCellTap, pips, saveStatus, tee, teeRows = [] }: StandardGridProps) {
+export function StandardGrid({
+  units,
+  participants,
+  values,
+  onCellTap,
+  pips,
+  saveStatus,
+  tee,
+  teeRows = [],
+  glorious = NO_GLORIOUS,
+}: StandardGridProps) {
+  // The ONE predicate — reused, never re-derived. `hole` = the unit's ARRAY
+  // POSITION (index + 1), matching the engine's numbering (buildDecided/
+  // holeWeight), not a parsed label. A non-contiguous/short `units` array (a
+  // 9-hole round, or a test fixture) naturally yields an empty set here — that
+  // IS the "glorious is inert on a short round" behavior, inherited for free,
+  // never special-cased.
+  const gloriousCols = new Set(units.map((_, i) => i).filter((i) => isGloriousHole(i + 1, glorious)));
+  const isGloriousCol = (i: number) => gloriousCols.has(i);
+  const gloriousWash: React.CSSProperties = { background: "var(--color-bt-glorious-faint)" };
   const front = units.filter((u) => u.section === "front");
   const back = units.filter((u) => u.section === "back");
   const hasSections = front.length > 0 && back.length > 0;
@@ -199,6 +229,16 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
               style={{ color: "var(--color-bt-text-dim)", transform: teePanelOpen ? "rotate(180deg)" : undefined, flexShrink: 0 }}
             />
           </button>
+          {/* Glorious label lives OUTSIDE the toggle button (a second nested
+              interactive/text element inside a <button> is the wrong idiom) —
+              a sibling line under the trigger, still read as part of the tees bar. */}
+          {gloriousCols.size > 0 && (
+            <div style={{ padding: "0 12px 8px", textAlign: "right" }}>
+              <span data-testid="glorious-tees-label" style={{ fontSize: 11, fontWeight: 700, color: "var(--color-bt-glorious)" }}>
+                {glorious.n} Glorious Finishing Holes · Worth Double
+              </span>
+            </div>
+          )}
           {teePanelOpen && (
             <div
               className="flex flex-wrap items-center gap-x-4 gap-y-2.5"
@@ -231,11 +271,19 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
           {teeRatings && (
             <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>· {teeRatings}</span>
           )}
+          {gloriousCols.size > 0 && (
+            <span
+              data-testid="glorious-tees-label"
+              style={{ marginLeft: "auto", fontSize: 11, fontWeight: 700, color: "var(--color-bt-glorious)" }}
+            >
+              {glorious.n} Glorious Finishing Holes · Worth Double
+            </span>
+          )}
         </div>
       ) : null}
       <div className="relative">
         <div className="no-scrollbar overflow-x-auto">
-          <div style={{ minWidth: "max-content" }}>
+          <div style={{ minWidth: "max-content", position: "relative" }}>
           {/* Header */}
           <div
             className="flex"
@@ -253,9 +301,26 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                 Hole
               </span>
             </div>
-            {units.map((u) => (
-              <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
-                <span style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>{u.label}</span>
+            {units.map((u, i) => (
+              // Header row: DIAMOND ONLY, no flat wash — layering both the same
+              // faint token double-stacks their alpha and muddies the diamond
+              // exactly where it needs to read clearest. The wash marks the
+              // column on the rows BELOW (yardage/par/index/score).
+              <div key={u.label} className="relative flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                {isGloriousCol(i) && (
+                  <span
+                    aria-hidden
+                    data-testid={`glorious-diamond-${u.label}`}
+                    style={{
+                      position: "absolute",
+                      width: 16,
+                      height: 16,
+                      background: "var(--color-bt-glorious-faint)",
+                      transform: "rotate(45deg)",
+                    }}
+                  />
+                )}
+                <span style={{ position: "relative", fontSize: 13, fontWeight: 600, color: "var(--color-bt-text-dim)" }}>{u.label}</span>
               </div>
             ))}
             {/* Out / In subtotals + Total as trailing columns. */}
@@ -304,7 +369,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                       </span>
                     </div>
                     {units.map((u, i) => (
-                      <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                      <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label), ...(isGloriousCol(i) ? gloriousWash : {}) }}>
                         <span style={{ fontSize: 11, color: valColor, opacity: row.isChosen ? 1 : 0.75, fontVariantNumeric: "tabular-nums" }}>{row.yards[i] ?? "—"}</span>
                       </div>
                     ))}
@@ -321,8 +386,8 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                       Yards
                     </span>
                   </div>
-                  {units.map((u) => (
-                    <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+                  {units.map((u, i) => (
+                    <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label), ...(isGloriousCol(i) ? gloriousWash : {}) }}>
                       <span style={{ fontSize: 11, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.yardage ?? "—"}</span>
                     </div>
                   ))}
@@ -340,8 +405,8 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                   Par
                 </span>
               </div>
-              {units.map((u) => (
-                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+              {units.map((u, i) => (
+                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label), ...(isGloriousCol(i) ? gloriousWash : {}) }}>
                   <span style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>{u.par}</span>
                 </div>
               ))}
@@ -359,8 +424,8 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                   Index
                 </span>
               </div>
-              {units.map((u) => (
-                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label) }}>
+              {units.map((u, i) => (
+                <div key={u.label} className="flex items-center justify-center" style={{ ...cellBase, ...divider(u.label), ...(isGloriousCol(i) ? gloriousWash : {}) }}>
                   <span style={{ fontSize: 12, color: "var(--color-bt-text-dim)", opacity: 0.75, fontVariantNumeric: "tabular-nums" }}>{u.strokeIndex}</span>
                 </div>
               ))}
@@ -382,7 +447,7 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                     {p.name}
                   </span>
                 </div>
-                {units.map((u) => {
+                {units.map((u, i) => {
                   const v = valOf(p.id, u.label);
                   const hasPip = pips?.[p.id]?.has(u.label);
                   const colored = v != null && hasPar && u.par != null;
@@ -397,6 +462,11 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
                         ...cellBase,
                         height: 44,
                         ...divider(u.label),
+                        // Wash sits on the button's OWN background — behind the
+                        // GolfChip/content, which always paints on top of an
+                        // element's background regardless of DOM order, so the
+                        // eagle ring etc. stay crisp over it (§7 DO-NOT).
+                        ...(isGloriousCol(i) ? gloriousWash : {}),
                         fontSize: 13,
                         fontWeight: 500,
                         color: v != null ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
@@ -418,6 +488,27 @@ export function StandardGrid({ units, participants, values, onCellTap, pips, sav
               </div>
             );
           })}
+          {/* Glorious bracket — a rectangle frame around the glorious columns,
+              spanning header through the last row. Border-only (the wash fill is
+              per-cell, above); pointerEvents:none so it never blocks a score-cell
+              tap. min/max of the glorious index set, not an assumed "last N" span
+              — robust if the predicate ever yields a non-suffix set. */}
+          {gloriousCols.size > 0 && (
+            <div
+              aria-hidden
+              data-testid="glorious-bracket"
+              style={{
+                position: "absolute",
+                left: NAME_W + Math.min(...gloriousCols) * HOLE_W,
+                width: (Math.max(...gloriousCols) - Math.min(...gloriousCols) + 1) * HOLE_W,
+                top: 0,
+                bottom: 0,
+                border: "1px solid var(--color-bt-glorious-border)",
+                pointerEvents: "none",
+                zIndex: 1,
+              }}
+            />
+          )}
           </div>
         </div>
         {/* Right-edge fade signalling more columns */}

--- a/src/lib/gloriousHoles.test.ts
+++ b/src/lib/gloriousHoles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { gloriousConfig, holeWeight, remainingSwing, NO_GLORIOUS } from "./gloriousHoles";
+import { gloriousConfig, holeWeight, remainingSwing, isGloriousHole, NO_GLORIOUS } from "./gloriousHoles";
 
 // The pure weight helper. The tally/close-out consequences (comeback, weighted
 // close-out, margin string) are gated in matchPlay.test.ts; this file pins the
@@ -71,5 +71,24 @@ describe("remainingSwing — over the actual unplayed-hole set", () => {
 
   it("with no glorious, weighted swing == raw hole count", () => {
     expect(remainingSwing([16, 17, 18], NO_GLORIOUS)).toBe(3);
+  });
+});
+
+describe("isGloriousHole — the ONE predicate the visual layer must call", () => {
+  const cfg = { enabled: true, n: 3 }; // last 3 → holes 16,17,18
+
+  it("true on the last N holes, false elsewhere", () => {
+    expect(isGloriousHole(15, cfg)).toBe(false);
+    expect(isGloriousHole(16, cfg)).toBe(true);
+    expect(isGloriousHole(17, cfg)).toBe(true);
+    expect(isGloriousHole(18, cfg)).toBe(true);
+  });
+
+  it("always false when disabled", () => {
+    for (const h of [16, 17, 18]) expect(isGloriousHole(h, NO_GLORIOUS)).toBe(false);
+  });
+
+  it("agrees with holeWeight (it's a thin wrapper, not a second source of truth)", () => {
+    for (let h = 1; h <= 18; h++) expect(isGloriousHole(h, cfg)).toBe(holeWeight(h, cfg) === 2);
   });
 });

--- a/src/lib/gloriousHoles.ts
+++ b/src/lib/gloriousHoles.ts
@@ -81,3 +81,13 @@ export function remainingSwing(unplayedHoles: Iterable<number>, cfg: GloriousCon
   for (const h of unplayedHoles) sum += holeWeight(h, cfg);
   return sum;
 }
+
+/**
+ * Is this hole glorious (worth 2×)? The ONE predicate the visual layer (scorecard
+ * diamond/bracket/wash, score-entry banner) must call — never re-inline
+ * `hole > 18 − n` in a component. `hole` is the engine's POSITION (1-based), the
+ * same numbering `holeWeight`/`buildDecided` use, not a display label.
+ */
+export function isGloriousHole(hole: number, cfg: GloriousConfig): boolean {
+  return holeWeight(hole, cfg) === 2;
+}


### PR DESCRIPTION
Adds the visual treatment for the already-shipped Glorious Finishing Holes engine (#569): players can now **see** which holes are worth double, on two surfaces only, both deriving from the SAME predicate the engine uses (`gloriousHoles.ts`) so display and computation can never disagree.

### What it does
- **Scorecard** (`StandardGrid`, every caller incl. the leaderboard course-preview): a faint gold **diamond** behind each glorious hole number (header row only — no double-layered wash there, which would muddy it), a gold **bracket** (border) around the glorious columns + a per-cell **wash** on the rows below (behind the score chips — the eagle ring stays crisp), and one **tees-bar label** `"N Glorious Finishing Holes · Worth Double"`. Score legend untouched. No fallback bar when there's no course (accepted degradation).
- **Score-entry** (`MatchEntryView`): a gold **banner** under the Hole/Par header, glorious holes only.
- **Pure config + format driven** — renders identically with zero scores/participants (the #501 setup-preview case) or with a full card; never gated on emptiness. Stroke/rack get nothing (format-guarded, free via `gloriousConfig`).
- New `--color-bt-glorious` token family, deliberately a different hue from `--color-bt-warning` (the scorecard's stroke pip already uses that token) — **verified live side-by-side on the actual dark card**, not just eyeballed: an initial `#e2a437` sat too close to the warning pip, landed on `#c9852f` (bronze-gold) instead.

### Phase 0 finding
The spec's `§3.2` STOP risk (scorecard config access) resolved cleanly: the in-game scorecard is built inside `MatchGameView`, which already computes the `glorious` config (#569) in the same scope — a one-prop pass, not a multi-layer thread. No STOP.

### Verification
- 17 new unit tests (`StandardGrid.test.tsx` ×12, `MatchEntryView.test.tsx` ×5) covering: right holes marked (N=3/N=4), legend untouched, banner presence/absence, format guard, zero-participants/zero-scores still renders, no-tee degradation, 9-hole inertness inherited (not special-cased).
- **Live-verified in the browser** on a real singles match: enabled glorious N=3 → diamond/bracket/wash/label on holes 16–18, entry banner on hole 16 (absent on 15), scorecard reads correctly with zero scores entered, and the bronze-gold color confirmed distinct from the amber stroke-pip token side-by-side on the actual card.
- `tsc --noEmit` clean · `eslint` clean · full Vitest **996 green** (2 file-level flakes were transient DB-contention noise under full-suite parallel load, confirmed clean in isolation — unrelated files, no individual test failed).
- `STYLE_GUIDE.md` documents the new token family.

Leaderboard chip and the value-row are explicitly out of scope (dropped, not deferred) — this is exactly what §8 of the spec asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)