### PR TITLE
Refactor A1: unify match play into one gtt_match_play type (+ re-tag migration)

### DIFF
--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -52,8 +52,9 @@ import { unconfirmedCount, type Participant, type ScoreValues } from "@/componen
 import { showToast } from "@/lib/toast";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MATCH_PLAY = "gtt_match_play_singles";
-const MATCH_PLAY_DOUBLES = "gtt_match_play_doubles";
+// One unified match-play type (Refactor A1). 1v1-vs-2v2 is per-match, derived from
+// each match's side type — not the game type. `MATCH_PLAY_DOUBLES` is retired.
+const MATCH_PLAY = "gtt_match_play";
 // Mirrors the server cap (matches router). Dynamic match count grows up to here.
 const MAX_MATCHES = 24;
 
@@ -210,12 +211,25 @@ export function MatchGameView() {
   }, [utils, tripId, gameId]);
   useConfigSync(tripId, gameId, !!gameId, onConfigChanged);
 
-  // Format: the resumed game's type is authoritative; a brand-new game (no game
-  // yet) reads the `?format=doubles` hint. `sided` switches the whole flow
-  // between 1v1 (a side is a user) and 2v2 (a side is a pair = a play_group).
-  // Default singles → existing URLs with no param are byte-for-byte unchanged.
-  const resumedTypeId = gameQ.data?.game_type_id as string | undefined;
-  const sided = resumedTypeId ? resumedTypeId === MATCH_PLAY_DOUBLES : search.get("format") === "doubles";
+  // Shape (Refactor A1): 1v1-vs-2v2 is a per-match property, so the AUTHORITATIVE
+  // signal is the game's own matches — a doubles game's `game_matches` carry
+  // `{type:"play_group"}` sides. Derive `sided` from those (not `game_type_id`,
+  // which is now the uniform `gtt_match_play` for every match game). A brand-new
+  // game with no matches yet reads the `?format=doubles` hint (the standalone
+  // create route), else defaults singles. This ALSO retires the old
+  // "matches-land-before-the-game-row" seed race: shape and matches now arrive
+  // from the SAME query (`matchesQ`), so there's no window where the game type is
+  // ahead of the matches. (A2 unfolds this game-level `sided` into a true
+  // per-match shape so a single game can mix 1v1 + 2v2.)
+  const loadedMatchesForShape = matchesQ.data?.matches ?? [];
+  const sided =
+    loadedMatchesForShape.length > 0
+      ? loadedMatchesForShape.some(
+          (m) =>
+            (m.side_a as { type?: string } | null)?.type === "play_group" ||
+            (m.side_b as { type?: string } | null)?.type === "play_group"
+        )
+      : search.get("format") === "doubles";
   const playersPerSide = sided ? 2 : 1;
 
   // The matches that are actually playable — both sides fully assigned. An
@@ -510,16 +524,12 @@ export function MatchGameView() {
     // The checklist lives on the settings overlay; seed the draft when it opens
     // with an empty local draft.
     if (!cfgOpen || draft.length > 0) return;
-    // WAIT for the game row before seeding. `sided` (→ playersPerSide) is derived
-    // from gameQ.data.game_type_id; matches.listByGame and games.getById are
-    // separate queries, and on a fresh reopen the leaderboard deep-links to
-    // `?game=X&settings=1` (no `format` hint), so matches can land BEFORE the game
-    // does. Seeding in that window uses the fallback `sided=false` and rebuilds a
-    // DOUBLES game as singles — each side's play_group id gets read as a user id —
-    // then the `draft.length > 0` guard freezes that wrong seed even after gameQ
-    // loads and sided flips true. (Singles is unaffected: sided=false is already
-    // correct, which is why 1v1 worked and 2v2 lost its matches on reopen.) Gate on
-    // the loaded row so the one seed we take uses the authoritative format.
+    // Wait for the game row before seeding (course/modifiers/name come from it).
+    // NB (Refactor A1): the old "matches-land-before-the-game-row → doubles seeded
+    // as singles" race is GONE — `sided` now derives from `matchesQ` (the same
+    // query as the matches being seeded), not `gameQ.data.game_type_id`, so shape
+    // and matches are always consistent. This gate remains only so the seed reads
+    // a loaded game row for its other fields.
     if (gameId && !gameQ.data) return;
     if (serverMatches.length > 0) {
       setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide));
