### PR TITLE
Fix: unlock Points Per Match on match-play games before any match is paired

### DIFF
--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -1398,7 +1398,13 @@ export function MatchGameView() {
               />
             )}
 
-            {/* Format · Points — the last Settings row (the spine: matches × value). */}
+            {/* Format · Points — the last Settings row (the spine: matches × value).
+                NOT gated on matchesExist (bug fix): the owner can set the per-match
+                value before any match is paired — points mean nothing to the LIVE
+                total yet, but the value itself isn't invalid, and it's fine for
+                "Total Points Available" to read 0 with no matches defined. Rack's
+                "Points per Slot" (GameConfigurationView) never had this lock either
+                — matching that, for consistency across match-format games. */}
             {gameQ.data && (
               <GameSetupRows
                 slot="config"
@@ -1408,7 +1414,6 @@ export function MatchGameView() {
                 canEdit={settingsEditable}
                 locked={scoringEnabled}
                 matchCount={filledDraft.length}
-                configLocked={!matchesExist}
                 configOpen={openRow === "config"}
                 onOpenConfig={() => changeOpenRow("config")}
                 onCloseEditor={() => changeOpenRow(null)}


### PR DESCRIPTION
The Points Per Match stepper on 1v1/2v2 match-play games was locked read-only until `matchesExist` — a readiness gate that made sense for the LIVE total, but not for the per-match value itself. The owner should be able to set the value any time; a "Total Points Available: 0" readout with no matches paired yet is correct and honest, not a reason to block input.

### What changed
Removed `configLocked={!matchesExist}` from the Format · Points `GameSetupRows` call in `MatchGameView`. No server-side change needed — `games.setPointsDistribution`'s `per_match` branch already has no matches-exist/total gate ("per_match carries no total relationship," per its own code comment).

Rack's parallel "Points per Slot" row (`GameConfigurationView`) never had this lock in the first place — match play was the inconsistent one.

`matchesExist` still correctly gates **Handicaps** (a legitimately separate concern — handicaps assign per matchup) and is unaffected by this change.

### Verification
Live-tested on both a no-matches-paired 1v1 game and a 2v2 game:
- Stepper is now interactive (no lock icon)
- Value increments and **persists** (`points_distribution: {type:"per_match", value:N}` confirmed via a direct tRPC fetch)
- "Total Points Available" correctly stays 0 with no matches defined
- Handicaps stays appropriately gated ("Set the matchups first")

`tsc` + lint clean · full Vitest 94/94 files, 996/996 tests (one run hit broad unrelated transient DB-contention flakes — archivedIdeas/expenses/logistics/schedule etc. — confirmed clean on retry, nothing touching this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)