### PR TITLE
Refactor A2a: per-match shape in the match-play builder (mixed games)

### DIFF
--- a/e2e/match-play.spec.ts
+++ b/e2e/match-play.spec.ts
@@ -144,8 +144,10 @@ async function driveToSetupWithHandicap(page: Page) {
   const pairings = page.getByTestId("match-pairings");
   await expect(pairings).toBeVisible({ timeout: 20_000 });
   // A new game opens at 0 matches (the valid empty state — just "Add match", no
-  // table). Add the first match to get the pairing slots.
+  // table). "Add match" reveals a shape choice (per-match shape, A2a); pick
+  // "Add singles" for a 1v1 match → two pairing slots.
   await pairings.getByRole("button", { name: "Add match" }).click();
+  await pairings.getByRole("button", { name: /Add singles/ }).click();
   // Fill slot A then slot B. Each pick is gated open→pick→closed so the picks can't
   // race the picker mount/unmount: open the slot, wait for the picker, pick (scoped
   // to the picker so the click can't hit a filled-slot button), wait for it to

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -21,6 +21,7 @@ import { StandardGrid } from "@/components/games/StandardGrid";
 import { ScorecardSheet } from "@/components/games/ScorecardSheet";
 import { useScorecardTeeRows } from "@/hooks/useScorecardTeeRows";
 import { RelHandicapControl } from "@/components/games/RelHandicapControl";
+import type { SidePlayer } from "@/components/games/MatchSides";
 import { DragHandle } from "@/components/games/DragHandle";
 import { RowNumber } from "@/components/games/RowNumber";
 import { PlayerChip } from "@/components/games/PlayerChip";
@@ -64,6 +65,9 @@ const MAX_MATCHES = 24;
 type SideRef = { type: "user" | "play_group"; id: string } | null;
 interface DraftMatch {
   matchNumber: number;
+  /** Per-match shape (Refactor A2a): 1 = 1v1, 2 = 2v2. One game can mix both — a
+   *  side is FILLED when it carries exactly this many members. */
+  playersPerSide: 1 | 2;
   a: string[]; // member user ids on side A (≤ playersPerSide)
   b: string[]; // member user ids on side B
   handicap: number; // signed: <0 → a gets |n|, >0 → b gets n, 0 → even
@@ -230,30 +234,36 @@ export function MatchGameView() {
             (m.side_b as { type?: string } | null)?.type === "play_group"
         )
       : search.get("format") === "doubles";
-  const playersPerSide = sided ? 2 : 1;
 
-  // The matches that are actually playable — both sides fully assigned. An
-  // unfilled slot is not a match (it never scores), so teeing off COLLAPSES the
-  // game to these: the unfilled slots are discarded and points-in-play / the cup
-  // clinch recompute from this count. "Defined" was builder-time intent only.
-  const filledDraft = useMemo(
-    () => filledMatches(draft, playersPerSide),
-    [draft, playersPerSide]
+  // The matches that are actually playable — both sides fully assigned to their
+  // OWN shape. An unfilled slot is not a match (it never scores), so teeing off
+  // COLLAPSES the game to these: the unfilled slots are discarded and points-in-
+  // play / the cup clinch recompute from this count.
+  const filledDraft = useMemo(() => filledMatches(draft), [draft]);
+
+  // Per-match score-entry type (A2a): a 1v1 match writes per-user entries, a 2v2
+  // match writes per-side (play_group) entries — in the SAME mixed game. So the
+  // saver's participant_type is resolved PER participant id: any id that is one of
+  // this game's play_groups is 'play_group', otherwise 'user'. (The play_group id
+  // space is disjoint from user ids.)
+  const playGroupIdSet = useMemo(
+    () => new Set((matchesQ.data?.playGroups ?? []).map((pg) => (pg as { id: string }).id)),
+    [matchesQ.data]
   );
-
+  const participantTypeOf = useCallback(
+    (pid: string): "user" | "play_group" => (playGroupIdSet.has(pid) ? "play_group" : "user"),
+    [playGroupIdSet]
+  );
   // Scoring — the connectivity-resilient saver owns `values` + `saveStatus`:
   // optimistic value, retry-with-backoff, per-cell status, kept-and-flagged
-  // (never rolled back) on failure. 2v2 records ONE entry per side (the
-  // play_group), so the saver tags writes with participant_type='play_group'.
+  // (never rolled back) on failure.
   const { values, setValues, saveStatus, onChange, onClear, retryCell } =
-    useScoreSaver(tripId, gameId, sided ? "play_group" : undefined);
+    useScoreSaver(tripId, gameId, participantTypeOf);
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
   const setPairings = trpc.matches.setPairings.useMutation();
   const setHandicap = trpc.matches.setHandicap.useMutation();
-  const setDoublesPairings = trpc.matches.setDoublesPairings.useMutation();
-  const setDoublesHandicap = trpc.matches.setDoublesHandicap.useMutation();
   const enableScoring = trpc.matches.enableScoring.useMutation();
   // Phase 2B.1: Disable scoring — close to the crew, back to setup, scores kept.
   const disableScoring = trpc.games.disableScoring.useMutation();
@@ -379,7 +389,10 @@ export function MatchGameView() {
   // A side's team, DERIVED from its player(s): a user side → that user's team; a
   // pair side → its members' team (both members share one, enforced at setup).
   const teamOfSide = (sideId: string): { id: string; name: string; short_name: string | null; color: string } | undefined => {
-    const memberId = sided ? (membersOfSide.get(sideId) ?? [])[0] : sideId;
+    // Per-match (A2a): resolve the side's type from the data, not a game flag — a
+    // 2v2 side is a play_group (in `membersOfSide`) → its first member's team; a
+    // 1v1 side IS the user. So one game can mix both.
+    const memberId = membersOfSide.has(sideId) ? (membersOfSide.get(sideId) ?? [])[0] : sideId;
     if (!memberId) return undefined;
     const teamId = teamOfUser.get(memberId);
     return teamId ? teamById.get(teamId) : undefined;
@@ -401,14 +414,14 @@ export function MatchGameView() {
   // play_group (2v2, from play_groups). Same map shape, the entry/board read it
   // identically.
   const handicapOf = useMemo(() => {
+    // Per-match (A2a): populate from BOTH tables unconditionally — user ids and
+    // play_group ids never collide, so a mixed game's sides each resolve against
+    // whichever holds their id (the server compute does exactly this).
     const m = new Map<string, number>();
-    if (sided) {
-      for (const pg of serverPlayGroups) m.set(pg.id, effectiveStrokes(pg));
-    } else {
-      for (const p of serverParticipants) m.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
-    }
+    for (const p of serverParticipants) m.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
+    for (const pg of serverPlayGroups) m.set(pg.id, effectiveStrokes(pg));
     return m;
-  }, [sided, serverParticipants, serverPlayGroups]);
+  }, [serverParticipants, serverPlayGroups]);
 
   function participant(id: string, fallbackColor?: string): Participant {
     const name = nameOf.get(id) ?? "Player";
@@ -420,12 +433,13 @@ export function MatchGameView() {
     };
   }
 
-  // A scoring side as one Participant. Singles → the user (unchanged). Doubles →
-  // the play_group: id = play_group id (the score key), name = "Alice & Bob".
-  // This is what lets the entry/board/overview render 2v2 with no changes — one
-  // input per side, exactly group_holes.
+  // A scoring side as one Participant, resolved PER SIDE (A2a): a 1v1 side is a user
+  // (unchanged); a 2v2 side is a play_group (id = play_group id = the score key).
+  // The score key + one-input-per-side shape is what lets entry/board/overview
+  // handle 2v2 with no change. (The overview strip's name is still the joined pair;
+  // the BUILDER surfaces render players via the shared SideChips instead.)
   function sideParticipant(sideId: string): Participant {
-    if (!sided) return participant(sideId);
+    if (!membersOfSide.has(sideId)) return participant(sideId); // 1v1 user side
     const members = membersOfSide.get(sideId) ?? [];
     const name = members.map((u) => nameOf.get(u) ?? "Player").join(" & ") || "TBD";
     return {
@@ -625,42 +639,28 @@ export function MatchGameView() {
     if (!tripId || !gameId) return false;
     const matches = filledDraft;
     if (matches.length === 0) return false;
-    if (sided) {
-      const saved = await setDoublesPairings.mutateAsync({
-        tripId,
-        gameId,
-        matches: matches.map((d, i) => ({
-          sideA: { members: d.a },
-          sideB: { members: d.b },
-          matchNumber: i + 1,
-        })),
-      });
-      const handicapWrites = matches.flatMap((d, i) => {
-        const row = saved[i] as { id: string; side_a: SideRef; side_b: SideRef } | undefined;
-        if (!row || d.handicap === 0) return [];
-        const recipient = d.handicap < 0 ? row.side_a : row.side_b;
-        if (!recipient?.id) return [];
-        return [setDoublesHandicap.mutateAsync({ tripId, gameId, matchId: row.id, recipientPlayGroupId: recipient.id, strokes: Math.abs(d.handicap) })];
-      });
-      await Promise.all(handicapWrites);
-    } else {
-      const saved = await setPairings.mutateAsync({
-        tripId,
-        gameId,
-        matches: matches.map((d, i) => ({
-          sideA: { type: "user" as const, id: d.a[0] },
-          sideB: { type: "user" as const, id: d.b[0] },
-          matchNumber: i + 1,
-        })),
-      });
-      const handicapWrites = matches.flatMap((d, i) => {
-        const row = saved[i] as { id: string } | undefined;
-        if (!row || d.handicap === 0) return [];
-        const recipientUserId = d.handicap < 0 ? d.a[0] : d.b[0];
-        return [setHandicap.mutateAsync({ tripId, gameId, matchId: row.id, recipientUserId, strokes: Math.abs(d.handicap) })];
-      });
-      await Promise.all(handicapWrites);
-    }
+    // ONE unified per-match write (A2a): each match carries its own shape via the
+    // members-per-side; the server mints a play_group only for a 2-member side.
+    const saved = await setPairings.mutateAsync({
+      tripId,
+      gameId,
+      matches: matches.map((d, i) => ({
+        playersPerSide: d.playersPerSide,
+        sideA: { members: d.a },
+        sideB: { members: d.b },
+        matchNumber: i + 1,
+      })),
+    });
+    // Handicap goes to the recipient SIDE by id — a user id (1v1) or the minted
+    // play_group id (2v2); the server resolves the table from the side's type.
+    const handicapWrites = matches.flatMap((d, i) => {
+      const row = saved[i] as { id: string; side_a: SideRef; side_b: SideRef } | undefined;
+      if (!row || d.handicap === 0) return [];
+      const recipient = d.handicap < 0 ? row.side_a : row.side_b;
+      if (!recipient?.id) return [];
+      return [setHandicap.mutateAsync({ tripId, gameId, matchId: row.id, recipientId: recipient.id, strokes: Math.abs(d.handicap) })];
+    });
+    await Promise.all(handicapWrites);
     return true;
   }
 
@@ -709,9 +709,8 @@ export function MatchGameView() {
       const allEmpty = draft.every((m) => m.a.length === 0 && m.b.length === 0);
       if (!allEmpty || !tripId || !gameId) return;
       try {
-        const empty = draft.map((_, i) => ({ sideA: null, sideB: null, matchNumber: i + 1 }));
-        if (sided) await setDoublesPairings.mutateAsync({ tripId, gameId, matches: empty });
-        else await setPairings.mutateAsync({ tripId, gameId, matches: empty });
+        const empty = draft.map((d, i) => ({ playersPerSide: d.playersPerSide, sideA: null, sideB: null, matchNumber: i + 1 }));
+        await setPairings.mutateAsync({ tripId, gameId, matches: empty });
         setCollapseError(false);
         if (competitionId) {
           utils.competitions.leaderboard.invalidate({ tripId, competitionId });
@@ -1180,14 +1179,14 @@ export function MatchGameView() {
         // physically gates Handicaps behind Matches. Collapse = acknowledge +
         // persist (the draft editors commit on close). Course + Name·Format·Points
         // stay overlays this pass (tracked follow-ons) but ride the same one-open.
-        const allFilled = allMatchesFilled(draft, playersPerSide);
+        const allFilled = allMatchesFilled(draft);
         // Roster integrity (team-identity PR 1, the D-gap catch): a paired side whose
         // player has LOST their team is invalid even though its SLOTS are full
         // (dropped-after-paired). The keystone predicate (teamRoster.ts) — distinct
         // from the slot-filled `allFilled` above. Only meaningful in a 2-team
         // competition (standalone match play has no teams → always roster-valid).
         const teamedUserIds = new Set(teamOfUser.keys());
-        const allRosterValid = !twoTeams || draft.every((d) => matchRosterValid(d.a, d.b, playersPerSide, teamedUserIds));
+        const allRosterValid = !twoTeams || draft.every((d) => matchRosterValid(d.a, d.b, d.playersPerSide, teamedUserIds));
         // C3: points > 0 joins the Enable gate (Phase C) — but ONLY for a
         // COMPETITION game. Points-per-match is a cup concept: the inline Points row
         // exists only when `gameCompId` is set (GameSetupRows gates it on
@@ -1204,10 +1203,8 @@ export function MatchGameView() {
         // and Handicaps stay LOCKED until a match exists (they attach to a matchup).
         // Modifiers are NO LONGER gated on this (Task 3b — they're an early format
         // decision, decidable before matchups are set). One named predicate, shared.
-        const matchesExist = hasValidMatch(draft, playersPerSide);
-        const savingSetup =
-          setPairings.isPending || setHandicap.isPending ||
-          setDoublesPairings.isPending || setDoublesHandicap.isPending;
+        const matchesExist = hasValidMatch(draft);
+        const savingSetup = setPairings.isPending || setHandicap.isPending;
         // Standalone-only readout now (T4 hides this row for competitions), so the
         // count is just the trip crew — no roster branch.
         const availableCount = crew.data?.length ?? 0;
@@ -1223,19 +1220,24 @@ export function MatchGameView() {
         // pairing, and a hard cap would BLOCK a legitimate real-world lineup. Cap
         // only where the maximum is genuinely fixed (1v1); leave 2v2 open (the 24
         // ceiling only) so it flexes to reality.
-        const singlesCap = twoTeams
-          ? Math.min(rosterOfTeam(teams[0].id).length, rosterOfTeam(teams[1].id).length)
-          : Math.floor(availableCount / 2);
-        const maxMatchesForAdd = !sided && singlesCap > 0 ? Math.min(MAX_MATCHES, singlesCap) : MAX_MATCHES;
-        // §5 row copy (visual-pass P-A). Matches title is the format name; the
-        // subtitle is a status line ("x of y matches assigned"), not a value dump
-        // (team names live in the expanded editor). Matches uses the INVALID state
-        // while any slot is empty (§4/§6.1 hard-block) — never plain dashed-empty,
-        // since the seeded match always has a slot to fill until paired.
-        const matchesTitle = sided ? "2v2 Matches" : "1-on-1 Matches";
+        // Per-match shape (A2a) means a game can mix 1v1 + 2v2, so the old
+        // singles-only team-size cap no longer applies at the game level — a mixed
+        // lineup can legitimately exceed it. Fall back to the generous MAX ceiling;
+        // per-shape caps can be reintroduced on the add-match choice if wanted.
+        const maxMatchesForAdd = MAX_MATCHES;
+        // §5 row copy. Per-match shape (A2a): the title is just "Matches" (a game
+        // can mix 1v1 + 2v2, so a single format name would lie); the subtitle is a
+        // COMPOSITION line — "6 singles · 1 doubles · X of Y assigned". Matches uses
+        // the INVALID state while any slot is empty (§4/§6.1 hard-block).
+        const matchesTitle = "Matches";
+        const singlesCount = draft.filter((d) => d.playersPerSide === 1).length;
+        const doublesCount = draft.filter((d) => d.playersPerSide === 2).length;
+        const compParts: string[] = [];
+        if (singlesCount) compParts.push(`${singlesCount} single${singlesCount > 1 ? "s" : ""}`);
+        if (doublesCount) compParts.push(`${doublesCount} double${doublesCount > 1 ? "s" : ""}`);
         const matchesSubtitle = draft.length === 0
           ? "No matches yet — add one to start"
-          : `${filledDraft.length} of ${draft.length} matches assigned`;
+          : [...compParts, `${filledDraft.length} of ${draft.length} assigned`].join(" · ");
         // Three-way: 0 matches is a VALID EMPTY state (neutral, not red — a brand-new
         // game shouldn't open in error); a draft with any unfilled/under-rostered slot
         // is invalid (red); all filled + rostered is resolved. (P2/P2b collapse-boundary
@@ -1380,7 +1382,6 @@ export function MatchGameView() {
                 tripId={tripId}
                 draft={draft}
                 setDraft={editDraft}
-                playersPerSide={playersPerSide}
                 nameOf={nameOf}
                 colorOf={colorOf}
                 teamColorOf={teamColorOf}
@@ -1458,14 +1459,12 @@ export function MatchGameView() {
               <HandicapsSection
                 draft={draft}
                 setDraft={editDraft}
-                playersPerSide={playersPerSide}
                 nameOf={nameOf}
                 colorOf={colorOf}
                 // Roster team color (the shared canonical resolver) — assigned
                 // players read their team color; an unassigned player gets undefined →
                 // the neutral palette (honest). Same source the Matches panel + overview use.
                 teamColorOf={teamColorOf}
-                avatarIconOf={avatarIconOf}
               />
             </ChecklistRow>
 
@@ -1585,7 +1584,7 @@ export function MatchGameView() {
             crew={selectorCrew}
             nameOf={nameOf}
             onPick={(userId) => {
-              editDraft((prev) => assignInDraft(prev, selector.matchIdx, selector.slot, selector.memberIdx, userId, playersPerSide));
+              editDraft((prev) => assignInDraft(prev, selector.matchIdx, selector.slot, selector.memberIdx, userId));
               setSelector(null);
             }}
             onClose={() => setSelector(null)}
@@ -1609,7 +1608,16 @@ function serverDraftFrom(
   return (serverMatches as { match_number: number; side_a: SideRef; side_b: SideRef }[]).map((mm, i) => {
     const hcA = mm.side_a?.id ? (handicapOf.get(mm.side_a.id) ?? 0) : 0;
     const hcB = mm.side_b?.id ? (handicapOf.get(mm.side_b.id) ?? 0) : 0;
-    return { matchNumber: mm.match_number ?? i + 1, a: sideMemberIds(mm.side_a, membersOfSide), b: sideMemberIds(mm.side_b, membersOfSide), handicap: hcA > 0 ? -hcA : hcB > 0 ? hcB : 0 };
+    // Per-match shape (A2a) read from the side's own type: a play_group side ⇒ 2v2.
+    const playersPerSide: 1 | 2 =
+      mm.side_a?.type === "play_group" || mm.side_b?.type === "play_group" ? 2 : 1;
+    return {
+      matchNumber: mm.match_number ?? i + 1,
+      playersPerSide,
+      a: sideMemberIds(mm.side_a, membersOfSide),
+      b: sideMemberIds(mm.side_b, membersOfSide),
+      handicap: hcA > 0 ? -hcA : hcB > 0 ? hcB : 0,
+    };
   });
 }
 
@@ -1622,10 +1630,11 @@ function assignInDraft(
   matchIdx: number,
   slot: "a" | "b",
   memberIdx: number,
-  userId: string,
-  playersPerSide: number
+  userId: string
 ): DraftMatch[] {
   const next = prev.map((d) => ({ ...d, a: [...d.a], b: [...d.b] }));
+  // Per-match shape (A2a): the target match's own shape drives the assignment.
+  const playersPerSide = next[matchIdx]?.playersPerSide ?? 1;
   if (playersPerSide === 1) {
     // Singles — identical to the original: clear from OTHER matches, set here.
     next.forEach((d, i) => {
@@ -1766,7 +1775,6 @@ const MATCH_GRID = "24px 22px minmax(0,1fr) auto minmax(0,1fr) 24px";
 function MatchSetup({
   draft,
   setDraft,
-  playersPerSide,
   nameOf,
   colorOf,
   teamColorOf,
@@ -1778,7 +1786,6 @@ function MatchSetup({
   tripId: string;
   draft: DraftMatch[];
   setDraft: (fn: (prev: DraftMatch[]) => DraftMatch[]) => void;
-  playersPerSide: number;
   nameOf: Map<string, string>;
   colorOf: Map<string, string>;
   /** A player's TEAM color from their ROSTER assignment (`teamOfUser`) — team
@@ -1804,6 +1811,13 @@ function MatchSetup({
   // slots/stepper inside the card stay tappable.
   const [dragState, setDragState] = useState<{ from: number; ins: number | null } | null>(null);
   const [armedIdx, setArmedIdx] = useState<number | null>(null);
+  // "＋ Add match" reveals the "Add singles / Add doubles" choice (A2a) so each
+  // match's shape is picked when it's added — a game can mix both.
+  const [addOpen, setAddOpen] = useState(false);
+  const addMatch = (pps: 1 | 2) => {
+    setDraft((prev) => [...prev, { matchNumber: prev.length + 1, playersPerSide: pps, a: [], b: [], handicap: 0 }]);
+    setAddOpen(false);
+  };
 
   const reorderTo = (from: number, ins: number) =>
     setDraft((prev) => {
@@ -1846,10 +1860,10 @@ function MatchSetup({
   // (the "span both rows, centered" effect). Each sub-slot picks a single player.
   // Team identity rides on the player avatar's ROSTER color (memberPart →
   // teamColorOf), never the slot — a dropped-from-team player reads neutral, honestly.
-  const sideSlots = (members: string[], matchIdx: number, slot: "a" | "b") => {
+  const sideSlots = (members: string[], matchIdx: number, slot: "a" | "b", pps: 1 | 2) => {
     return (
       <div className="flex flex-col gap-1.5">
-        {Array.from({ length: playersPerSide }).map((_, k) => (
+        {Array.from({ length: pps }).map((_, k) => (
           <Slot key={k} player={memberPart(members[k])} onTap={() => openSelector(matchIdx, slot, k)} />
         ))}
       </div>
@@ -1945,11 +1959,27 @@ function MatchSetup({
               )}
               {/* grab — far left, away from the × (reorder isn't next to remove). */}
               <DragHandle onMouseDown={() => setArmedIdx(i)} onMouseUp={() => setArmedIdx(null)} />
-              {/* # — the table index column (separate from grab). */}
-              <RowNumber number={i + 1} />
-              {sideSlots(d.a, i, "a")}
+              {/* # — the table index column (separate from grab). A small shape tag
+                  sits under it so a mixed game's 1v1 vs 2v2 cards read at a glance. */}
+              <div className="flex flex-col items-center gap-1">
+                <RowNumber number={i + 1} />
+                <span
+                  style={{
+                    fontSize: 8,
+                    fontWeight: 800,
+                    letterSpacing: "0.03em",
+                    padding: "1px 4px",
+                    borderRadius: 4,
+                    color: d.playersPerSide === 2 ? "#c4b5fd" : "#93c5fd",
+                    background: d.playersPerSide === 2 ? "rgba(167,139,250,0.14)" : "rgba(96,165,250,0.14)",
+                  }}
+                >
+                  {d.playersPerSide === 2 ? "2V2" : "1V1"}
+                </span>
+              </div>
+              {sideSlots(d.a, i, "a", d.playersPerSide)}
               <span className="text-center" style={{ fontSize: 12, fontWeight: 700, color: "var(--color-bt-text-dim)" }}>vs</span>
-              {sideSlots(d.b, i, "b")}
+              {sideSlots(d.b, i, "b", d.playersPerSide)}
               {/* Remove = the itinerary-builder "×" dismiss (NOT a trash can), DIM not
                   red — draft removal is free (no persisted scores) and the open panel
                   must never read as an error. Far right. Always REMOVES the row —
@@ -1972,21 +2002,47 @@ function MatchSetup({
         </>
       )}
 
-      {/* Add another match — dynamic count grows one at a time, up to `maxMatches`
-          (the 1v1 players-per-team cap, or the 24 ceiling for 2v2 — Task 3a). Once
-          at the cap the affordance is hidden: every player already has a match. */}
+      {/* Add another match (A2a) — "＋ Add match" reveals a singles/doubles choice
+          so a game can mix shapes; each new card carries the chosen playersPerSide.
+          Hidden at the generous MAX ceiling. */}
       {draft.length < maxMatches && (
-        <button
-          type="button"
-          onClick={() => setDraft((prev) => [...prev, { matchNumber: prev.length + 1, a: [], b: [], handicap: 0 }])}
-          className="mt-3 flex w-full items-center justify-center gap-1.5"
-          style={{ height: 46, borderRadius: 12, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
-        >
-          <Plus size={16} />
-          Add match
-        </button>
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => setAddOpen((o) => !o)}
+            aria-expanded={addOpen}
+            className="flex w-full items-center justify-center gap-1.5"
+            style={{ height: 46, borderRadius: 12, background: "var(--color-bt-card-raised)", border: "1.5px dashed var(--color-bt-border)", color: "var(--color-bt-text)", fontSize: 14, fontWeight: 600 }}
+          >
+            <Plus size={16} />
+            Add match
+          </button>
+          {addOpen && (
+            <div className="mt-2.5 flex gap-2.5" data-testid="add-match-choice">
+              <AddShapeButton kind="1V1" label="Add singles" onClick={() => addMatch(1)} />
+              <AddShapeButton kind="2V2" label="Add doubles" onClick={() => addMatch(2)} />
+            </div>
+          )}
+        </div>
       )}
     </div>
+  );
+}
+
+/** One choice in the Add-match disclosure: a shape tag (1V1 blue / 2V2 purple) over
+ *  a plain label, matching the mockup's two-button "Add singles / Add doubles". */
+function AddShapeButton({ kind, label, onClick }: { kind: "1V1" | "2V2"; label: string; onClick: () => void }) {
+  const doubles = kind === "2V2";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-1 flex-col items-center gap-0.5"
+      style={{ padding: 11, borderRadius: 11, background: "var(--color-bt-card-raised)", border: "1px solid var(--color-bt-border)" }}
+    >
+      <span style={{ fontSize: 9.5, fontWeight: 800, letterSpacing: "0.04em", color: doubles ? "#c4b5fd" : "#93c5fd" }}>{kind}</span>
+      <span style={{ fontSize: 10.5, fontWeight: 700, color: "var(--color-bt-text-dim)" }}>{label}</span>
+    </button>
   );
 }
 
@@ -2000,15 +2056,12 @@ function MatchSetup({
 function HandicapsSection({
   draft,
   setDraft,
-  playersPerSide,
   nameOf,
   colorOf,
   teamColorOf,
-  avatarIconOf,
 }: {
   draft: DraftMatch[];
   setDraft: (fn: (prev: DraftMatch[]) => DraftMatch[]) => void;
-  playersPerSide: number;
   nameOf: Map<string, string>;
   colorOf: Map<string, string>;
   /** A player's TEAM color from their roster assignment (`teamOfUser`), the same
@@ -2019,20 +2072,17 @@ function HandicapsSection({
    *  standalone (non-2-team) game too. (P-D defect 1: colorOf alone was the neutral
    *  palette and lost team identity for the assigned players.) */
   teamColorOf: (userId: string) => string | undefined;
-  avatarIconOf: Map<string, string | null>;
 }) {
-  const sidePart = (members: string[]): Participant | null => {
-    if (members.length === 0) return null;
-    return {
-      id: members.join("+"),
-      name: members.map((u) => nameOf.get(u) ?? "Player").join(" & "),
-      color: teamColorOf(members[0]) ?? colorOf.get(members[0]) ?? PLAYER_COLORS[0],
-      avatarIcon: avatarIconOf.get(members[0]) ?? null,
-    };
-  };
+  // Each side as its players (stacked chips via the shared SideChips) + a display
+  // name for the stroke caption. Replaces the old compound "R&"-avatar / "Name & …"
+  // treatment (A2a) — one chip per player, team-colored, avatar-left.
+  const sidePlayers = (members: string[]): SidePlayer[] =>
+    members.map((u) => ({ id: u, name: nameOf.get(u) ?? "Player", teamColor: teamColorOf(u) ?? colorOf.get(u) ?? PLAYER_COLORS[0] }));
+  const sideName = (members: string[]) => members.map((u) => nameOf.get(u) ?? "Player").join(" & ");
+  // Per-match filled (A2a): both sides at the match's OWN players-per-side.
   const filled = draft
     .map((d, i) => ({ d, i }))
-    .filter(({ d }) => d.a.length === playersPerSide && d.b.length === playersPerSide);
+    .filter(({ d }) => d.a.length === d.playersPerSide && d.b.length === d.playersPerSide);
 
   if (filled.length === 0) {
     return (
@@ -2057,8 +2107,8 @@ function HandicapsSection({
           }}
         >
           <RelHandicapControl
-            a={sidePart(d.a)!}
-            b={sidePart(d.b)!}
+            a={{ players: sidePlayers(d.a), name: sideName(d.a) }}
+            b={{ players: sidePlayers(d.b), name: sideName(d.b) }}
             value={d.handicap}
             matchNumber={draft.length > 1 ? i + 1 : undefined}
             onChange={(v) => setDraft((prev) => prev.map((x, j) => (j === i ? { ...x, handicap: v } : x)))}

--- a/src/components/games/MatchSides.tsx
+++ b/src/components/games/MatchSides.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { PlayerChip } from "@/components/games/PlayerChip";
+
+/**
+ * The shared match-participant renderer (Refactor A2a). A match's sides are shown as
+ * **stacked per-player avatar chips** — the one `PlayerChip` (team-colored avatar
+ * LEFT of the name), one chip for a 1v1 side, two stacked for a 2v2 side. This is
+ * the single home for "how a match's players look," reused by:
+ *   - the Matches cards (both sides via `MatchSides`),
+ *   - the Handicaps section (each selectable side via `SideChips`),
+ *   - the Total Points override panel (A2b).
+ * It replaces the old compound "R&"-avatar + truncated "Name & …" doubles treatment
+ * everywhere — the fix is adoption, not re-solving per surface.
+ */
+
+export interface SidePlayer {
+  id: string;
+  name: string;
+  /** The player's team color (roster assignment); null → PlayerChip's neutral fallback. */
+  teamColor?: string | null;
+}
+
+/** One side's players as a vertical stack of chips (1 for singles, 2 for doubles).
+ *  `chipStyle` lets a wrapper strip the chip surface (e.g. the handicap segment owns
+ *  its own selection surface and shows the chip through it). */
+export function SideChips({
+  players,
+  chipStyle,
+  gap = 6,
+}: {
+  players: SidePlayer[];
+  chipStyle?: React.CSSProperties;
+  gap?: number;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col" style={{ gap }}>
+      {players.map((p) => (
+        <PlayerChip key={p.id} name={p.name} teamColor={p.teamColor} style={chipStyle} />
+      ))}
+    </div>
+  );
+}
+
+/** A full matchup: side A's stacked chips | vs | side B's stacked chips. The card +
+ *  override-panel display of a match. Singles → one chip per column; doubles → two.
+ *  (Named `MatchupChips` — `MatchSides` is already a draft-pairing type in
+ *  `matchDraft.ts`.) */
+export function MatchupChips({
+  a,
+  b,
+  className = "",
+}: {
+  a: SidePlayer[];
+  b: SidePlayer[];
+  className?: string;
+}) {
+  return (
+    <div className={`flex items-center ${className}`} style={{ gap: 9 }}>
+      <div className="min-w-0 flex-1">
+        <SideChips players={a} />
+      </div>
+      <span
+        className="flex-shrink-0 self-center"
+        style={{ fontSize: 10, fontWeight: 700, color: "var(--color-bt-text-dim)" }}
+      >
+        vs
+      </span>
+      <div className="min-w-0 flex-1">
+        <SideChips players={b} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -4,8 +4,14 @@ import { useEffect, useRef, useState } from "react";
 import { strokeHoles } from "@/lib/matchPlay";
 import { Stepper } from "@/components/games/Stepper";
 import { RowNumber } from "@/components/games/RowNumber";
-import { PlayerChip } from "@/components/games/PlayerChip";
-import type { Participant } from "./types";
+import { SideChips, type SidePlayer } from "@/components/games/MatchSides";
+
+/** One side of the handicap control: its players (stacked chips, A2a) + a display
+ *  name for the stroke caption ("{name} gets strokes on holes …"). */
+export interface HandicapSide {
+  players: SidePlayer[];
+  name: string;
+}
 
 /**
  * RelHandicapControl — the relative-handicap control for 1v1 (Slice B §6, as
@@ -67,8 +73,8 @@ export function relHandicapView(value: number, aName: string, bName: string): Re
 }
 
 interface RelHandicapControlProps {
-  a: Participant;
-  b: Participant;
+  a: HandicapSide;
+  b: HandicapSide;
   value: number; // signed, ∈ [−MAX, MAX]
   onChange: (value: number) => void;
   /** Small left-gutter match number (§8). Omit for a lone match (no number shown). */
@@ -142,16 +148,17 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
         {/* Segmented selector */}
         <div className="flex" style={{ gap: 4, padding: 4, borderRadius: 12, background: "var(--color-bt-card)" }}>
           <Segment selected={side === "a"} onClick={() => pickSide("a")} innerRef={segARef}>
-            {/* The SHARED PlayerChip (avatar 30, left-aligned) — identical to the
-                Matches chip. The segment wrapper owns the selection surface, so the
-                chip's own surface is stripped to transparent and shows it through. */}
-            <PlayerChip name={a.name} teamColor={a.color} style={{ background: "transparent", border: "none", height: "100%" }} />
+            {/* The SHARED SideChips (avatar-left PlayerChips) — one chip for a 1v1
+                side, two stacked for 2v2 (A2a: no compound avatar / "Name & …"). The
+                segment wrapper owns the selection surface, so each chip's own surface
+                is stripped to transparent and shows it through. */}
+            <SideChips players={a.players} chipStyle={{ background: "transparent", border: "none", height: "100%" }} />
           </Segment>
           <Segment selected={even} onClick={() => onChange(0)} narrow>
             Even
           </Segment>
           <Segment selected={side === "b"} onClick={() => pickSide("b")} innerRef={segBRef}>
-            <PlayerChip name={b.name} teamColor={b.color} style={{ background: "transparent", border: "none", height: "100%" }} />
+            <SideChips players={b.players} chipStyle={{ background: "transparent", border: "none", height: "100%" }} />
           </Segment>
         </div>
 

--- a/src/components/games/RelHandicapControl.tsx
+++ b/src/components/games/RelHandicapControl.tsx
@@ -152,13 +152,13 @@ export function RelHandicapControl({ a, b, value, onChange, matchNumber }: RelHa
                 side, two stacked for 2v2 (A2a: no compound avatar / "Name & …"). The
                 segment wrapper owns the selection surface, so each chip's own surface
                 is stripped to transparent and shows it through. */}
-            <SideChips players={a.players} chipStyle={{ background: "transparent", border: "none", height: "100%" }} />
+            <SideChips players={a.players} chipStyle={{ background: "transparent", border: "none" }} />
           </Segment>
           <Segment selected={even} onClick={() => onChange(0)} narrow>
             Even
           </Segment>
           <Segment selected={side === "b"} onClick={() => pickSide("b")} innerRef={segBRef}>
-            <SideChips players={b.players} chipStyle={{ background: "transparent", border: "none", height: "100%" }} />
+            <SideChips players={b.players} chipStyle={{ background: "transparent", border: "none" }} />
           </Segment>
         </div>
 
@@ -223,10 +223,13 @@ function Segment({
       style={{
         flex: narrow ? "0 0 auto" : "1 1 0",
         justifyContent: "center",
-        // Player segments carry the shared PlayerChip (which owns its own avatar
+        // Player segments carry the shared SideChips (which own their own avatar
         // inset), so the segment adds no padding; the narrow Even segment hugs its
-        // centered label with its own padding.
-        height: 44,
+        // centered label with its own padding. `minHeight` (not a fixed height) so a
+        // DOUBLES side's two stacked chips grow the row instead of being clipped;
+        // singles keep the 44 baseline, and the flex row stretches all segments
+        // (incl. Even) to the tallest.
+        minHeight: 44,
         borderRadius: 10,
         padding: narrow ? "0 14px" : 0,
         // Selection treatment = TEAL FILL (the scoped expansion of the teal

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -53,10 +53,22 @@ const retryDelay = (attempt: number) => Math.min(500 * 2 ** attempt, 8000);
 export function useScoreSaver(
   tripId: string | undefined,
   gameId: string | null | undefined,
-  // The scoring unit's type. Omitted → 'user' (singles/stroke — server default,
-  // unchanged). 2v2 passes 'play_group' so each side records one entry.
-  participantType?: "user" | "play_group",
+  // The scoring unit's type per write. Omitted → 'user' (singles/stroke — server
+  // default). A constant tags every write (a uniform game). A RESOLVER
+  // `(participantId) => type` tags each write by its own participant — needed by a
+  // MIXED match-play game (A2a), where a 1v1 match writes 'user' entries and a 2v2
+  // match writes 'play_group' entries in the SAME game. Memoize a resolver so the
+  // callbacks stay identity-stable.
+  participantType?:
+    | "user"
+    | "play_group"
+    | ((participantId: string) => "user" | "play_group" | undefined),
 ) {
+  const typeOf = useCallback(
+    (participantId: string): "user" | "play_group" | undefined =>
+      typeof participantType === "function" ? participantType(participantId) : participantType,
+    [participantType],
+  );
   const [values, setValues] = useState<ScoreValues>({});
   const [saveStatus, setSaveStatus] = useState<SaveStatusMap>({});
   // A live mirror of saveStatus so `reconcile` can read the latest without being
@@ -118,7 +130,7 @@ export function useScoreSaver(
       // them reach the server (idempotent upserts); this restores per-cell
       // STATUS only.
       upsertEntry
-        .mutateAsync({ tripId, gameId, participantId, unitLabel, value, participantType })
+        .mutateAsync({ tripId, gameId, participantId, unitLabel, value, participantType: typeOf(participantId) })
         // Confirmed on the server → safe to drop the durable copy.
         .then(() => {
           mark(key, "saved");
@@ -128,7 +140,7 @@ export function useScoreSaver(
         // never roll back; the outbox re-sends it on the next mount.
         .catch(() => mark(key, "error"));
     },
-    [tripId, gameId, upsertEntry, mark, participantType],
+    [tripId, gameId, upsertEntry, mark, typeOf],
   );
 
   const onClear = useCallback(
@@ -148,7 +160,7 @@ export function useScoreSaver(
       // mutateAsync per call (see onChange): concurrent clears must each resolve
       // their own outcome, never be orphaned by a later one on the shared observer.
       deleteEntry
-        .mutateAsync({ tripId, gameId, participantId, unitLabel, participantType })
+        .mutateAsync({ tripId, gameId, participantId, unitLabel, participantType: typeOf(participantId) })
         // A failed delete means the value is still on the server — restore it
         // (accurate) and flag it so the user knows the clear didn't take.
         .catch(() => {
@@ -164,7 +176,7 @@ export function useScoreSaver(
           }
         });
     },
-    [tripId, gameId, values, deleteEntry, mark, participantType],
+    [tripId, gameId, values, deleteEntry, mark, typeOf],
   );
 
   /**

--- a/src/lib/matchDraft.test.ts
+++ b/src/lib/matchDraft.test.ts
@@ -6,15 +6,15 @@ import { isMatchFilled, filledMatches, allMatchesFilled, matchPlayReady, hasVali
 // Readiness rework P3 — the downstream gate (Points/Handicaps/Modifiers locked
 // until a valid match exists).
 describe("hasValidMatch (the downstream gate)", () => {
-  const s = (a: string[], b: string[]): MatchSides => ({ a, b });
+  const s = (a: string[], b: string[]): MatchSides => ({ playersPerSide: (Math.max(a.length, b.length) || 1) as 1 | 2, a, b });
   it("true only when ≥1 match is fully paired", () => {
-    expect(hasValidMatch([s(["x"], ["y"])], 1)).toBe(true); // 1 paired
-    expect(hasValidMatch([s(["x"], ["y"]), s([], [])], 1)).toBe(true); // ≥1 paired (the other empty)
+    expect(hasValidMatch([s(["x"], ["y"])])).toBe(true); // 1 paired
+    expect(hasValidMatch([s(["x"], ["y"]), s([], [])])).toBe(true); // ≥1 paired (the other empty)
   });
   it("false at zero paired — incl. a seeded-but-empty match", () => {
-    expect(hasValidMatch([s([], [])], 1)).toBe(false); // seeded empty only
-    expect(hasValidMatch([s(["x"], [])], 1)).toBe(false); // half-paired only
-    expect(hasValidMatch([], 1)).toBe(false);
+    expect(hasValidMatch([s([], [])])).toBe(false); // seeded empty only
+    expect(hasValidMatch([s(["x"], [])])).toBe(false); // half-paired only
+    expect(hasValidMatch([])).toBe(false);
   });
 });
 
@@ -30,9 +30,9 @@ describe("pointsReady (the points term of the Enable gate)", () => {
 });
 
 describe("the Enable gate = all matches paired AND points > 0 (C3)", () => {
-  const s = (a: string[], b: string[]): MatchSides => ({ a, b });
+  const s = (a: string[], b: string[]): MatchSides => ({ playersPerSide: (Math.max(a.length, b.length) || 1) as 1 | 2, a, b });
   const enableReady = (draft: MatchSides[], pps: number, points: number) =>
-    allMatchesFilled(draft, pps) && pointsReady(points);
+    allMatchesFilled(draft) && pointsReady(points);
   it("true only when every match is paired AND points > 0", () => {
     expect(enableReady([s(["x"], ["y"])], 1, 3)).toBe(true); // paired + points
   });
@@ -58,20 +58,20 @@ describe("matchPlayReady (the shared threshold)", () => {
 // match must keep "Enable scoring" disabled (no silent collapse to the filled
 // count). These guard the pure rule the setup face derives the gate from.
 
-const singles = (a: string[], b: string[]): MatchSides => ({ a, b });
+const singles = (a: string[], b: string[]): MatchSides => ({ playersPerSide: (Math.max(a.length, b.length) || 1) as 1 | 2, a, b });
 
 describe("isMatchFilled", () => {
   it("singles (1 per side): filled only when both sides have a player", () => {
-    expect(isMatchFilled(singles(["x"], ["y"]), 1)).toBe(true);
-    expect(isMatchFilled(singles([], ["y"]), 1)).toBe(false);
-    expect(isMatchFilled(singles(["x"], []), 1)).toBe(false);
-    expect(isMatchFilled(singles([], []), 1)).toBe(false);
+    expect(isMatchFilled(singles(["x"], ["y"]))).toBe(true);
+    expect(isMatchFilled(singles([], ["y"]))).toBe(false);
+    expect(isMatchFilled(singles(["x"], []))).toBe(false);
+    expect(isMatchFilled(singles([], []))).toBe(false);
   });
 
   it("2v2 (2 per side): a half-filled side is not full strength", () => {
-    expect(isMatchFilled(singles(["a", "b"], ["c", "d"]), 2)).toBe(true);
-    expect(isMatchFilled(singles(["a"], ["c", "d"]), 2)).toBe(false);
-    expect(isMatchFilled(singles(["a", "b"], ["c"]), 2)).toBe(false);
+    expect(isMatchFilled(singles(["a", "b"], ["c", "d"]))).toBe(true);
+    expect(isMatchFilled(singles(["a"], ["c", "d"]))).toBe(false);
+    expect(isMatchFilled(singles(["a", "b"], ["c"]))).toBe(false);
   });
 });
 
@@ -82,7 +82,7 @@ describe("filledMatches", () => {
       singles(["c"], []),
       singles(["d"], ["e"]),
     ];
-    const out = filledMatches(draft, 1);
+    const out = filledMatches(draft);
     expect(out).toHaveLength(2);
     expect(out[0]).toBe(draft[0]);
     expect(out[1]).toBe(draft[2]);
@@ -91,25 +91,25 @@ describe("filledMatches", () => {
 
 describe("allMatchesFilled (the Enable-scoring gate)", () => {
   it("is FALSE for an empty draft (nothing to score)", () => {
-    expect(allMatchesFilled([], 1)).toBe(false);
+    expect(allMatchesFilled([])).toBe(false);
   });
 
   it("is TRUE when every match is fully paired", () => {
-    expect(allMatchesFilled([singles(["a"], ["b"]), singles(["c"], ["d"])], 1)).toBe(true);
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles(["c"], ["d"])])).toBe(true);
   });
 
   it("HARD-BLOCKS: a single unfilled slot anywhere disables the gate", () => {
     // The just-added empty match (build-as-you-go) keeps the gate shut...
-    expect(allMatchesFilled([singles(["a"], ["b"]), singles([], [])], 1)).toBe(false);
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles([], [])])).toBe(false);
     // ...as does a half-filled trailing match.
-    expect(allMatchesFilled([singles(["a"], ["b"]), singles(["c"], [])], 1)).toBe(false);
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles(["c"], [])])).toBe(false);
     // ...and an unfilled match in the MIDDLE (not just the trailing one).
-    expect(allMatchesFilled([singles(["a"], ["b"]), singles([], ["x"]), singles(["c"], ["d"])], 1)).toBe(false);
+    expect(allMatchesFilled([singles(["a"], ["b"]), singles([], ["x"]), singles(["c"], ["d"])])).toBe(false);
   });
 
   it("2v2: every side must be at full strength", () => {
-    expect(allMatchesFilled([singles(["a", "b"], ["c", "d"])], 2)).toBe(true);
-    expect(allMatchesFilled([singles(["a", "b"], ["c"])], 2)).toBe(false);
+    expect(allMatchesFilled([singles(["a", "b"], ["c", "d"])])).toBe(true);
+    expect(allMatchesFilled([singles(["a", "b"], ["c"])])).toBe(false);
   });
 });
 
@@ -145,7 +145,7 @@ describe("sideMemberIds (type-driven side → member ids)", () => {
   it("a filled 2v2 match reconstructs as two 2-member sides (both fully paired)", () => {
     const a = sideMemberIds({ type: "play_group", id: "pgA" }, members);
     const b = sideMemberIds({ type: "play_group", id: "pgB" }, members);
-    expect(isMatchFilled({ a, b }, 2)).toBe(true); // survives the reopen as a real match
+    expect(isMatchFilled({ playersPerSide: 2, a, b })).toBe(true); // survives the reopen as a real match
   });
 });
 
@@ -183,7 +183,7 @@ describe("flushOnOverlayClose (persist-on-overlay-close decision)", () => {
 // (the table hides; only "Add match" shows), so the last match is deletable — no
 // floor-clamp.
 describe("removeMatchRow (the × action)", () => {
-  const m = (a: string[], b: string[], handicap = 0) => ({ a, b, handicap, matchNumber: 0 });
+  const m = (a: string[], b: string[], handicap = 0) => ({ playersPerSide: (Math.max(a.length, b.length) || 1) as 1 | 2, a, b, handicap, matchNumber: 0 });
 
   it("with >1 match, REMOVES the match at the index", () => {
     const draft = [m(["a"], ["b"]), m(["c"], ["d"]), m(["e"], ["f"])];
@@ -202,8 +202,8 @@ describe("removeMatchRow (the × action)", () => {
   it("an empty draft reads as NOT ready (Enable still blocked on 0 matches)", () => {
     const empty = removeMatchRow([m(["a"], ["b"])], 0);
     expect(empty).toHaveLength(0);
-    expect(allMatchesFilled(empty, 1)).toBe(false); // can't enable an empty game
-    expect(hasValidMatch(empty, 1)).toBe(false); // Points/Handicaps/Modifiers stay locked
+    expect(allMatchesFilled(empty)).toBe(false); // can't enable an empty game
+    expect(hasValidMatch(empty)).toBe(false); // Points/Handicaps/Modifiers stay locked
   });
 
   it("does not mutate the input draft", () => {

--- a/src/lib/matchDraft.ts
+++ b/src/lib/matchDraft.ts
@@ -11,8 +11,11 @@
  * slot is an unfinished add, not a quiet drop.
  */
 
-/** A side-pairing — the only fields the readiness rule needs. */
+/** A side-pairing — the only fields the readiness rule needs. `playersPerSide` is
+ *  the match's own shape (1 = 1v1, 2 = 2v2), so a mixed game's readiness is judged
+ *  per match, not off an ambient game-level flag (Refactor A2a). */
 export interface MatchSides {
+  playersPerSide: 1 | 2;
   a: string[];
   b: string[];
 }
@@ -28,14 +31,14 @@ export function removeMatchRow<M extends MatchSides>(draft: M[], index: number):
   return draft.filter((_, j) => j !== index);
 }
 
-/** True when both sides carry exactly `playersPerSide` players. */
-export function isMatchFilled(match: MatchSides, playersPerSide: number): boolean {
-  return match.a.length === playersPerSide && match.b.length === playersPerSide;
+/** True when both sides carry exactly the match's own `playersPerSide` players. */
+export function isMatchFilled(match: MatchSides): boolean {
+  return match.a.length === match.playersPerSide && match.b.length === match.playersPerSide;
 }
 
 /** The filled subset — the matches that would actually be created/scored. */
-export function filledMatches<M extends MatchSides>(draft: M[], playersPerSide: number): M[] {
-  return draft.filter((m) => isMatchFilled(m, playersPerSide));
+export function filledMatches<M extends MatchSides>(draft: M[]): M[] {
+  return draft.filter((m) => isMatchFilled(m));
 }
 
 /**
@@ -51,8 +54,8 @@ export function filledMatches<M extends MatchSides>(draft: M[], playersPerSide: 
  * Keep them apart: P3 = "can the row be edited at all"; P-C = "does the Enable
  * button light up."
  */
-export function hasValidMatch(draft: MatchSides[], playersPerSide: number): boolean {
-  return filledMatches(draft, playersPerSide).length > 0;
+export function hasValidMatch(draft: MatchSides[]): boolean {
+  return filledMatches(draft).length > 0;
 }
 
 /**
@@ -74,8 +77,8 @@ export function matchPlayReady(pairedCount: number, totalCount: number): boolean
  * NOT ready (the hard block — no silent collapse to the filled count). Delegates
  * to `matchPlayReady` so the threshold is shared with the server, not duplicated.
  */
-export function allMatchesFilled(draft: MatchSides[], playersPerSide: number): boolean {
-  return matchPlayReady(filledMatches(draft, playersPerSide).length, draft.length);
+export function allMatchesFilled(draft: MatchSides[]): boolean {
+  return matchPlayReady(filledMatches(draft).length, draft.length);
 }
 
 /** A server match side: one user (1v1), one play_group (2v2), or an empty slot. */

--- a/src/server/routers/competitions.d2.test.ts
+++ b/src/server/routers/competitions.d2.test.ts
@@ -312,7 +312,7 @@ describe("D2 §6 — leaderboard response shape includes D2 fields", () => {
     // assigned, everywhere." It must STILL read Setting up and add no points.
     await ctx.caller().matches.setPairings({
       tripId, gameId: g.id,
-      matches: [{ sideA: { type: "user", id: ctx.user.id }, sideB: null, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [ctx.user.id] }, sideB: null, matchNumber: 1 }],
     });
     lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
     game = lb.games.find((x: { id: string }) => x.id === g.id) as { ready: boolean; configured: boolean; pointsTotal: number | null };

--- a/src/server/routers/delegateSetupGate.test.ts
+++ b/src/server/routers/delegateSetupGate.test.ts
@@ -67,7 +67,7 @@ describe("matches setup gate admits the game delegate (§10)", () => {
     await expect(
       member.matches.setPairings({
         tripId, gameId: mine,
-        matches: [{ sideA: { type: "user", id: ownerId }, sideB: { type: "user", id: memberId }, matchNumber: 1 }],
+        matches: [{ playersPerSide: 1, sideA: { members: [ownerId] }, sideB: { members: [memberId] }, matchNumber: 1 }],
       })
     ).resolves.toBeTruthy();
     // …enableScoring too (the gate admits the delegate; the game is ready).
@@ -77,7 +77,7 @@ describe("matches setup gate admits the game delegate (§10)", () => {
 
     // …but NOT another game (game-isolated).
     await expect(
-      member.matches.setPairings({ tripId, gameId: other, matches: [{ sideA: null, sideB: null, matchNumber: 1 }] })
+      member.matches.setPairings({ tripId, gameId: other, matches: [{ playersPerSide: 1, sideA: null, sideB: null, matchNumber: 1 }] })
     ).rejects.toThrow(/Organizer|game-organizer/i);
   });
 
@@ -87,7 +87,7 @@ describe("matches setup gate admits the game delegate (§10)", () => {
       ctx.callerAs("member").matches.setPairings({
         tripId,
         gameId: g,
-        matches: [{ sideA: null, sideB: null, matchNumber: 1 }],
+        matches: [{ playersPerSide: 1, sideA: null, sideB: null, matchNumber: 1 }],
       })
     ).rejects.toThrow(/Organizer|game-organizer/i);
   });

--- a/src/server/routers/matches.doubles.test.ts
+++ b/src/server/routers/matches.doubles.test.ts
@@ -67,11 +67,12 @@ async function freshGame(name: string) {
 
 /** Pair (owner+planner) vs (member+outsider). Returns the two play_group ids. */
 async function pairUp(gameId: string): Promise<{ pgA: string; pgB: string; matchId: string }> {
-  const matches = (await ctx.caller().matches.setDoublesPairings({
+  const matches = (await ctx.caller().matches.setPairings({
     tripId,
     gameId,
     matches: [
       {
+        playersPerSide: 2,
         sideA: { members: [owner, planner] },
         sideB: { members: [member, outsider] },
         matchNumber: 1,
@@ -83,7 +84,7 @@ async function pairUp(gameId: string): Promise<{ pgA: string; pgB: string; match
 }
 
 describe("doubles setup — sides are play_groups", () => {
-  it("setDoublesPairings creates a play_group per side with its two members", async () => {
+  it("setPairings creates a play_group per side with its two members", async () => {
     const gameId = await freshGame("Pairing");
     const { pgA, pgB } = await pairUp(gameId);
 
@@ -111,14 +112,14 @@ describe("doubles setup — sides are play_groups", () => {
     expect(m.side_b?.type).toBe("play_group");
   });
 
-  it("setDoublesHandicap stores the side handicap on play_groups (recipient n, other 0)", async () => {
+  it("setHandicap stores the side handicap on play_groups (recipient n, other 0)", async () => {
     const gameId = await freshGame("Side handicap");
     const { pgA, pgB, matchId } = await pairUp(gameId);
-    await ctx.callerAs("planner").matches.setDoublesHandicap({
+    await ctx.callerAs("planner").matches.setHandicap({
       tripId,
       gameId,
       matchId,
-      recipientPlayGroupId: pgB,
+      recipientId: pgB,
       strokes: 2,
     });
     const { data } = await ctx.admin.from("play_groups").select("id, handicap_strokes").eq("game_id", gameId);
@@ -132,11 +133,11 @@ describe("doubles setup — sides are play_groups", () => {
   it("a plain Member cannot set doubles pairings", async () => {
     const gameId = await freshGame("Gate");
     await expect(
-      ctx.callerAs("member").matches.setDoublesPairings({
+      ctx.callerAs("member").matches.setPairings({
         tripId,
         gameId,
         matches: [
-          { sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 },
+          { playersPerSide: 2, sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 },
         ],
       })
     ).rejects.toThrow();
@@ -176,7 +177,7 @@ describe("doubles results — one score per side, match engine reused", () => {
     const gameId = await freshGame("Side net");
     const { pgA, pgB, matchId } = await pairUp(gameId);
     // Side B gets 1 stroke → fallback puts it on hole 1.
-    await ctx.caller().matches.setDoublesHandicap({ tripId, gameId, matchId, recipientPlayGroupId: pgB, strokes: 1 });
+    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientId: pgB, strokes: 1 });
     // Hole 1: A gross 4, B gross 5 → B net 4 → halved, not an A win.
     await enterSides(gameId, pgA, pgB, { 1: 4 }, { 1: 5 });
 
@@ -222,12 +223,12 @@ describe("doubles team integrity — same-team pairs + correct attribution", () 
   it("hard-blocks a cross-team pair (setup-integrity backstop)", async () => {
     const gameId = await compGame("Cross-team");
     await expect(
-      ctx.caller().matches.setDoublesPairings({
+      ctx.caller().matches.setPairings({
         tripId,
         gameId,
         matches: [
           // owner=Blue + member=Red → a structurally invalid pair.
-          { sideA: { members: [owner, member] }, sideB: { members: [planner, outsider] }, matchNumber: 1 },
+          { playersPerSide: 2, sideA: { members: [owner, member] }, sideB: { members: [planner, outsider] }, matchNumber: 1 },
         ],
       })
     ).rejects.toThrow(/same team/i);
@@ -235,11 +236,11 @@ describe("doubles team integrity — same-team pairs + correct attribution", () 
 
   it("accepts same-team pairs and rolls match points to the winning team", async () => {
     const gameId = await compGame("Blue vs Red");
-    const matches = (await ctx.caller().matches.setDoublesPairings({
+    const matches = (await ctx.caller().matches.setPairings({
       tripId,
       gameId,
       matches: [
-        { sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 },
+        { playersPerSide: 2, sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 },
       ],
     })) as MatchRow[];
     const pgA = matches[0].side_a!.id; // Blue

--- a/src/server/routers/matches.test.ts
+++ b/src/server/routers/matches.test.ts
@@ -49,8 +49,8 @@ describe("matches router (Slice B — setup + visibility)", () => {
       tripId,
       gameId,
       matches: [
-        { sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 },
-        { sideA: { type: "user", id: planner }, sideB: null, matchNumber: 2 },
+        { playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 },
+        { playersPerSide: 1, sideA: { members: [planner] }, sideB: null, matchNumber: 2 },
       ],
     })) as MatchRow[];
     expect(matches).toHaveLength(2);
@@ -66,7 +66,7 @@ describe("matches router (Slice B — setup + visibility)", () => {
       tripId,
       gameId,
       matchId: m1,
-      recipientUserId: member,
+      recipientId: member,
       strokes: 3,
     });
     const { data } = await ctx.admin
@@ -104,7 +104,7 @@ describe("matches router (Slice B — setup + visibility)", () => {
     // under-configured (one empty slot) → enable REFUSED
     await ctx.callerAs("planner").matches.setPairings({
       tripId, gameId: g.id,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: null, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: null, matchNumber: 1 }],
     });
     await expect(
       ctx.callerAs("planner").matches.enableScoring({ tripId, gameId: g.id })
@@ -112,7 +112,7 @@ describe("matches router (Slice B — setup + visibility)", () => {
     // fully paired → enable succeeds: publishes, member can see, status goes active
     await ctx.callerAs("planner").matches.setPairings({
       tripId, gameId: g.id,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     await ctx.callerAs("planner").matches.enableScoring({ tripId, gameId: g.id });
     const res = await ctx.callerAs("member").matches.listByGame({ tripId, gameId: g.id });
@@ -162,7 +162,7 @@ describe("matches router (Slice B — setup + visibility)", () => {
       ctx.callerAs("member").matches.setPairings({
         tripId,
         gameId,
-        matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+        matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
       })
     ).rejects.toThrow();
     await expect(ctx.callerAs("member").matches.enableScoring({ tripId, gameId })).rejects.toThrow();
@@ -199,7 +199,7 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     // owner wins holes 1-3, halves 4-16 → +3 frozen at hole 16 = 3&2.
     const aWins = { 1: 4, 2: 4, 3: 4 };
@@ -235,7 +235,7 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     // Make it a 9-hole round (loadStrokeIndex reads units.count for the count).
     await ctx.admin.from("games").update({ scorecard_schema: { units: { count: 9 } } }).eq("id", gameId);
@@ -259,7 +259,7 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     const aHalf: Record<number, number> = {};
     const bHalf: Record<number, number> = {};
@@ -288,7 +288,7 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
   }
   // A is 6 DOWN thru 15 (loses 1–6, halves 7–15), then A wins 16/17/18.
@@ -353,10 +353,10 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     // member gets 1 stroke → fallback puts it on hole 1.
-    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId: (await firstMatchId(gameId)), recipientUserId: member, strokes: 1 });
+    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId: (await firstMatchId(gameId)), recipientId: member, strokes: 1 });
     // hole 1: owner 4, member 5 → gross owner wins, but member's net 4 → halved.
     await enter(gameId, owner, member, { 1: 4 }, { 1: 5 });
 
@@ -380,8 +380,8 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
       tripId,
       gameId,
       matches: [
-        { sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 },
-        { sideA: { type: "user", id: planner }, sideB: { type: "user", id: outsider }, matchNumber: 2 },
+        { playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 },
+        { playersPerSide: 1, sideA: { members: [planner] }, sideB: { members: [outsider] }, matchNumber: 2 },
       ],
     });
     // Match 1: owner wins holes 1-10 → closes 10&8. Match 2: only hole 1 entered → in progress.
@@ -420,18 +420,18 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     const matchId = await firstMatchId(gameId);
     // Hole 1: owner 5, member 4 → with no strokes, member wins the hole.
     await enter(gameId, owner, member, { 1: 5 }, { 1: 4 });
-    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientUserId: member, strokes: 0 });
+    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientId: member, strokes: 0 });
     expect(await positionOf(gameId, member)).toBe(1); // member leads
     expect(await positionOf(gameId, owner)).toBe(2);
 
     // Give OWNER a stroke on hole 1 (fallback) → owner net 4 = member 4 → halved.
     // The previously-shown member win must NOT persist — the result re-derives.
-    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientUserId: owner, strokes: 1 });
+    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientId: owner, strokes: 1 });
     expect(await positionOf(gameId, owner)).toBe(1); // all square now
     expect(await positionOf(gameId, member)).toBe(1);
   });
@@ -441,7 +441,7 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
     await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { type: "user", id: owner }, sideB: { type: "user", id: member }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
     });
     const matchId = await firstMatchId(gameId);
     // Close 3&2: owner wins 1-3, halves 4-16.
@@ -456,7 +456,7 @@ describe("match-play results — computeMatchPlayResults via games.finish", () =
 
     // A big late handicap to member would change earlier holes — but the match
     // is frozen, so its recorded result must be untouched.
-    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientUserId: member, strokes: 18 });
+    await ctx.caller().matches.setHandicap({ tripId, gameId, matchId, recipientId: member, strokes: 18 });
     const { data } = await ctx.admin.from("game_matches").select("result, margin, status").eq("id", matchId).single();
     expect(data).toMatchObject({ result: "a_win", margin: "3&2", status: "complete" });
   });

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -28,11 +28,12 @@ import { computeMatchPlayResults } from "../lib/matchPlay";
 // generous ceiling — far above any realistic field — not the old fixed 4.
 const MAX_MATCHES = 24;
 
-const sideSchema = z.object({ type: z.literal("user"), id: z.string().min(1) });
-// 2v2 (doubles): a side is a PAIR of users. setDoublesPairings creates a
-// play_group per side and stores side_a/side_b as {"type":"play_group","id":pgId}
-// — the SAME match engine as singles, with the side being a pair.
-const doublesSideSchema = z.object({ members: z.array(z.string().min(1)).length(2) });
+// Unified per-match side (Refactor A2a). A side is a list of member user-ids:
+// ONE member = a 1v1 side (stored `{type:"user",id}`, no play_group), TWO members
+// = a 2v2 side (a play_group is minted, stored `{type:"play_group",id:pgId}`).
+// Which it is comes from the match's own `playersPerSide`, so ONE game can mix 1v1
+// and 2v2 matches. The result engine resolves a side by id regardless of type.
+const unifiedSideSchema = z.object({ members: z.array(z.string().min(1)).min(1).max(2) });
 
 async function assertGameInTrip(
   ctx: { supabase: { from: (t: string) => unknown } },
@@ -58,9 +59,13 @@ async function assertGameInTrip(
 }
 
 export const matchesRouter = router({
-  // setPairings — Owner/Organizer. Replaces the game's matches and seeds the
-  // foursome card (one play_group shared by the matches). Empty slots allowed
-  // (filled later via assignPlayer); only set sides become participants.
+  // setPairings — Owner/Organizer. Clean-replaces the game's matches. Each match
+  // declares its own `playersPerSide` (1 = 1v1, 2 = 2v2), so ONE game can mix both
+  // (Refactor A2a). Per side: a 1v1 side becomes `{type:"user",id}` (no play_group);
+  // a 2v2 side mints a play_group and stores `{type:"play_group",id:pgId}`. Empty
+  // slots (null) are allowed. The result math (computeMatchPlayResults) resolves a
+  // side by id regardless of type, so a mixed game computes with no engine change.
+  // (Unifies the former setPairings + setDoublesPairings.)
   setPairings: authedProcedure
     .input(
       z.object({
@@ -69,8 +74,9 @@ export const matchesRouter = router({
         matches: z
           .array(
             z.object({
-              sideA: sideSchema.nullable(),
-              sideB: sideSchema.nullable(),
+              playersPerSide: z.union([z.literal(1), z.literal(2)]),
+              sideA: unifiedSideSchema.nullable(),
+              sideB: unifiedSideSchema.nullable(),
               matchNumber: z.number().int().min(1),
             })
           )
@@ -84,46 +90,105 @@ export const matchesRouter = router({
     .mutation(async ({ ctx, input }) => {
       await assertGameInTrip(ctx, input.gameId, ctx.tripId);
 
-      // Replace existing matches for a clean re-save. play_group_id is NOT
-      // written in Slice B — the overview is a flat list, not foursome-grouped
-      // (the play_groups table is Slice C's 2v2 scoring side).
-      await ctx.supabase.from("game_matches").delete().eq("game_id", input.gameId);
+      // Per-match shape sanity: a non-null side carries exactly its match's
+      // players-per-side (1 for 1v1, 2 for 2v2). The client only sends complete
+      // sides; the raw API is validated here too.
+      for (const m of input.matches) {
+        for (const side of [m.sideA, m.sideB]) {
+          if (side && side.members.length !== m.playersPerSide) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `A ${m.playersPerSide === 2 ? "2v2" : "1v1"} side must have ${m.playersPerSide} player(s)`,
+            });
+          }
+        }
+      }
 
-      const rows = input.matches.map((m, i) => ({
+      // Setup-integrity backstop: in a competition, both members of a 2v2 pair
+      // MUST be on the same team (a side is one team's pair). The client's picker
+      // prevents it; this hard-blocks the raw API (defense in depth).
+      const { data: gameRow } = await ctx.supabase
+        .from("games")
+        .select("competition_id")
+        .eq("id", input.gameId)
+        .maybeSingle();
+      const competitionId = (gameRow?.competition_id as string | null) ?? null;
+      if (competitionId) {
+        const { data: assigns } = await ctx.supabase
+          .from("team_assignments")
+          .select("user_id, team_id")
+          .eq("competition_id", competitionId);
+        const teamOf = new Map<string, string>();
+        for (const a of assigns ?? []) teamOf.set(a.user_id as string, a.team_id as string);
+        for (const m of input.matches) {
+          if (m.playersPerSide !== 2) continue;
+          for (const side of [m.sideA, m.sideB]) {
+            if (!side) continue;
+            const t0 = teamOf.get(side.members[0]);
+            const t1 = teamOf.get(side.members[1]);
+            if (t0 && t1 && t0 !== t1) {
+              throw new TRPCError({ code: "BAD_REQUEST", message: "A 2v2 pair must be from the same team" });
+            }
+          }
+        }
+      }
+
+      // Clean replace (setup-time, before scoring). Order: matches + participants
+      // reference play_groups (ON DELETE SET NULL), so clear children then groups.
+      await ctx.supabase.from("game_matches").delete().eq("game_id", input.gameId);
+      await ctx.supabase.from("game_participants").delete().eq("game_id", input.gameId);
+      await ctx.supabase.from("play_groups").delete().eq("game_id", input.gameId);
+
+      const pgRows: { id: string; game_id: string; display_name: null }[] = [];
+      const partRows: {
+        id: string;
+        game_id: string;
+        user_id: string;
+        play_group_id: string | null;
+        team_id: null;
+      }[] = [];
+      // Build a side ref from its member list: 1 member = user side (participant,
+      // no group); 2 members = a minted play_group side (participants tagged with
+      // the group). null = empty slot.
+      const mkSide = (side: { members: string[] } | null): { type: string; id: string } | null => {
+        if (!side) return null;
+        if (side.members.length === 1) {
+          const uid = side.members[0];
+          partRows.push({ id: crypto.randomUUID(), game_id: input.gameId, user_id: uid, play_group_id: null, team_id: null });
+          return { type: "user", id: uid };
+        }
+        const pgId = crypto.randomUUID();
+        pgRows.push({ id: pgId, game_id: input.gameId, display_name: null });
+        for (const uid of side.members) {
+          partRows.push({ id: crypto.randomUUID(), game_id: input.gameId, user_id: uid, play_group_id: pgId, team_id: null });
+        }
+        return { type: "play_group", id: pgId };
+      };
+      const matchRows = input.matches.map((m, i) => ({
         id: crypto.randomUUID(),
         game_id: input.gameId,
         play_group_id: null,
         match_number: m.matchNumber,
         display_order: i,
-        side_a: m.sideA,
-        side_b: m.sideB,
+        side_a: mkSide(m.sideA),
+        side_b: mkSide(m.sideB),
         status: "pending",
       }));
-      const { error } = await ctx.supabase.from("game_matches").insert(rows);
-      if (error) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `Failed to set pairings: ${error.message}`,
-        });
-      }
 
-      // Seed participant rows (handicap_strokes lives here) for every set side.
-      const userIds = [
-        ...new Set(
-          input.matches.flatMap((m) => [m.sideA?.id, m.sideB?.id]).filter((x): x is string => !!x)
-        ),
-      ];
-      if (userIds.length > 0) {
-        await ctx.supabase.from("game_participants").upsert(
-          userIds.map((userId) => ({
-            id: crypto.randomUUID(),
-            game_id: input.gameId,
-            user_id: userId,
-            play_group_id: null,
-            team_id: null,
-          })),
-          { onConflict: "game_id,user_id", ignoreDuplicates: true }
-        );
+      if (pgRows.length > 0) {
+        const { error } = await ctx.supabase.from("play_groups").insert(pgRows);
+        if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to create sides: ${error.message}` });
+      }
+      if (partRows.length > 0) {
+        // One row per user per game (UNIQUE game_id,user_id) — a player is on one side.
+        const { error } = await ctx.supabase
+          .from("game_participants")
+          .upsert(partRows, { onConflict: "game_id,user_id" });
+        if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to seed players: ${error.message}` });
+      }
+      const { error } = await ctx.supabase.from("game_matches").insert(matchRows);
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set pairings: ${error.message}` });
       }
 
       const { data } = await ctx.supabase
@@ -225,15 +290,18 @@ export const matchesRouter = router({
       return data ?? [];
     }),
 
-  // setHandicap — Owner/Organizer. One side gets `strokes`, the other 0.
-  // Never split. (strokes=0 → even match, both 0.)
+  // setHandicap — Owner/Organizer. One side of a match gets `strokes`, the other
+  // 0 — never split (Refactor A2a: unifies setHandicap + setDoublesHandicap). The
+  // recipient is a SIDE id: a user id (1v1 → handicap on game_participants) or a
+  // play_group id (2v2 → handicap on play_groups). Both sides of a match share the
+  // same shape, so the target table is resolved once from the recipient's side type.
   setHandicap: authedProcedure
     .input(
       z.object({
         tripId: z.string(),
         gameId: z.string(),
         matchId: z.string().min(1),
-        recipientUserId: z.string().min(1),
+        recipientId: z.string().min(1),
         strokes: z.number().int().min(0).max(36),
       })
     )
@@ -250,29 +318,42 @@ export const matchesRouter = router({
       if (!match) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
       }
-      const sides = [
-        (match.side_a as { id: string } | null)?.id,
-        (match.side_b as { id: string } | null)?.id,
-      ].filter((x): x is string => !!x);
-      if (!sides.includes(input.recipientUserId)) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Recipient is not in this match",
-        });
+      const sideA = match.side_a as { type: string; id: string } | null;
+      const sideB = match.side_b as { type: string; id: string } | null;
+      const recipientSide = [sideA, sideB].find((s) => s?.id === input.recipientId);
+      if (!recipientSide) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Recipient is not a side in this match" });
       }
-      const other = sides.find((id) => id !== input.recipientUserId);
+      const other = [sideA, sideB].find((s) => s && s.id !== input.recipientId) ?? null;
 
-      await ctx.supabase
-        .from("game_participants")
-        .update({ handicap_strokes: input.strokes })
-        .eq("game_id", input.gameId)
-        .eq("user_id", input.recipientUserId);
-      if (other) {
+      // The side's own type picks the handicap home: a user side → game_participants
+      // (keyed by user_id); a play_group side → play_groups (keyed by id).
+      if (recipientSide.type === "play_group") {
+        await ctx.supabase
+          .from("play_groups")
+          .update({ handicap_strokes: input.strokes })
+          .eq("id", input.recipientId)
+          .eq("game_id", input.gameId);
+        if (other) {
+          await ctx.supabase
+            .from("play_groups")
+            .update({ handicap_strokes: 0 })
+            .eq("id", other.id)
+            .eq("game_id", input.gameId);
+        }
+      } else {
         await ctx.supabase
           .from("game_participants")
-          .update({ handicap_strokes: 0 })
+          .update({ handicap_strokes: input.strokes })
           .eq("game_id", input.gameId)
-          .eq("user_id", other);
+          .eq("user_id", input.recipientId);
+        if (other) {
+          await ctx.supabase
+            .from("game_participants")
+            .update({ handicap_strokes: 0 })
+            .eq("game_id", input.gameId)
+            .eq("user_id", other.id);
+        }
       }
       // Handicap is a recompute INPUT — re-derive in-progress matches so existing
       // hole results reflect the new strokes (a frozen/complete match is skipped).
@@ -280,194 +361,16 @@ export const matchesRouter = router({
       return { ok: true };
     }),
 
-  // ── 2v2 / doubles (Slice C) ────────────────────────────────────────────────
-  // The side is a PAIR (a play_group), the score is one entry per side per hole.
-  // These are the doubles analogues of setPairings / setHandicap; the singles
-  // procedures above are untouched, and the result math (computeMatchPlayResults)
-  // is shared — it resolves a side by id whether the id is a user or a play_group.
-
-  // setDoublesPairings — Owner/Organizer. Clean-replace the game's matches:
-  // create a play_group per side (its 2 members → game_participants), and one
-  // game_match between the two play-group sides. Mirrors setPairings' clean
-  // re-save (setup-time; before scores exist).
-  setDoublesPairings: authedProcedure
-    .input(
-      z.object({
-        tripId: z.string(),
-        gameId: z.string(),
-        matches: z
-          .array(
-            z.object({
-              sideA: doublesSideSchema.nullable(),
-              sideB: doublesSideSchema.nullable(),
-              matchNumber: z.number().int().min(1),
-            })
-          )
-          // 0 matches is a valid empty state (see setPairings).
-          .min(0)
-          .max(MAX_MATCHES),
-      })
-    )
-    .use(requireGameEdit())
-    .mutation(async ({ ctx, input }) => {
-      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
-
-      // Setup-integrity backstop: in a competition, both members of a pair MUST
-      // be on the same team — a side is one team's pair. The client constrains
-      // the picker so this can't happen from the UI; this hard-blocks the raw API
-      // (defense in depth — never silently accept a cross-team pair).
-      const { data: gameRow } = await ctx.supabase
-        .from("games")
-        .select("competition_id")
-        .eq("id", input.gameId)
-        .maybeSingle();
-      const competitionId = (gameRow?.competition_id as string | null) ?? null;
-      if (competitionId) {
-        const { data: assigns } = await ctx.supabase
-          .from("team_assignments")
-          .select("user_id, team_id")
-          .eq("competition_id", competitionId);
-        const teamOf = new Map<string, string>();
-        for (const a of assigns ?? []) teamOf.set(a.user_id as string, a.team_id as string);
-        for (const m of input.matches) {
-          for (const side of [m.sideA, m.sideB]) {
-            if (!side) continue;
-            const t0 = teamOf.get(side.members[0]);
-            const t1 = teamOf.get(side.members[1]);
-            if (t0 && t1 && t0 !== t1) {
-              throw new TRPCError({ code: "BAD_REQUEST", message: "A 2v2 pair must be from the same team" });
-            }
-          }
-        }
-      }
-
-      // Clean replace (setup-time, before scoring — mirrors setPairings). Order
-      // matters: matches reference play_groups (SET NULL), participants reference
-      // play_groups (SET NULL); clear children then the play_groups.
-      await ctx.supabase.from("game_matches").delete().eq("game_id", input.gameId);
-      await ctx.supabase.from("game_participants").delete().eq("game_id", input.gameId);
-      await ctx.supabase.from("play_groups").delete().eq("game_id", input.gameId);
-
-      const pgRows: { id: string; game_id: string; display_name: null }[] = [];
-      const partRows: {
-        id: string;
-        game_id: string;
-        user_id: string;
-        play_group_id: string;
-        team_id: null;
-      }[] = [];
-      const matchRows = input.matches.map((m, i) => {
-        const mkSide = (side: { members: string[] } | null) => {
-          if (!side) return null;
-          const pgId = crypto.randomUUID();
-          pgRows.push({ id: pgId, game_id: input.gameId, display_name: null });
-          for (const uid of side.members) {
-            partRows.push({
-              id: crypto.randomUUID(),
-              game_id: input.gameId,
-              user_id: uid,
-              play_group_id: pgId,
-              team_id: null,
-            });
-          }
-          return { type: "play_group" as const, id: pgId };
-        };
-        return {
-          id: crypto.randomUUID(),
-          game_id: input.gameId,
-          play_group_id: null,
-          match_number: m.matchNumber,
-          display_order: i,
-          side_a: mkSide(m.sideA),
-          side_b: mkSide(m.sideB),
-          status: "pending",
-        };
-      });
-
-      if (pgRows.length > 0) {
-        const { error } = await ctx.supabase.from("play_groups").insert(pgRows);
-        if (error) {
-          throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to create sides: ${error.message}` });
-        }
-      }
-      if (partRows.length > 0) {
-        // One row per user per game (UNIQUE game_id,user_id) — a player is on one side.
-        const { error } = await ctx.supabase
-          .from("game_participants")
-          .upsert(partRows, { onConflict: "game_id,user_id" });
-        if (error) {
-          throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to seed players: ${error.message}` });
-        }
-      }
-      const { error } = await ctx.supabase.from("game_matches").insert(matchRows);
-      if (error) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set pairings: ${error.message}` });
-      }
-
-      const { data } = await ctx.supabase
-        .from("game_matches")
-        .select("*")
-        .eq("game_id", input.gameId)
-        .order("display_order", { ascending: true });
-      return data ?? [];
-    }),
-
-  // setDoublesHandicap — Owner/Organizer. The recipient SIDE (a play_group) gets
-  // `strokes`, the other side 0 — never split. The side handicap lives on
-  // play_groups.handicap_strokes (the doubles analogue of game_participants).
-  setDoublesHandicap: authedProcedure
-    .input(
-      z.object({
-        tripId: z.string(),
-        gameId: z.string(),
-        matchId: z.string().min(1),
-        recipientPlayGroupId: z.string().min(1),
-        strokes: z.number().int().min(0).max(36),
-      })
-    )
-    .use(requireGameEdit())
-    .mutation(async ({ ctx, input }) => {
-      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
-
-      const { data: match } = await ctx.supabase
-        .from("game_matches")
-        .select("side_a, side_b")
-        .eq("id", input.matchId)
-        .eq("game_id", input.gameId)
-        .maybeSingle();
-      if (!match) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
-      }
-      const sides = [
-        (match.side_a as { id: string } | null)?.id,
-        (match.side_b as { id: string } | null)?.id,
-      ].filter((x): x is string => !!x);
-      if (!sides.includes(input.recipientPlayGroupId)) {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "Recipient is not a side in this match" });
-      }
-      const other = sides.find((id) => id !== input.recipientPlayGroupId);
-
-      await ctx.supabase
-        .from("play_groups")
-        .update({ handicap_strokes: input.strokes })
-        .eq("id", input.recipientPlayGroupId)
-        .eq("game_id", input.gameId);
-      if (other) {
-        await ctx.supabase
-          .from("play_groups")
-          .update({ handicap_strokes: 0 })
-          .eq("id", other)
-          .eq("game_id", input.gameId);
-      }
-      // Handicap is a recompute input — re-derive in-progress matches (#9 freeze).
-      await computeMatchPlayResults(ctx.supabase, input.gameId, { skipComplete: true });
-      return { ok: true };
-    }),
+  // ── legacy doubles twins removed (Refactor A2a) ─────────────────────────────
+  // setDoublesPairings / setDoublesHandicap were folded into the per-match
+  // setPairings / setHandicap above (shape comes from each match's playersPerSide
+  // / side type), so ONE game can mix 1v1 and 2v2. The result math was always
+  // shared (computeMatchPlayResults resolves a side by id regardless of type).
 
   // addMatch — Owner/Organizer/delegate. Append ONE empty match (the dynamic
   // "+1"). The configured match count = game_matches rows, so a new row raises
   // the clinch goalpost (value × count) immediately, paired or not. Sides get
-  // filled after via assignPlayer (1v1) / the doubles assignment flow. A match
+  // filled after via the setPairings clean-replace (per-match shape). A match
   // added to an already-active game is itself active (scoreable now); on a
   // pending game it stays pending until activate. Refuses past the cap.
   addMatch: authedProcedure

--- a/src/server/routers/scores.permissions.test.ts
+++ b/src/server/routers/scores.permissions.test.ts
@@ -106,8 +106,8 @@ describe("1v1 match — the unit is the match (its two players)", () => {
       tripId,
       gameId,
       matches: [
-        { sideA: { type: "user", id: owner }, sideB: { type: "user", id: planner }, matchNumber: 1 },
-        { sideA: { type: "user", id: member }, sideB: { type: "user", id: outsider }, matchNumber: 2 },
+        { playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [planner] }, matchNumber: 1 },
+        { playersPerSide: 1, sideA: { members: [member] }, sideB: { members: [outsider] }, matchNumber: 2 },
       ],
     });
     await ctx.caller().games.enableScoring({ tripId, gameId });
@@ -133,10 +133,10 @@ describe("2v2 match — the unit is the match (its two side groups)", () => {
   beforeAll(async () => {
     const g = await ctx.caller().games.create({ tripId, gameTypeId: DOUBLES, name: "Doubles Perms" });
     gameId = g.id;
-    const matches = (await ctx.caller().matches.setDoublesPairings({
+    const matches = (await ctx.caller().matches.setPairings({
       tripId,
       gameId,
-      matches: [{ sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 }],
+      matches: [{ playersPerSide: 2, sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 }],
     })) as MatchRow[];
     pgA = matches[0].side_a!.id; // owner+planner
     pgB = matches[0].side_b!.id; // member+outsider


### PR DESCRIPTION
## Summary

Phase **A2a** of the match-play builder refactor. Makes a **mixed** match-play game buildable — some matches 1v1, some 2v2, in one game (the Buddy case: 6 singles + 1 doubles). Shape becomes a per-**match** property derived from each match's side type; the game-level `sided` fork is unfolded. **Points stay on the current uniform `per_match` model this sub-phase** — the Total Points model + per-match overrides land in **A2b**. The scoring engine is untouched (already shape-blind).

Phase 0 was reported separately (rewrite sites re-verified; `per_match` write/read paths mapped; override storage chosen — reuse `points_total` for the A2b total + a new `game_matches.point_value` for overrides, confirmed `points_total` is inert for match games with all its format-specific reads type-gated; Handicaps render site located).

## Server — unify the twinned mutations
- **One `setPairings`** taking `matches:[{playersPerSide:1|2, sideA:{members[]}|null, sideB, matchNumber}]`. A 1-member side → `{type:"user"}` (no play_group); a 2-member side → a minted play_group. Per-match shape sanity + the same-team guard (2-member sides only).
- **One `setHandicap`** resolving the recipient's table (`game_participants` vs `play_groups`) from the match's own side type.
- The `setDoublesPairings`/`setDoublesHandicap` twins **retired**. `computeMatchPlayResults` is **unchanged** — it already resolves a side by id regardless of type, so a mixed game computes with zero engine change.

## Client (`MatchGameView`)
- `DraftMatch` gains `playersPerSide`; `matchDraft.ts` predicates read it per-match; `serverDraftFrom` sets it from `side_a.type` (which also keeps the reopen-race fix).
- `saveSetup`/`persistDraftOnCollapse` emit the one unified array (`recipientId` = the side id for both shapes).
- Two memos (`teamOfSide`, `handicapOf`) branch on the **side's own type** / populate from both tables.
- **Per-match score-entry participant_type**: `useScoreSaver` gains a resolver overload; `MatchGameView` passes `(pid) => playGroupIdSet.has(pid) ? "play_group" : "user"`, so a mixed game tags 1v1 writes `'user'` and 2v2 writes `'play_group'` in the same game.
- **"＋ Add match → Add singles / Add doubles"** disclosure; each card carries its shape (a 1V1/2V2 tag); **"Matches"** title + composition subtitle (`6 singles · 1 doubles · X of Y assigned`).

## Shared renderer
- New `MatchSides.tsx`: **`SideChips`** (a side = stacked avatar-left `PlayerChip`s) + `MatchupChips`. **Handicaps** (`RelHandicapControl`) repointed at `SideChips`, killing the compound-"R&"-avatar + truncated "Name & …" doubles treatment (A2a-2). The builder cards already render per-player slots (no compound), so the only compound/truncation site was Handicaps — now gone.

## Test plan
- `tsc --noEmit` clean, `next lint` clean (no warnings).
- **72 pure-logic + component tests** green (matchDraft, matchPlay, RelHandicapControl, projection).
- **55 DB-integration tests** green — the unified mutations proven end-to-end: singles + doubles + empty slots, both handicap tables, the same-team guard, the cross-team block, doubles `play_group` results (matches / matches.doubles / scores.permissions / delegateSetupGate / competitions.d2).
- No migration in A2a. Existing games unaffected; engine byte-unchanged.
- **Remaining**: by-eye on the preview — build the Buddy mixed game (6 singles + 1 doubles), confirm the add-singles/doubles disclosure, the 1V1/2V2 card tags, stacked-chip Handicaps, and end-to-end scoring. (A2a-4 engine-unchanged is covered by the unchanged `matchState`/`buildDecided` + green match tests.)

## Guardrails
`per_match` untouched this phase. A2b (Total Points model, overrides — which subsumes the old A3 multiplier) is a separate PR, not started until A2a ships + verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)