### PR TITLE
Competition leaderboard: live projected-points pill (Path A, server-side)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,13 @@ These patterns have been established through prior work. Follow them exactly —
    imports the pure fn. Mirror this split for every new `result_strategy`, and
    branch `games.finish` on the template's `result_strategy` (data-driven, NOT a
    hardcoded format name) so new strategies slot in without touching `finish`.
+   The competition board's LIVE projected-points pill extends this: the read-only
+   `src/server/lib/liveProjection.ts` runs the SAME pure projection fns the game
+   pages use (`rollupMatchPlay` / `computeRack("projected")`) server-side and
+   folds the result into the `competitions.leaderboard` payload (rides its 30s
+   poll, no new client fetch), so the board pill and the game-page projection row
+   can't diverge. When a surface needs a live projection, reuse the pure fn — do
+   NOT write a second rollup.
 9. **Derived values recompute on every input — not just the obvious one.** A value
    derived from multiple inputs must re-derive when *any* of them changes;
    enumerate the full trigger set, not just the one that's easy to think of.

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Settings, Users } from "lucide-react";
-import { fmtPts } from "./GameRow";
+import { fmtPts, ProjectionPill } from "./GameRow";
 import type { LBTeam } from "./CompetitionLeaderboard";
 import type { ScoringModel } from "@/lib/gameTypes";
 
