### PR TITLE
Fix rack projection: competition points (slots × per_match), not raw slots

### DIFF
--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -28,7 +28,7 @@ import { FoursomeEntry, type FoursomeGroupView } from "@/components/games/rack/F
 import { HandicapList, type HandicapPlayer } from "@/components/games/HandicapRoster";
 import { ChecklistRow } from "@/components/games/ChecklistRow";
 import { useScreenHistory } from "@/hooks/useScreenHistory";
-import { playerStats, computeRack, type RackPlayer, type RackMode } from "@/lib/rackNStack";
+import { playerStats, computeRack, rackProjectedTeamPoints, type RackPlayer, type RackMode } from "@/lib/rackNStack";
 import { strokeHoles } from "@/lib/matchPlay";
 import { unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
 import { effectiveStrokes } from "@/lib/handicap";
@@ -282,9 +282,21 @@ export function RackGameView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [participants, teamOf, handicapOf, scUnits, scIndex, coursePar, loadedValues, values]);
   const rack = useMemo(() => computeRack(rackPlayers, mode, coursePar), [rackPlayers, mode, coursePar]);
-  // #533 projection (rack) — REUSE the existing rack projection ("if it ended now"
-  // = computeRack in "projected" mode), NOT a rebuild. Map A/B → the two team ids.
-  const projectedPoints = useMemo(() => computeRack(rackPlayers, "projected", coursePar).points, [rackPlayers, coursePar]);
+  // Rack's `per_match` = points PER SLOT (the "Points per Slot" field); a legacy
+  // rack with no per_match distribution → 1, mirroring the decided path
+  // (`computeRackNStackResults`: `value = perMatch ? dist.value : 1`).
+  const perSlotValue = useMemo(() => {
+    const dist = gameQ.data?.points_distribution;
+    return dist?.type === "per_match" ? dist.value : 1;
+  }, [gameQ.data]);
+  // #533 projection (rack) — "if it ended now" projected slots × the per-slot
+  // value = COMPETITION points (the SAME shared helper the board's liveProjection
+  // uses, so the two can't diverge; and the same currency as a match pill). Map
+  // A/B → the two team ids.
+  const projectedPoints = useMemo(
+    () => rackProjectedTeamPoints(rackPlayers, coursePar, perSlotValue),
+    [rackPlayers, coursePar, perSlotValue]
+  );
 
   // Rack SLOT count = the number of rank-paired 1v1s = min(grouped-A, grouped-B),
   // mirroring computeRack's `n = min(A.length, B.length)`. Derived from the

