### PR TITLE
Fix: score-entry resume hole (rack + stroke) + misleading rack Finish subtext

### DIFF
--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -259,6 +259,17 @@ export function RackGameView() {
     return m;
   }, [participants]);
 
+  // A group's current hole = the first hole ANY of its members hasn't scored
+  // yet, so opening a group drops you where it's at — not hole 1 every time
+  // (the match-play board's currentHoleFor uses the same pattern, two-sided).
+  const currentHoleForGroup = (groupId: string) => {
+    const memberIds = participants.filter((p) => p.play_group_id === groupId).map((p) => p.user_id as string);
+    for (let h = 1; h <= scUnits.length; h++) {
+      if (memberIds.some((pid) => mergedFor(pid)[String(h)] == null)) return h;
+    }
+    return scUnits.length;
+  };
+
   const rackPlayers = useMemo(() => {
     const players: RackPlayer[] = [];
     for (const p of participants) {
@@ -656,6 +667,12 @@ export function RackGameView() {
             onBack={back}
             onOpenGrid={() => setGridOpen(true)}
             onFinish={back}
+            // "Finish" here is pure navigation back to the hub (onFinish={back}
+            // above, no mutation) — the shared default subtext ("Saves results ·
+            // shows final standings") describes stroke's games.finish-calling
+            // Finish, not rack's. The real rack finalize is the hub's separate
+            // "Lock the result" action.
+            finishSubtext=""
             pips={groupPips}
           />
         </div>
@@ -865,7 +882,7 @@ export function RackGameView() {
             : undefined
         }
       />
-      <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(1); setGridOpen(false); }} />
+      <FoursomeEntry groups={groupViews} onEnter={(id) => { setEntryGroupId(id); setCurrentHole(currentHoleForGroup(id)); setGridOpen(false); }} />
       {/* #501 Part 3: the scoring board is read-and-score only — "Edit handicaps"
           (config) is gone. Edit handicaps in Setup mode (gear → Who's playing ·
           Handicaps), where mid-game config is deliberate. */}

--- a/src/components/games/ScoreEntryView.tsx
+++ b/src/components/games/ScoreEntryView.tsx
@@ -64,6 +64,13 @@ interface ScoreEntryViewProps {
    *  back/title (+ the config gear). The scorecard affordance relocates to the
    *  right of the "Scores" strip (mirrors match's card-header placement). */
   hideHeader?: boolean;
+  /** Bottom-CTA subtext once every hole is filled (mirrors MatchEntryView's
+   *  `finishSubtext`). Defaults to the stroke-play copy ("Finish" here calls
+   *  games.finish, which really does save results). Rack passes "" — its
+   *  "Finish" is pure navigation back to the hub (no mutation), so the generic
+   *  "Saves results · shows final standings" line doesn't apply. A save/error
+   *  reason (`finishReason`) always overrides this regardless. */
+  finishSubtext?: string;
 }
 
 export function ScoreEntryView({
@@ -83,6 +90,7 @@ export function ScoreEntryView({
   onRetryCell,
   pips,
   hideHeader = false,
+  finishSubtext = "Saves results · shows final standings",
 }: ScoreEntryViewProps) {
   const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
   const hole = currentHole ?? holeInternal;
@@ -440,7 +448,7 @@ export function ScoreEntryView({
           icon
           onClick={() => onFinish?.()}
           disabled={gameGate.total > 0}
-          subtext={finishReason ?? "Saves results · shows final standings"}
+          subtext={finishReason ?? finishSubtext}
         />
       ) : currentComplete && hole < units.length ? (
         <BottomCTA

--- a/src/components/games/StrokeGameView.tsx
+++ b/src/components/games/StrokeGameView.tsx
@@ -310,6 +310,42 @@ export function StrokeGameView() {
     reconcile(loaded);
   }, [urlGameId, scoresQ.data, reconcile]);
 
+  // Resume at the CURRENT hole (the first hole any participant hasn't scored
+  // yet) instead of always landing on hole 1 — seeded ONCE per game, right
+  // after the first score load resolves. Never re-seeds afterward, so it
+  // doesn't fight manual navigation once you're in the entry view (same
+  // pattern as modifiersSeededRef). Mirrors the match-play board's per-group
+  // currentHoleFor / rack's currentHoleForGroup — stroke has no per-group
+  // selection step, so this seeds directly off the single continuous round.
+  //
+  // ⚠ Computes its OWN `loaded` map straight from `scoresQ.data`, deliberately
+  // NOT from `values` — the reconcile effect above (same scoresQ.data trigger)
+  // populates `values` via `reconcile()`, but that's a SEPARATE state update
+  // that lands on a LATER render, not synchronously within this same effect
+  // pass. Reading `values` here raced it: on the very first resolve, `values`
+  // was still the pre-load empty map, so every hole looked incomplete, this
+  // seeded hole 1, and the ref then blocked any correction once `values`
+  // actually caught up one render later. Recomputing from `scoresQ.data`
+  // directly removes the cross-effect ordering dependency entirely.
+  const currentHoleSeededRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!game || !scoresQ.data || currentHoleSeededRef.current === game.id) return;
+    currentHoleSeededRef.current = game.id;
+    const loaded: ScoreValues = {};
+    for (const e of scoresQ.data as { participant_id: string; unit_label: string; value: number | null }[]) {
+      if (e.value == null) continue;
+      (loaded[e.participant_id] ??= {})[e.unit_label] = e.value;
+    }
+    for (let h = 1; h <= scUnits.length; h++) {
+      const label = String(h);
+      if (game.participants.some((p) => loaded[p.id]?.[label] == null)) {
+        setCurrentHole(h);
+        return;
+      }
+    }
+    setCurrentHole(scUnits.length);
+  }, [game, scoresQ.data, scUnits.length]);
+
   // Config sync: poll the cheap config hash on the same tick (batched with the
   // score poll) and, when it changes on another device, silently refetch THIS
   // game's config so groupings/modifiers/rules/course/status converge. Stroke's


### PR DESCRIPTION
Three fixes from the same conversation, all in the score-entry area.

## 1. Rack-n-stack: opening a group always landed on Hole 1
`FoursomeEntry`'s `onEnter` hardcoded `setCurrentHole(1)`. Added `currentHoleForGroup(groupId)` — the first hole where *any* member of that group lacks a value (same pattern as `MatchGameView`'s `currentHoleFor`, adapted for a group of up to 4) — and wired it into `onEnter`.

## 2. Rack-n-stack: misleading Finish subtext
The Finish button read "Saves results · shows final standings" — but rack's Finish is pure navigation (`onFinish={back}`, no mutation; the real finalize is the hub's separate "Lock the result" → `games.finish`). Added a `finishSubtext` prop to the shared `ScoreEntryView` (mirrors `MatchEntryView`'s existing prop), defaulting to the original copy so **stroke is unaffected** — its Finish genuinely calls `games.finish`, so the subtext is accurate there. Rack passes `""`.

## 3. Stroke play: same "always Hole 1" bug, different root cause
Stroke has no per-group entry step, so `currentHole` just sat at its `useState(1)` default forever — nothing corrected it from already-loaded scores. Added a seed-once effect (ref-gated per `game.id`, mirrors the existing `modifiersSeededRef`) that computes the resume hole once the first score load resolves.

**Caught a real timing bug during live verification**: the first version read the reconcile effect's `values` state, which updates on a *later* render, not synchronously within the same effect pass — so on first resolve it saw an empty map, wrongly seeded hole 1, and the ref then permanently blocked the correction. Fixed by computing the loaded-scores map directly from `scoresQ.data` instead of depending on `values` catching up.

### Verification
- Rack: opened a group mid-round ("thru 2"), confirmed it now lands on hole 2 (not hole 1), with the player who'd already entered that hole's score preserved.
- Stroke: entered hole 1 (full) + hole 2 (partial) on a real game, did a genuine hard reload, confirmed it resumes on hole 2 — the buggy first version was caught landing back on hole 1 live, which is what drove the fix.

`tsc` + lint clean · full Vitest 94/94 files, 996/996 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)