### PR TITLE
Hero projection tier — 'if today holds'

### DIFF
--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Settings, Users } from "lucide-react";
+import { Settings, Trophy, Users } from "lucide-react";
 import { fmtPts, ProjectionPill } from "./GameRow";
 import type { LBTeam } from "./CompetitionLeaderboard";
 import type { ScoringModel } from "@/lib/gameTypes";
@@ -74,6 +74,8 @@ export function CompetitionHero({
   tagline,
   teams,
   teamTotals,
+  projectedTeamTotals,
+  hasLiveProjection = false,
   pointsAvailable,
   winNumber,
   clincher,
@@ -87,6 +89,12 @@ export function CompetitionHero({
   tagline: string | null;
   teams: LBTeam[];
   teamTotals: Record<string, number>;
+  /** Per-team projected total ("if today holds") = banked + Σ live projections
+   *  (server-summed). Absent on callers with no projection (game-page header). */
+  projectedTeamTotals?: Record<string, number>;
+  /** ≥1 game live → render the projected tier at all (independent of any delta).
+   *  Default false → no tier (the between-rounds / points-cup / collapsed cases). */
+  hasLiveProjection?: boolean;
   pointsAvailable: number;
   winNumber: number;
   clincher: LBTeam | null;
@@ -245,6 +253,29 @@ export function CompetitionHero({
                 ? `First to ${fmtPts(winNumber)} wins`
                 : "No points in play yet"}
             </p>
+
+            {/* PROJECTED "if today holds" tier (Path A) — banked + Σ live-game
+                projections per team, with a ▲ delta pill. TIER GATE: only when ≥1
+                game is live (hasLiveProjection); nothing live → the hero collapses to
+                just the banked score above. */}
+            {hasLiveProjection && a && b && (
+              <div
+                className="mt-3.5 pt-3.5"
+                style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}
+                data-testid="hero-projected-tier"
+              >
+                <p
+                  className="mb-2 text-center"
+                  style={{ fontSize: 10.5, letterSpacing: "0.1em", textTransform: "uppercase", fontWeight: 700, color: "var(--color-bt-text-dim)" }}
+                >
+                  Projected if today holds
+                </p>
+                <div className="flex items-center justify-between">
+                  <HeroProjSide team={a} projected={projectedTeamTotals?.[a.id] ?? aTotal} banked={aTotal} winNumber={winNumber} align="left" />
+                  <HeroProjSide team={b} projected={projectedTeamTotals?.[b.id] ?? bTotal} banked={bTotal} winNumber={winNumber} align="right" />
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>
@@ -685,6 +716,57 @@ function TeamName({
     >
       {content}
     </button>
+  );
+}
+
+/**
+ * HeroProjSide — one team's projected "if today holds" block: the projected TOTAL
+ * (team-colored) + a ▲ delta pill, mirrored on each side (left / row-reversed right).
+ *
+ * Per-team pill GATE: the pill shows ONLY when delta > 0. A team the live games add
+ * nothing to shows a BARE projected number (which equals its banked number) — the
+ * absent pill is the signal that it projects no gain (the matching number is correct,
+ * not a bug). The shared `ProjectionPill` carries the ▲ grammar.
+ *
+ * Projected-win FLAIR: a small cup icon when the projected total crosses the win
+ * threshold ("if today holds, they clinch"). Threshold comparison ONLY — this is not
+ * clinch detection (no terminal state / once-fire / correction-safety); it's a purely
+ * presentational icon driven by the live projected number.
+ */
+function HeroProjSide({
+  team,
+  projected,
+  banked,
+  winNumber,
+  align,
+}: {
+  team: LBTeam;
+  projected: number;
+  banked: number;
+  winNumber: number;
+  align: "left" | "right";
+}) {
+  const delta = projected - banked; // ≥ 0 (projections are awarded points)
+  const projectsWin = projected >= winNumber;
+  const cup = projectsWin ? (
+    <Trophy size={15} style={{ color: team.color }} aria-label="Projected to win" data-testid={`hero-proj-cup-${align === "left" ? "a" : "b"}`} />
+  ) : null;
+  const num = (
+    <span className="tabular-nums" style={{ fontSize: 30, fontWeight: 800, lineHeight: 1, color: team.color }}>
+      {fmtPts(projected)}
+    </span>
+  );
+  // Pill only when the team projects a gain; delta 0 → bare number (no pill).
+  const pill = delta > 0 ? <ProjectionPill color={team.color} value={delta} /> : null;
+  return (
+    <div
+      className={`flex items-center gap-2 ${align === "right" ? "flex-row-reverse" : ""}`}
+      data-testid={`hero-proj-${align === "left" ? "a" : "b"}`}
+    >
+      {cup}
+      {num}
+      {pill}
+    </div>
   );
 }
 

--- a/src/components/competition/CompetitionHero.tsx
+++ b/src/components/competition/CompetitionHero.tsx
@@ -721,17 +721,24 @@ function TeamName({
 
 /**
  * HeroProjSide — one team's projected "if today holds" block: the projected TOTAL
- * (team-colored) + a ▲ delta pill, mirrored on each side (left / row-reversed right).
+ * (team-colored, the OUTER element) + a ▲ delta pill on the INNER side (toward center),
+ * mirrored on each side. The number is always outermost so it stays aligned with the
+ * banked score directly above it — nothing is placed on its outer edge.
  *
  * Per-team pill GATE: the pill shows ONLY when delta > 0. A team the live games add
  * nothing to shows a BARE projected number (which equals its banked number) — the
  * absent pill is the signal that it projects no gain (the matching number is correct,
  * not a bug). The shared `ProjectionPill` carries the ▲ grammar.
  *
- * Projected-win FLAIR: a small cup icon when the projected total crosses the win
- * threshold ("if today holds, they clinch"). Threshold comparison ONLY — this is not
- * clinch detection (no terminal state / once-fire / correction-safety); it's a purely
- * presentational icon driven by the live projected number.
+ * Projected-win FLAIR: a small cup icon on the INNER side of the pill (toward center:
+ * to the right of the pill for the left team, to the left of the pill for the right
+ * team), when the projected total crosses the win threshold ("if today holds, they
+ * clinch"). Innermost so it never sits on the score's outer edge → the score stays
+ * aligned. Threshold comparison ONLY — this is not clinch detection (no terminal state
+ * / once-fire / correction-safety); it's a purely presentational icon.
+ *
+ * Order is [number, pill, cup] with the row REVERSED for the right team, so the number
+ * is always outermost (aligned with the banked score above) and the cup is innermost.
  */
 function HeroProjSide({
   team,
@@ -748,9 +755,6 @@ function HeroProjSide({
 }) {
   const delta = projected - banked; // ≥ 0 (projections are awarded points)
   const projectsWin = projected >= winNumber;
-  const cup = projectsWin ? (
-    <Trophy size={15} style={{ color: team.color }} aria-label="Projected to win" data-testid={`hero-proj-cup-${align === "left" ? "a" : "b"}`} />
-  ) : null;
   const num = (
     <span className="tabular-nums" style={{ fontSize: 30, fontWeight: 800, lineHeight: 1, color: team.color }}>
       {fmtPts(projected)}
@@ -758,14 +762,19 @@ function HeroProjSide({
   );
   // Pill only when the team projects a gain; delta 0 → bare number (no pill).
   const pill = delta > 0 ? <ProjectionPill color={team.color} value={delta} /> : null;
+  const cup = projectsWin ? (
+    <Trophy size={15} style={{ color: team.color }} aria-label="Projected to win" data-testid={`hero-proj-cup-${align === "left" ? "a" : "b"}`} />
+  ) : null;
+  // [number, pill, cup] → the row reverses for the right team, keeping the number
+  // outermost (aligned) and the cup innermost (toward center, inner side of the pill).
   return (
     <div
       className={`flex items-center gap-2 ${align === "right" ? "flex-row-reverse" : ""}`}
       data-testid={`hero-proj-${align === "left" ? "a" : "b"}`}
     >
-      {cup}
       {num}
       {pill}
+      {cup}
     </div>
   );
 }

--- a/src/components/competition/CompetitionLeaderboard.tsx
+++ b/src/components/competition/CompetitionLeaderboard.tsx
@@ -67,6 +67,11 @@ interface LeaderboardData {
    *  ▲ projected-points pill). Absent games have no live projection. */
   projections: Record<string, Record<string, number>>;
   teamTotals: Record<string, number>;
+  /** Per-team projected total ("if today holds") = banked + Σ live-game projections
+   *  (server-summed). The hero's projected tier reads it; delta = this − teamTotals. */
+  projectedTeamTotals: Record<string, number>;
+  /** ≥1 game live → show the hero's projected tier at all (independent of any delta). */
+  hasLiveProjection: boolean;
   pointsAvailable: number;
   winNumber: number;
   pointsToClinch: Record<string, number>;
@@ -230,6 +235,8 @@ export function CompetitionLeaderboard({ competitionId, tripId, cupName, tagline
         tagline={tagline}
         teams={teams}
         teamTotals={teamTotals}
+        projectedTeamTotals={data.projectedTeamTotals}
+        hasLiveProjection={data.hasLiveProjection}
         pointsAvailable={pointsAvailable}
         winNumber={winNumber}
         clincher={clincher}

--- a/src/components/competition/HeroProjection.test.tsx
+++ b/src/components/competition/HeroProjection.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CompetitionHero } from "./CompetitionHero";
+import type { LBTeam } from "./CompetitionLeaderboard";
+
+/**
+ * Hero "if today holds" projected tier (Path A). The expanded 2-team hero shows a
+ * PROJECTED tier below the banked score: per-team projected total + a ▲ delta pill.
+ * Two gates: the tier only when ≥1 game live; a team's pill only when its delta > 0.
+ * A cup icon marks a team whose projected total crosses the win threshold (flair).
+ * Rendered via react-dom/server (node env). The pill's ▲ (U+25B2) is the tell we
+ * count to assert which teams show a pill.
+ */
+
+const team = (id: string, name: string, color: string): LBTeam => ({ id, name, short_name: name.slice(0, 3).toUpperCase(), color });
+const teams = [team("a", "Manhattans", "#4ade80"), team("b", "Centurions", "#fb923c")];
+const TRI = /▲/g; // ▲ — the ProjectionPill triangle
+
+function hero(props: Partial<React.ComponentProps<typeof CompetitionHero>>) {
+  return renderToStaticMarkup(
+    <CompetitionHero
+      cupName="BBMI Test Cup"
+      tagline={null}
+      teams={teams}
+      teamTotals={{ a: 8, b: 8 }}
+      pointsAvailable={100}
+      winNumber={40}
+      clincher={null}
+      scoringModel="match_play"
+      canEdit={false}
+      {...props}
+    />
+  );
+}
+
+describe("hero projected tier — visibility gate", () => {
+  it("HIDES the whole tier when nothing is live (hasLiveProjection false)", () => {
+    const html = hero({ hasLiveProjection: false, projectedTeamTotals: { a: 8, b: 8 } });
+    expect(html).not.toContain("Projected if today holds");
+    expect(html).not.toContain("hero-projected-tier");
+    expect((html.match(TRI) ?? []).length).toBe(0);
+  });
+
+  it("SHOWS the tier when at least one game is live", () => {
+    const html = hero({ hasLiveProjection: true, projectedTeamTotals: { a: 10, b: 14 } });
+    expect(html).toContain("Projected if today holds");
+    expect(html).toContain("hero-projected-tier");
+  });
+});
+
+describe("hero projected tier — both teams project", () => {
+  const html = hero({ hasLiveProjection: true, projectedTeamTotals: { a: 10, b: 14 } });
+
+  it("shows each team's projected TOTAL (banked + Σ projections)", () => {
+    expect(html).toContain(">10<"); // Manhattans 8 + 2
+    expect(html).toContain(">14<"); // Centurions 8 + 6
+  });
+
+  it("shows a ▲ pill for BOTH teams (both deltas > 0)", () => {
+    expect((html.match(TRI) ?? []).length).toBe(2);
+  });
+
+  it("no cup icon — neither projected total crosses the win threshold (40)", () => {
+    expect(html).not.toContain("hero-proj-cup");
+  });
+});
+
+describe("hero projected tier — only one team projects (per-team pill gate)", () => {
+  // Manhattans +2 → 10; Centurions +0 → bare 8 (== its banked), no pill.
+  const html = hero({ hasLiveProjection: true, projectedTeamTotals: { a: 10, b: 8 } });
+
+  it("shows exactly ONE pill (the gaining team); the delta-0 team is a bare number", () => {
+    expect((html.match(TRI) ?? []).length).toBe(1);
+    expect(html).toContain(">10<"); // Manhattans projected (with pill)
+    expect(html).toContain(">8<"); // Centurions bare projected == banked, no pill
+  });
+});
+
+describe("hero projected tier — projected-win cup icon (flair)", () => {
+  it("shows the cup for a team whose projected total ≥ win threshold, not for one below", () => {
+    // Manhattans 8 + 34 = 42 ≥ 40 → cup; Centurions 10 < 40 → no cup.
+    const html = hero({ hasLiveProjection: true, projectedTeamTotals: { a: 42, b: 10 }, winNumber: 40 });
+    expect(html).toContain("hero-proj-cup-a");
+    expect(html).not.toContain("hero-proj-cup-b");
+  });
+
+  it("no cup when both are below threshold", () => {
+    const html = hero({ hasLiveProjection: true, projectedTeamTotals: { a: 10, b: 14 }, winNumber: 40 });
+    expect(html).not.toContain("hero-proj-cup");
+  });
+});

--- a/src/lib/gameProjection.test.ts
+++ b/src/lib/gameProjection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { rollupMatchPlay, type ProjMatch } from "./gameProjection";
+import { rollupMatchPlay, projectedTeamTotals, type ProjMatch } from "./gameProjection";
 
 // #533 — the match-play projection rule: up → leader's full points, all-square
 // (started) → halved, not-started → nothing. Summed per team, N-team-aware.
@@ -70,5 +70,41 @@ describe("rollupMatchPlay", () => {
   it("a null/undefined `points` falls back to the even share", () => {
     const withNull: ProjMatch = { ...m("blue", "red", "A", true), points: null };
     expect(rollupMatchPlay([withNull], 3)).toEqual({ blue: 3 });
+  });
+});
+
+// The hero "if today holds" rollup — banked + Σ live-game projections per team.
+describe("projectedTeamTotals", () => {
+  const ids = ["blue", "red"];
+
+  it("sums each team's live-game projections onto its banked total", () => {
+    const { totals, hasLive } = projectedTeamTotals(
+      { blue: 8, red: 8 },
+      { g1: { blue: 2 }, g2: { red: 4, blue: 0 }, g3: { red: 2 } }, // blue +2, red +6
+      ids,
+    );
+    expect(totals).toEqual({ blue: 10, red: 14 });
+    expect(hasLive).toBe(true);
+    // Delta (projected − banked) = Σ projections, ≥ 0 for every team.
+    expect(totals.blue - 8).toBe(2);
+    expect(totals.red - 8).toBe(6);
+  });
+
+  it("hasLive is FALSE when no game is live (empty projections) → totals = banked", () => {
+    const { totals, hasLive } = projectedTeamTotals({ blue: 8, red: 8 }, {}, ids);
+    expect(totals).toEqual({ blue: 8, red: 8 });
+    expect(hasLive).toBe(false);
+  });
+
+  it("hasLive is TRUE even when a live game projects 0 to a team (delta 0 ≠ no live)", () => {
+    // One team gains, the other gets a bare number — the tier still shows.
+    const { totals, hasLive } = projectedTeamTotals({ blue: 8, red: 8 }, { g1: { blue: 2 } }, ids);
+    expect(totals).toEqual({ blue: 10, red: 8 }); // red delta 0 → bare number in the UI
+    expect(hasLive).toBe(true);
+  });
+
+  it("seeds every team from teamIds (a team with no banked entry starts at 0)", () => {
+    const { totals } = projectedTeamTotals({ blue: 5 }, { g1: { red: 3 } }, ids);
+    expect(totals).toEqual({ blue: 5, red: 3 });
   });
 });

--- a/src/lib/gameProjection.ts
+++ b/src/lib/gameProjection.ts
@@ -38,6 +38,35 @@ export interface ProjMatch {
  * even-share `pointsPerMatch` — so an overridden ("counts double") match projects at
  * its real value, exactly as the finish path awards it.
  */
+/**
+ * Competition-total projection ("if today holds") — the FIRST rollup of projected
+ * points to a competition total. Per team: banked (`teamTotals`) + Σ of that team's
+ * live-game projections (the per-game `projections` the board already computes, Path A).
+ * Summed SERVER-SIDE so one authoritative total rides the board payload and the hero
+ * reads it directly — no client re-aggregation, no board-vs-client drift.
+ *
+ * `hasLive` = at least one game is live (the `projections` map is non-empty). This is
+ * the tier-visibility gate — TRUE even when a live game projects 0 to a team (that team
+ * shows a bare number, no pill), so it must reflect live-game PRESENCE, not any delta.
+ *
+ * Projections are awarded points (≥ 0), so each projected total ≥ its banked total →
+ * every delta (projected − banked) is ≥ 0 and the pill is always ▲.
+ */
+export function projectedTeamTotals(
+  teamTotals: Record<string, number>,
+  projections: Record<string, Record<string, number>>,
+  teamIds: string[],
+): { totals: Record<string, number>; hasLive: boolean } {
+  const totals: Record<string, number> = {};
+  for (const id of teamIds) totals[id] = teamTotals[id] ?? 0;
+  for (const perTeam of Object.values(projections)) {
+    for (const [teamId, pts] of Object.entries(perTeam)) {
+      totals[teamId] = (totals[teamId] ?? 0) + pts;
+    }
+  }
+  return { totals, hasLive: Object.keys(projections).length > 0 };
+}
+
 export function rollupMatchPlay(matches: ProjMatch[], pointsPerMatch: number): Record<string, number> {
   const out: Record<string, number> = {};
   const add = (teamId: string | null, n: number) => {

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { rollUp, placementDetail, awardedForGame, type LiveGame } from "@/lib/competitionPlacement";
 import { isPerMatch, isPlacement, type PointsDistribution } from "@/lib/pointsDistribution";
 import { deriveMatchCount, type MatchFormat } from "@/lib/gameConfig";
+import { projectedTeamTotals } from "@/lib/gameProjection";
 import { isManualGameType } from "@/lib/gameTypes";
 // isConfigured (+ the type sets) moved to gameReadiness.ts (A2-core) so the same
 // "is it configured?" signal backs both this display AND the server enable guard.
@@ -291,6 +292,17 @@ export async function computeCompetitionLeaderboard(
     });
   const projections = await computeLiveProjections(supabase, competitionId, liveProjectionInputs);
 
+  // Competition-total projection ("if today holds"): banked (teamTotals) + Σ of each
+  // team's live-game projections, summed SERVER-SIDE so the hero reads one authoritative
+  // total off this payload (no client re-aggregation → no board-vs-client drift). Rides
+  // the same 30s poll + faceBootstrap seed as the per-game pills. `hasLive` gates the
+  // hero's whole projected tier (≥1 game live), independent of any team's delta.
+  const projected = projectedTeamTotals(
+    Object.fromEntries(roll.teamTotals),
+    projections,
+    teamIds,
+  );
+
   return {
     teams: teams ?? [],
     defendingTeamId: (comp?.defending_team_id as string | null) ?? null,
@@ -341,6 +353,10 @@ export async function computeCompetitionLeaderboard(
     pointsAvailable: roll.pointsAvailable,
     winNumber: roll.winNumber,
     teamTotals: Object.fromEntries(roll.teamTotals),
+    // Hero "if today holds" tier: per-team projected total (banked + Σ live projections)
+    // + whether any game is live (the tier-visibility gate). Server-summed (Path A).
+    projectedTeamTotals: projected.totals,
+    hasLiveProjection: projected.hasLive,
     pointsToClinch: Object.fromEntries(roll.pointsToClinch),
   };
 }


### PR DESCRIPTION
Adds a second tier to the competition hero: below the **banked** cup score, a
**PROJECTED IF TODAY HOLDS** tier = banked + Σ(live-game projections) per team,
with team-colored **▲ delta pills**. This is the first competition-total rollup of
projected points — aggregation + layout, **no engine / projection-compute change.**

Built to `hero_projection_mockup.html`.

## Phase 0 (confirmed, no STOP)
The per-game projections already compute server-side (`computeLiveProjections`, Path A)
and land on the board payload; banked = `teamTotals`, threshold = `winNumber`, both at
board-assembly time. Summing there keeps one authoritative total on the payload.

## Changes
- **Server sum (Path A)** — pure `projectedTeamTotals(teamTotals, projections, teamIds)`
  in `gameProjection.ts` → `{ totals, hasLive }`. `competitionLeaderboard` emits
  `projectedTeamTotals` + `hasLiveProjection` on the **same payload** (rides the 30s
  poll + faceBootstrap; no new query/cadence, no client re-aggregation → no drift).
- **Hero render** — `HeroProjSide` per team: projected total (team-colored) + a ▲
  `ProjectionPill` (the shared grammar). Two gates:
  - **tier-level** — shown only when `hasLiveProjection` (≥1 game live); nothing live →
    the hero collapses to the banked score.
  - **per-team pill** — shown only when delta > 0; delta 0 → a bare projected number
    (== banked), the absent pill being the "no gain" signal.
- **Projected-win cup icon** — a `Trophy` when `projected ≥ winNumber`. Flair only:
  threshold comparison, no clinch detection / terminal state / once-fire.

## Tests
- Pure `projectedTeamTotals`: sum, `hasLive` gate (empty vs delta-0), team seeding, ≥0.
- `HeroProjection.test.tsx` (react-dom/server): tier hidden/shown; both-project (2 pills);
  one-team (1 pill + bare number); cup-icon threshold.
- tsc + next lint clean; affected suite green.

## Verified live
On the BBMI Test Cup board (banked 5 / 13, two live games): projected **12½ ▲7½** /
**33½ ▲20½** — the hero deltas equal the **sum of the per-game pills** on the rows below
(ties out), both ▲ (≥0), no cup icon (neither ≥ 45½). Screenshot capture hit the
documented Browser-pane stuck-renderer limit, but the structured read + text confirm the
tier and the exact math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)