--- a/src/lib/rackNStack.test.ts
+++ b/src/lib/rackNStack.test.ts
@@ -3,6 +3,7 @@ import {
   playerStats,
   projectedNetToPar,
   computeRack,
+  rackProjectedTeamPoints,
   fmtToPar,
   fmtPoints,
   type RackPlayer,
@@ -115,6 +116,38 @@ describe("computeRack — projected mode reorders by pace", () => {
     expect(proj.slots[0].a.id).toBe("a2");
     expect(proj.slots[0].a.value).toBeCloseTo(0, 5);
     expect(proj.slots[1].a.value).toBeCloseTo(2, 5);
+  });
+});
+
+describe("rackProjectedTeamPoints — slots × per-slot value = competition points", () => {
+  // thru 18 for all → projectedNetToPar(net,18,72) = net − 72, so a player's
+  // projected value is net − coursePar. One slot won + one halved → {A:1.5, B:0.5}.
+  const players: RackPlayer[] = [
+    { id: "a1", team: "A", stats: { netToPar: -2, netStrokes: 70, gross: 70, thru: 18 } }, // proj −2
+    { id: "a2", team: "A", stats: { netToPar: 2, netStrokes: 74, gross: 74, thru: 18 } }, //  proj +2
+    { id: "b1", team: "B", stats: { netToPar: -1, netStrokes: 71, gross: 71, thru: 18 } }, // proj −1
+    { id: "b2", team: "B", stats: { netToPar: 2, netStrokes: 74, gross: 74, thru: 18 } }, //  proj +2
+  ];
+
+  it("baseline: raw projected slot points are {A:1.5, B:0.5} (a1 wins slot 1, slot 2 halved)", () => {
+    expect(computeRack(players, "projected", COURSE_PAR).points).toEqual({ A: 1.5, B: 0.5 });
+  });
+
+  it("multiplies the fractional slot points by the per-slot value (× 2 → {A:3, B:1})", () => {
+    expect(rackProjectedTeamPoints(players, COURSE_PAR, 2)).toEqual({ A: 3, B: 1 });
+  });
+
+  it("× 1 (legacy fallback) leaves raw slot points unchanged", () => {
+    expect(rackProjectedTeamPoints(players, COURSE_PAR, 1)).toEqual({ A: 1.5, B: 0.5 });
+  });
+
+  it("zero projected slots → {A:0, B:0} regardless of value (still always-▲ 0 on the board)", () => {
+    // Nobody started (thru 0) → no slots → 0 points, ×value stays 0.
+    const unstarted: RackPlayer[] = [
+      { id: "a", team: "A", stats: { netToPar: 0, netStrokes: 0, gross: 0, thru: 0 } },
+      { id: "b", team: "B", stats: { netToPar: 0, netStrokes: 0, gross: 0, thru: 0 } },
+    ];
+    expect(rackProjectedTeamPoints(unstarted, COURSE_PAR, 3)).toEqual({ A: 0, B: 0 });
   });
 });
 

--- a/src/lib/rackNStack.ts
+++ b/src/lib/rackNStack.ts
@@ -155,6 +155,31 @@ export function computeRack(players: RackPlayer[], mode: RackMode, coursePar: nu
   return { slots, sitOut: surplus, points: { A: pa, B: pb } };
 }
 
