### PR TITLE
Refactor A2b: the Total Points model (completes Refactor A)

### DIFF
--- a/src/components/games/ChecklistRow.tsx
+++ b/src/components/games/ChecklistRow.tsx
@@ -81,6 +81,7 @@ export function ChecklistRow({
   onToggle,
   children,
   control,
+  headerControl,
   disabled,
   locked,
   testId,
@@ -106,6 +107,11 @@ export function ChecklistRow({
    *  accordion** (W-GAMEPAGE Phase C: the Points row). Mutually exclusive with
    *  accordion/overlay; the control owns its own taps. */
   control?: React.ReactNode;
+  /** An ACCORDION row that ALSO carries a header control (e.g. the A2b Total Points
+   *  row: a ± total stepper beside the expand chevron). Rendered in the header,
+   *  OUTSIDE the toggle button (so its own buttons don't nest in / trigger the
+   *  toggle), before the chevron. Only honored on accordion rows. */
+  headerControl?: React.ReactNode;
   /** Dependency not yet met — the row would be an accordion, but its prerequisite
    *  isn't satisfied (e.g. Handicaps before a course is chosen). Renders VISIBLY
    *  disabled (dimmed, non-interactive — the Danger-Zone dimming pattern) instead
@@ -218,9 +224,25 @@ export function ChecklistRow({
   if (accordion) {
     return (
       <div ref={rowRef} className="rounded-xl" style={{ ...containerStyle, scrollMarginTop: 12 }} data-testid={testId}>
-        <button type="button" onClick={onToggle} className={headerClass} aria-expanded={isOpen}>
-          {headerInner}
-        </button>
+        {headerControl ? (
+          // A header-control accordion (Total Points): the icon+title toggle the
+          // panel; the control (a stepper) sits beside the chevron OUTSIDE that
+          // button, owning its own taps. Split so we never nest buttons.
+          <div className={headerClass}>
+            <button type="button" onClick={onToggle} className="flex min-w-0 flex-1 items-center gap-3 text-left" aria-expanded={isOpen}>
+              {iconBlock}
+              {content}
+            </button>
+            <span className="flex shrink-0 items-center">{headerControl}</span>
+            <button type="button" onClick={onToggle} aria-label="Toggle" aria-expanded={isOpen} className="flex shrink-0 items-center">
+              <ChevronDown size={16} style={{ color: "var(--color-bt-text-dim)", transform: isOpen ? "rotate(180deg)" : undefined, transition: "transform 120ms" }} />
+            </button>
+          </div>
+        ) : (
+          <button type="button" onClick={onToggle} className={headerClass} aria-expanded={isOpen}>
+            {headerInner}
+          </button>
+        )}
         {isOpen && (
           // No under-header divider — the body is the SAME surface as the header,
           // so there's no seam to mark; an abrupt border read as a defect.

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -29,6 +29,7 @@ import { Avatar } from "@/components/Avatar";
 import { TimePicker } from "@/components/TimePicker";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
 import { GameSetupRows } from "@/components/games/GameSetupRows";
+import { MatchPointsRow, type PointsMatch } from "@/components/games/MatchPointsRow";
 import { SettingsColumn } from "@/components/games/SettingsColumn";
 import { GameIdentityHeader } from "@/components/games/GameIdentityHeader";
 import { GameRulesNote } from "@/components/games/GameRulesNote";
@@ -422,6 +423,48 @@ export function MatchGameView() {
     for (const pg of serverPlayGroups) m.set(pg.id, effectiveStrokes(pg));
     return m;
   }, [serverParticipants, serverPlayGroups]);
+
+  // A2b Total Points — the PAIRED server matches resolved to display players + each
+  // match's per-match override (game_matches.point_value). Paired-only, so it's the
+  // same denominator the award/leaderboard use. Feeds the Total Points row's override
+  // panel (shared MatchupChips renderer) + the game-page projection's per-match value.
+  const pointsMatches = useMemo<PointsMatch[]>(() => {
+    const memberList = (side: { type: string; id: string } | null): string[] =>
+      side ? (membersOfSide.has(side.id) ? membersOfSide.get(side.id) ?? [] : [side.id]) : [];
+    const toPlayers = (ids: string[]): SidePlayer[] =>
+      ids.map((u) => ({ id: u, name: nameOf.get(u) ?? "Player", teamColor: teamColorOf(u) ?? colorOf.get(u) ?? PLAYER_COLORS[0] }));
+    return serverMatches
+      .filter((mm) => (mm as { side_a: unknown; side_b: unknown }).side_a && (mm as { side_b: unknown }).side_b)
+      .map((mm) => {
+        const row = mm as { id: string; match_number: number | null; side_a: { type: string; id: string } | null; side_b: { type: string; id: string } | null; point_value: number | null };
+        return {
+          id: row.id,
+          number: row.match_number ?? 0,
+          aPlayers: toPlayers(memberList(row.side_a)),
+          bPlayers: toPlayers(memberList(row.side_b)),
+          pointValue: row.point_value ?? null,
+        };
+      });
+    // teamColorOf/colorOf/nameOf are per-render closures over memoized maps; react to
+    // the underlying data instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverMatches, membersOfSide, nameOf, colorOf, teamById, teamOfUser, twoTeams]);
+
+  // matchId → override, for the game-page projection (per-match award value).
+  const pointValueByMatch = useMemo(() => {
+    const m = new Map<string, number | null>();
+    for (const mm of serverMatches) m.set((mm as { id: string }).id, ((mm as { point_value: number | null }).point_value) ?? null);
+    return m;
+  }, [serverMatches]);
+
+  // Default total = players per team (total competition players ÷ teams) — the
+  // first-setup default the Total Points row persists (behavior only, §3).
+  const defaultTotal = useMemo(() => {
+    const totalPlayers = (assignQ.data ?? []).length;
+    const teamCount = teams.length;
+    if (teamCount === 0 || totalPlayers === 0) return 0;
+    return Math.round(totalPlayers / teamCount);
+  }, [assignQ.data, teams.length]);
 
   function participant(id: string, fallbackColor?: string): Participant {
     const name = nameOf.get(id) ?? "Player";
@@ -976,13 +1019,16 @@ export function MatchGameView() {
         bTeamId: teamOfSide(g.b.id)?.id ?? null,
         leader: st.leader,
         started: st.thru > 0,
+        // A2b: this match's own override (else the even-share pointsPerMatch fallback)
+        // so the game-page projection double-counts an overridden match too.
+        points: pointValueByMatch.get(g.matchId) ?? null,
       };
     });
     return rollupMatchPlay(projMatches, pointsPerMatch);
     // decidedFor/teamOfSide are per-render closures; we depend on the DATA they
     // read (scores via loadedValues/values, handicaps, roster→team, scorecard).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groups, loadedValues, values, handicapOf, scIndex, scUnits, twoTeams, teamOfUser, teamById, membersOfSide, pointsPerMatch, glorious]);
+  }, [groups, loadedValues, values, handicapOf, scIndex, scUnits, twoTeams, teamOfUser, teamById, membersOfSide, pointsPerMatch, pointValueByMatch, glorious]);
 
   const entryPips = useMemo(() => {
     const m: Record<string, Set<string>> = {};
@@ -1193,11 +1239,13 @@ export function MatchGameView() {
         // competitionId), and a STANDALONE match game has no points at all (created
         // with points_distribution null). So the points term is conditional —
         // otherwise a standalone game (no Points UI, always 0) could NEVER enable.
-        // The per-match value read here is the SAME number the inline Points row
-        // shows, so the row's resolved state and the gate agree (one truth);
-        // pointsReady is the family's client-gate extension (matchDraft.ts).
-        const pointsPerMatch = gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0;
-        const enableReady = allFilled && allRosterValid && (!gameCompId || pointsReady(pointsPerMatch));
+        // A2b: readiness keys on the owner-set TOTAL (effectiveTotal = points_total ??
+        // players-per-team default), NOT the even share — an all-overridden game has a
+        // 0 even share but a real total, and must still be enable-able. This is the
+        // SAME resolved truth the Total Points row shows (total > 0), so the row's
+        // state and the gate agree; pointsReady is the family's client-gate extension.
+        const effectiveTotal = ((gameQ.data?.points_total as number | null) ?? null) ?? defaultTotal;
+        const enableReady = allFilled && allRosterValid && (!gameCompId || pointsReady(effectiveTotal));
         const anyHandicap = draft.some((d) => d.handicap !== 0);
         // ≥1 valid (paired) match — the downstream gate (readiness rework P3). Points
         // and Handicaps stay LOCKED until a match exists (they attach to a matchup).
@@ -1411,25 +1459,27 @@ export function MatchGameView() {
               />
             )}
 
-            {/* Format · Points — the last Settings row (the spine: matches × value).
-                NOT gated on matchesExist (bug fix): the owner can set the per-match
-                value before any match is paired — points mean nothing to the LIVE
-                total yet, but the value itself isn't invalid, and it's fine for
-                "Total Points Available" to read 0 with no matches defined. Rack's
-                "Points per Slot" (GameConfigurationView) never had this lock either
-                — matching that, for consistency across match-format games. */}
-            {gameQ.data && (
-              <GameSetupRows
-                slot="config"
+            {/* Total Points — the A2b spine (Refactor A2b): the owner sets a TOTAL,
+                the per-match value DERIVES (total ÷ matches), and individual matches
+                can be OVERRIDDEN with the remainder redistributing to keep the total
+                locked. Replaces the old inline "Points Per Match" stepper for match
+                play; rack keeps its "Points per Slot" inline control (GameSetupRows).
+                Competition games only (a standalone match has no points). */}
+            {gameQ.data && gameCompId && (
+              <MatchPointsRow
                 tripId={tripId}
+                gameId={gameId!}
                 competitionId={gameCompId}
-                game={gameQ.data as unknown as GameRow}
+                matches={pointsMatches}
+                pointsTotal={(gameQ.data?.points_total as number | null) ?? null}
+                pointsDistributionValue={
+                  gameQ.data?.points_distribution?.type === "per_match" ? gameQ.data.points_distribution.value : 0
+                }
+                defaultTotal={defaultTotal}
                 canEdit={settingsEditable}
                 locked={scoringEnabled}
-                matchCount={filledDraft.length}
-                configOpen={openRow === "config"}
-                onOpenConfig={() => changeOpenRow("config")}
-                onCloseEditor={() => changeOpenRow(null)}
+                expanded={openRow === "config"}
+                onToggle={() => toggleRow("config")}
                 onChanged={onSetupChanged}
               />
             )}

--- a/src/components/games/MatchPointsRow.tsx
+++ b/src/components/games/MatchPointsRow.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Hash, X } from "lucide-react";
+import { trpc } from "@/lib/trpc-client";
+import { ChecklistRow } from "@/components/games/ChecklistRow";
+import { Stepper } from "@/components/games/Stepper";
+import { MatchupChips, type SidePlayer } from "@/components/games/MatchSides";
+import { evenShare } from "@/lib/pointsDistribution";
+
+/**
+ * MatchPointsRow — the A2b **Total Points** row (Refactor A2b — the last piece of
+ * Refactor A). Inverts match-play points config: the owner sets a TOTAL; the
+ * per-match value DERIVES (total ÷ matches, the "even share"); individual matches
+ * can be OVERRIDDEN and the remainder REDISTRIBUTES to keep the total locked.
+ * "Counts double" is just an override — there is no separate multiplier.
+ *
+ * Storage (locked by Phase 0, unchanged field names — `per_match` is REUSED, never
+ * renamed):
+ *   - total          → `games.points_total`            (owner-set, via setPointsTotal)
+ *   - even share     → `games.points_distribution.value` (derived, via setPointsDistribution)
+ *   - per-match ovr  → `game_matches.point_value`       (via matches.setPointValue; null = even)
+ * The award sites read `point_value ?? points_distribution.value` per match; the
+ * leaderboard total reads `points_total` (authoritative). This component is the ONLY
+ * writer of that trio for match play.
+ *
+ * Header: title "Total Points" + a ± stepper (sets the total) + "Points per match: X"
+ * subtext (flips to "Custom" when any override exists). Expanded = the override list
+ * ONLY (via the shared `MatchupChips` renderer): the even share as the dim default,
+ * amber when overridden, × to reset. Honest fractions are shown (amber hint), never
+ * auto-rounded. No "Total allocated" row — locked-total redistribution makes
+ * mis-allocation impossible, so showing it would imply a failure mode that can't occur.
+ */
+
+const MAX_TOTAL = 999;
+
+/** One paired match, resolved to its display players + current override. */
+export interface PointsMatch {
+  id: string;
+  number: number;
+  aPlayers: SidePlayer[];
+  bPlayers: SidePlayer[];
+  /** game_matches.point_value — null = uses the even share. */
+  pointValue: number | null;
+}
+
+const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
+
+export function MatchPointsRow({
+  tripId,
+  gameId,
+  competitionId,
+  matches,
+  pointsTotal,
+  pointsDistributionValue,
+  defaultTotal,
+  canEdit,
+  locked,
+  expanded,
+  onToggle,
+  onChanged,
+}: {
+  tripId: string;
+  gameId: string;
+  competitionId: string | null;
+  /** Paired matches only (both sides set) — the award/leaderboard denominator. */
+  matches: PointsMatch[];
+  /** Persisted owner total (null until first setup). */
+  pointsTotal: number | null;
+  /** Persisted even share (`points_distribution.value`) — for the drift reconcile. */
+  pointsDistributionValue: number;
+  /** Players-per-team = total competition players ÷ teams. The first-setup default. */
+  defaultTotal: number;
+  canEdit: boolean;
+  /** Live-scoring freeze (#512) — read-only + lock icon. */
+  locked: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  onChanged?: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const setTotalM = trpc.games.setPointsTotal.useMutation();
+  const setDistM = trpc.games.setPointsDistribution.useMutation();
+  const setPvM = trpc.matches.setPointValue.useMutation();
+
+  const matchCount = matches.length;
+  // Effective total: the owner's set value, else the players-per-team default.
+  const effectiveTotal = pointsTotal ?? defaultTotal;
+  // Local total for snappy stepping; re-sync when the persisted value changes
+  // (render-phase adjust-on-prop-change, no effect).
+  const [localTotal, setLocalTotal] = useState(effectiveTotal);
+  const [lastEffectiveTotal, setLastEffectiveTotal] = useState(effectiveTotal);
+  if (effectiveTotal !== lastEffectiveTotal) {
+    setLastEffectiveTotal(effectiveTotal);
+    setLocalTotal(effectiveTotal);
+  }
+
+  const overrideValues = matches.map((m) => m.pointValue).filter((v): v is number => v != null);
+  const even = evenShare(localTotal, overrideValues, matchCount);
+  const anyOverride = overrideValues.length > 0;
+  const cleanEven = Number.isInteger(even);
+
+  // Persist the even share for the given (total, overrides) — always derived.
+  const persistEven = async (total: number, ovrs: number[]) => {
+    const ev = evenShare(total, ovrs, matchCount);
+    await setDistM.mutateAsync({ tripId, gameId, distribution: { type: "per_match", value: ev } });
+  };
+  const bumpBoard = () => {
+    utils.games.listByTrip.invalidate({ tripId });
+    utils.games.getById.invalidate({ tripId, gameId });
+    utils.matches.listByGame.invalidate({ tripId, gameId });
+    // CLAUDE.md #10: the Live face re-seeds child caches from faceBootstrap, so a
+    // points change must invalidate faceBootstrap or the board reads stale until poll.
+    if (competitionId) utils.competitions.faceBootstrap.invalidate({ tripId });
+    onChanged?.();
+  };
+
+  // The owner steps the TOTAL. Optimistic local, then persist total + derived even share.
+  const onTotalChange = async (next: number) => {
+    setLocalTotal(next);
+    try {
+      await setTotalM.mutateAsync({ tripId, gameId, total: next });
+      await persistEven(next, overrideValues);
+      bumpBoard();
+    } catch {
+      utils.games.getById.invalidate({ tripId, gameId });
+    }
+  };
+
+  // Set / clear one match's override, then redistribute the remainder (even share).
+  const onOverride = async (matchId: string, value: number | null) => {
+    try {
+      await setPvM.mutateAsync({ tripId, gameId, matchId, value });
+      const nextOvrs = matches
+        .map((m) => (m.id === matchId ? value : m.pointValue))
+        .filter((v): v is number => v != null);
+      await persistEven(localTotal, nextOvrs);
+      bumpBoard();
+    } catch {
+      utils.matches.listByGame.invalidate({ tripId, gameId });
+    }
+  };
+
+  // Reconcile the PERSISTED even share with the derived value: (1) first-setup default
+  // — no total yet → write players-per-team once; (2) keep points_distribution.value in
+  // sync as matches are added/removed or overrides change (recompute-on-input). Based on
+  // PERSISTED props (not local optimistic state) so it converges and never loops.
+  const didDefault = useRef(false);
+  useEffect(() => {
+    if (!canEdit || locked || matchCount === 0) return;
+    const persistedOvrs = matches.map((m) => m.pointValue).filter((v): v is number => v != null);
+    if (pointsTotal == null) {
+      if (defaultTotal > 0 && !didDefault.current) {
+        didDefault.current = true;
+        void (async () => {
+          await setTotalM.mutateAsync({ tripId, gameId, total: defaultTotal });
+          await persistEven(defaultTotal, persistedOvrs);
+          bumpBoard();
+        })();
+      }
+      return;
+    }
+    const ev = evenShare(pointsTotal, persistedOvrs, matchCount);
+    if (Math.abs(ev - pointsDistributionValue) > 1e-9) {
+      void (async () => {
+        await persistEven(pointsTotal, persistedOvrs);
+        bumpBoard();
+      })();
+    }
+    // persistEven/bumpBoard are stable-enough closures; we react to the DATA inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pointsTotal, defaultTotal, matchCount, pointsDistributionValue, canEdit, locked, matches.map((m) => `${m.id}:${m.pointValue}`).join(",")]);
+
+  const subtitle = (
+    <>
+      Points per match:{" "}
+      <span style={{ color: "var(--color-bt-accent)", fontWeight: 600 }}>
+        {anyOverride ? "Custom" : fmt(even)}
+      </span>
+    </>
+  );
+
+  return (
+    <ChecklistRow
+      icon={Hash}
+      title="Total Points"
+      subtitle={subtitle}
+      state={effectiveTotal > 0 ? "resolved" : "empty"}
+      disabled={!canEdit}
+      locked={locked}
+      expanded={expanded}
+      onToggle={onToggle}
+      testId="row-total-points"
+      headerControl={
+        <Stepper
+          size="inline"
+          value={localTotal}
+          min={0}
+          max={MAX_TOTAL}
+          onChange={locked || !canEdit ? () => {} : (v) => void onTotalChange(v)}
+          disabled={locked || !canEdit}
+          testId="total-points-stepper"
+        />
+      }
+    >
+      <div className="flex flex-col" data-testid="points-override-panel">
+        {matches.map((m, idx) => (
+          <div
+            key={m.id}
+            className="flex items-center gap-3"
+            style={{
+              borderTop: idx > 0 ? "1px solid var(--color-bt-border)" : undefined,
+              paddingTop: idx > 0 ? 12 : 0,
+              paddingBottom: 12,
+            }}
+          >
+            <span
+              className="flex flex-shrink-0 items-center justify-center"
+              style={{ width: 18, height: 18, borderRadius: 5, background: "var(--color-bt-card-raised)", fontSize: 10, fontWeight: 800, color: "var(--color-bt-text-dim)" }}
+            >
+              {m.number}
+            </span>
+            <div className="min-w-0 flex-1">
+              <MatchupChips a={m.aPlayers} b={m.bPlayers} />
+            </div>
+            <OverrideField
+              even={even}
+              value={m.pointValue}
+              disabled={locked || !canEdit}
+              onCommit={(v) => void onOverride(m.id, v)}
+            />
+          </div>
+        ))}
+
+        {/* Honest fraction (never rounded): shown when the even share isn't whole and
+            no override is masking it — nudge a divisible total or an override. */}
+        {!cleanEven && !anyOverride && matchCount > 0 && (
+          <p className="text-[11px]" style={{ color: "var(--color-bt-warning)", lineHeight: 1.4, marginTop: 4 }} data-testid="points-fraction-hint">
+            {fmt(localTotal)} ÷ {matchCount} = {fmt(even)} — not whole. Pick a total divisible by the match count, or override a match to clean up the rest.
+          </p>
+        )}
+      </div>
+    </ChecklistRow>
+  );
+}
+
+/** One match's override input: the even share as a dim default when unset; an amber
+ *  value + × reset when overridden. Commits on blur / Enter. */
+function OverrideField({
+  even,
+  value,
+  disabled,
+  onCommit,
+}: {
+  even: number;
+  value: number | null;
+  disabled: boolean;
+  onCommit: (value: number | null) => void;
+}) {
+  const isOverridden = value != null;
+  const [draft, setDraft] = useState(isOverridden ? String(value) : "");
+  // Resync when the persisted override changes externally — React's render-phase
+  // "adjust state on prop change" pattern (no effect, no cascading-render lint trip).
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    setDraft(value != null ? String(value) : "");
+  }
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      if (isOverridden) onCommit(null); // cleared → back to the even share
+      return;
+    }
+    const n = Number(trimmed);
+    if (!Number.isFinite(n) || n < 0) {
+      setDraft(isOverridden ? String(value) : ""); // reject → revert
+      return;
+    }
+    if (n !== value) onCommit(n);
+  };
+
+  return (
+    <div className="flex flex-shrink-0 items-center" style={{ gap: 5, width: 78, justifyContent: "flex-end" }}>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={draft}
+        placeholder={fmt(even)}
+        disabled={disabled}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        }}
+        data-testid="points-override-input"
+        style={{
+          width: 48,
+          textAlign: "center",
+          borderRadius: 8,
+          padding: "5px 4px",
+          fontSize: 13,
+          fontWeight: 700,
+          background: isOverridden ? "var(--color-bt-warning-faint)" : "var(--color-bt-base)",
+          border: `1px solid ${isOverridden ? "var(--color-bt-warning-border)" : "var(--color-bt-border)"}`,
+          color: isOverridden ? "var(--color-bt-warning)" : "var(--color-bt-text)",
+          outline: "none",
+        }}
+      />
+      <button
+        type="button"
+        aria-label="Reset to even share"
+        onClick={() => onCommit(null)}
+        disabled={disabled}
+        className="flex items-center justify-center"
+        style={{ width: 12, visibility: isOverridden ? "visible" : "hidden", color: "var(--color-bt-text-dim)" }}
+        data-testid="points-override-reset"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/gameProjection.test.ts
+++ b/src/lib/gameProjection.test.ts
@@ -51,4 +51,24 @@ describe("rollupMatchPlay", () => {
     expect(rollupMatchPlay([m("blue", null, "A", true)], 2)).toEqual({ blue: 2 });
     expect(rollupMatchPlay([m("blue", null, null, true)], 2)).toEqual({ blue: 1 }); // halve: only blue credited
   });
+
+  // A2b — a match's own `points` (game_matches.point_value) OVERRIDES the even share.
+  it("awards a match's OVERRIDE value over the even-share fallback", () => {
+    const over = (leader: "A" | "B" | null, points: number): ProjMatch => ({ ...m("blue", "red", leader, true), points });
+    expect(rollupMatchPlay([over("A", 4)], 2)).toEqual({ blue: 4 }); // counts double, not the even 2
+    expect(rollupMatchPlay([over("B", 4)], 2)).toEqual({ red: 4 });
+    expect(rollupMatchPlay([over(null, 4)], 2)).toEqual({ blue: 2, red: 2 }); // halved override
+  });
+
+  it("mixes overridden and even-share matches (the Buddy shape)", () => {
+    // 6 singles at the even share 2 + 1 doubles overridden to 4.
+    const singles = Array.from({ length: 6 }, () => m("blue", "red", "A", true)); // blue sweeps → 6×2
+    const doubles: ProjMatch = { ...m("blue", "red", "A", true), points: 4 }; // blue wins the double → +4
+    expect(rollupMatchPlay([...singles, doubles], 2)).toEqual({ blue: 16 }); // 12 + 4, total 16
+  });
+
+  it("a null/undefined `points` falls back to the even share", () => {
+    const withNull: ProjMatch = { ...m("blue", "red", "A", true), points: null };
+    expect(rollupMatchPlay([withNull], 3)).toEqual({ blue: 3 });
+  });
 });

--- a/src/lib/gameProjection.ts
+++ b/src/lib/gameProjection.ts
@@ -19,6 +19,11 @@ export interface ProjMatch {
   leader: "A" | "B" | null;
   /** Has any hole been decided yet? An unstarted match projects to nothing. */
   started: boolean;
+  /** A2b: this match's OWN points value (`game_matches.point_value`). When set it
+   *  OVERRIDES the game's even-share `pointsPerMatch` for this match only; null/omit
+   *  → the even share. So a "counts double" match is just a match carrying its own
+   *  value — no separate multiplier. */
+  points?: number | null;
 }
 
 /**
@@ -28,6 +33,10 @@ export interface ProjMatch {
  *   - all-square but STARTED → halved → the points split (½ to each side's team);
  *   - not started → contributes nothing.
  * Teams beyond two accumulate independently (a points-cup 2v2 with N teams).
+ *
+ * A2b: each match is worth its own `points` when set (an override), else the game's
+ * even-share `pointsPerMatch` — so an overridden ("counts double") match projects at
+ * its real value, exactly as the finish path awards it.
  */
 export function rollupMatchPlay(matches: ProjMatch[], pointsPerMatch: number): Record<string, number> {
   const out: Record<string, number> = {};
@@ -36,12 +45,13 @@ export function rollupMatchPlay(matches: ProjMatch[], pointsPerMatch: number): R
   };
   for (const m of matches) {
     if (!m.started) continue; // not started → 0
-    if (m.leader === "A") add(m.aTeamId, pointsPerMatch);
-    else if (m.leader === "B") add(m.bTeamId, pointsPerMatch);
+    const value = m.points ?? pointsPerMatch; // A2b: per-match override wins
+    if (m.leader === "A") add(m.aTeamId, value);
+    else if (m.leader === "B") add(m.bTeamId, value);
     else {
       // all-square, in progress → halved
-      add(m.aTeamId, pointsPerMatch / 2);
-      add(m.bTeamId, pointsPerMatch / 2);
+      add(m.aTeamId, value / 2);
+      add(m.bTeamId, value / 2);
     }
   }
   return out;

--- a/src/lib/pointsDistribution.test.ts
+++ b/src/lib/pointsDistribution.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { evenShare, isPerMatch, isPlacement } from "./pointsDistribution";
+
+// A2b — the derived even share for non-overridden matches:
+//   (total − Σ overrides) ÷ (matchCount − overrideCount).
+describe("evenShare (A2b Total Points model)", () => {
+  it("splits the whole total when there are NO overrides", () => {
+    expect(evenShare(16, [], 8)).toBe(2); // clean: 16 ÷ 8
+  });
+
+  it("redistributes the REMAINDER after overrides, keeping the total locked (Buddy)", () => {
+    // 16 total, one match overridden to 4 → the other 6 split (16 − 4) = 12 → 2 each.
+    expect(evenShare(16, [4], 7)).toBe(2);
+  });
+
+  it("handles multiple overrides", () => {
+    // 20 total, two overrides (5, 3) → remainder 12 across 4 → 3 each.
+    expect(evenShare(20, [5, 3], 6)).toBe(3);
+  });
+
+  it("surfaces an HONEST fraction, never rounded", () => {
+    expect(evenShare(16, [], 7)).toBeCloseTo(2.2857, 3); // 16 ÷ 7
+  });
+
+  it("returns 0 when EVERY match is overridden (no even share to spread)", () => {
+    expect(evenShare(16, [8, 8], 2)).toBe(0);
+  });
+
+  it("returns 0 with no matches", () => {
+    expect(evenShare(16, [], 0)).toBe(0);
+  });
+
+  it("can go negative if overrides exceed the total (honest, caller/UI flags it)", () => {
+    // 10 total, one override of 12 → remainder −2 across 1 non-overridden → −2.
+    expect(evenShare(10, [12], 2)).toBe(-2);
+  });
+});
+
+// The tagged-shape guards are unchanged by A2b — a quick regression that reuse
+// didn't perturb them.
+describe("distribution shape guards", () => {
+  it("isPerMatch / isPlacement discriminate", () => {
+    expect(isPerMatch({ type: "per_match", value: 2 })).toBe(true);
+    expect(isPerMatch({ type: "placement", values: [5, 3] })).toBe(false);
+    expect(isPlacement({ type: "placement", values: [5, 3] })).toBe(true);
+    expect(isPlacement(null)).toBe(false);
+  });
+});

--- a/src/lib/pointsDistribution.ts
+++ b/src/lib/pointsDistribution.ts
@@ -30,3 +30,24 @@ export function isPlacement(d: unknown): d is PlacementDistribution {
     (d as PlacementDistribution).type === "placement"
   );
 }
+
+/**
+ * A2b — the derived EVEN SHARE for a match-play game's NON-overridden matches:
+ *   (total − Σ overrides) ÷ (matchCount − overrideCount).
+ *
+ * `overrides` is the list of explicit per-match `game_matches.point_value`s; every
+ * other match splits the remainder equally. The Total Points model persists ONLY
+ * the overrides — this even share is derived from live inputs (never snapshotted
+ * per-match) and written to `points_distribution.value`, which the award sites read
+ * as the fallback (`point_value ?? points_distribution.value`).
+ *
+ * Returns 0 when every match is overridden (no even share to spread) or there are no
+ * matches. NOT rounded — honest fractions (16 ÷ 7 = 2.285…) are surfaced in the UI,
+ * never silently rounded, so the persisted award value and the displayed value agree.
+ */
+export function evenShare(total: number, overrides: number[], matchCount: number): number {
+  const nonOverridden = matchCount - overrides.length;
+  if (nonOverridden <= 0) return 0;
+  const remainder = total - overrides.reduce((s, v) => s + v, 0);
+  return remainder / nonOverridden;
+}

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -180,6 +180,7 @@ export async function computeCompetitionLeaderboard(
 
     if (isPerMatch(rawDist)) {
       const typeId = g.game_type_id as string | null;
+      const isMatchPlayType = typeId != null && MATCH_PLAY_TYPES.has(typeId);
       // Match play (singles/doubles): available = value × the game's ASSIGNED
       // match count (game_matches rows with both sides paired) — an unfilled slot
       // isn't a match, so it adds no points (round-3.1 "a match = assigned"). The
@@ -187,11 +188,18 @@ export async function computeCompetitionLeaderboard(
       // per_match formats (rack-n-stack) DON'T use game_matches; their count is
       // the team-size-derived head-to-head sizing (unchanged stable model) — so
       // counting rows there would zero them out.
-      const mc =
-        typeId && MATCH_PLAY_TYPES.has(typeId)
-          ? matchCountByGame.get(g.id as string) ?? 0
-          : deriveMatchCount(teamSizes, matchFormat(typeId)) ?? 0;
-      const pointsTotal = rawDist.value * mc;
+      const mc = isMatchPlayType
+        ? matchCountByGame.get(g.id as string) ?? 0
+        : deriveMatchCount(teamSizes, matchFormat(typeId)) ?? 0;
+      // A2b: match play's authoritative total is the owner-set `points_total`.
+      // `value × mc` only equals the total when there are NO overrides — once a
+      // match is overridden it drifts, so read the total directly (derive-don't-
+      // snapshot). A legacy match game with a null total (pre-A2b) falls back to
+      // `value × mc`, its old behavior. RACK is unchanged: its total genuinely IS
+      // value × slots (no points_total, no game_matches).
+      const pointsTotal = isMatchPlayType
+        ? (g.points_total as number | null) ?? rawDist.value * mc
+        : rawDist.value * mc;
       if (standings.length === 0) {
         // No decided matches yet — contributes its available pool, no awards.
         return { id: g.id as string, distribution: null, numTeams: teamIds.length, standings: [], direction: "high_wins" as const, pointsTotal };

--- a/src/server/lib/liveProjection.test.ts
+++ b/src/server/lib/liveProjection.test.ts
@@ -38,6 +38,31 @@ describe("projectGame — match play", () => {
     expect(projectGame(input, data)).toEqual({ blue: 3, red: 1 });
   });
 
+  it("A2b — a match's point_value OVERRIDES the even-share pointsPerMatch in the projection", () => {
+    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play", pointsPerMatch: 2 };
+    const data: GameProjectionData = {
+      schema: { units: { count: 2 } },
+      modifiers: null,
+      matches: [
+        // alice sweeps → blue; this match "counts double" (override 4), not the even 2.
+        { side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" }, point_value: 4 },
+        // carol sweeps → blue at the even share (no override).
+        { side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" }, point_value: null },
+      ],
+      parts: [part("alice"), part("bob"), part("carol"), part("dave")],
+      playGroups: [],
+      gross: gross({
+        alice: { "1": 4, "2": 4 },
+        bob: { "1": 5, "2": 5 },
+        carol: { "1": 4, "2": 4 },
+        dave: { "1": 5, "2": 5 },
+      }),
+      userTeam: userTeam({ alice: "blue", bob: "red", carol: "blue", dave: "red" }),
+    };
+    // blue = 4 (overridden match) + 2 (even-share match) = 6.
+    expect(projectGame(input, data)).toEqual({ blue: 6 });
+  });
+
   it("an unpaired match (a side missing) contributes nothing", () => {
     const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play", pointsPerMatch: 2 };
     const data: GameProjectionData = {

--- a/src/server/lib/liveProjection.ts
+++ b/src/server/lib/liveProjection.ts
@@ -56,7 +56,8 @@ export interface LiveProjectionInput {
 export interface GameProjectionData {
   schema: SchemaShape | null;
   modifiers: ModifiersMap | null;
-  matches: { side_a: SideRef | null; side_b: SideRef | null }[];
+  /** A2b: `point_value` is the per-match override (null → the even share). */
+  matches: { side_a: SideRef | null; side_b: SideRef | null; point_value?: number | null }[];
   parts: { user_id: string; play_group_id: string | null; handicap_strokes: number | null }[];
   playGroups: { id: string; handicap_strokes: number | null }[];
   /** participant_id → { unit_label: gross }. */
@@ -93,7 +94,7 @@ export async function computeLiveProjections(
   const [gamesMetaRes, matchRowsRes, participantRowsRes, playGroupRowsRes, entryRowsRes, assignRes] =
     await Promise.all([
       supabase.from("games").select("id, scorecard_schema, modifiers").in("id", gameIds),
-      supabase.from("game_matches").select("game_id, side_a, side_b").in("game_id", gameIds),
+      supabase.from("game_matches").select("game_id, side_a, side_b, point_value").in("game_id", gameIds),
       supabase
         .from("game_participants")
         .select("game_id, user_id, play_group_id, handicap_strokes")
@@ -118,10 +119,14 @@ export async function computeLiveProjections(
     });
   }
 
-  const matchesByGame = new Map<string, { side_a: SideRef | null; side_b: SideRef | null }[]>();
+  const matchesByGame = new Map<string, { side_a: SideRef | null; side_b: SideRef | null; point_value: number | null }[]>();
   for (const m of matchRowsRes.data ?? []) {
     const arr = matchesByGame.get(m.game_id as string) ?? [];
-    arr.push({ side_a: (m.side_a as SideRef | null) ?? null, side_b: (m.side_b as SideRef | null) ?? null });
+    arr.push({
+      side_a: (m.side_a as SideRef | null) ?? null,
+      side_b: (m.side_b as SideRef | null) ?? null,
+      point_value: (m.point_value as number | null) ?? null,
+    });
     matchesByGame.set(m.game_id as string, arr);
   }
 
@@ -216,7 +221,14 @@ function projectMatch(g: LiveProjectionInput, data: GameProjectionData): Record<
       holeCount
     );
     const st = matchState(decided, holeCount, glorious);
-    projMatches.push({ aTeamId: sideTeam(a), bTeamId: sideTeam(b), leader: st.leader, started: st.thru > 0 });
+    projMatches.push({
+      aTeamId: sideTeam(a),
+      bTeamId: sideTeam(b),
+      leader: st.leader,
+      started: st.thru > 0,
+      // A2b: carry this match's override so rollupMatchPlay awards it over the even share.
+      points: m.point_value ?? null,
+    });
   }
   return rollupMatchPlay(projMatches, g.pointsPerMatch);
 }

--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -59,7 +59,9 @@ export async function computeMatchPlayResults(
   const skipComplete = opts?.skipComplete ?? false;
   const { data: matches } = await supabase
     .from("game_matches")
-    .select("id, side_a, side_b, status, result")
+    // point_value = the A2b per-match override (null → the even share). Read here so
+    // the team-points adapter awards `point_value ?? even share` per match.
+    .select("id, side_a, side_b, status, result, point_value")
     .eq("game_id", gameId);
 
   // Stroke index: the game's course snapshot if one is applied, else undefined
@@ -197,6 +199,8 @@ export async function computeMatchPlayResults(
       supabase,
       gameId,
       gameInfo.competition_id as string,
+      // A2b: the even share = points_distribution.value, used as the per-match
+      // FALLBACK. Each match awards its own `point_value` when set, else this.
       (gameInfo.points_distribution as PerMatchDistribution).value,
       matches ?? [],
       outcomes
@@ -247,13 +251,17 @@ function mkResult(
 /** Aggregate decided match outcomes into per-team competition points and write
  *  them to game_results (entity_type='team', raw_score=accumulated points).
  *  Combines skipped-complete matches (from the initial query's result field)
- *  with freshly-computed outcomes so the team total is always complete. */
+ *  with freshly-computed outcomes so the team total is always complete.
+ *
+ *  A2b: each match is worth `point_value ?? evenShareFallback` — the per-match
+ *  override when set, else the game's derived even share (points_distribution.value,
+ *  passed as `evenShareFallback`). So a "counts double" match awards its own value. */
 async function writeTeamMatchPoints(
   supabase: SupabaseClient,
   gameId: string,
   competitionId: string,
-  perMatchValue: number,
-  allMatches: { id: unknown; side_a: unknown; side_b: unknown; result: unknown }[],
+  evenShareFallback: number,
+  allMatches: { id: unknown; side_a: unknown; side_b: unknown; result: unknown; point_value?: unknown }[],
   freshOutcomes: MatchOutcome[]
 ) {
   // Fresh outcomes override stale results for the matches we just processed.
@@ -306,14 +314,16 @@ async function writeTeamMatchPoints(
     const bTeam = sideTeam(b);
     if (!aTeam || !bTeam) continue;
 
+    // A2b award rule: this match's own override, else the even share.
+    const value = (m.point_value as number | null) ?? evenShareFallback;
     if (result === "a_win") {
-      teamPoints.set(aTeam, (teamPoints.get(aTeam) ?? 0) + perMatchValue);
+      teamPoints.set(aTeam, (teamPoints.get(aTeam) ?? 0) + value);
     } else if (result === "b_win") {
-      teamPoints.set(bTeam, (teamPoints.get(bTeam) ?? 0) + perMatchValue);
+      teamPoints.set(bTeam, (teamPoints.get(bTeam) ?? 0) + value);
     } else {
       // halve — each side gets half
-      teamPoints.set(aTeam, (teamPoints.get(aTeam) ?? 0) + perMatchValue / 2);
-      teamPoints.set(bTeam, (teamPoints.get(bTeam) ?? 0) + perMatchValue / 2);
+      teamPoints.set(aTeam, (teamPoints.get(aTeam) ?? 0) + value / 2);
+      teamPoints.set(bTeam, (teamPoints.get(bTeam) ?? 0) + value / 2);
     }
   }
 

--- a/src/server/routers/matches.pointsA2b.test.ts
+++ b/src/server/routers/matches.pointsA2b.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+import { evenShare } from "@/lib/pointsDistribution";
+
+/**
+ * Refactor A2b — the Total Points model, end-to-end through the DB.
+ *
+ * The owner sets a TOTAL (games.points_total); the per-match value DERIVES (the even
+ * share → points_distribution.value); individual matches OVERRIDE via
+ * game_matches.point_value with the remainder redistributing to keep the total locked.
+ * The award sites read `point_value ?? points_distribution.value`; the leaderboard
+ * points-in-play reads the authoritative `points_total`.
+ *
+ * The exact Buddy math (16 total, doubles overridden to 4, six singles → 2 each) is
+ * locked by the pure unit tests (pointsDistribution.test.ts / gameProjection.test.ts).
+ * These prove the WIRING with the 4 shared users: 2 singles with one overridden proves
+ * override + redistribution + the points_total leaderboard switch + the award read rule
+ * — the same properties, a testable size. A 1-match doubles case proves the override
+ * awards on a play_group side too.
+ */
+
+const MATCH_PLAY = "gtt_match_play";
+
+let ctx: TestContext;
+let tripId: string;
+let owner: string, planner: string, member: string, outsider: string;
+const gameIds: string[] = [];
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("A2b Total Points Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer");
+  await ctx.addTripMember(tripId, "member", "Member");
+  await ctx.addTripMember(tripId, "outsider", "Member");
+  owner = ctx.user.id;
+  planner = ctx.getUser("planner").id;
+  member = ctx.getUser("member").id;
+  outsider = ctx.getUser("outsider").id;
+});
+
+afterAll(async () => {
+  if (gameIds.length) {
+    await ctx.admin.from("game_results").delete().in("game_id", gameIds);
+    await ctx.admin.from("games").delete().in("id", gameIds);
+  }
+  await ctx.cleanup();
+}, 30000);
+
+type Side = { type: string; id: string } | null;
+interface MatchRow {
+  id: string;
+  side_a: Side;
+  side_b: Side;
+}
+
+/** A competition with Blue (owner+planner) vs Red (member+outsider). */
+async function makeComp(name: string): Promise<{ comp: string; blue: string; red: string }> {
+  const comp = await ctx.createCompetition(tripId, name);
+  const blue = await ctx.createTeam(comp, "Blue", { color: "#2563eb" });
+  const red = await ctx.createTeam(comp, "Red", { color: "#dc2626" });
+  await ctx.admin.from("team_assignments").insert([
+    { competition_id: comp, user_id: owner, team_id: blue },
+    { competition_id: comp, user_id: planner, team_id: blue },
+    { competition_id: comp, user_id: member, team_id: red },
+    { competition_id: comp, user_id: outsider, team_id: red },
+  ]);
+  return { comp, blue, red };
+}
+
+async function makeGame(comp: string, name: string): Promise<string> {
+  const g = (await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name, competitionId: comp })) as { id: string };
+  gameIds.push(g.id);
+  return g.id;
+}
+
+/** Set the owner total + derive & persist the even share (the client's setup writes). */
+async function setTotal(gameId: string, total: number, overrides: number[], matchCount: number) {
+  await ctx.caller().games.setPointsTotal({ tripId, gameId, total });
+  await ctx.caller().games.setPointsDistribution({ tripId, gameId, distribution: { type: "per_match", value: evenShare(total, overrides, matchCount) } });
+}
+
+/** Blue (side A) sweeps side B: A shoots 4, B shoots 5 over `holes` holes → A closes
+ *  out (10&8 by hole 10). participantType per the side shape. */
+async function blueSweeps(gameId: string, aId: string, bId: string, type: "user" | "play_group", holes = 10) {
+  const caller = ctx.caller();
+  await caller.games.enableScoring({ tripId, gameId });
+  for (let h = 1; h <= holes; h++) {
+    await caller.scores.upsertEntry({ tripId, gameId, participantId: aId, unitLabel: String(h), value: 4, participantType: type });
+    await caller.scores.upsertEntry({ tripId, gameId, participantId: bId, unitLabel: String(h), value: 5, participantType: type });
+  }
+}
+
+describe("A2b — override redistributes; award reads point_value ?? even share", () => {
+  it("2 singles, total 6, one overridden to 4 → other redistributes to 2; Blue sweeps → 6", async () => {
+    const { comp, blue, red } = await makeComp("A2b Redistribute");
+    const gameId = await makeGame(comp, "Two Singles");
+    const matches = (await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [
+        { playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 },
+        { playersPerSide: 1, sideA: { members: [planner] }, sideB: { members: [outsider] }, matchNumber: 2 },
+      ],
+    })) as MatchRow[];
+    const m1 = matches[0], m2 = matches[1];
+
+    // Owner total 6, even 3/3 at first.
+    await setTotal(gameId, 6, [], 2);
+    // Override match 1 to 4 → the other redistributes to (6−4)/1 = 2.
+    await ctx.caller().matches.setPointValue({ tripId, gameId, matchId: m1.id, value: 4 });
+    await ctx.caller().games.setPointsDistribution({ tripId, gameId, distribution: { type: "per_match", value: evenShare(6, [4], 2) } });
+
+    // The override persisted; the even share is 2.
+    const { data: mrow } = await ctx.admin.from("game_matches").select("id, point_value").eq("id", m1.id).maybeSingle();
+    expect(Number((mrow as { point_value: number }).point_value)).toBe(4);
+    const { data: grow } = await ctx.admin.from("games").select("points_total, points_distribution").eq("id", gameId).maybeSingle();
+    expect((grow as { points_total: number }).points_total).toBe(6);
+    expect((grow as { points_distribution: { value: number } }).points_distribution.value).toBe(2);
+
+    // Blue sweeps both singles (side A wins each).
+    const caller = ctx.caller();
+    await caller.games.enableScoring({ tripId, gameId });
+    for (const [aId, bId] of [[owner, member], [planner, outsider]] as const) {
+      for (let h = 1; h <= 10; h++) {
+        await caller.scores.upsertEntry({ tripId, gameId, participantId: aId, unitLabel: String(h), value: 4, participantType: "user" });
+        await caller.scores.upsertEntry({ tripId, gameId, participantId: bId, unitLabel: String(h), value: 5, participantType: "user" });
+      }
+    }
+    await ctx.caller().games.finish({ tripId, gameId });
+
+    // Blue earns the override (4) + the even share (2) = 6; Red 0. Award read rule.
+    const { data: teamRows } = await ctx.admin
+      .from("game_results").select("entity_id, raw_score").eq("game_id", gameId).eq("entity_type", "team");
+    const byTeam = Object.fromEntries((teamRows as { entity_id: string; raw_score: number }[]).map((r) => [r.entity_id, Number(r.raw_score)]));
+    expect(byTeam[blue]).toBe(6); // 4 (M1 override) + 2 (M2 even) — locked total, redistributed
+    expect(byTeam[red] ?? 0).toBe(0);
+
+    // Leaderboard points-in-play = points_total (6), NOT the recomputed even × mc (2×2=4).
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    const gameCell = lb.games.find((g) => g.id === gameId);
+    expect(gameCell?.pointsTotal).toBe(6); // authoritative total, no value×mc snapshot drift
+    expect(lb.teamTotals[blue]).toBe(6);
+
+    void m2; // (referenced for clarity; its even value is asserted via byTeam)
+  }, 60000);
+
+  it("clearing an override reverts the match to the even share (point_value → null)", async () => {
+    const { comp } = await makeComp("A2b Clear");
+    const gameId = await makeGame(comp, "Clearable");
+    const matches = (await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [
+        { playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 },
+        { playersPerSide: 1, sideA: { members: [planner] }, sideB: { members: [outsider] }, matchNumber: 2 },
+      ],
+    })) as MatchRow[];
+    await setTotal(gameId, 6, [], 2);
+    await ctx.caller().matches.setPointValue({ tripId, gameId, matchId: matches[0].id, value: 4 });
+    // Clear it.
+    await ctx.caller().matches.setPointValue({ tripId, gameId, matchId: matches[0].id, value: null });
+    const { data } = await ctx.admin.from("game_matches").select("point_value").eq("id", matches[0].id).maybeSingle();
+    expect((data as { point_value: number | null }).point_value).toBeNull();
+  }, 30000);
+});
+
+describe("A2b — existing games safe (null total → value × mc fallback)", () => {
+  it("a pre-A2b game (null points_total, no override) awards on the even-share fallback", async () => {
+    const { comp, blue, red } = await makeComp("A2b Legacy");
+    const gameId = await makeGame(comp, "Legacy Match");
+    await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [
+        { playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 },
+        { playersPerSide: 1, sideA: { members: [planner] }, sideB: { members: [outsider] }, matchNumber: 2 },
+      ],
+    });
+    // Simulate a pre-A2b game: a per_match distribution, NO owner total, NO overrides.
+    await ctx.admin.from("games").update({ points_total: null, points_distribution: { type: "per_match", value: 2 } }).eq("id", gameId);
+
+    const caller = ctx.caller();
+    await caller.games.enableScoring({ tripId, gameId });
+    for (const [aId, bId] of [[owner, member], [planner, outsider]] as const) {
+      for (let h = 1; h <= 10; h++) {
+        await caller.scores.upsertEntry({ tripId, gameId, participantId: aId, unitLabel: String(h), value: 4, participantType: "user" });
+        await caller.scores.upsertEntry({ tripId, gameId, participantId: bId, unitLabel: String(h), value: 5, participantType: "user" });
+      }
+    }
+    await ctx.caller().games.finish({ tripId, gameId });
+
+    const { data: teamRows } = await ctx.admin
+      .from("game_results").select("entity_id, raw_score").eq("game_id", gameId).eq("entity_type", "team");
+    const byTeam = Object.fromEntries((teamRows as { entity_id: string; raw_score: number }[]).map((r) => [r.entity_id, Number(r.raw_score)]));
+    expect(byTeam[blue]).toBe(4); // 2 (value) × 2 matches — the null-total fallback, unchanged
+    expect(byTeam[red] ?? 0).toBe(0);
+
+    // Leaderboard points-in-play falls back to value × mc (2 × 2 = 4) with a null total.
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.games.find((g) => g.id === gameId)?.pointsTotal).toBe(4);
+  }, 60000);
+});
+
+describe("A2b — a doubles override awards on the play_group side", () => {
+  it("a 2v2 match overridden to 4 awards 4 to the winning pair's team", async () => {
+    const { comp, blue, red } = await makeComp("A2b Doubles Override");
+    const gameId = await makeGame(comp, "Doubles Override");
+    const matches = (await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [
+        { playersPerSide: 2, sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 },
+      ],
+    })) as MatchRow[];
+    const pgA = matches[0].side_a!.id;
+    const pgB = matches[0].side_b!.id;
+
+    await setTotal(gameId, 2, [], 1); // even share 2 for the lone match…
+    await ctx.caller().matches.setPointValue({ tripId, gameId, matchId: matches[0].id, value: 4 }); // …overridden to 4
+
+    await blueSweeps(gameId, pgA, pgB, "play_group");
+    await ctx.caller().games.finish({ tripId, gameId });
+
+    const { data: teamRows } = await ctx.admin
+      .from("game_results").select("entity_id, raw_score").eq("game_id", gameId).eq("entity_type", "team");
+    const byTeam = Object.fromEntries((teamRows as { entity_id: string; raw_score: number }[]).map((r) => [r.entity_id, Number(r.raw_score)]));
+    expect(byTeam[blue]).toBe(4); // the override, not the even share of 2
+    expect(byTeam[red] ?? 0).toBe(0);
+  }, 60000);
+});