@@ -606,7 +606,10 @@ function ProjTeam({
       {fmtPts(total)}
     </span>
   );
-  const chip = <DeltaChip color={team.color} delta={p} />;
+  // The game's point contribution, as the shared ▲ pill (extracted to GameRow so
+  // the hero and the board's live cell share one grammar). No `alwaysTriangle`
+  // here → the ▲ shows only for a positive delta, a plain 0 otherwise.
+  const chip = <ProjectionPill color={team.color} value={p} />;
   return (
     <div
       className={`flex min-w-0 items-baseline gap-2 ${align === "right" ? "justify-end" : ""}`}
@@ -614,30 +617,6 @@ function ProjTeam({
     >
       {align === "left" ? (<>{num}{chip}</>) : (<>{chip}{num}</>)}
     </div>
-  );
-}
-
-/** Delta chip — this game's point contribution, as a team-tinted pill (team color
- *  on a 16%-alpha team fill). ▲ for a positive contribution; a plain 0 when the
- *  game hasn't moved the team yet (match-play contributions are never negative). */
-function DeltaChip({ color, delta }: { color: string; delta: number }) {
-  return (
-    <span
-      className="inline-flex items-center tabular-nums"
-      style={{
-        gap: 2,
-        padding: "2px 8px",
-        borderRadius: 9999,
-        fontSize: 11.5,
-        fontWeight: 700,
-        lineHeight: 1,
-        background: `color-mix(in srgb, ${color} 16%, transparent)`,
-        color,
-      }}
-    >
-      {delta > 0 && <span style={{ fontSize: 8 }}>&#9650;</span>}
-      {fmtPts(delta)}
-    </span>
   );
 }
 

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -63,6 +63,9 @@ interface LeaderboardData {
   teams: LBTeam[];
   games: LBGame[];
   cells: LBCell[];
+  /** gameId → teamId → projected points, for LIVE match/rack games only (the
+   *  ▲ projected-points pill). Absent games have no live projection. */
+  projections: Record<string, Record<string, number>>;
   teamTotals: Record<string, number>;
   pointsAvailable: number;
   winNumber: number;
@@ -287,6 +290,7 @@ export function CompetitionLeaderboard({ competitionId, tripId, cupName, tagline
         games={liveGames}
         teams={teams}
         cellsByGame={cellsByGame}
+        projections={data.projections ?? {}}
         scoringModel={scoringModel}
         tripId={tripId}
         mineSet={mineSet}
@@ -304,11 +308,12 @@ export function CompetitionLeaderboard({ competitionId, tripId, cupName, tagline
 // entry). Empty → the bones prompt + "Add a game"; populated → the session
 // breakdown + "Add a game". Editor-gated; the crew sees the list only.
 function GamesSection({
-  games, teams, cellsByGame, scoringModel, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame,
+  games, teams, cellsByGame, projections, scoringModel, tripId, mineSet, viewer, onPrefetch, canEdit, onAddGame,
 }: {
   games: LBGame[];
   teams: LBTeam[];
   cellsByGame: Map<string, Map<string, LBCell>>;
+  projections: Record<string, Record<string, number>>;
   scoringModel: ScoringModel;
   tripId: string;
   mineSet: Set<string>;
@@ -356,6 +361,7 @@ function GamesSection({
         games={games}
         teams={teams}
         cellsByGame={cellsByGame}
+        projections={projections}
         scoringModel={scoringModel}
         tripId={tripId}
         mineSet={mineSet}
@@ -502,6 +508,7 @@ function SessionBreakdown({
   games,
   teams,
   cellsByGame,
+  projections,
   scoringModel,
   tripId,
   mineSet,
@@ -512,6 +519,7 @@ function SessionBreakdown({
   games: LBGame[];
   teams: LBTeam[];
   cellsByGame: Map<string, Map<string, LBCell>>;
+  projections: Record<string, Record<string, number>>;
   scoringModel: ScoringModel;
   tripId: string;
   mineSet: Set<string>;
@@ -583,6 +591,8 @@ function SessionBreakdown({
                     game={game}
                     teams={teams}
                     cells={cellsByGame.get(game.id)}
+                    projection={projections[game.id]}
+                    scoringModel={scoringModel}
                     tripId={tripId}
                     mine={mineSet.has(game.id)}
                     canEdit={canEdit}

--- a/src/components/competition/GameRow.tsx
+++ b/src/components/competition/GameRow.tsx
@@ -124,6 +124,8 @@ export function GameRow({
   game,
   teams,
   cells,
+  scoringModel,
+  projection,
   tripId,
   mine,
   canEdit,
@@ -135,6 +137,13 @@ export function GameRow({
   game: LBGame;
   teams: LBTeam[];
   cells: Map<string, LBCell> | undefined;
+  /** The competition's scoring model — gates the LIVE projected-points pill grid
+   *  to match_play boards (the same boards whose completed rows use the team-column
+   *  grid). Points cups keep the plain outer column on live rows. */
+  scoringModel: ScoringModel;
+  /** teamId → projected points for THIS game (LIVE match/rack only). Present →
+   *  the row renders the ▲ pill grid instead of the outer `N PTS` column. */
+  projection?: Record<string, number>;
   tripId: string;
   mine: boolean;
   /** Trip-level edit access (Owner/Organizer). ORed with `mine` (this game's
@@ -198,6 +207,15 @@ export function GameRow({
   const armed = iconArmed(game);
   const armedIcon = armed && !isFinal;
 
+  // LIVE projected-points pill grid (leaderboard grid Phase 2). A live (on-tap)
+  // match/rack game in a match_play cup carries a per-team projection → the row
+  // trades its outer `N PTS` column for a ▲ pill in each team column (aligned to
+  // the completed grid's short-name header). No projection (stroke, not-yet-
+  // started, a points cup) → the plain outer column stays. Gated on match_play so
+  // the pills line up with the completed team-column grid (points cups use a
+  // podium there, not team columns).
+  const showProjectionPills = section === "on-tap" && scoringModel === "match_play" && projection != null;
+
   // Subtitle / running state (§A3), all keyed off the one derived section:
   //  - on-tap    → running state (the real "Blue 2 up · thru 13" is deferred).
   //  - ready     → Ready for Play: enabled + pairings up, waiting on the first score.
@@ -211,7 +229,9 @@ export function GameRow({
   //  - completed → none; the compressed row + outer result speak for it.
   const subtitle =
     section === "on-tap"
-      ? "Underway · scoring"
+      ? showProjectionPills
+        ? "Projected results" // the cells now carry projections → the subtitle says so
+        : "Underway · scoring"
       : section === "ready"
       ? "Ready to play"
       : section === "preparing"
@@ -337,10 +357,24 @@ export function GameRow({
           </span>
         ))}
 
-      {/* Outer column — pts-or-result, pinned right, right-aligned (§A5). */}
-      <div className="flex shrink-0 flex-col items-end" style={{ minWidth: 44 }}>
-        <OuterColumn game={game} teams={teams} cells={cells} isFinal={isFinal} hasScores={!!hasScores} />
-      </div>
+      {/* LIVE → the ▲ projected-points pill in each team column (aligned to the
+          completed grid's GRID_COLW columns via the shared width). Else the outer
+          pts-or-result column, pinned right (§A5). */}
+      {showProjectionPills ? (
+        teams.map((t) => (
+          <span
+            key={t.id}
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: GRID_COLW }}
+          >
+            <ProjectionPill color={t.color} value={projection![t.id] ?? 0} alwaysTriangle />
+          </span>
+        ))
+      ) : (
+        <div className="flex shrink-0 flex-col items-end" style={{ minWidth: 44 }}>
+          <OuterColumn game={game} teams={teams} cells={cells} isFinal={isFinal} hasScores={!!hasScores} />
+        </div>
+      )}
     </div>
   );
 
@@ -443,6 +477,47 @@ function ordinal(n: number): string {
  *  row's grid cells (match_play only) — the two can never misalign since both
  *  read the same constant. Sized for a short-name (≤5 char) column. */
 const GRID_COLW = 56;
+
+/**
+ * ProjectionPill — the ▲ projected-points pill (leaderboard grid Phase 2). A
+ * team-tinted pill: team color on a 16%-alpha team fill, the value in team color.
+ * The SAME visual grammar as the game-page projection strip (this is the extracted
+ * home of `CompetitionHero`'s old `DeltaChip`, which now delegates here so the two
+ * surfaces share one pill).
+ *
+ * `alwaysTriangle`: the board's live cell shows ▲ even at 0 (unambiguously a
+ * PROJECTION, distinct from a completed score of 0). The hero's contribution chip
+ * omits it (shows the ▲ only for a positive delta, a plain 0 otherwise).
+ */
+export function ProjectionPill({
+  color,
+  value,
+  alwaysTriangle = false,
+}: {
+  color: string;
+  value: number;
+  alwaysTriangle?: boolean;
+}) {
+  const triangle = alwaysTriangle || value > 0;
+  return (
+    <span
+      className="inline-flex items-center tabular-nums"
+      style={{
+        gap: 2,
+        padding: "2px 8px",
+        borderRadius: 9999,
+        fontSize: 11.5,
+        fontWeight: 700,
+        lineHeight: 1,
+        background: `color-mix(in srgb, ${color} 16%, transparent)`,
+        color,
+      }}
+    >
+      {triangle && <span style={{ fontSize: 8 }}>&#9650;</span>}
+      {fmtPts(value)}
+    </span>
+  );
+}
 
 /**
  * GridColumnHeader — team short-name column labels (team-colored, small caps,

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -6,6 +6,7 @@ import { isManualGameType } from "@/lib/gameTypes";
 // isConfigured (+ the type sets) moved to gameReadiness.ts (A2-core) so the same
 // "is it configured?" signal backs both this display AND the server enable guard.
 import { isConfigured, MATCH_PLAY_TYPES, RACK_TYPE } from "@/server/lib/gameReadiness";
+import { computeLiveProjections, type LiveProjectionInput } from "@/server/lib/liveProjection";
 
 /** Singles vs doubles head-to-head sizing for the team-size-derived formats
  *  (rack-n-stack). Match play itself counts its configured rows instead. */
@@ -254,6 +255,31 @@ export async function computeCompetitionLeaderboard(
     }
   }
 
+  // Live per-team projections (leaderboard grid Phase 2). Only in-progress
+  // (active & started) match/rack games get a "if today holds" projection — the
+  // board's LIVE-section pill. Runs the SAME pure functions the game page uses
+  // (Path A), read-only, and rides this payload's existing 30s poll (no new
+  // fetch on the client, converges across devices for free). Stroke/non-golf and
+  // not-yet-started games have no projection → their rows keep the plain layout.
+  const liveProjectionInputs: LiveProjectionInput[] = allGames
+    .filter((g) => {
+      const t = g.game_type_id as string | null;
+      return (
+        g.status === "active" &&
+        startedByGame.has(g.id as string) &&
+        ((t != null && MATCH_PLAY_TYPES.has(t)) || t === RACK_TYPE)
+      );
+    })
+    .map((g) => {
+      const dist = g.points_distribution as PointsDistribution | null;
+      return {
+        id: g.id as string,
+        gameTypeId: (g.game_type_id as string | null) ?? null,
+        pointsPerMatch: isPerMatch(dist) ? dist.value : 0,
+      };
+    });
+  const projections = await computeLiveProjections(supabase, competitionId, liveProjectionInputs);
+
   return {
     teams: teams ?? [],
     defendingTeamId: (comp?.defending_team_id as string | null) ?? null,
@@ -298,6 +324,9 @@ export async function computeCompetitionLeaderboard(
       };
     }),
     cells,
+    // gameId → teamId → projected points (LIVE match/rack games only). The board
+    // renders these as the ▲ projected-points pill in each team column.
+    projections,
     pointsAvailable: roll.pointsAvailable,
     winNumber: roll.winNumber,
     teamTotals: Object.fromEntries(roll.teamTotals),

--- a/src/server/lib/liveProjection.test.ts
+++ b/src/server/lib/liveProjection.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { projectGame, type GameProjectionData, type LiveProjectionInput } from "./liveProjection";
+
+/**
+ * Live projection mapping (leaderboard grid Phase 2, Path A). The pure rollups
+ * (rollupMatchPlay / computeRack) have their own tests; this covers what THIS
+ * layer adds — building each match's current standing (buildDecided → matchState),
+ * resolving each side to its team, and dispatching by format — so the board pill
+ * can't drift from the game page's projection.
+ */
+
+const gross = (m: Record<string, Record<string, number>>): Map<string, Record<string, number>> =>
+  new Map(Object.entries(m));
+const userTeam = (m: Record<string, string>): Map<string, string> => new Map(Object.entries(m));
+const part = (user_id: string) => ({ user_id, play_group_id: null, handicap_strokes: 0 });
+
+describe("projectGame — match play", () => {
+  it("sums each match's current standing to per-team COMPETITION points (leader full, all-square halved)", () => {
+    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play_singles", pointsPerMatch: 2 };
+    const data: GameProjectionData = {
+      schema: { units: { count: 2 } }, // 2-hole round, no course index → sequential fallback
+      modifiers: null,
+      matches: [
+        { side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" } }, // alice sweeps → blue
+        { side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" } }, // 1 hole halved → all-square
+      ],
+      parts: [part("alice"), part("bob"), part("carol"), part("dave")],
+      playGroups: [],
+      gross: gross({
+        alice: { "1": 4, "2": 4 },
+        bob: { "1": 5, "2": 5 },
+        carol: { "1": 4 }, // only hole 1 in → started, all-square
+        dave: { "1": 4 },
+      }),
+      userTeam: userTeam({ alice: "blue", bob: "red", carol: "blue", dave: "red" }),
+    };
+    // match 1: blue up → blue +2. match 2: all-square started → blue +1, red +1.
+    expect(projectGame(input, data)).toEqual({ blue: 3, red: 1 });
+  });
+
+  it("an unpaired match (a side missing) contributes nothing", () => {
+    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play_singles", pointsPerMatch: 2 };
+    const data: GameProjectionData = {
+      schema: { units: { count: 2 } },
+      modifiers: null,
+      matches: [{ side_a: { type: "user", id: "alice" }, side_b: null }],
+      parts: [part("alice")],
+      playGroups: [],
+      gross: gross({ alice: { "1": 4, "2": 4 } }),
+      userTeam: userTeam({ alice: "blue" }),
+    };
+    expect(projectGame(input, data)).toEqual({});
+  });
+});
+
+describe("projectGame — rack", () => {
+  it("returns per-team raw slot points (matching the rack game page's projection)", () => {
+    const input: LiveProjectionInput = { id: "g2", gameTypeId: "gtt_rack_n_stack", pointsPerMatch: 3 };
+    const data: GameProjectionData = {
+      schema: { units: { metadata: { par: [4, 4], handicap_index: [1, 2] } } },
+      modifiers: null,
+      matches: [],
+      parts: [part("p1"), part("p2"), part("p3"), part("p4")],
+      playGroups: [],
+      gross: gross({
+        p1: { "1": 3, "2": 3 }, // team t1 — lowest
+        p3: { "1": 4, "2": 4 }, // team t1
+        p4: { "1": 4, "2": 4 }, // team t2
+        p2: { "1": 5, "2": 5 }, // team t2 — highest
+      }),
+      userTeam: userTeam({ p1: "t1", p3: "t1", p2: "t2", p4: "t2" }),
+    };
+    // rank-paired: (p1<p4) → t1, (p3<p2) → t1 → t1 sweeps both slots (raw points).
+    expect(projectGame(input, data)).toEqual({ t1: 2, t2: 0 });
+  });
+});
+
+describe("projectGame — no projection", () => {
+  it("returns null for a format without a live projection (stroke play)", () => {
+    const input: LiveProjectionInput = { id: "g3", gameTypeId: "gtt_stroke_play", pointsPerMatch: 0 };
+    const data: GameProjectionData = {
+      schema: null,
+      modifiers: null,
+      matches: [],
+      parts: [],
+      playGroups: [],
+      gross: new Map(),
+      userTeam: new Map(),
+    };
+    expect(projectGame(input, data)).toBeNull();
+  });
+});

--- a/src/server/lib/liveProjection.ts
+++ b/src/server/lib/liveProjection.ts
@@ -1,0 +1,263 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildDecided, matchState } from "@/lib/matchPlay";
+import { gloriousConfig } from "@/lib/gloriousHoles";
+import type { ModifiersMap } from "@/lib/modifiers";
+import { effectiveStrokes } from "@/lib/handicap";
+import { rollupMatchPlay, type ProjMatch } from "@/lib/gameProjection";
+import { playerStats, computeRack, type RackPlayer, type Team } from "@/lib/rackNStack";
+import { getGameTypeDefinition } from "@/lib/gameTypes";
+import { MATCH_PLAY_TYPES, RACK_TYPE } from "@/server/lib/gameReadiness";
+
+/**
+ * Live-game projected-points, server-side (leaderboard grid Phase 2, Path A).
+ *
+ * The competition board needs a per-team "if today holds" projection for each
+ * in-progress game, but its main compute (`competitionLeaderboard.ts`) reads only
+ * REALIZED `game_results`. This helper fills that gap by running the SAME pure
+ * projection functions the game pages use — `rollupMatchPlay` (match) and
+ * `computeRack("projected")` (rack) — server-side, so the board pill and the
+ * game-page projection row can't diverge (CLAUDE.md #8, same principle that lets
+ * `computeMatchPlayResults` reuse `matchState`). READ-ONLY: no writes, no result
+ * rows — it mirrors the finish path's reads but stops at the pure rollup.
+ *
+ * Rides the board's existing 30s poll (it's extra fields on the same payload), so
+ * projections converge across devices with zero new polling.
+ *
+ * Values match each format's game page verbatim:
+ *  - match → per-team COMPETITION points (pointsPerMatch per won match);
+ *  - rack  → raw slot points (`computeRack("projected").points`, NO ×value) — the
+ *    same value `RackGameView` shows. (The rack game page's raw-vs-×value framing
+ *    is a pre-existing question, deliberately NOT "fixed" here so board==game-page.)
+ *
+ * Only match singles/doubles + rack live games project; stroke has no on-page
+ * rollup and non-golf never runs live (it posts straight to complete).
+ */
+
+interface SideRef {
+  type: string;
+  id: string;
+}
+interface SchemaShape {
+  units?: { count?: number; metadata?: { par?: number[]; handicap_index?: number[] } };
+}
+
+export interface LiveProjectionInput {
+  id: string;
+  gameTypeId: string | null;
+  /** per_match value from `points_distribution` — match play's pointsPerMatch.
+   *  Unused by rack (which returns raw slot points to match its game page). */
+  pointsPerMatch: number;
+}
+
+/** The per-game data the pure projection needs — built from the bulk reads by
+ *  `computeLiveProjections`, or hand-constructed by a test. Keeps the projection
+ *  math (side→team resolution, matchState→ProjMatch, computeRack) DB-free and
+ *  unit-testable via `projectGame`. */
+export interface GameProjectionData {
+  schema: SchemaShape | null;
+  modifiers: ModifiersMap | null;
+  matches: { side_a: SideRef | null; side_b: SideRef | null }[];
+  parts: { user_id: string; play_group_id: string | null; handicap_strokes: number | null }[];
+  playGroups: { id: string; handicap_strokes: number | null }[];
+  /** participant_id → { unit_label: gross }. */
+  gross: Map<string, Record<string, number>>;
+  /** user_id → team_id (competition-level). */
+  userTeam: Map<string, string>;
+}
+
+/** gameId → (teamId → projected points). Only games with a projection appear. */
+export type LiveProjections = Record<string, Record<string, number>>;
+
+/** Dispatch one game to its format projection (pure — no DB). Exported for the
+ *  unit test; `computeLiveProjections` calls it per game with data from the bulk
+ *  reads. Unknown/stroke/non-golf types return null (no live projection). */
+export function projectGame(input: LiveProjectionInput, data: GameProjectionData): Record<string, number> | null {
+  const t = input.gameTypeId;
+  if (t && MATCH_PLAY_TYPES.has(t)) return projectMatch(input, data);
+  if (t === RACK_TYPE) return projectRack(input, data);
+  return null;
+}
+
+export async function computeLiveProjections(
+  supabase: SupabaseClient,
+  competitionId: string,
+  games: LiveProjectionInput[]
+): Promise<LiveProjections> {
+  const out: LiveProjections = {};
+  if (games.length === 0) return out;
+  const gameIds = games.map((g) => g.id);
+
+  // Bulk reads, scoped to the live game ids only (a completed game's per-hole
+  // scores never load). One wave, parallel — the board compute's cost stays a
+  // fixed handful of extra queries regardless of live-game count.
+  const [gamesMetaRes, matchRowsRes, participantRowsRes, playGroupRowsRes, entryRowsRes, assignRes] =
+    await Promise.all([
+      supabase.from("games").select("id, scorecard_schema, modifiers").in("id", gameIds),
+      supabase.from("game_matches").select("game_id, side_a, side_b").in("game_id", gameIds),
+      supabase
+        .from("game_participants")
+        .select("game_id, user_id, play_group_id, handicap_strokes")
+        .in("game_id", gameIds),
+      supabase.from("play_groups").select("game_id, id, handicap_strokes").in("game_id", gameIds),
+      supabase
+        .from("score_entries")
+        .select("game_id, participant_id, unit_label, value")
+        .in("game_id", gameIds)
+        .in("participant_type", ["user", "play_group"]),
+      supabase.from("team_assignments").select("user_id, team_id").eq("competition_id", competitionId),
+    ]);
+
+  const userTeam = new Map<string, string>();
+  for (const a of assignRes.data ?? []) userTeam.set(a.user_id as string, a.team_id as string);
+
+  const metaByGame = new Map<string, { schema: SchemaShape | null; modifiers: ModifiersMap | null }>();
+  for (const g of gamesMetaRes.data ?? []) {
+    metaByGame.set(g.id as string, {
+      schema: (g.scorecard_schema as SchemaShape | null) ?? null,
+      modifiers: (g.modifiers as ModifiersMap | null) ?? null,
+    });
+  }
+
+  const matchesByGame = new Map<string, { side_a: SideRef | null; side_b: SideRef | null }[]>();
+  for (const m of matchRowsRes.data ?? []) {
+    const arr = matchesByGame.get(m.game_id as string) ?? [];
+    arr.push({ side_a: (m.side_a as SideRef | null) ?? null, side_b: (m.side_b as SideRef | null) ?? null });
+    matchesByGame.set(m.game_id as string, arr);
+  }
+
+  const partsByGame = new Map<
+    string,
+    { user_id: string; play_group_id: string | null; handicap_strokes: number | null }[]
+  >();
+  for (const p of participantRowsRes.data ?? []) {
+    const arr = partsByGame.get(p.game_id as string) ?? [];
+    arr.push({
+      user_id: p.user_id as string,
+      play_group_id: (p.play_group_id as string | null) ?? null,
+      handicap_strokes: (p.handicap_strokes as number | null) ?? null,
+    });
+    partsByGame.set(p.game_id as string, arr);
+  }
+
+  const pgByGame = new Map<string, { id: string; handicap_strokes: number | null }[]>();
+  for (const pg of playGroupRowsRes.data ?? []) {
+    const arr = pgByGame.get(pg.game_id as string) ?? [];
+    arr.push({ id: pg.id as string, handicap_strokes: (pg.handicap_strokes as number | null) ?? null });
+    pgByGame.set(pg.game_id as string, arr);
+  }
+
+  // game → participant_id → { unit_label: gross }.
+  const grossByGame = new Map<string, Map<string, Record<string, number>>>();
+  for (const e of entryRowsRes.data ?? []) {
+    if (e.value == null) continue;
+    const gid = e.game_id as string;
+    const gm = grossByGame.get(gid) ?? new Map<string, Record<string, number>>();
+    const pid = e.participant_id as string;
+    const rec = gm.get(pid) ?? {};
+    rec[e.unit_label as string] = e.value as number;
+    gm.set(pid, rec);
+    grossByGame.set(gid, gm);
+  }
+
+  for (const g of games) {
+    const meta = metaByGame.get(g.id);
+    const proj = projectGame(g, {
+      schema: meta?.schema ?? null,
+      modifiers: meta?.modifiers ?? null,
+      matches: matchesByGame.get(g.id) ?? [],
+      parts: partsByGame.get(g.id) ?? [],
+      playGroups: pgByGame.get(g.id) ?? [],
+      gross: grossByGame.get(g.id) ?? new Map(),
+      userTeam,
+    });
+    if (proj) out[g.id] = proj;
+  }
+  return out;
+}
+
+/** Match singles/doubles → build each match's current standing (the same
+ *  `buildDecided`→`matchState` the finish path runs), resolve each side to its
+ *  team, and sum via the shared `rollupMatchPlay`. */
+function projectMatch(g: LiveProjectionInput, data: GameProjectionData): Record<string, number> | null {
+  const { schema, matches, parts, playGroups, gross, userTeam } = data;
+  const strokeIndex = schema?.units?.metadata?.handicap_index;
+  const holeCount = schema?.units?.count;
+  const glorious = gloriousConfig(g.gameTypeId, data.modifiers);
+
+  // Side handicaps, keyed by SIDE id (1v1 side = a user; 2v2 side = a play_group).
+  const hcap = new Map<string, number>();
+  for (const p of parts) hcap.set(p.user_id, effectiveStrokes(p));
+  for (const pg of playGroups) hcap.set(pg.id, effectiveStrokes(pg));
+
+  // play_group → team (2v2): resolve a pair's team via any member (both partners
+  // share a team in a two-team competition).
+  const pgTeam = new Map<string, string>();
+  for (const p of parts) {
+    if (!p.play_group_id || pgTeam.has(p.play_group_id)) continue;
+    const t = userTeam.get(p.user_id);
+    if (t) pgTeam.set(p.play_group_id, t);
+  }
+  const sideTeam = (s: SideRef | null): string | null => {
+    if (!s?.id) return null;
+    return (s.type === "play_group" ? pgTeam.get(s.id) : userTeam.get(s.id)) ?? null;
+  };
+
+  const projMatches: ProjMatch[] = [];
+  for (const m of matches) {
+    const a = m.side_a;
+    const b = m.side_b;
+    if (!a?.id || !b?.id) continue; // an unpaired slot isn't a match yet
+    const decided = buildDecided(
+      gross.get(a.id) ?? {},
+      gross.get(b.id) ?? {},
+      hcap.get(a.id) ?? 0,
+      hcap.get(b.id) ?? 0,
+      strokeIndex,
+      holeCount
+    );
+    const st = matchState(decided, holeCount, glorious);
+    projMatches.push({ aTeamId: sideTeam(a), bTeamId: sideTeam(b), leader: st.leader, started: st.thru > 0 });
+  }
+  return rollupMatchPlay(projMatches, g.pointsPerMatch);
+}
+
+/** Rack → the same read-model `computeRackNStackResults` builds, but in
+ *  "projected" mode (pace-normalized net-to-par) and read-only. Returns raw slot
+ *  points per team (matching `RackGameView`'s projection row — see file header). */
+function projectRack(g: LiveProjectionInput, data: GameProjectionData): Record<string, number> | null {
+  const { parts, gross, userTeam } = data;
+  // Effective par/index: the game's course snapshot, else its format's default.
+  let schema = data.schema;
+  if (!schema?.units?.metadata?.par && g.gameTypeId) {
+    schema = (getGameTypeDefinition(g.gameTypeId)?.scorecardSchema as SchemaShape | null) ?? null;
+  }
+  const par = schema?.units?.metadata?.par;
+  const strokeIndex = schema?.units?.metadata?.handicap_index;
+  if (!par || !strokeIndex) return null;
+  const coursePar = par.reduce((a, p) => a + p, 0);
+
+  // The two competing teams, sorted deterministically for a stable A/B (the same
+  // convention `computeRackNStackResults` uses). computeRack is symmetric, so the
+  // A/B choice can't change a team's points — we map slot back to team id below.
+  const teamOf = new Map<string, string>();
+  for (const p of parts) {
+    const t = userTeam.get(p.user_id);
+    if (t) teamOf.set(p.user_id, t);
+  }
+  const teamIds = [...new Set([...teamOf.values()])].sort();
+  if (teamIds.length < 2) return null;
+  const slot: Record<string, Team> = { [teamIds[0]]: "A", [teamIds[1]]: "B" };
+
+  const players: RackPlayer[] = [];
+  for (const p of parts) {
+    const tid = teamOf.get(p.user_id);
+    if (!tid || !(tid in slot)) continue;
+    players.push({
+      id: p.user_id,
+      team: slot[tid],
+      stats: playerStats(gross.get(p.user_id) ?? {}, effectiveStrokes(p), par, strokeIndex),
+    });
+  }
+  const { points } = computeRack(players, "projected", coursePar);
+  return { [teamIds[0]]: points.A, [teamIds[1]]: points.B };
+}


### PR DESCRIPTION
## Summary

The LIVE piece the leaderboard-grid Phase 0 STOP'd on. Each in-progress match/rack game now shows a team-colored ▲ projected-points pill ("if today holds") in every team column, replacing the placeholder outer column, with the subtitle flipped to "Projected results". Closes #576.

**Phase 0 chose Path A (server-side) over the spec's Path B lean, on evidence:**
- The pure rollup functions (`rollupMatchPlay`, `computeRack`) already run server-side in production today (`server/lib/matchPlay.ts`, `server/lib/rackNStack.ts`) — so A extends a proven pattern, no new isomorphism risk.
- A adds **zero** new client queries/polls — the projection is extra fields on the existing `competitions.leaderboard` payload, riding its 30s poll, so it converges across devices for free (and `faceBootstrap` seeds it too, same compute).
- One authoritative projection number on the wire vs. B's N×3 per-game client fetches on mount.

No STOP condition; the fork was clean either way.

## What changed

- **New `src/server/lib/liveProjection.ts`** (`computeLiveProjections`): read-only, bulk-fetches scoped to the live game ids, and runs the **same pure functions the game pages use** — `rollupMatchPlay` (match singles/doubles) and `computeRack("projected")` (rack) — to produce `gameId → teamId → projected points`. No writes; it mirrors the finish path's reads but stops at the pure rollup. The pure dispatch (`projectGame`) is factored out for a fast, DB-free unit test.
- **`computeCompetitionLeaderboard`** attaches a `projections` field for LIVE (`active && started`) match/rack games.
- **`GameRow`** renders the ▲ pill in each team column for live match_play rows (aligned to the completed grid's short-name header, always-▲ even at 0 so it reads as a *projection*), flips the subtitle, and falls back to the plain outer column when there's no projection (stroke, not-yet-started, points cups).
- **Extracted** the ▲ pill from `CompetitionHero`'s private `DeltaChip` into a shared `ProjectionPill` (in `GameRow`); the hero now delegates to it, so the board and the game-page projection strip share one visual grammar.
- **CLAUDE.md** pattern #8 extended to note the board's live projection reuses the pure rollup fns server-side.

## Reviewer notes

- **DoD #3 (board == game page) holds by construction** — the server helper runs the identical pure functions with identical inputs; the unit test exercises those real functions through `projectGame`. I could not do a live side-by-side panel check: the Browser pane can't reliably drive the History-API game-panel open (a documented limitation), and the screenshot tool timed out. Verified instead via the live board's rendered values + DOM measurement + the unit test.
- **Pre-existing rack raw-vs-×value inconsistency (deliberately not "fixed" here).** The rack game page shows *raw slot points* in its projection (`computeRack("projected").points`, no ×value — `RackGameView.tsx`), while match play shows competition points. I matched each game page verbatim so board == game page holds — which means rack pills read smaller than match pills beside them. Correcting it (×value on both surfaces) would fix the pre-existing game-page understatement but *break* the board==game-page gate, so it's surfaced as a separate decision rather than silently changed.

## Test plan

- New `src/server/lib/liveProjection.test.ts`: match (leader → full points, all-square-started → halved, unpaired → nothing), rack (raw slot points per team), and null for a non-projecting format (stroke).
- `vitest` green — 80 scoped tests incl. the `competitions.d2` leaderboard integration test (now exercises the payload with the new `projections` field), the pure `gameProjection`/`rackNStack`/`matchPlay` suites, and the competition-face component tests. (Scoped past the pre-existing stale `.claude/worktrees/` test-runner issue, #549.)
- `tsc --noEmit` clean, `next lint` clean.
- Verified live on the BBMI Test Cup board: pills render with correct values (2v2 ▲1/▲3, rack ▲2½/▲5½, 1v1 ▲0/▲4), aligned to the completed header (1px = card border), subtitle "Projected results", completed grid untouched, no per-row Live badge, server logs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)