+/**
+ * Rack PROJECTED competition points per team = raw projected slot points ×
+ * `perSlotValue` (the `per_match` field, which in rack means **points per slot**;
+ * defaults to 1 for a legacy/placement rack). This mirrors the DECIDED path's
+ * downstream multiply (`computeRackNStackResults`: `teamPoints × value`) — the
+ * projected path historically returned RAW slots, so a rack pill read in a
+ * different currency than a match pill. Applying the multiply HERE (a consumer-
+ * layer helper, NOT inside `computeRack`) keeps the decided path — which does its
+ * own downstream multiply — from double-applying.
+ *
+ * The multiply is linear over the summed slot points (incl. ½ halves and the
+ * min(A,B) pairing `computeRack` already resolves), so `points × value` is exactly
+ * "each won slot worth `value`" (2½ slots × 2 = 5). Both projected consumers (the
+ * board's `liveProjection.ts` and the rack game page) call this, so they stay
+ * equal by construction.
+ */
+export function rackProjectedTeamPoints(
+  players: RackPlayer[],
+  coursePar: number,
+  perSlotValue: number
+): { A: number; B: number } {
+  const { points } = computeRack(players, "projected", coursePar);
+  return { A: points.A * perSlotValue, B: points.B * perSlotValue };
+}
+
 /** Format a net-to-par for display: "E" / "+n" / "−n" (rounds projected). */
 export function fmtToPar(value: number): string {
   const r = Math.round(value);

--- a/src/server/lib/liveProjection.test.ts
+++ b/src/server/lib/liveProjection.test.ts
@@ -54,7 +54,7 @@ describe("projectGame — match play", () => {
 });
 
 describe("projectGame — rack", () => {
-  it("returns per-team raw slot points (matching the rack game page's projection)", () => {
+  it("returns per-team COMPETITION points = projected slots × per-slot value (per_match)", () => {
     const input: LiveProjectionInput = { id: "g2", gameTypeId: "gtt_rack_n_stack", pointsPerMatch: 3 };
     const data: GameProjectionData = {
       schema: { units: { metadata: { par: [4, 4], handicap_index: [1, 2] } } },
@@ -70,7 +70,27 @@ describe("projectGame — rack", () => {
       }),
       userTeam: userTeam({ p1: "t1", p3: "t1", p2: "t2", p4: "t2" }),
     };
-    // rank-paired: (p1<p4) → t1, (p3<p2) → t1 → t1 sweeps both slots (raw points).
+    // rank-paired: (p1<p4) → t1, (p3<p2) → t1 → t1 sweeps both slots = 2 slots.
+    // × per_match (3, points-per-slot) → 6 competition points (NOT raw 2).
+    expect(projectGame(input, data)).toEqual({ t1: 6, t2: 0 });
+  });
+
+  it("a legacy rack with no per_match value (0) falls back to ×1 (raw slots)", () => {
+    const input: LiveProjectionInput = { id: "g2", gameTypeId: "gtt_rack_n_stack", pointsPerMatch: 0 };
+    const data: GameProjectionData = {
+      schema: { units: { metadata: { par: [4, 4], handicap_index: [1, 2] } } },
+      modifiers: null,
+      matches: [],
+      parts: [part("p1"), part("p2"), part("p3"), part("p4")],
+      playGroups: [],
+      gross: gross({
+        p1: { "1": 3, "2": 3 },
+        p3: { "1": 4, "2": 4 },
+        p4: { "1": 4, "2": 4 },
+        p2: { "1": 5, "2": 5 },
+      }),
+      userTeam: userTeam({ p1: "t1", p3: "t1", p2: "t2", p4: "t2" }),
+    };
     expect(projectGame(input, data)).toEqual({ t1: 2, t2: 0 });
   });
 });

--- a/src/server/lib/liveProjection.ts
+++ b/src/server/lib/liveProjection.ts
@@ -4,7 +4,7 @@ import { gloriousConfig } from "@/lib/gloriousHoles";
 import type { ModifiersMap } from "@/lib/modifiers";
 import { effectiveStrokes } from "@/lib/handicap";
 import { rollupMatchPlay, type ProjMatch } from "@/lib/gameProjection";
-import { playerStats, computeRack, type RackPlayer, type Team } from "@/lib/rackNStack";
+import { playerStats, rackProjectedTeamPoints, type RackPlayer, type Team } from "@/lib/rackNStack";
 import { getGameTypeDefinition } from "@/lib/gameTypes";
 import { MATCH_PLAY_TYPES, RACK_TYPE } from "@/server/lib/gameReadiness";
 
@@ -23,11 +23,11 @@ import { MATCH_PLAY_TYPES, RACK_TYPE } from "@/server/lib/gameReadiness";
  * Rides the board's existing 30s poll (it's extra fields on the same payload), so
  * projections converge across devices with zero new polling.
  *
- * Values match each format's game page verbatim:
- *  - match → per-team COMPETITION points (pointsPerMatch per won match);
- *  - rack  → raw slot points (`computeRack("projected").points`, NO ×value) — the
- *    same value `RackGameView` shows. (The rack game page's raw-vs-×value framing
- *    is a pre-existing question, deliberately NOT "fixed" here so board==game-page.)
+ * Values match each format's game page verbatim, both in COMPETITION points:
+ *  - match → pointsPerMatch per won match (`rollupMatchPlay`);
+ *  - rack  → projected slots × per-slot value (`rackProjectedTeamPoints`, which
+ *    mirrors the decided path's `teamPoints × value`). Both the board and the rack
+ *    game page call that shared helper, so they can't diverge.
  *
  * Only match singles/doubles + rack live games project; stroke has no on-page
  * rollup and non-golf never runs live (it posts straight to complete).
@@ -258,6 +258,11 @@ function projectRack(g: LiveProjectionInput, data: GameProjectionData): Record<s
       stats: playerStats(gross.get(p.user_id) ?? {}, effectiveStrokes(p), par, strokeIndex),
     });
   }
