### PR TITLE
Fix: team-assignment race + rack group-builder modal behind bottom nav

### DIFF
--- a/src/components/competition/TeamsPanel.tsx
+++ b/src/components/competition/TeamsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import {
   ArrowRight,
   ChevronDown,
@@ -155,8 +155,40 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
   const utils = trpc.useUtils();
   const queryKey = { tripId, competitionId };
 
+  // Rapid-fire calls (e.g. quickly assigning several players in a row) race their
+  // independent onSettled → invalidate() calls: an EARLIER mutation's refetch can
+  // resolve AFTER a LATER mutation's optimistic write lands, overwriting the cache
+  // with server data that hasn't caught up to the later write yet — silently
+  // dropping it (the "assign too fast, a player reappears unassigned" bug). Defer
+  // the invalidate to the TRAILING EDGE of a burst: track in-flight mutations
+  // across all four calls sharing this hook instance and only invalidate once the
+  // count drops back to 0, so a fast burst gets exactly one, fully-settled refetch
+  // instead of N racing ones. `needsLeaderboard` preserves each mutation type's own
+  // invalidation set (reorder/setCaptain never touched leaderboard — team SIZE is
+  // unchanged — so a reorder-only burst doesn't force an extra leaderboard refetch).
+  const pendingRef = useRef(0);
+  const needsLeaderboardRef = useRef(false);
+  const beginMutation = (needsLeaderboard: boolean) => {
+    pendingRef.current += 1;
+    if (needsLeaderboard) needsLeaderboardRef.current = true;
+  };
+  const settleMutation = () => {
+    pendingRef.current = Math.max(0, pendingRef.current - 1);
+    if (pendingRef.current > 0) return; // more of this burst still in flight
+    utils.teamAssignments.list.invalidate(queryKey);
+    if (needsLeaderboardRef.current) {
+      utils.competitions.leaderboard.invalidate(queryKey);
+      needsLeaderboardRef.current = false;
+    }
+    // faceBootstrap ALSO seeds teamAssignments.list (#10): the consolidated
+    // TeamSheet opens OUTSIDE the LiveFace re-seed path, so re-resolve the
+    // bootstrap or the board reads stale until the 30s poll.
+    utils.competitions.faceBootstrap.invalidate({ tripId });
+  };
+
   const assign = trpc.teamAssignments.assign.useMutation({
     onMutate: async (vars) => {
+      beginMutation(true); // team-size change → leaderboard points move
       await utils.teamAssignments.list.cancel(queryKey);
       const previous = utils.teamAssignments.list.getData(queryKey);
       utils.teamAssignments.list.setData(queryKey, (old) => {
@@ -180,23 +212,12 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
         utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
       }
     },
-    onSettled: () => {
-      utils.teamAssignments.list.invalidate(queryKey);
-      // The leaderboard roll-up derives per_match points from TEAM SIZES, so a
-      // (re)assignment moves pointsAvailable / winNumber. The board reads the
-      // bootstrap-seeded competitions.leaderboard cache — invalidate it too so
-      // the leaderboard reflects the change without a hard refresh.
-      utils.competitions.leaderboard.invalidate(queryKey);
-      // faceBootstrap ALSO seeds teamAssignments.list (#10): the consolidated
-      // TeamSheet opens OUTSIDE the LiveFace re-seed path, so re-resolve the
-      // bootstrap or the board reads stale until the 30s poll. (setCaptain already
-      // does this; assign/remove/reorder carry it too for consistency.)
-      utils.competitions.faceBootstrap.invalidate({ tripId });
-    },
+    onSettled: settleMutation,
   });
 
   const remove = trpc.teamAssignments.remove.useMutation({
     onMutate: async (vars) => {
+      beginMutation(true); // team-size change → leaderboard points move
       await utils.teamAssignments.list.cancel(queryKey);
       const previous = utils.teamAssignments.list.getData(queryKey);
       utils.teamAssignments.list.setData(queryKey, (old) => {
@@ -210,13 +231,7 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
         utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
       }
     },
-    onSettled: () => {
-      utils.teamAssignments.list.invalidate(queryKey);
-      // Removing a player changes team sizes → the leaderboard roll-up's
-      // per_match points. Refresh the board's seeded cache (see `assign`).
-      utils.competitions.leaderboard.invalidate(queryKey);
-      utils.competitions.faceBootstrap.invalidate({ tripId });
-    },
+    onSettled: settleMutation,
   });
 
   // reorder (Part 3) — optimistic: rewrite sort_order for this team per the new
@@ -225,6 +240,7 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
   // so re-resolve it (#10) — the order survives an overlay/modal close + reopen.
   const reorder = trpc.teamAssignments.reorder.useMutation({
     onMutate: async (vars) => {
+      beginMutation(false); // sort_order only — team size/points unaffected
       await utils.teamAssignments.list.cancel(queryKey);
       const previous = utils.teamAssignments.list.getData(queryKey);
       const orderIndex = new Map(vars.orderedUserIds.map((id, i) => [id, i]));
@@ -243,10 +259,7 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
         utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
       }
     },
-    onSettled: () => {
-      utils.teamAssignments.list.invalidate(queryKey);
-      utils.competitions.faceBootstrap.invalidate({ tripId });
-    },
+    onSettled: settleMutation,
   });
 
   // setCaptain (PR b) — optimistic: the target gets the flag; any other captain
@@ -255,6 +268,7 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
   // overlay close/reopen, not just the live optimistic state.
   const setCaptain = trpc.teamAssignments.setCaptain.useMutation({
     onMutate: async (vars) => {
+      beginMutation(false); // captain flag only — team size/points unaffected
       await utils.teamAssignments.list.cancel(queryKey);
       const previous = utils.teamAssignments.list.getData(queryKey);
       utils.teamAssignments.list.setData(queryKey, (old) => {
@@ -272,10 +286,7 @@ function useTeamAssignmentMutations(tripId: string, competitionId: string) {
         utils.teamAssignments.list.setData(queryKey, ctxRollback.previous);
       }
     },
-    onSettled: () => {
-      utils.teamAssignments.list.invalidate(queryKey);
-      utils.competitions.faceBootstrap.invalidate({ tripId });
-    },
+    onSettled: settleMutation,
   });
 
   return { assign, remove, setCaptain, reorder };

--- a/src/components/games/rack/RackGroupBuilder.tsx
+++ b/src/components/games/rack/RackGroupBuilder.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { Plus, X } from "lucide-react";
 import { PlayerChip } from "@/components/games/PlayerChip";
 import { Avatar } from "@/components/Avatar";
@@ -153,6 +154,17 @@ export function RackGroupBuilder({
  * The combined-pool picker — a bottom sheet with BOTH teams as two columns (A left,
  * B right). Available = roster minus everyone already in a group. Tap adds to the
  * open group and the sheet stays up (multi-add up to 4); Done closes.
+ *
+ * Containing-block gotcha: RackGroupBuilder renders inside the game PANEL, whose
+ * host wrapper is `position: fixed; z-index: 30` (CompetitionFace) — a positioned,
+ * z-indexed ancestor creates a stacking context that CAPS every descendant
+ * z-index, including a `position: fixed` one (fixed escapes LAYOUT, not stacking
+ * containment). So this sheet's own z-50 only ever competed against other content
+ * INSIDE the z-30 panel — never against the bottom nav (z-40, a sibling outside
+ * the panel), which is why it rendered UNDER the nav and covered the bottom row of
+ * players. Same fix as AboutModal / FeedbackModal / InfoTileModal: escape via
+ * createPortal(..., document.body), which is unaffected by any ancestor's
+ * position/z-index/containing-block at all.
  */
 function CombinedPicker({
   teamA,
@@ -202,7 +214,12 @@ function CombinedPicker({
     );
   };
 
-  return (
+  // SSR guard (matches AboutModal/FeedbackModal/InfoTileModal) — document is
+  // undefined on the server; this component only ever mounts client-side anyway
+  // (behind pickerFor !== null, a client interaction), so this never actually
+  // renders null in practice.
+  if (typeof document === "undefined") return null;
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-end" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onClose}>
       <div
         onClick={(e) => e.stopPropagation()}
@@ -223,6 +240,7 @@ function CombinedPicker({
           {column(teamB)}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
Two independent bug fixes.

## 1. Rapid team assignment race
Assigning players "too quickly" could make one reappear in the unassigned list even though the assignment succeeded.

**Root cause:** `assign`/`remove`/`reorder`/`setCaptain` each fire their own independent `onSettled → invalidate()`. In a rapid burst, an earlier mutation's invalidate-triggered refetch can resolve *after* a later mutation's optimistic write has landed — overwriting the cache with server data that hasn't caught up yet, silently dropping the later write. On the mobile picker, this was masked by a fixed 320ms exit-animation window, but once that window elapsed unconditionally, the dropped assignment became visible again.

**Fix:** defer the invalidate to the trailing edge of a burst — track in-flight mutations via a ref counter shared across all four mutation types in `useTeamAssignmentMutations`, and only invalidate once the count returns to 0. Preserves each mutation's own invalidation set exactly (assign/remove still invalidate the leaderboard since team size changes affect points; reorder/setCaptain don't).

*(Not reproduced live — the only available test competition has teams locked, since scoring is already active there, and forcing this network-timing-dependent race deterministically isn't reliable even with a fresh one. Verified via tsc/lint/full-suite and a precise root-cause trace instead.)*

## 2. Rack-n-stack group-builder modal behind the bottom nav
The "Add to Group N" bottom sheet rendered *under* the bottom nav bar, making the last row of players untappable.

**Root cause:** the modal mounts inline inside the game panel, whose host wrapper is `position: fixed; z-index: 30` (`CompetitionFace`) — a positioned, z-indexed ancestor creates a stacking context that caps every descendant z-index, including a `position: fixed` one (fixed escapes layout, not stacking containment). So the modal's own `z-50` only ever competed against content *inside* the z-30 panel — never against the bottom nav (`z-40`, a sibling outside the panel) — so the nav always won.

**Fix:** portal the picker to `document.body` via `createPortal` — the identical fix already established in this codebase for the same class of bug (`AboutModal` / `FeedbackModal` / `InfoTileModal`, which document the same containing-block gotcha inline).

**Verified live**: reproduced the bug, applied the fix, confirmed the modal now renders full-screen with the bottom nav fully covered (not peeking through) and every player row tappable, and confirmed via DOM query that the modal's root is now a direct child of `document.body`.

---
`tsc` + lint clean · full Vitest 94/94 files, 996/996 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)