### PR TITLE
Competition leaderboard: score grid for completed games + section renames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,13 @@ These patterns have been established through prior work. Follow them exactly —
   the caller, and PRESERVES score state (the caller's `useScoreSaver` feeds both the
   base view and the sheet). Reuse the `Sheet` primitive for overlay surfaces; this
   is also the working reference for the someday unified `<Overlay>` primitive.
+- **Game-type icon = `categoryIcon`/`CATEGORY_ICONS`** (`src/lib/gameCategoryIcon.ts`)
+  — ONE shared category→icon map (golf/card/yard/bar/other), sourced from each
+  game type's `category` field in `gameTypes.ts`. The add-game picker
+  (`CompetitionGamesPanel.tsx`) and the leaderboard board (`GameRow.tsx`'s
+  `formatIcon`) both resolve through it, so they can't drift. Key icons by
+  CATEGORY, never by scoring format — a format-keyed map (swords for match play,
+  layers for rack) reads as "combat/stack" on a board that's half non-golf.
 
 ## Guest → real-user conversion (auth)
 

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -37,6 +37,38 @@ multi-match cards, singles (1v1) and doubles (2v2).
 Competition close → `circle_events` entry is unconfirmed/likely still open —
 verify before closing it out too.
 
+### Leaderboard live-game projected-points pill (deferred — needs new server computation) — #576
+
+*Captured 2026-07-11 during the leaderboard-grid pass (Phase 0 STOP condition).
+The completed-game score grid (team columns, short-name header, winner chip)
+shipped for match_play; the live-game "▲ projected points" pill from the same
+spec did not — this is that gap, logged so it isn't lost.*
+
+A per-game, per-team live projection already exists (`src/lib/gameProjection.ts`
+`rollupMatchPlay`, `computeRack("projected", ...)`), but it's computed
+**client-side, inside each individual game page**, from that page's own
+already-fetched live scoring state (`GamePageHeader`'s `ProjectionRow`). It has
+never been wired to the board. The board's server compute,
+`computeCompetitionLeaderboard`, does not fetch live scores/matches for
+in-progress games at all — only final `game_results` (populated on completion)
+and a boolean "started" flag.
+
+**To build this:** either (a) extend `computeCompetitionLeaderboard` to fetch
+each live game's raw scores/matches and run the existing pure rollup functions
+server-side, or (b) have the board client fire additional per-game queries for
+just the LIVE-section games and compute client-side (reusing
+`gameProjection.ts` as-is, no server change, but N extra queries + new poll
+wiring — the board polls its own 30s interval, separate from `useConfigSync`'s
+20s game-page interval). Until this lands, LIVE rows show today's existing
+treatment (subtitle "Underway · scoring", `N PTS` outer column) rather than a
+pill promising data that isn't there.
+
+**Points cups already have the games×teams grid** — `PointsMatrix.tsx` (the
+collapsible "Game by game" audit table below the standings glance) already
+implements the same team-columns-per-game concept for points competitions.
+The completed-grid work above deliberately did not duplicate it — only
+match_play (which had no aligned-column treatment at all) got the new grid.
+
 ### Slice C — remaining formats (narrowed — most of this shipped)
 
 Shipped: **Rack-n-stack** (`gtt_rack_n_stack`, `user_holes` entry, positional

--- a/src/components/competition/CompetitionGamesPanel.tsx
+++ b/src/components/competition/CompetitionGamesPanel.tsx
@@ -2,14 +2,16 @@
 
 import { useEffect, useState } from "react";
 import {
-  Flag, Plus, X, Trophy,
-  Spade, Target, Beer, Dices, Swords, Radio, ChevronUp, ChevronDown, Check, Users, Info,
+  Plus, X, Trophy,
+  Target, Swords, Radio, ChevronUp, ChevronDown, Check, Users, Info,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { ScrollLock } from "@/hooks/useScrollLock";
 import { Stepper } from "@/components/games/Stepper";
 import type { PointsDistribution } from "@/lib/pointsDistribution";
 import { validatePlacement } from "@/lib/gameConfig";
+import { CATEGORY_ICONS } from "@/lib/gameCategoryIcon";
 // Format definitions live in code (W-PERF-01) — the catalog + its type come from
 // here, read synchronously, never fetched. Re-exported below so existing
 // consumers (CompetitionFace, GameSetupRows) keep their `from "./CompetitionGamesPanel"`
@@ -64,13 +66,16 @@ interface Member { memberId: string; displayName: string }
 
 // ── Static option tables ──────────────────────────────────────────────────────
 
+// Icons sourced from the shared `gameCategoryIcon.ts` map (leaderboard-grid
+// pass) — the leaderboard board resolves the same icon per category, so this
+// picker and the board can never drift. Only the label stays local (picker copy).
 const CATEGORY_ORDER = ["golf", "card", "yard", "bar", "other"] as const;
-const CATEGORY_META: Record<string, { label: string; Icon: typeof Flag }> = {
-  golf: { label: "Golf", Icon: Flag },
-  card: { label: "Card", Icon: Spade },
-  yard: { label: "Yard", Icon: Target },
-  bar: { label: "Bar", Icon: Beer },
-  other: { label: "Other", Icon: Dices },
+const CATEGORY_META: Record<string, { label: string; Icon: LucideIcon }> = {
+  golf: { label: "Golf", Icon: CATEGORY_ICONS.golf },
+  card: { label: "Card", Icon: CATEGORY_ICONS.card },
+  yard: { label: "Yard", Icon: CATEGORY_ICONS.yard },
+  bar: { label: "Bar", Icon: CATEGORY_ICONS.bar },
+  other: { label: "Other", Icon: CATEGORY_ICONS.other },
 };
 
 const COMP_FORMATS = [

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -486,15 +486,16 @@ function NTeamRankedList({
 // ── SessionBreakdown ─────────────────────────────────────────────────────────
 
 // Section order + labels (leaderboard-grid pass §1.3): single-word lifecycle
-// names, order NEW → CONFIGURING → READY → LIVE → COMPLETED (what's most
-// actionable first; done work recedes to the bottom). The Completed section
-// renders compressed single-line rows; the rest use the full GameRow.
+// names. Render order stays Completed-first, descending to New (unchanged from
+// before this pass) — only the label strings + LIVE's teal treatment changed.
+// The Completed section renders compressed single-line rows; the rest use the
+// full GameRow.
 const SECTION_ORDER: { key: GameSection; label: string }[] = [
-  { key: "skeleton", label: "New" },
-  { key: "preparing", label: "Configuring" },
-  { key: "ready", label: "Ready" },
-  { key: "on-tap", label: "Live" },
   { key: "completed", label: "Completed" },
+  { key: "on-tap", label: "Live" },
+  { key: "ready", label: "Ready" },
+  { key: "preparing", label: "Configuring" },
+  { key: "skeleton", label: "New" },
 ];
 
 function SessionBreakdown({

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -5,7 +5,7 @@ import { Trophy, CloudOff, RefreshCw, Plus } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import type { ScoringModel } from "@/lib/gameTypes";
-import { GameRow, CompletedRow, sectionOf, fmtPts, type GameSection } from "./GameRow";
+import { GameRow, CompletedRow, GridColumnHeader, sectionOf, fmtPts, type GameSection } from "./GameRow";
 import { StickyCollapseHero } from "./CompetitionHero";
 import { PointsMatrix } from "./PointsMatrix";
 
@@ -485,14 +485,16 @@ function NTeamRankedList({
 
 // ── SessionBreakdown ─────────────────────────────────────────────────────────
 
-// Section order + labels (Task 4). The Completed section renders compressed
-// single-line rows; the rest use the full GameRow.
+// Section order + labels (leaderboard-grid pass §1.3): single-word lifecycle
+// names, order NEW → CONFIGURING → READY → LIVE → COMPLETED (what's most
+// actionable first; done work recedes to the bottom). The Completed section
+// renders compressed single-line rows; the rest use the full GameRow.
 const SECTION_ORDER: { key: GameSection; label: string }[] = [
+  { key: "skeleton", label: "New" },
+  { key: "preparing", label: "Configuring" },
+  { key: "ready", label: "Ready" },
+  { key: "on-tap", label: "Live" },
   { key: "completed", label: "Completed" },
-  { key: "on-tap", label: "On Tap" },
-  { key: "ready", label: "Ready for Play" },
-  { key: "preparing", label: "Preparing for Gameplay" },
-  { key: "skeleton", label: "Skeleton" },
 ];
 
 function SessionBreakdown({
@@ -535,17 +537,34 @@ function SessionBreakdown({
       {SECTION_ORDER.map(({ key, label }) => {
         const sectionGames = bySection.get(key);
         if (!sectionGames || sectionGames.length === 0) return null; // empty sections hidden
+        // LIVE (on-tap) is the one section that carries the liveness signal —
+        // teal label + dot (§1.3/§1.4). The per-row LIVE badge was removed in
+        // favor of this single section-level tell.
+        const isLive = key === "on-tap";
+        const labelColor = isLive ? "var(--color-bt-accent)" : "var(--color-bt-text-dim)";
         return (
           <div key={key} data-testid={`games-section-${key}`}>
             <p
-              className="mb-2 text-[11px] font-semibold uppercase tracking-wider"
-              style={{ color: "var(--color-bt-text-dim)" }}
+              className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider"
+              style={{ color: labelColor }}
             >
+              {isLive && (
+                <span
+                  className="inline-block h-1 w-1 rounded-full"
+                  style={{ background: "currentColor", boxShadow: "0 0 0 3px var(--color-bt-accent-faint)" }}
+                />
+              )}
               {label}{" "}
               <span style={{ color: "var(--color-bt-text)" }}>· {sectionGames.length}</span>
             </p>
-            <div className="flex flex-col gap-2">
-              {sectionGames.map((game) =>
+            {/* Team short-name column header — sits directly above COMPLETED
+                only (§1.2), match_play only (points cups get their own
+                team-column header inside PointsMatrix). */}
+            {key === "completed" && scoringModel === "match_play" && (
+              <GridColumnHeader teams={teams} />
+            )}
+            <div className={key === "completed" ? "flex flex-col" : "flex flex-col gap-2"}>
+              {sectionGames.map((game, i) =>
                 key === "completed" ? (
                   <CompletedRow
                     key={game.id}
@@ -554,6 +573,7 @@ function SessionBreakdown({
                     cells={cellsByGame.get(game.id)}
                     scoringModel={scoringModel}
                     tripId={tripId}
+                    isLast={i === sectionGames.length - 1}
                     onPrefetch={onPrefetch}
                   />
                 ) : (

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -3,10 +3,11 @@
 import { createElement } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Radio, Flag, Swords, Layers, Gamepad2, Table2 } from "lucide-react";
+import { Table2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Avatar } from "@/components/Avatar";
 import { gameHref, isGolfFormat, opensAsPanel } from "@/lib/gameRoutes";
+import { categoryIcon } from "@/lib/gameCategoryIcon";
 import type { ScoringModel } from "@/lib/gameTypes";
 import type { LBGame, LBTeam, LBCell } from "./CompetitionLeaderboard";
 
@@ -48,16 +49,15 @@ export function fmtPts(n: number): string {
 
 /** §A1 format icon — the leading glyph that names the game's format, glanceable
  *  down the board. Its COLOR carries the arming tell (§A4, applied in Commit 3);
- *  the glyph itself just identifies the format. Unknown types fall back to a
- *  generic game glyph rather than going blank. */
-const FORMAT_ICONS: Record<string, LucideIcon> = {
-  gtt_stroke_play: Flag,
-  gtt_match_play_singles: Swords,
-  gtt_match_play_doubles: Swords,
-  gtt_rack_n_stack: Layers,
-};
+ *  the glyph itself identifies the game's CATEGORY (golf/card/yard/bar/other),
+ *  not its scoring format — sourced from the same shared map the add-game
+ *  picker uses (`gameCategoryIcon.ts`), so the two surfaces can't drift. All
+ *  golf formats (stroke/singles/doubles/rack) share the flag; format-specific
+ *  glyphs (swords/layers) read as "combat/stack" on a board that's half
+ *  non-golf, which this fixes. Unknown types fall back to a generic game glyph
+ *  rather than going blank. */
 export function formatIcon(gameTypeId: string | null): LucideIcon {
-  return (gameTypeId && FORMAT_ICONS[gameTypeId]) || Gamepad2;
+  return categoryIcon(gameTypeId);
 }
 
 /**
@@ -112,8 +112,9 @@ export function iconArmed(game: LBGame): boolean {
  * - `scorecard btn` sits just inboard of it — golf-only, and dropped at Final —
  *   so the column that vanishes is the inner one and the outer edge holds steady.
  * - the format icon's color is the arming tell (§A4); the name never gets
- *   crowded out (§A6). The full §A3 layer table (outline / name strength / the
- *   one Live background / LIVE badge) lands in Commit 3.
+ *   crowded out (§A6). The §A3 layer table is outline / name strength / the one
+ *   Live background — no per-row LIVE badge (the teal LIVE section header now
+ *   carries that signal once, at the section level; leaderboard-grid pass).
  *
  * Subtitle and name+delegate stack vertically inside the name column (mobile —
  * keeps the name uncrowded); the delegate chip travels with the name (§A1) and
@@ -283,7 +284,6 @@ export function GameRow({
               className="shrink-0"
             />
           )}
-          {section === "on-tap" && <LiveBadge />}
         </div>
         {subtitle && (
           <span className="text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>
@@ -439,17 +439,63 @@ function ordinal(n: number): string {
   return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
 }
 
+/** Fixed column width shared between `GridColumnHeader` and each completed
+ *  row's grid cells (match_play only) — the two can never misalign since both
+ *  read the same constant. Sized for a short-name (≤5 char) column. */
+const GRID_COLW = 56;
+
 /**
- * CompletedRow (Task 5) — a finished game compressed to ONE line: format icon +
- * name (left), result (right). Recessed like the old Final tile but far shorter
- * (the old Final `GameRow` stacked the team results vertically in the outer
- * column). The result shape keys on scoring_model:
- *   match_play → each team's points, team-colored, in HERO left-right order
- *                (the `teams` array order the hero uses) so they scan against the
- *                hero. NO winner emphasis — both read at the same weight.
- *   points     → a horizontal placement podium (1st/2nd/3rd…) in the shared
- *                `--color-bt-place-*` tokens (R2 — a small inline podium, not the
- *                games-side FinalStandings screen, which doesn't fit a board row).
+ * GridColumnHeader — team short-name column labels (team-colored, small caps,
+ * an underline tab), sitting directly above the COMPLETED block ONLY. Not
+ * top-pinned across sections: the sections below (Live/Ready/Configuring/New)
+ * either don't award team points yet or are still being set up, so there's no
+ * team-column meaning to label there — header lives where team-vs-team scoring
+ * lives. match_play only (points cups get their own team-column header inside
+ * `PointsMatrix`'s game-by-game table — no duplicate header here).
+ */
+export function GridColumnHeader({ teams }: { teams: LBTeam[] }) {
+  return (
+    <div
+      className="flex items-center gap-3 px-4 pb-2"
+      style={{ borderBottom: "1px solid var(--color-bt-border)" }}
+    >
+      <span
+        className="min-w-0 flex-1 text-[10px] font-semibold uppercase tracking-wider"
+        style={{ color: "var(--color-bt-text-dim)" }}
+      >
+        Game
+      </span>
+      {teams.map((t) => (
+        <span
+          key={t.id}
+          className="relative shrink-0 pb-1 text-center text-[11px] font-extrabold uppercase tracking-wide"
+          style={{ width: GRID_COLW, color: t.color }}
+        >
+          {t.short_name}
+          <span
+            className="absolute bottom-0 left-1/2 h-[2px] w-5 -translate-x-1/2 rounded-full"
+            style={{ background: "currentColor", opacity: 0.9 }}
+          />
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * CompletedRow — a finished game compressed to ONE flat, single-line row: no
+ * card background, no border box, no icon tile, no status subtitle (leaderboard-
+ * grid pass §1.1). A faint hairline sits BETWEEN completed rows (suppressed on
+ * the last) so the flat list stays scannable. The result shape keys on
+ * scoring_model:
+ *   match_play → CompletedGridCells — each team's points as a bare, bold,
+ *                team-colored number in a column that aligns to
+ *                `GridColumnHeader` above. Winner gets a faint team-tinted
+ *                chip; loser is dimmed; a tie gives both equal weight (no chip).
+ *   points     → the existing horizontal placement podium (1st/2nd/3rd…) — left
+ *                as-is; `PointsMatrix` (the collapsible games×teams audit table)
+ *                already gives points cups the full per-game team-column grid,
+ *                so this compact row isn't duplicating that.
  */
 export function CompletedRow({
   game,
@@ -457,6 +503,7 @@ export function CompletedRow({
   cells,
   scoringModel,
   tripId,
+  isLast,
   onPrefetch,
 }: {
   game: LBGame;
@@ -464,6 +511,8 @@ export function CompletedRow({
   cells: Map<string, LBCell> | undefined;
   scoringModel: ScoringModel;
   tripId: string;
+  /** Suppresses the between-rows hairline on the last completed row. */
+  isLast?: boolean;
   onPrefetch: (gameId: string) => void;
 }) {
   const pathname = usePathname();
@@ -473,9 +522,12 @@ export function CompletedRow({
   // Complete → never setup, so no `?settings=1`. Stroke keeps the route <Link>.
   const panelFormat = opensAsPanel(game.gameTypeId);
   const inner = (
-    <div className="flex items-center gap-3 px-4 py-2.5" style={{ opacity: 0.75 }}>
+    <div
+      className="flex items-center gap-3 px-4 py-2"
+      style={{ borderBottom: isLast ? undefined : "1px solid var(--color-bt-border)" }}
+    >
       {createElement(formatIcon(game.gameTypeId), {
-        size: 16,
+        size: 15,
         className: "shrink-0",
         style: { color: "var(--color-bt-text-dim)" },
       })}
@@ -488,11 +540,10 @@ export function CompletedRow({
       {scoringModel === "points" ? (
         <CompletedPodium teams={teams} cells={cells} />
       ) : (
-        <CompletedScores teams={teams} cells={cells} />
+        <CompletedGridCells teams={teams} cells={cells} />
       )}
     </div>
   );
-  const panelStyle: React.CSSProperties = { border: "1px solid var(--color-bt-border)" };
   if (panelFormat) {
     return (
       <button
@@ -500,8 +551,7 @@ export function CompletedRow({
         onClick={() => openGamePanel(pathname, game.id, false)}
         onPointerEnter={() => onPrefetch(game.id)}
         onPointerDown={() => onPrefetch(game.id)}
-        className="block w-full rounded-xl overflow-hidden text-left hover:opacity-80 transition-opacity"
-        style={panelStyle}
+        className="block w-full text-left hover:opacity-80 transition-opacity"
         data-testid="open-game-panel"
       >
         {inner}
@@ -511,35 +561,56 @@ export function CompletedRow({
   return href ? (
     <Link
       href={href}
-      className="block rounded-xl overflow-hidden hover:opacity-80 transition-opacity"
-      style={panelStyle}
+      className="block hover:opacity-80 transition-opacity"
       onPointerEnter={() => onPrefetch(game.id)}
       onPointerDown={() => onPrefetch(game.id)}
     >
       {inner}
     </Link>
   ) : (
-    <div className="rounded-xl overflow-hidden" style={panelStyle}>
-      {inner}
-    </div>
+    <div>{inner}</div>
   );
 }
 
-/** match_play completed result — each team's points as a team-color dot + the
- *  number in white, in the SAME left-right order as the hero (the `teams` array
- *  order). No winner emphasis. */
-function CompletedScores({ teams, cells }: { teams: LBTeam[]; cells: Map<string, LBCell> | undefined }) {
+/** match_play completed grid cells — each team's points as a bare, bold,
+ *  team-colored number in a fixed-width column aligned to `GridColumnHeader`.
+ *  The winner's cell carries a faint team-tinted chip (fill + 1px team
+ *  border); the loser's number is team-colored at reduced opacity; a tie gives
+ *  both equal weight (no chip) — the colorblind-safe distinction is the chip's
+ *  FILL, not a hue. */
+function CompletedGridCells({ teams, cells }: { teams: LBTeam[]; cells: Map<string, LBCell> | undefined }) {
+  const values = teams.map((t) => cells?.get(t.id)?.points ?? null);
+  const numeric = values.filter((v): v is number => v != null);
+  const max = numeric.length ? Math.max(...numeric) : null;
+  const isTie = max != null && numeric.filter((v) => v === max).length > 1;
   return (
-    <div className="flex shrink-0 items-center gap-3 tabular-nums">
-      {teams.map((t) => (
-        <span key={t.id} className="flex items-center gap-1.5">
-          <span className="h-1.5 w-1.5 rounded-full" style={{ background: t.color }} />
-          <span className="text-sm font-semibold" style={{ color: "var(--color-bt-text)" }}>
-            {fmtPts(cells?.get(t.id)?.points ?? 0)}
+    <>
+      {teams.map((t, i) => {
+        const v = values[i];
+        const isWinner = !isTie && v != null && max != null && v === max;
+        const isLoser = v != null && max != null && v !== max;
+        return (
+          <span
+            key={t.id}
+            className="shrink-0 rounded-lg text-center text-[15px] font-extrabold tabular-nums"
+            style={{
+              width: GRID_COLW,
+              padding: "3px 0",
+              color: t.color,
+              opacity: isLoser ? 0.62 : 1,
+              background: isWinner
+                ? `color-mix(in srgb, ${t.color} 14%, transparent)`
+                : undefined,
+              boxShadow: isWinner
+                ? `inset 0 0 0 1px color-mix(in srgb, ${t.color} 45%, transparent)`
+                : undefined,
+            }}
+          >
+            {v != null ? fmtPts(v) : "–"}
           </span>
-        </span>
-      ))}
-    </div>
+        );
+      })}
+    </>
   );
 }
 
@@ -571,24 +642,6 @@ function CompletedPodium({ teams, cells }: { teams: LBTeam[]; cells: Map<string,
         );
       })}
     </div>
-  );
-}
-
-/** §A2 — LIVE is the one surviving word-badge (the OPEN badge is removed; arming
- *  is carried by the format-icon color, §A4). */
-export function LiveBadge() {
-  return (
-    <span
-      className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
-      style={{
-        background: "var(--color-bt-accent-faint)",
-        color: "var(--color-bt-accent)",
-        border: "1px solid var(--color-bt-accent-border)",
-      }}
-    >
-      <Radio size={9} />
-      Live
-    </span>
   );
 }
 

--- a/src/lib/gameCategoryIcon.ts
+++ b/src/lib/gameCategoryIcon.ts
@@ -1,0 +1,25 @@
+import { Flag, Spade, Target, Beer, Dices, Gamepad2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { getGameTypeDefinition, type GameCategory } from "@/lib/gameTypes";
+
+/**
+ * One shared game-type icon source (add-game picker + competition leaderboard).
+ * Keyed by CATEGORY (golf/card/yard/bar/other), not scoring format — all golf
+ * formats (stroke/singles/doubles/rack) share the flag. Format-specific icons
+ * (swords for match play, layers for rack) read as "combat/stack" on a board
+ * that's half non-golf; category is what actually orients a viewer.
+ */
+export const CATEGORY_ICONS: Record<GameCategory, LucideIcon> = {
+  golf: Flag,
+  card: Spade,
+  yard: Target,
+  bar: Beer,
+  other: Dices,
+};
+
+/** Resolve a game's icon from its type id via the category it belongs to.
+ *  Unregistered/null ids fall back to a generic glyph rather than going blank. */
+export function categoryIcon(gameTypeId: string | null | undefined): LucideIcon {
+  const category = getGameTypeDefinition(gameTypeId)?.category;
+  return (category && CATEGORY_ICONS[category]) || Gamepad2;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the leaderboard-grid CC Build Spec (`CC_SPEC_leaderboard_grid.md`, design ref `leaderboard_grid_mockup.html`). Phase 0 confirmed two gating unknowns: the game-type icon map resolved as clean reuse; the live-game projected-points pill did not — it needs new server computation that doesn't exist today (`computeCompetitionLeaderboard` never fetches live scores for in-progress games). That's a real STOP condition per the spec's own rules, so this PR ships everything that cleared Phase 0 and defers the rest.

- **Completed-game score grid (match_play competitions).** Team-colored short-name column header sits above the Completed section only. Each completed row shows bare, bold, team-colored point totals per column: winner gets a faint team-tinted chip (fill + 1px border ring), loser is dimmed, a tie gives both equal weight (no chip). Completed rows go flat — no card background, no border box, no icon tile, single line, hairline divider between rows (suppressed on the last one).
  - Points competitions are untouched: `PointsMatrix.tsx` already implements the same games×teams grid concept (a collapsible "Game by game" audit table with team-colored headers) for points cups, so this doesn't duplicate it.
- **Section renames**, labels only — render order stays Completed-first (unchanged, receding down to New): On Tap → **Live**, Ready for Play → **Ready**, Preparing for Gameplay → **Configuring**, Skeleton → **New**. Live gets a teal label + dot; the per-row LIVE badge is removed since the section header now carries that signal once.
- **New shared `src/lib/gameCategoryIcon.ts`** — one category→icon map (golf/card/yard/bar/other) that both the add-game picker (`CompetitionGamesPanel.tsx`) and the leaderboard board (`GameRow.tsx`'s `formatIcon`) resolve through, replacing two independent hardcoded maps. Fixes golf formats (stroke/singles/doubles/rack) showing swords/layers — which read as "combat/stack" on a board that's half non-golf — instead of a consistent flag.

## Deferred (captured at source)

The live-pill projected-points feature is logged in `DEFERRED.md` under "Leaderboard live-game projected-points pill" and filed as [#576](https://github.com/zgrether/buddytrip/issues/576). Until it ships, LIVE rows keep today's existing treatment (subtitle "Underway · scoring", `N PTS` outer column) rather than a pill promising data that isn't there.

## Fixed during review

An earlier commit on this branch also reordered the sections to match the spec's literal "NEW → CONFIGURING → READY → LIVE → COMPLETED" text — that was wrong (a UX regression from the app's existing Completed-first order) and was caught and reverted; only the label strings + LIVE's teal treatment were ever supposed to change, not the render order.

## Test plan

- `tsc --noEmit` clean, `next lint` clean.
- Verified live in the browser against the BBMI Test Cup board: section order/labels, teal LIVE dot, grid header alignment, winner-chip rendering (confirmed against a real non-tied completed game, 0–8), tie rendering (no chip), category icons across all golf formats (identical flag glyph), add-game picker unaffected.
- `vitest` green (27/27) on the touched surfaces (`CompetitionFace.test.tsx`, `competitions.d2.test.ts`, `CollapsedHero.test.tsx`, `ProjectionRow.test.tsx`) — scoped past the pre-existing stale `.claude/worktrees/` test-runner issue (#549, unrelated to this change, confirmed by diffing which files actually fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)