@@ -559,7 +569,9 @@ export function MatchGameView() {
     if (!tripId) return;
     const g = await createGame.mutateAsync({
       tripId,
-      gameTypeId: sided ? MATCH_PLAY_DOUBLES : MATCH_PLAY,
+      // One unified type (A1) — the shape lives on the matches the builder writes,
+      // not the game type. The name still reflects the current game-level shape.
+      gameTypeId: MATCH_PLAY,
       name: sided ? "2v2 Match Play" : "Singles Match Play",
       teeTime: teeTime || null,
     });

--- a/src/lib/gameRoutes.test.ts
+++ b/src/lib/gameRoutes.test.ts
@@ -4,8 +4,7 @@ import { gameHref, isGolfFormat, MANUAL_ROUTE } from "@/lib/gameRoutes";
 describe("gameHref", () => {
   it("routes golf formats to their per-format game pages", () => {
     expect(gameHref("trip1", "gtt_stroke_play", "g1")).toBe("/trips/trip1/games/new?game=g1");
-    expect(gameHref("trip1", "gtt_match_play_singles", "g1")).toBe("/trips/trip1/games/match/new?game=g1");
-    expect(gameHref("trip1", "gtt_match_play_doubles", "g1")).toBe("/trips/trip1/games/match/new?game=g1");
+    expect(gameHref("trip1", "gtt_match_play", "g1")).toBe("/trips/trip1/games/match/new?game=g1");
     expect(gameHref("trip1", "gtt_rack_n_stack", "g1")).toBe("/trips/trip1/games/rack/new?game=g1");
   });
 
@@ -24,7 +23,7 @@ describe("gameHref", () => {
     expect(gameHref("trip1", "gtt_stroke_play", "g1", { settings: true })).toBe(
       "/trips/trip1/games/new?game=g1&settings=1"
     );
-    expect(gameHref("trip1", "gtt_match_play_singles", "g1", { settings: true })).toBe(
+    expect(gameHref("trip1", "gtt_match_play", "g1", { settings: true })).toBe(
       "/trips/trip1/games/match/new?game=g1&settings=1"
     );
     expect(gameHref("trip1", "gtt_rack_n_stack", "g1", { settings: true })).toBe(
@@ -44,7 +43,7 @@ describe("gameHref", () => {
 
   it("scorecard → the single format-agnostic empty-preview route, golf only", () => {
     // Every golf format shares ONE scorecard route (it only needs the schema).
-    for (const t of ["gtt_stroke_play", "gtt_match_play_singles", "gtt_match_play_doubles", "gtt_rack_n_stack"]) {
+    for (const t of ["gtt_stroke_play", "gtt_match_play", "gtt_rack_n_stack"]) {
       expect(gameHref("trip1", t, "g1", { scorecard: true })).toBe("/trips/trip1/games/scorecard?game=g1");
     }
     // Non-golf has no course → no scorecard link.

--- a/src/lib/gameRoutes.ts
+++ b/src/lib/gameRoutes.ts
@@ -11,8 +11,7 @@ import { isManualGameType } from "@/lib/gameTypes";
  *  deliberately does NOT make it read as golf.) */
 const GAME_ROUTES: Record<string, string> = {
   gtt_stroke_play: "new",
-  gtt_match_play_singles: "match/new",
-  gtt_match_play_doubles: "match/new",
+  gtt_match_play: "match/new",
   gtt_rack_n_stack: "rack/new",
 };
 
@@ -58,10 +57,10 @@ export function isGolfFormat(gameTypeId: string | null): boolean {
   return !!gameTypeId && gameTypeId in GAME_ROUTES;
 }
 
-/** Match-play formats (singles + doubles). Match play was the FIRST format to
- *  open as a layered panel (Spec 2 Phase 1). */
+/** Match play (1v1 / 2v2 / mixed — one unified type as of Refactor A1). Match play
+ *  was the FIRST format to open as a layered panel (Spec 2 Phase 1). */
 export function isMatchPlayFormat(gameTypeId: string | null): boolean {
-  return gameTypeId === "gtt_match_play_singles" || gameTypeId === "gtt_match_play_doubles";
+  return gameTypeId === "gtt_match_play";
 }
 
 /** Rack-n-stack. Opens as a panel (Spec 2 Phase 2). */

--- a/src/lib/gameTypes.test.ts
+++ b/src/lib/gameTypes.test.ts
@@ -16,7 +16,7 @@ const id = (t: { id: string }) => t.id;
 
 describe("isGameTypeForScoringModel", () => {
   const stroke = GAME_TYPES.find((t) => t.id === "gtt_stroke_play")!;
-  const singles = GAME_TYPES.find((t) => t.id === "gtt_match_play_singles")!;
+  const matchPlay = GAME_TYPES.find((t) => t.id === "gtt_match_play")!;
   const rack = GAME_TYPES.find((t) => t.id === "gtt_rack_n_stack")!;
   const manual = GAME_TYPES.find((t) => t.id === "gtt_manual")!;
 
@@ -25,9 +25,9 @@ describe("isGameTypeForScoringModel", () => {
     expect(isGameTypeForScoringModel(stroke, "match_play")).toBe(false);
   });
 
-  it("match-play formats are match_play-only", () => {
-    expect(isGameTypeForScoringModel(singles, "match_play")).toBe(true);
-    expect(isGameTypeForScoringModel(singles, "points")).toBe(false);
+  it("match play is match_play-only", () => {
+    expect(isGameTypeForScoringModel(matchPlay, "match_play")).toBe(true);
+    expect(isGameTypeForScoringModel(matchPlay, "points")).toBe(false);
   });
 
   it("rack-n-stack is match_play (net-stroke ENTRY is not the points scoring-model)", () => {
@@ -42,15 +42,14 @@ describe("isGameTypeForScoringModel", () => {
 
   it("a null/absent scoring-model is permissive (never an empty menu)", () => {
     expect(isGameTypeForScoringModel(stroke, null)).toBe(true);
-    expect(isGameTypeForScoringModel(singles, undefined)).toBe(true);
+    expect(isGameTypeForScoringModel(matchPlay, undefined)).toBe(true);
   });
 });
 
 describe("gameTypesForScoringModel — the offered menu", () => {
-  it("a match_play comp offers 1v1/2v2/rack + manual, NOT stroke", () => {
+  it("a match_play comp offers match play + rack + manual, NOT stroke", () => {
     const offered = gameTypesForScoringModel("match_play").map(id);
-    expect(offered).toContain("gtt_match_play_singles");
-    expect(offered).toContain("gtt_match_play_doubles");
+    expect(offered).toContain("gtt_match_play"); // one unified type (was singles + doubles)
     expect(offered).toContain("gtt_rack_n_stack");
     expect(offered).toContain("gtt_manual"); // manual types fit any comp
     expect(offered).not.toContain("gtt_stroke_play");
@@ -60,8 +59,7 @@ describe("gameTypesForScoringModel — the offered menu", () => {
     const offered = gameTypesForScoringModel("points").map(id);
     expect(offered).toContain("gtt_stroke_play");
     expect(offered).toContain("gtt_manual");
-    expect(offered).not.toContain("gtt_match_play_singles");
-    expect(offered).not.toContain("gtt_match_play_doubles");
+    expect(offered).not.toContain("gtt_match_play");
     expect(offered).not.toContain("gtt_rack_n_stack");
   });
 

--- a/src/lib/gameTypes.ts
+++ b/src/lib/gameTypes.ts
@@ -116,21 +116,18 @@ const strokeSchema = {
   participants: { min: 2, max: 4, participant_type: "individual", assigned_pairings: false },
 } as ScorecardSchema;
 
-const singlesSchema = {
+// Unified match-play scorecard (Refactor A1) — one schema for singles + doubles +
+// mixed, since 1v1-vs-2v2 is a per-MATCH property (each `game_matches.side_a/b`
+// carries its own `{type:"user"|"play_group"}`), not a game-level fact. Carries
+// par + handicap_index (the former singles schema; the old doubles schema dropped
+// handicap_index — incidental drift, corrected here). The participants block is
+// display metadata only — the engine reads shape per-match from the side refs.
+const matchPlaySchema = {
   units: { type: "holes", count: 18, ordered: true, labels: HOLE_LABELS, metadata: { par: PAR_72, handicap_index: STROKE_INDEX_DEFAULT } },
   entry: { value_type: "integer", value_label: "Strokes", min: 1, max: null },
   scoring: { strategy: "match_play", direction: "low_wins", aggregation: "match", sections: SECTIONS_18, tiebreaker: "shared" },
   interaction: { model: "simultaneous", entry_timing: "per_unit" },
-  participants: { min: 2, max: 4, participant_type: "individual", assigned_pairings: true },
-} as ScorecardSchema;
-
-const doublesSchema = {
-  // NB: doubles carries par only (no handicap_index) — matches the live row.
-  units: { type: "holes", count: 18, ordered: true, labels: HOLE_LABELS, metadata: { par: PAR_72 } },
-  entry: { value_type: "integer", value_label: "Strokes", min: 1, max: null },
-  scoring: { strategy: "match_play", direction: "low_wins", aggregation: "match", sections: SECTIONS_18, tiebreaker: "shared" },
-  interaction: { model: "simultaneous", entry_timing: "per_unit" },
-  participants: { min: 4, max: 8, participant_type: "side", players_per_side: 2, assigned_pairings: true },
+  participants: { min: 2, max: 8, participant_type: "individual", assigned_pairings: true },
 } as ScorecardSchema;
 
 const rackSchema = {
@@ -167,37 +164,32 @@ export const GAME_TYPE_DEFINITIONS: Record<string, GameTypeDefinition> = {
     maxPlayersPerSide: null,
     compatibleScoringModels: ["points"],
   },
-  gtt_match_play_singles: {
-    id: "gtt_match_play_singles",
-    key: "match_play_singles",
-    name: "Singles Match Play",
-    description: "You versus one other player, straight up. Low net score wins each hole — win more holes than your opponent and the match is yours.",
+  gtt_match_play: {
+    // Refactor A1 — the unified match-play type (was gtt_match_play_singles +
+    // gtt_match_play_doubles). 1v1-vs-2v2 is a per-MATCH property (each match's
+    // side type), so a game can be all-singles, all-doubles, or a mix. The engine
+    // was already shape-agnostic (reads side type per row); this collapses the
+    // game-level fork. A migration re-tags existing singles/doubles rows to this id.
+    id: "gtt_match_play",
+    key: "match_play",
+    name: "Match Play",
+    description: "Head-to-head, hole by hole — low net score wins each hole, and winning more holes wins the match. Each match is 1v1 or 2v2, and one game can mix both.",
     sortOrder: 1,
     category: "golf",
+    // entrySchema is inert metadata (no runtime reader) — per-match entry
+    // granularity (per-user 1v1 vs per-side 2v2) is derived from each match's side
+    // type, not this field.
     entrySchema: "user_holes",
     resultStrategy: "match_play",
-    scorecardSchema: singlesSchema,
-    compatibleModifiers: ["moving_tees", "glorious_holes"], // BOTH branch — glorious applies to match play (scoring engine)
+    scorecardSchema: matchPlaySchema,
+    // Union of the former singles+doubles sets. Still the provisional test-matrix
+    // (see DEFERRED's modifier-applicability reconcile) — not final applicability.
+    compatibleModifiers: ["moving_tees", "glorious_holes"],
     supportsFreeForAll: false,
     supportsSides: true,
     requiresSides: true,
-    maxPlayersPerSide: 1,
-    compatibleScoringModels: ["match_play"],
-  },
-  gtt_match_play_doubles: {
-    id: "gtt_match_play_doubles",
-    key: "match_play_doubles",
-    name: "2v2 Match Play",
-    description: "You and a teammate take on another pair from the opposing side. Together, you put your score up against your opponents and whichever side wins the most holes takes the match.",
-    sortOrder: 2,
-    category: "golf",
-    entrySchema: "group_holes",
-    resultStrategy: "match_play",
-    scorecardSchema: doublesSchema,
-    compatibleModifiers: ["glorious_holes"], // stepper-only branch — glorious applies to match play (scoring engine)
-    supportsFreeForAll: false,
-    supportsSides: true,
-    requiresSides: true,
+    // Per-match now — inert metadata (no runtime reader); kept as the max any
+    // single match supports.
     maxPlayersPerSide: 2,
     compatibleScoringModels: ["match_play"],
   },

--- a/src/lib/gloriousHoles.test.ts
+++ b/src/lib/gloriousHoles.test.ts
@@ -9,17 +9,17 @@ describe("gloriousConfig — read + format guard", () => {
   const on = { glorious_holes: { holes: 3 } };
 
   it("reads enabled + N off a match-play game's modifiers", () => {
-    expect(gloriousConfig("gtt_match_play_singles", on)).toEqual({ enabled: true, n: 3 });
-    expect(gloriousConfig("gtt_match_play_doubles", { glorious_holes: { holes: 5 } })).toEqual({ enabled: true, n: 5 });
+    expect(gloriousConfig("gtt_match_play", on)).toEqual({ enabled: true, n: 3 });
+    expect(gloriousConfig("gtt_match_play", { glorious_holes: { holes: 5 } })).toEqual({ enabled: true, n: 5 });
   });
 
   it("legacy `{}` shape reads as the default N=3 (existing rows don't break)", () => {
-    expect(gloriousConfig("gtt_match_play_singles", { glorious_holes: {} })).toEqual({ enabled: true, n: 3 });
+    expect(gloriousConfig("gtt_match_play", { glorious_holes: {} })).toEqual({ enabled: true, n: 3 });
   });
 
   it("absent key = disabled (presence-model)", () => {
-    expect(gloriousConfig("gtt_match_play_singles", {})).toBe(NO_GLORIOUS);
-    expect(gloriousConfig("gtt_match_play_singles", null)).toBe(NO_GLORIOUS);
+    expect(gloriousConfig("gtt_match_play", {})).toBe(NO_GLORIOUS);
+    expect(gloriousConfig("gtt_match_play", null)).toBe(NO_GLORIOUS);
   });
 
   it("FORMAT GUARD: inert for stroke / rack / manual even with the flag forced on", () => {

--- a/src/lib/modifiers.test.ts
+++ b/src/lib/modifiers.test.ts
@@ -58,11 +58,8 @@ describe("render-branch matrix (gameTypes.ts → registry)", () => {
   it("stroke_play → [checkbox] (CHECKBOX-only — moving_tees; glorious does NOT apply to stroke)", () => {
     expect(controlsFor("gtt_stroke_play")).toEqual(["checkbox"]);
   });
-  it("match_play_doubles → [checkbox+stepper] (STEPPER-only — glorious applies)", () => {
-    expect(controlsFor("gtt_match_play_doubles")).toEqual(["checkbox+stepper"]);
-  });
-  it("match_play_singles → [checkbox, checkbox+stepper] (BOTH — moving_tees + glorious)", () => {
-    expect(controlsFor("gtt_match_play_singles")).toEqual(["checkbox", "checkbox+stepper"]);
+  it("match_play → [checkbox, checkbox+stepper] (BOTH — moving_tees + glorious; unified type)", () => {
+    expect(controlsFor("gtt_match_play")).toEqual(["checkbox", "checkbox+stepper"]);
   });
 });
 

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -8,10 +8,13 @@ import { isManualGameType } from "@/lib/gameTypes";
 import { isConfigured, MATCH_PLAY_TYPES, RACK_TYPE } from "@/server/lib/gameReadiness";
 import { computeLiveProjections, type LiveProjectionInput } from "@/server/lib/liveProjection";
 
-/** Singles vs doubles head-to-head sizing for the team-size-derived formats
- *  (rack-n-stack). Match play itself counts its configured rows instead. */
-function matchFormat(gameTypeId: string | null): MatchFormat {
-  return gameTypeId === "gtt_match_play_doubles" ? "doubles" : "singles";
+/** Head-to-head sizing for the team-size-derived per_match formats (rack-n-stack,
+ *  whose slots are always 1v1). Match play itself counts its configured
+ *  `game_matches` rows (`matchCountByGame`), never this path — and the standalone
+ *  doubles game type was unified away (Refactor A1), so there is no game-level
+ *  "doubles" left to size. Kept as a stable seam for `deriveMatchCount`. */
+function matchFormat(_gameTypeId: string | null): MatchFormat {
+  return "singles";
 }
 
 /**

--- a/src/server/lib/gameReadiness.ts
+++ b/src/server/lib/gameReadiness.ts
@@ -12,7 +12,10 @@ import { matchPlayReady } from "@/lib/matchDraft";
  * handicaps are optional and NEVER gate readiness.
  */
 
-export const MATCH_PLAY_TYPES = new Set(["gtt_match_play_singles", "gtt_match_play_doubles"]);
+// One unified match-play type (Refactor A1) — 1v1/2v2/mixed is per-match, not a
+// game type. A Set is kept (rather than an equality) so any future match-play
+// variant slots in without touching call sites.
+export const MATCH_PLAY_TYPES = new Set(["gtt_match_play"]);
 export const RACK_TYPE = "gtt_rack_n_stack";
 // Roster-gated golf formats: a stroke field is "configured" once it has
 // participants; rack additionally requires those participants to be GROUPED into

--- a/src/server/lib/liveProjection.test.ts
+++ b/src/server/lib/liveProjection.test.ts
@@ -16,7 +16,7 @@ const part = (user_id: string) => ({ user_id, play_group_id: null, handicap_stro
 
 describe("projectGame — match play", () => {
   it("sums each match's current standing to per-team COMPETITION points (leader full, all-square halved)", () => {
-    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play_singles", pointsPerMatch: 2 };
+    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play", pointsPerMatch: 2 };
     const data: GameProjectionData = {
       schema: { units: { count: 2 } }, // 2-hole round, no course index → sequential fallback
       modifiers: null,
@@ -39,7 +39,7 @@ describe("projectGame — match play", () => {
   });
 
   it("an unpaired match (a side missing) contributes nothing", () => {
-    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play_singles", pointsPerMatch: 2 };
+    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play", pointsPerMatch: 2 };
     const data: GameProjectionData = {
       schema: { units: { count: 2 } },
       modifiers: null,

--- a/src/server/routers/competitions.d1followon.test.ts
+++ b/src/server/routers/competitions.d1followon.test.ts
@@ -15,7 +15,7 @@ import { TestContext } from "../../__tests__/helpers/test-setup";
  */
 
 const MANUAL = "gtt_manual";
-const MATCH_PLAY = "gtt_match_play_singles";
+const MATCH_PLAY = "gtt_match_play";
 
 let ctx: TestContext;
 let tripId: string;

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -294,7 +294,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     await ctx.createTeam(comp, "A", { shortName: "A" });
     await ctx.createTeam(comp, "B", { shortName: "B" });
     const g = await ctx.caller().games.create({
-      tripId, gameTypeId: "gtt_match_play_singles", name: "Roster Gate", competitionId: comp,
+      tripId, gameTypeId: "gtt_match_play", name: "Roster Gate", competitionId: comp,
       pointsDistribution: { type: "per_match", value: 2 },
     }) as { id: string };
     gameIds.push(g.id);
@@ -341,7 +341,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     await ctx.createTeam(comp, "A", { shortName: "A" });
     await ctx.createTeam(comp, "B", { shortName: "B" });
     const g = await ctx.caller().games.create({
-      tripId, gameTypeId: "gtt_match_play_singles", name: "Partial", competitionId: comp,
+      tripId, gameTypeId: "gtt_match_play", name: "Partial", competitionId: comp,
       pointsDistribution: { type: "per_match", value: 2 },
     }) as { id: string };
     gameIds.push(g.id);

--- a/src/server/routers/competitions.reset.test.ts
+++ b/src/server/routers/competitions.reset.test.ts
@@ -63,7 +63,7 @@ async function makeMatchGame(): Promise<string> {
   const id = gid("reset-match");
   gameIds.push(id);
   await ctx.admin.from("games").insert({
-    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play_singles",
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play",
     name: "Match", status: "complete", corrections_open: false, scoring_enabled: true,
     points_distribution: { type: "per_match", value: 2 }, points_total: null,
   });
@@ -88,7 +88,7 @@ async function makeDoublesGame(): Promise<string> {
   const id = gid("reset-doubles");
   gameIds.push(id);
   await ctx.admin.from("games").insert({
-    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play_doubles",
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play",
     name: "Doubles", status: "active", scoring_enabled: true,
     points_distribution: { type: "per_match", value: 1 },
   });

--- a/src/server/routers/courses.test.ts
+++ b/src/server/routers/courses.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext } from "../../__tests__/helpers/test-setup";
 
-const MATCH_PLAY = "gtt_match_play_singles";
+const MATCH_PLAY = "gtt_match_play";
 const PAR = [4, 5, 3, 4, 4, 3, 5, 4, 4, 4, 3, 5, 4, 4, 3, 4, 5, 4];
 const IDX = [7, 3, 15, 1, 11, 5, 17, 9, 13, 8, 4, 16, 2, 12, 6, 18, 10, 14];
 

--- a/src/server/routers/delegateSetupGate.test.ts
+++ b/src/server/routers/delegateSetupGate.test.ts
@@ -14,7 +14,7 @@ import { TestContext } from "../../__tests__/helpers/test-setup";
  *   - the grant is game-isolated (delegate of A can't touch B).
  */
 
-const MATCH = "gtt_match_play_singles";
+const MATCH = "gtt_match_play";
 const RACK = "gtt_rack_n_stack";
 
 let ctx: TestContext;

--- a/src/server/routers/games.reset.test.ts
+++ b/src/server/routers/games.reset.test.ts
@@ -32,7 +32,7 @@ async function makeMatchGame(name: string): Promise<string> {
   const id = genId("pgreset-match");
   gameIds.push(id);
   await ctx.admin.from("games").insert({
-    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play_singles",
+    id, trip_id: tripId, competition_id: competitionId, game_type_id: "gtt_match_play",
     name, status: "complete", corrections_open: true, scoring_enabled: true,
     scorecard_schema: { units: { metadata: { par: [4, 4] } } },
     points_distribution: { type: "per_match", value: 2 }, points_total: null,
@@ -155,7 +155,7 @@ describe("games.resetToSkeleton — one game's config cleared, identity kept (in
     expect(tg.scoring_enabled).toBe(false); // un-armed
     // IDENTITY kept: shell + the per-match point VALUE survives (§E-1).
     expect(tg.name).toBe("SkelTarget");
-    expect(tg.game_type_id).toBe("gtt_match_play_singles");
+    expect(tg.game_type_id).toBe("gtt_match_play");
     expect(tg.points_distribution).toMatchObject({ type: "per_match", value: 2 });
 
     // SIBLING untouched: config + scoring all survive.

--- a/src/server/routers/matches.doubles.test.ts
+++ b/src/server/routers/matches.doubles.test.ts
@@ -10,7 +10,7 @@ import { TestContext } from "../../__tests__/helpers/test-setup";
  * game_results with entity_type='play_group'.
  */
 
-const DOUBLES = "gtt_match_play_doubles";
+const DOUBLES = "gtt_match_play";
 
 type Side = { type: string; id: string } | null;
 interface MatchRow {

--- a/src/server/routers/matches.test.ts
+++ b/src/server/routers/matches.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext } from "../../__tests__/helpers/test-setup";
 
-const MATCH_PLAY = "gtt_match_play_singles";
+const MATCH_PLAY = "gtt_match_play";
 
 type Side = { type: string; id: string } | null;
 interface MatchRow {

--- a/src/server/routers/rosterLock.test.ts
+++ b/src/server/routers/rosterLock.test.ts
@@ -52,7 +52,7 @@ describe("roster-removal lock", () => {
       const gameId = genId("rl-game");
       await ctx.admin.from("games").insert({
         id: gameId, trip_id: tripId, competition_id: competitionId,
-        game_type_id: "gtt_match_play_singles", name: "Locker", status: "active",
+        game_type_id: "gtt_match_play", name: "Locker", status: "active",
         points_distribution: { type: "per_match", value: 2 },
       });
       const { error } = await ctx.admin.from("score_entries").insert({

--- a/src/server/routers/scores.permissions.test.ts
+++ b/src/server/routers/scores.permissions.test.ts
@@ -12,8 +12,8 @@ import { TestContext } from "../../__tests__/helpers/test-setup";
  * (pure); this proves the guard is WIRED on every format's write path.
  */
 const STROKE = "gtt_stroke_play";
-const SINGLES = "gtt_match_play_singles";
-const DOUBLES = "gtt_match_play_doubles";
+const SINGLES = "gtt_match_play";
+const DOUBLES = "gtt_match_play";
 const RACK = "gtt_rack_n_stack";
 
 let ctx: TestContext;

--- a/supabase/migrations/20260712120000_073_unify_match_play.sql
+++ b/supabase/migrations/20260712120000_073_unify_match_play.sql
@@ -1,0 +1,90 @@
+-- 073 — Unify match play: gtt_match_play_singles + gtt_match_play_doubles → one
+--       gtt_match_play game type (Refactor A1).
+--
+-- 1v1-vs-2v2 is a per-MATCH property, not a game type: each `game_matches` row
+-- already carries a self-describing `{type:"user"|"play_group"}` side ref, and the
+-- scoring engine (buildDecided / matchState / computeMatchPlayResults) resolves
+-- each side PER ROW — it never reads game_type_id. So the two types were one type
+-- encoded as two. This collapses them: insert the unified template, then re-tag
+-- every existing singles/doubles game to it. Existing games keep working unchanged
+-- (their shape lives on their match sides, which this does not touch).
+--
+-- SAFETY (RLS-risk class — game_type_id): audited every policy + SECURITY DEFINER
+-- function; NONE branch on game_type_id. The one format-adjacent function,
+-- can_score_unit (mig 072), resolves the scoring unit from game_matches side type
+-- + game_participants.play_group_id, NOT game_type_id — so re-tagging cannot shift
+-- any access decision. Idempotent.
+
+-- ── 1. The unified template row ──────────────────────────────────────────────
+-- Same engine as before (result_strategy='match_play'); shape is per-match, so
+-- max_players_per_side is the max any single match supports (2). scorecard_schema
+-- carries par + handicap_index (the singles schema; the old doubles row dropped
+-- handicap_index — incidental drift, corrected here). compatible_modifiers is the
+-- union of the former sets.
+INSERT INTO public.game_type_templates (
+  id, key, name, description, sort_order,
+  entry_schema, result_strategy,
+  supports_free_for_all, supports_sides, requires_sides, max_players_per_side,
+  compatible_competition_formats, compatible_modifiers, category,
+  config_schema, scorecard_schema
+)
+VALUES (
+  'gtt_match_play', 'match_play', 'Match Play',
+  'Head-to-head, hole by hole — low net score wins each hole, and winning more holes wins the match. Each match is 1v1 or 2v2, and one game can mix both.', 1,
+  'user_holes', 'match_play',
+  false, true, true, 2,
+  ARRAY['ryder_cup']::text[], ARRAY['moving_tees', 'glorious_holes']::text[], 'golf',
+  '{}'::jsonb,
+  '{
+    "units": {
+      "type": "holes", "count": 18, "ordered": true,
+      "labels": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18"],
+      "metadata": {
+        "par": [4,5,3,4,4,3,5,4,4,4,3,5,4,4,3,4,5,4],
+        "handicap_index": [7,3,15,1,11,5,17,9,13,8,4,16,2,12,6,18,10,14]
+      }
+    },
+    "entry": { "value_type": "integer", "value_label": "Strokes", "min": 1, "max": null },
+    "scoring": {
+      "strategy": "match_play", "direction": "low_wins", "aggregation": "match",
+      "sections": [
+        { "name": "Front 9", "units": ["1","2","3","4","5","6","7","8","9"] },
+        { "name": "Back 9", "units": ["10","11","12","13","14","15","16","17","18"] }
+      ],
+      "tiebreaker": "shared"
+    },
+    "participants": { "min": 2, "max": 8, "participant_type": "individual", "assigned_pairings": true },
+    "interaction": { "model": "simultaneous", "entry_timing": "per_unit" }
+  }'::jsonb
+)
+ON CONFLICT (id) DO UPDATE SET
+  key = EXCLUDED.key,
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  sort_order = EXCLUDED.sort_order,
+  entry_schema = EXCLUDED.entry_schema,
+  result_strategy = EXCLUDED.result_strategy,
+  supports_free_for_all = EXCLUDED.supports_free_for_all,
+  supports_sides = EXCLUDED.supports_sides,
+  requires_sides = EXCLUDED.requires_sides,
+  max_players_per_side = EXCLUDED.max_players_per_side,
+  compatible_competition_formats = EXCLUDED.compatible_competition_formats,
+  compatible_modifiers = EXCLUDED.compatible_modifiers,
+  category = EXCLUDED.category,
+  config_schema = EXCLUDED.config_schema,
+  scorecard_schema = EXCLUDED.scorecard_schema;
+
+-- ── 2. Re-tag existing games ─────────────────────────────────────────────────
+-- Every singles/doubles game becomes a unified match_play game. Their per-match
+-- shape is untouched (it lives on game_matches.side_a/side_b), so they compute and
+-- render identically — a doubles game's play_group-typed sides still read as 2v2.
+UPDATE public.games
+SET game_type_id = 'gtt_match_play'
+WHERE game_type_id IN ('gtt_match_play_singles', 'gtt_match_play_doubles');
+
+-- ── 3. Old template rows ─────────────────────────────────────────────────────
+-- The gtt_match_play_singles / gtt_match_play_doubles template rows are now
+-- orphaned anchors (no games reference them after step 2; no runtime code queries
+-- game_type_templates — gameTypes.ts is the code home of record). Left in place;
+-- a dedicated cleanup migration can drop them once confirmed unreferenced across
+-- all environments (audit-before-delete).


### PR DESCRIPTION
## Summary

Phase **A1** of Refactor A (match-play participant shape). Collapses `gtt_match_play_singles` + `gtt_match_play_doubles` into **one `gtt_match_play`** type, where 1v1-vs-2v2 is a per-match property. This is the deliberately **risky-boring** first phase — unify the *type* and re-tag existing data safely. The per-match **builder** (mixed games) is A2; the "counts double" multiplier is A3. Neither is in this PR.

Basis: the match-play engine diagnosis, which found the scoring engine already shape-agnostic (each `game_matches.side_a/b` carries a self-describing `{type:"user"|"play_group"}` ref; `buildDecided`/`matchState`/`computeMatchPlayResults` never read `game_type_id`).

## Phase 0 (reported & gated before building)

- **RLS gate — PASSED.** Audited every policy + `SECURITY DEFINER` function: **none** branch on `game_type_id`. The one format-adjacent function, `can_score_unit` (mig 072), resolves the scoring unit from `game_matches` side type + `game_participants.play_group_id` — never `game_type_id` — so re-tagging cannot shift any access decision.
- **Canonical id — new `gtt_match_play`** (re-tag *both* old ids), chosen over reusing the singles id to avoid a permanent "singles"-named-doubles-game false-friend.

## Changes

- **`gameTypes.ts`** — one `gtt_match_play` definition. `compatibleModifiers` = union of the two former sets; scorecard schema keeps `handicap_index` (the old doubles schema had dropped it — incidental drift, corrected). `entrySchema`/`maxPlayersPerSide` are inert metadata (no runtime reader) — per-match granularity comes from the side type.
- **Predicates collapsed** — `gameRoutes` (`GAME_ROUTES` + `isMatchPlayFormat`), `gameReadiness` (`MATCH_PLAY_TYPES`), `competitionLeaderboard` (`matchFormat` — its doubles branch was already dead; only the rack fallback reaches it).
- **`MatchGameView`** — `sided` now derives from the game's **own matches** (`side_a.type === "play_group"`), not `game_type_id`. This also **retires the documented "matches-land-before-the-game-row → doubles seeded as singles" race** (shape + matches now come from the same query). `handleCreate` creates the one unified id. The twinned `setPairings`/`setDoublesPairings` mutations **stay** (A2 unifies them per-match).
- **Migration 073** — insert the `gtt_match_play` template row, then re-tag every existing singles/doubles game to it. Idempotent (`ON CONFLICT DO UPDATE` + `UPDATE … WHERE IN`). Old template rows left as inert anchors (cleanup deferred, audit-before-delete). **The scoring engine is untouched** — it was already shape-agnostic.

## Deliberate A1 phase boundary (flagged)

The picker now offers **one "Match Play" chip**; a picker-created game defaults to singles-shaped building. **Existing doubles games (including scored ones) are fully preserved** — their `play_group`-typed sides make `sided` read 2v2, and the engine computes them identically. Building **new** doubles/mixed games is A2's per-match builder. The standalone `/games/match/new?format=doubles` route still builds doubles in A1.

## Test plan

- `tsc --noEmit` clean, `next lint` clean.
- **108 pure-logic tests green locally** (gameTypes / gameRoutes / gloriousHoles / modifiers / matchPlay / rackNStack / projection).
- The **DB-integration suite needs the migration**, which **CI applies (`db push`) before vitest** against the same remote project — so those run green in CI, not locally (no local DB URL here). ~16 test fixtures re-pointed to `gtt_match_play` (doubles fixtures still build `play_group` sides).
- **Real-data verification follows on the Vercel preview deploy** (post-CI-apply): existing singles + doubles games open/score/finish identically; picker offers one "Match Play". This is the A1 "verify on real data before A2" gate.

## Guardrails

`per_match` is **not** renamed. The scoring engine, permission model, projection, and finish path are untouched. The A3 per-match multiplier is a distinct concept, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)