--- a/src/server/routers/matches.ts
+++ b/src/server/routers/matches.ts
@@ -361,6 +361,48 @@ export const matchesRouter = router({
       return { ok: true };
     }),
 
+  // setPointValue — Owner/Organizer/delegate (requireGameEdit — the "distribute
+  // within" right; the owner-set TOTAL stays Organizer-only via games.setPointsTotal).
+  // A2b per-match points OVERRIDE: write game_matches.point_value. NULL clears it →
+  // the match reverts to the even share. This mutation owns ONLY the single per-match
+  // column; the client recomputes + persists the REMAINING matches' even share via
+  // games.setPointsDistribution (it holds the live match set). point_value is an AWARD
+  // input, so we re-derive in-progress team points (skipComplete leaves frozen match
+  // results intact; writeTeamMatchPoints re-reads the fresh override). No scores yet →
+  // computeMatchPlayResults early-returns, so this is a cheap no-op during setup.
+  setPointValue: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        matchId: z.string().min(1),
+        value: z.number().min(0).nullable(),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      await assertGameInTrip(ctx, input.gameId, ctx.tripId);
+      const { data: match } = await ctx.supabase
+        .from("game_matches")
+        .select("id")
+        .eq("id", input.matchId)
+        .eq("game_id", input.gameId)
+        .maybeSingle();
+      if (!match) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
+      }
+      const { error } = await ctx.supabase
+        .from("game_matches")
+        .update({ point_value: input.value })
+        .eq("id", input.matchId)
+        .eq("game_id", input.gameId);
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to set match points: ${error.message}` });
+      }
+      await computeMatchPlayResults(ctx.supabase, input.gameId, { skipComplete: true });
+      return { ok: true };
+    }),
+
   // ── legacy doubles twins removed (Refactor A2a) ─────────────────────────────
   // setDoublesPairings / setDoublesHandicap were folded into the per-match
   // setPairings / setHandicap above (shape comes from each match's playersPerSide

--- a/supabase/migrations/20260712140000_074_match_point_value.sql
+++ b/supabase/migrations/20260712140000_074_match_point_value.sql
@@ -1,0 +1,25 @@
+-- 074: per-match points override (Refactor A2b — the Total Points model).
+--
+-- A2b inverts match-play points config: the owner sets a TOTAL (games.points_total),
+-- the per-match value DERIVES from it (total ÷ matches, written to
+-- points_distribution.value as the "even share"), and INDIVIDUAL matches can be
+-- OVERRIDDEN. This column holds that override:
+--   NULL  = this match uses the even share (points_distribution.value);
+--   set   = this match's overridden competition-point value.
+-- The remainder redistributes across the non-overridden matches to keep the total
+-- locked. Redistribution is DERIVED, never snapshotted — only the explicit overrides
+-- persist here; the even share is always recomputed from
+-- (points_total − Σ overrides) ÷ nonOverriddenCount.
+--
+-- Award/read rule (the 4 award sites): each match awards
+--   point_value ?? points_distribution.value.
+--
+-- numeric (not int) so an owner CAN override to a fractional value if they choose —
+-- honest fractions are surfaced, never auto-rounded. Additive nullable column on a
+-- small table (sub-ms lock); safe for existing games, which read NULL → the even
+-- share, i.e. unchanged behavior.
+ALTER TABLE public.game_matches
+  ADD COLUMN IF NOT EXISTS point_value numeric;
+
+COMMENT ON COLUMN public.game_matches.point_value IS
+  'A2b per-match points override. NULL = use the even share (points_distribution.value); set = this match''s overridden competition-point value. Only overrides persist; the even share is always derived from (points_total - sum(overrides)) / nonOverriddenCount.';


### PR DESCRIPTION
The last piece of Refactor A. Inverts match-play points config: the owner sets a
**Total Points** value, the per-match value **derives** (total ÷ matches), and
individual matches can be **overridden** with the remainder **redistributing** to keep
the total locked. "Counts double" becomes an override — no separate multiplier
(this subsumes the old A3 multiplier idea).

Built to the Phase-0-locked storage split; a brief re-confirm against current `main`
(A2a merged) found no drift.

## Guardrail honored
`per_match` is **reused, never renamed** — rack still shows it as "Points per Slot"
(false friend), match play shows it *derived* as "Points per match." A2b inverts the
input direction only; the field/data name stays `points_distribution.value`.

## Storage (locked by Phase 0)
- **Total** → reuse `games.points_total` (owner-set, Organizer+ via `setPointsTotal`).
- **Even share** → keep writing `points_distribution.value` = `(total − Σoverrides) ÷ nonOverriddenCount`.
- **Per-match override** → new nullable `game_matches.point_value` (migration 074).
- **Award/read rule**: each match awards `point_value ?? points_distribution.value`.
- **Leaderboard points-in-play**: match play now reads the authoritative `points_total`
  (`value × mc` is only correct with no overrides); rack unchanged; legacy null-total
  match games fall back to `value × mc`.

## Changes
- **Migration 074** — nullable `game_matches.point_value`.
- **Pure `evenShare`** (`pointsDistribution.ts`) — honest fractions, unrounded.
- **4 award sites** threaded with the read rule: `writeTeamMatchPoints`,
  `rollupMatchPlay` (`ProjMatch.points`), `liveProjection` `projectMatch`, leaderboard.
- **`matches.setPointValue`** mutation (requireGameEdit) — writes the override,
  re-derives in-progress team points.
- **`MatchPointsRow`** — header title + total stepper + "Points per match: X / Custom"
  subtext; expanded override list via the shared `MatchupChips` renderer (amber when
  set, × to reset); honest-fraction hint; first-setup default = players per team.
  Replaces match play's inline stepper; rack's inline "Points per Slot" untouched.
- **`ChecklistRow`** gains a `headerControl` slot (accordion + header stepper, split
  out of the toggle button).

## Tests (§4 gates)
- Pure: `evenShare` (Buddy 16÷[4]/7→2, honest fractions, all-overridden, negative);
  `rollupMatchPlay` + `projectGame` override/mixed/fallback.
- DB integration (`matches.pointsA2b.test.ts`): 2 singles / total 6 / one overridden to
  4 → other redistributes to 2, Blue sweeps → 6 (award read rule); leaderboard
  points-in-play = `points_total` (6), **not** `value × mc` (the authoritative-total
  switch, no snapshot drift); clearing → `point_value` null; existing-games-safe
  (null total → `value × mc`); a 2v2 override awards on the play_group side.
- tsc + next lint clean; affected suite (55 tests) green locally.

## Acceptance
The Buddy math (6 singles + 1 doubles, total 16, doubles → 4, others → 2) is locked by
the pure tests; the DB tests prove the same wiring end-to-end at a 4-user-testable size.

In-browser: the Total Points header renders per mockup with a **live honest fraction**
(8 ÷ 3 = 2.67, unrounded) and the header-stepper/chevron split; no runtime errors. The
override-panel interaction wasn't drivable in the Browser pane (the documented game-
surface limitation — a stuck renderer), but it's pure reuse of the A2a `MatchupChips`
and every mutation it calls is covered by the passing DB tests.

**Refactor A complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)