-  const { points } = computeRack(players, "projected", coursePar);
+  // Rack's `per_match` = points PER SLOT; a legacy/placement rack has none → 1
+  // (mirrors the decided path's `value = perMatch ? dist.value : 1`). × slots →
+  // competition points, so the board rack pill reads in the same currency as a
+  // match pill.
+  const perSlotValue = g.pointsPerMatch || 1;
+  const points = rackProjectedTeamPoints(players, coursePar, perSlotValue);
   return { [teamIds[0]]: points.A, [teamIds[1]]: points.B };
 }


### PR DESCRIPTION
## Summary

Follow-up to #578 (live projected-points pill). Rack **projections** showed **raw slots won** while match projections show **competition points** — so a rack pill and a match pill sat in the same team column in *different units*. This fixes the rack projection to competition points on both surfaces, keeping them equal — now equal *and* correct.

## Phase 0 — where the multiply belongs (the whole risk)

- **Decided rack path** applies `per_match` **downstream** of `computeRack`: [`computeRackNStackResults`](src/server/lib/rackNStack.ts) runs `computeRack("current")` → raw slots, then writes `raw_score = teamPoints × value`. `computeRack` itself returns raw slots in **both** modes.
- **Projected path** skipped that multiply on **both** consumers — the board ([`liveProjection.ts::projectRack`](src/server/lib/liveProjection.ts)) and the rack game page ([`RackGameView`](src/components/games/RackGameView.tsx)), which both used raw `computeRack("projected").points`.
- **So the fix goes in the projected consumers, NOT inside `computeRack`** — putting `×value` in `computeRack` would double-apply on the decided path (which multiplies downstream). No STOP: the application point is unambiguous and cleanly mirrorable.

## The fix

- New shared pure helper **`rackProjectedTeamPoints(players, coursePar, perSlotValue)`** in `lib/rackNStack.ts` = `computeRack("projected").points × perSlotValue`. Both projected consumers call it, so board == game page **by construction**.
- Board and rack game page both pass the rack's `per_match` value (points-per-slot; `1` for a legacy/placement rack, mirroring the decided path's `value = perMatch ? dist.value : 1`).
- `computeRack` and the decided finish path (`server/lib/rackNStack.ts`) are **byte-unchanged** — no double-apply. Match projection untouched.

**Naming:** `per_match` is not renamed (load-bearing field). In rack it semantically means *points per slot* ("Points per Slot" label); the multiply applies per slot and sums — linear over the summed slot points incl. ½ halves — so `2½ slots × value` is correct.

## Test plan (spec §4 gates)

- **(a)** `rackProjectedTeamPoints` unit test: × non-1 value, a **fractional** slot ({A:1.5,B:0.5} × 2 → {A:3,B:1}), × 1 legacy fallback, and **zero** slots → {A:0,B:0} (still always-▲ 0 on the board).
- **(b)** Board == game page: both call the one helper → equal by construction.
- **(c) Decided rack UNCHANGED (critical regression gate):** the server integration test *"a per_match rack writes raw_score = slot points × value"* re-run **green, unchanged**; `server/lib/rackNStack.ts` has zero diff.
- **(d)** Match projection/results untouched.
- **(e)** Edges: fractional/zero slots covered above.
- **(f)** Grep confirms `per_match` only *read*, never renamed; "Points per Slot" label intact.
- `tsc --noEmit` clean, `next lint` clean, `vitest` green (154 unit + the 6-test decided-path integration suite).

## Verified live

The RacknStack board pill now reads **▲7½ / ▲16½** (was ▲2½ / ▲5½ raw slots; `per_match = 3`) — same currency as the match pills (2v2 ▲1/▲3, 1v1 ▲0/▲4), and 7½+16½ = 24 = that rack's points-in-play.

*(The board==game-page side-by-side couldn't be eyeballed in an open game panel — the Browser pane can't drive the History-API panel open, a documented limitation — but it's guaranteed by the shared helper + verified by the unit tests.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)