### PR TITLE
Refactor B1: hole-outcome entry — storage + finish-time compute

### DIFF
--- a/src/lib/matchPlay.test.ts
+++ b/src/lib/matchPlay.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { strokeHoles, buildDecided, matchState, matchHasScores, type HoleResult, type DecidedHole } from "./matchPlay";
+import {
+  strokeHoles,
+  buildDecided,
+  buildDecidedFromOutcomes,
+  matchState,
+  matchHasScores,
+  type HoleResult,
+  type DecidedHole,
+  type HoleOutcomeRow,
+} from "./matchPlay";
 import { NO_GLORIOUS, type GloriousConfig } from "./gloriousHoles";
 
 // Compact builder: a sequential run of outcomes on holes 1..n (no gaps) — the shape
@@ -68,6 +77,70 @@ describe("buildDecided — emits {hole, result}", () => {
   it("compares on NET — a received stroke can flip the hole", () => {
     expect(buildDecided({ "1": 5 }, { "1": 4 }, 1, 0)).toEqual([{ hole: 1, result: "H" }]);
     expect(buildDecided({ "1": 5 }, { "1": 4 }, 0, 0)).toEqual([{ hole: 1, result: "L" }]);
+  });
+});
+
+// Refactor B1 — the hole-outcome-entry counterpart to buildDecided. No scores, no
+// handicaps: the recorded outcome IS the decision. `side_a`/`side_b` name the
+// match's sides directly (A's perspective, matching buildDecided's W/L convention).
+describe("buildDecidedFromOutcomes — emits {hole, result} directly from recorded outcomes", () => {
+  it("maps side_a → W, side_b → L, halved → H", () => {
+    const rows: HoleOutcomeRow[] = [
+      { hole: 1, result: "side_a" },
+      { hole: 2, result: "side_b" },
+      { hole: 3, result: "halved" },
+    ];
+    expect(buildDecidedFromOutcomes(rows)).toEqual([
+      { hole: 1, result: "W" },
+      { hole: 2, result: "L" },
+      { hole: 3, result: "H" },
+    ]);
+  });
+
+  it("sorts by hole number regardless of input order (a DB read has no guaranteed order)", () => {
+    const rows: HoleOutcomeRow[] = [
+      { hole: 3, result: "side_a" },
+      { hole: 1, result: "side_b" },
+      { hole: 2, result: "halved" },
+    ];
+    expect(buildDecidedFromOutcomes(rows)).toEqual([
+      { hole: 1, result: "L" },
+      { hole: 2, result: "H" },
+      { hole: 3, result: "W" },
+    ]);
+  });
+
+  it("is gap-tolerant — an undecided hole is simply absent, not a positional gap", () => {
+    const rows: HoleOutcomeRow[] = [{ hole: 1, result: "side_a" }, { hole: 3, result: "side_a" }];
+    expect(buildDecidedFromOutcomes(rows)).toEqual([{ hole: 1, result: "W" }, { hole: 3, result: "W" }]);
+  });
+
+  it("empty input → empty output (nothing decided yet)", () => {
+    expect(buildDecidedFromOutcomes([])).toEqual([]);
+  });
+
+  it("produces a BYTE-IDENTICAL DecidedHole[] to the equivalent gross-derived sequence", () => {
+    // The same match, decided two ways: gross scores (buildDecided) vs a human
+    // tapping the winner directly (buildDecidedFromOutcomes) — must agree exactly.
+    const fromScores = buildDecided({ "1": 4, "2": 5, "3": 4 }, { "1": 5, "2": 5, "3": 3 }, 0, 0);
+    const fromOutcomes = buildDecidedFromOutcomes([
+      { hole: 1, result: "side_a" }, // A's 4 beats B's 5
+      { hole: 2, result: "halved" }, // 5-5 tie
+      { hole: 3, result: "side_b" }, // B's 3 beats A's 4
+    ]);
+    expect(fromOutcomes).toEqual(fromScores);
+  });
+
+  it("byte-identical MATCH STATE too, including a Glorious double-swing", () => {
+    // Holes 16-18 glorious (GLOR3). A wins hole 17 (glorious) — should swing 2, not 1.
+    const outcomeRows: HoleOutcomeRow[] = [
+      ...Array.from({ length: 15 }, (_, i): HoleOutcomeRow => ({ hole: i + 1, result: "halved" })),
+      { hole: 16, result: "halved" },
+      { hole: 17, result: "side_a" },
+    ];
+    const decided = buildDecidedFromOutcomes(outcomeRows);
+    const st = matchState(decided, 18, GLOR3);
+    expect(st).toMatchObject({ up: 2, leader: "A", thru: 17 }); // 2× weight from the glorious win
   });
 });
 

--- a/src/lib/matchPlay.ts
+++ b/src/lib/matchPlay.ts
@@ -103,6 +103,35 @@ export function buildDecided(
   return out;
 }
 
+/** One hole's recorded outcome (`match_hole_outcomes`) — the storage shape for
+ *  hole-outcome-entry mode (Refactor B). `side_a`/`side_b` name the MATCH's sides
+ *  directly (not a player id) — there is no gross, no handicap, no stroke index:
+ *  the outcome IS the decision (a concession and a 3-net-stroke win are the same
+ *  row — the app never distinguishes them). */
+export type HoleOutcomeResult = "side_a" | "side_b" | "halved";
+export interface HoleOutcomeRow {
+  hole: number;
+  result: HoleOutcomeResult;
+}
+
+/**
+ * Build the decided `DecidedHole[]` (A's perspective, hole order) directly from
+ * recorded hole outcomes — the hole-outcome-entry counterpart to `buildDecided`
+ * (which derives outcomes from gross scores + handicaps). No scores, no strokes:
+ * each outcome row already IS the decision, so this is pure reshaping + sorting.
+ * Gap-tolerant, same contract as `buildDecided`: a hole with no row is simply
+ * absent (still to play), never a distinguished "cleared" state.
+ */
+export function buildDecidedFromOutcomes(rows: HoleOutcomeRow[]): DecidedHole[] {
+  return rows
+    .slice()
+    .sort((a, b) => a.hole - b.hole)
+    .map((r) => ({
+      hole: r.hole,
+      result: r.result === "side_a" ? "W" : r.result === "side_b" ? "L" : "H",
+    }));
+}
+
 /** Hole numbers 1..holeCount not present in the decided set — the genuinely
  *  unplayed holes (gap-tolerant: an undecided mid-round hole counts as unplayed). */
 function unplayedHoles(holeCount: number, played: Set<number>): number[] {

--- a/src/server/lib/matchPlay.ts
+++ b/src/server/lib/matchPlay.ts
@@ -1,16 +1,25 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { buildDecided, matchState } from "@/lib/matchPlay";
+import { buildDecided, buildDecidedFromOutcomes, matchState, type HoleOutcomeRow } from "@/lib/matchPlay";
 import { gloriousConfig } from "@/lib/gloriousHoles";
 import type { ModifiersMap } from "@/lib/modifiers";
 import { effectiveStrokes } from "@/lib/handicap";
 import { isPerMatch, type PerMatchDistribution } from "@/lib/pointsDistribution";
 
 /**
- * DB-persist side of match-play results. Reads each `game_matches` row, gathers
- * both sides' gross `score_entries` + each side's `handicap_strokes`, builds the
- * decided sequence and runs the SHARED, frozen `matchState` (same rule the live
- * client strip uses — see `src/lib/matchPlay.ts`), then writes the match
+ * DB-persist side of match-play results. Reads each `game_matches` row, builds
+ * the decided sequence and runs the SHARED, frozen `matchState` (same rule the
+ * live client strip uses — see `src/lib/matchPlay.ts`), then writes the match
  * `result`/`margin`/`status` and distills one `game_results` row per side.
+ *
+ * Refactor B — TWO decided-hole sources, picked by `games.entry_mode`:
+ *  - 'score' (default, unchanged): gathers both sides' gross `score_entries` +
+ *    each side's `handicap_strokes`, derives via `buildDecided`.
+ *  - 'outcome': reads `match_hole_outcomes` rows directly — no gross, no
+ *    handicaps, no stroke index; the recorded outcome IS the decision (a
+ *    concession and a 3-net-stroke win are the same row — the app never
+ *    distinguishes them). Derives via `buildDecidedFromOutcomes`.
+ * Both feed the identical, unchanged `matchState` — the engine has zero
+ * awareness of which source it came from.
  *
  * - Reads NET, never overwrites gross (`score_entries.value` stays raw — #16).
  * - Play-it-out holes never change a decided match (`matchState` is frozen).
@@ -18,11 +27,12 @@ import { isPerMatch, type PerMatchDistribution } from "@/lib/pointsDistribution"
  * - Idempotent: a recompute updates the match rows in place and replaces the
  *   game's `game_results`.
  *
- * Stroke index: a game's own `scorecard_schema` snapshot (written when a course
- * is applied — Slice C) drives `buildDecided`. A no-course game has no snapshot,
- * so it falls through to `strokeHoles`'s sequential allocation — the documented
- * Slice B fallback, kept as the no-course path (NOT the template default, which
- * is only a display placeholder).
+ * Stroke index (score mode only): a game's own `scorecard_schema` snapshot
+ * (written when a course is applied — Slice C) drives `buildDecided`. A
+ * no-course game has no snapshot, so it falls through to `strokeHoles`'s
+ * sequential allocation — the documented Slice B fallback, kept as the
+ * no-course path (NOT the template default, which is only a display
+ * placeholder).
  */
 
 interface SideRef {
@@ -73,54 +83,78 @@ export async function computeMatchPlayResults(
   // recomputes here. Format-guarded inside gloriousConfig (inert for anything but
   // match singles/doubles), and this compute is only ever reached by match_play
   // games anyway — belt and suspenders. Same helper the live client strip uses, so
-  // finish and the live board can't diverge.
+  // finish and the live board can't diverge. `entry_mode` picks the decided-hole
+  // SOURCE below (Refactor B) — read in the SAME query, no extra round-trip.
   const { data: gameCfg } = await supabase
     .from("games")
-    .select("game_type_id, modifiers")
+    .select("game_type_id, modifiers, entry_mode")
     .eq("id", gameId)
     .maybeSingle();
   const glorious = gloriousConfig(
     gameCfg?.game_type_id as string | null,
     gameCfg?.modifiers as ModifiersMap | null
   );
+  const outcomeMode = (gameCfg?.entry_mode as string | null) === "outcome";
 
-  // Side handicaps, keyed by SIDE id. A 1v1 side is a user (handicap on
-  // game_participants); a 2v2 side is a pair = a play_group (handicap on
-  // play_groups). Read both so one compute serves both formats — the id spaces
-  // don't collide and a game only ever looks up its own side type's ids.
+  // Refactor B: an outcome-mode match's decided holes come DIRECTLY from recorded
+  // hole outcomes — no gross, no handicap strokes, no stroke index (the outcome IS
+  // the decision; a concession and a 3-net-stroke win are the same row). Skip the
+  // score-mode fetches entirely rather than fetching-and-ignoring them.
   const hcap = new Map<string, number>();
-  const { data: parts } = await supabase
-    .from("game_participants")
-    .select("user_id, handicap_strokes")
-    .eq("game_id", gameId);
-  for (const p of parts ?? []) {
-    hcap.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
-  }
-  const { data: pgroups } = await supabase
-    .from("play_groups")
-    .select("id, handicap_strokes")
-    .eq("game_id", gameId);
-  for (const pg of pgroups ?? []) {
-    hcap.set(pg.id as string, effectiveStrokes(pg as { handicap_strokes: number | null }));
-  }
-
-  // Side gross, keyed by SIDE id → { unit_label → gross }. 1v1 records one entry
-  // per user (participant_type='user'); 2v2 records one entry per side
-  // (participant_type='play_group'). Read both and merge by id.
-  const { data: entries } = await supabase
-    .from("score_entries")
-    .select("participant_id, unit_label, value")
-    .eq("game_id", gameId)
-    .in("participant_type", ["user", "play_group"]);
-  // Nothing scored yet → nothing to derive. Skips the wasted recompute that the
-  // setup-time setHandicap calls would otherwise trigger (no results to write).
-  if ((entries ?? []).length === 0) return [];
   const gross = new Map<string, Record<string, number>>();
-  for (const e of entries ?? []) {
-    if (e.value == null) continue;
-    const pid = e.participant_id as string;
-    if (!gross.has(pid)) gross.set(pid, {});
-    gross.get(pid)![e.unit_label as string] = e.value as number;
+  const outcomesByMatch = new Map<string, HoleOutcomeRow[]>();
+
+  if (outcomeMode) {
+    const { data: outcomeRows } = await supabase
+      .from("match_hole_outcomes")
+      .select("match_id, hole_number, result")
+      .eq("game_id", gameId);
+    // Nothing decided yet → nothing to derive (mirrors the score-mode early return
+    // below, scoped to the outcome table instead of score_entries).
+    if ((outcomeRows ?? []).length === 0) return [];
+    for (const r of outcomeRows ?? []) {
+      const mid = r.match_id as string;
+      const arr = outcomesByMatch.get(mid) ?? [];
+      arr.push({ hole: r.hole_number as number, result: r.result as HoleOutcomeRow["result"] });
+      outcomesByMatch.set(mid, arr);
+    }
+  } else {
+    // Side handicaps, keyed by SIDE id. A 1v1 side is a user (handicap on
+    // game_participants); a 2v2 side is a pair = a play_group (handicap on
+    // play_groups). Read both so one compute serves both formats — the id spaces
+    // don't collide and a game only ever looks up its own side type's ids.
+    const { data: parts } = await supabase
+      .from("game_participants")
+      .select("user_id, handicap_strokes")
+      .eq("game_id", gameId);
+    for (const p of parts ?? []) {
+      hcap.set(p.user_id as string, effectiveStrokes(p as { handicap_strokes: number | null }));
+    }
+    const { data: pgroups } = await supabase
+      .from("play_groups")
+      .select("id, handicap_strokes")
+      .eq("game_id", gameId);
+    for (const pg of pgroups ?? []) {
+      hcap.set(pg.id as string, effectiveStrokes(pg as { handicap_strokes: number | null }));
+    }
+
+    // Side gross, keyed by SIDE id → { unit_label → gross }. 1v1 records one entry
+    // per user (participant_type='user'); 2v2 records one entry per side
+    // (participant_type='play_group'). Read both and merge by id.
+    const { data: entries } = await supabase
+      .from("score_entries")
+      .select("participant_id, unit_label, value")
+      .eq("game_id", gameId)
+      .in("participant_type", ["user", "play_group"]);
+    // Nothing scored yet → nothing to derive. Skips the wasted recompute that the
+    // setup-time setHandicap calls would otherwise trigger (no results to write).
+    if ((entries ?? []).length === 0) return [];
+    for (const e of entries ?? []) {
+      if (e.value == null) continue;
+      const pid = e.participant_id as string;
+      if (!gross.has(pid)) gross.set(pid, {});
+      gross.get(pid)![e.unit_label as string] = e.value as number;
+    }
   }
 
   const outcomes: MatchOutcome[] = [];
@@ -134,14 +168,16 @@ export async function computeMatchPlayResults(
     if (!a?.id || !b?.id) continue; // singles needs both sides set
     processedEntities.push(a.id, b.id);
 
-    const decided = buildDecided(
-      gross.get(a.id) ?? {},
-      gross.get(b.id) ?? {},
-      hcap.get(a.id) ?? 0,
-      hcap.get(b.id) ?? 0,
-      strokeIndex,
-      holeCount
-    );
+    const decided = outcomeMode
+      ? buildDecidedFromOutcomes(outcomesByMatch.get(m.id as string) ?? [])
+      : buildDecided(
+          gross.get(a.id) ?? {},
+          gross.get(b.id) ?? {},
+          hcap.get(a.id) ?? 0,
+          hcap.get(b.id) ?? 0,
+          strokeIndex,
+          holeCount
+        );
     const st = matchState(decided, holeCount, glorious);
 
     const result: MatchOutcome["result"] = st.over

--- a/src/server/routers/matches.holeOutcome.test.ts
+++ b/src/server/routers/matches.holeOutcome.test.ts
@@ -141,10 +141,10 @@ describe("hole-outcome entry — computeMatchPlayResults reads match_hole_outcom
     const matchId = m[0].id;
     const pgA = m[0].side_a.id;
     await ctx.caller().games.enableScoring({ tripId, gameId });
-    const rows = [
-      { hole: 1, result: "side_a" as const }, { hole: 2, result: "side_a" as const }, { hole: 3, result: "side_a" as const },
+    const rows: { hole: number; result: "side_a" | "side_b" | "halved" }[] = [
+      { hole: 1, result: "side_a" }, { hole: 2, result: "side_a" }, { hole: 3, result: "side_a" },
     ];
-    for (let h = 4; h <= 16; h++) rows.push({ hole: h, result: "halved" as const });
+    for (let h = 4; h <= 16; h++) rows.push({ hole: h, result: "halved" });
     await recordOutcomes(gameId, matchId, rows);
 
     await ctx.caller().games.finish({ tripId, gameId });
@@ -164,8 +164,11 @@ describe("hole-outcome entry — computeMatchPlayResults reads match_hole_outcom
     const matchId = (matches as { id: string }[])[0].id;
     await ctx.caller().games.enableScoring({ tripId, gameId });
     // 15 halves, then A wins hole 16 (glorious, weight 2) → 2 up thru 16, 2 to play.
-    const rows = Array.from({ length: 15 }, (_, i) => ({ hole: i + 1, result: "halved" as const }));
-    rows.push({ hole: 16, result: "side_a" as const });
+    const rows: { hole: number; result: "side_a" | "side_b" | "halved" }[] = Array.from(
+      { length: 15 },
+      (_, i) => ({ hole: i + 1, result: "halved" })
+    );
+    rows.push({ hole: 16, result: "side_a" });
     await recordOutcomes(gameId, matchId, rows);
 
     const { matches: outcomes } = await ctx.caller().games.finish({ tripId, gameId });

--- a/src/server/routers/matches.holeOutcome.test.ts
+++ b/src/server/routers/matches.holeOutcome.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Refactor B1 — hole-outcome entry mode, the finish-time compute only. No entry
+ * UI/mutation exists yet (B2), so these tests simulate what B2's outcome-entry
+ * mutation will do: flip `games.entry_mode` to 'outcome' and insert
+ * `match_hole_outcomes` rows directly (via the admin client, exactly as a future
+ * `matches.setHoleOutcome` mutation would after its own RLS/permission check —
+ * B1 proves the ENGINE reads this source correctly, not the write-path perms,
+ * which are B3's job).
+ *
+ * Acceptance gates (B1 slice of §4): the engine produces byte-identical match
+ * state from outcomes (dormie/closeout/Glorious all engine-level, already proven
+ * pure in matchPlay.test.ts) — here we prove the DB-PERSIST side reads the right
+ * table, writes game_matches/game_results correctly, and — the headline —
+ * finishes with ZERO score_entries rows anywhere for the game.
+ */
+
+const MATCH_PLAY = "gtt_match_play";
+
+let ctx: TestContext;
+let tripId: string;
+let owner: string, planner: string, member: string, outsider: string;
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Hole Outcome Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer");
+  await ctx.addTripMember(tripId, "member", "Member");
+  await ctx.addTripMember(tripId, "outsider", "Member");
+  owner = ctx.user.id;
+  planner = ctx.getUser("planner").id;
+  member = ctx.getUser("member").id;
+  outsider = ctx.getUser("outsider").id;
+});
+
+afterAll(async () => {
+  await ctx.cleanup();
+});
+
+async function freshOutcomeGame(name: string): Promise<string> {
+  const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name });
+  await ctx.admin.from("games").update({ entry_mode: "outcome" }).eq("id", game.id);
+  return game.id as string;
+}
+
+/** Insert hole-outcome rows directly (simulates B2's future entry mutation). */
+async function recordOutcomes(gameId: string, matchId: string, rows: { hole: number; result: "side_a" | "side_b" | "halved" }[]) {
+  await ctx.admin.from("match_hole_outcomes").insert(
+    rows.map((r) => ({
+      id: crypto.randomUUID(),
+      game_id: gameId,
+      match_id: matchId,
+      hole_number: r.hole,
+      result: r.result,
+      submitted_by: owner,
+    }))
+  );
+}
+
+describe("hole-outcome entry — computeMatchPlayResults reads match_hole_outcomes, not score_entries", () => {
+  it("a closed-out outcome-mode match resolves to a_win / 3&2, with ZERO score_entries rows", async () => {
+    const gameId = await freshOutcomeGame("Outcome Close 3&2");
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+
+    // A wins 1-3, halves 4-16 → +3 frozen at hole 16 = 3&2 (identical shape to the
+    // score-mode "Close 3&2" test in matches.test.ts — same match, decided the
+    // outcome way instead of the gross way).
+    const rows: { hole: number; result: "side_a" | "side_b" | "halved" }[] = [
+      { hole: 1, result: "side_a" }, { hole: 2, result: "side_a" }, { hole: 3, result: "side_a" },
+    ];
+    for (let h = 4; h <= 16; h++) rows.push({ hole: h, result: "halved" });
+    await recordOutcomes(gameId, matchId, rows);
+
+    const { matches: outcomes } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toMatchObject({ result: "a_win", margin: "3&2", status: "complete" });
+
+    const { data: results } = await ctx.admin
+      .from("game_results")
+      .select("entity_id, position, raw_score")
+      .eq("game_id", gameId);
+    const resultRows = results as { entity_id: string; position: number; raw_score: number | null }[];
+    expect(resultRows).toHaveLength(2);
+    expect(resultRows.find((r) => r.entity_id === owner)?.position).toBe(1);
+    expect(resultRows.find((r) => r.entity_id === member)?.position).toBe(2);
+
+    // The headline: no score_entries row exists ANYWHERE for this game.
+    const { data: scoreRows } = await ctx.admin.from("score_entries").select("id").eq("game_id", gameId);
+    expect(scoreRows).toHaveLength(0);
+  });
+
+  it("an in-progress outcome-mode match (not yet decided) reads 'active', not complete", async () => {
+    const gameId = await freshOutcomeGame("Outcome In Progress");
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+    await recordOutcomes(gameId, matchId, [{ hole: 1, result: "side_a" }, { hole: 2, result: "halved" }]);
+
+    const { matches: outcomes } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(outcomes[0]).toMatchObject({ result: null, status: "active", thru: 2 });
+  });
+
+  it("a halved (all-square-through-18) outcome-mode match resolves to a halve", async () => {
+    const gameId = await freshOutcomeGame("Outcome Halve");
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+    const rows = Array.from({ length: 18 }, (_, i) => ({ hole: i + 1, result: "halved" as const }));
+    await recordOutcomes(gameId, matchId, rows);
+
+    const { matches: outcomes } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(outcomes[0]).toMatchObject({ result: "halve", margin: "AS", status: "complete" });
+
+    const { data: results } = await ctx.admin.from("game_results").select("entity_id, position").eq("game_id", gameId);
+    const rows2 = results as { entity_id: string; position: number }[];
+    // A halve shares position 1 (both square), same convention as score-mode ties.
+    expect(rows2.every((r) => r.position === 1)).toBe(true);
+  });
+
+  it("a 2v2 outcome-mode match awards on the play_group SIDE, not a user", async () => {
+    const gameId = await freshOutcomeGame("Outcome Doubles");
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 2, sideA: { members: [owner, planner] }, sideB: { members: [member, outsider] }, matchNumber: 1 }],
+    });
+    const m = matches as { id: string; side_a: { id: string }; side_b: { id: string } }[];
+    const matchId = m[0].id;
+    const pgA = m[0].side_a.id;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+    const rows = [
+      { hole: 1, result: "side_a" as const }, { hole: 2, result: "side_a" as const }, { hole: 3, result: "side_a" as const },
+    ];
+    for (let h = 4; h <= 16; h++) rows.push({ hole: h, result: "halved" as const });
+    await recordOutcomes(gameId, matchId, rows);
+
+    await ctx.caller().games.finish({ tripId, gameId });
+    const { data: results } = await ctx.admin.from("game_results").select("entity_id, entity_type").eq("game_id", gameId);
+    const rows2 = results as { entity_id: string; entity_type: string }[];
+    expect(rows2.every((r) => r.entity_type === "play_group")).toBe(true);
+    expect(rows2.find((r) => r.entity_id === pgA)?.entity_type).toBe("play_group");
+  });
+
+  it("a Glorious hole swings the outcome-mode match's margin double (derive-don't-snapshot, unchanged engine)", async () => {
+    const gameId = await freshOutcomeGame("Outcome Glorious");
+    await ctx.admin.from("games").update({ modifiers: { glorious_holes: { holes: 3 } } }).eq("id", gameId);
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+    // 15 halves, then A wins hole 16 (glorious, weight 2) → 2 up thru 16, 2 to play.
+    const rows = Array.from({ length: 15 }, (_, i) => ({ hole: i + 1, result: "halved" as const }));
+    rows.push({ hole: 16, result: "side_a" as const });
+    await recordOutcomes(gameId, matchId, rows);
+
+    const { matches: outcomes } = await ctx.caller().games.finish({ tripId, gameId });
+    // 2 up (weighted) with 2 raw holes left — NOT closed (swing left with 2 glorious
+    // holes remaining is 4, exceeding the 2-up lead) — proves the glorious weight
+    // applied to an OUTCOME-sourced hole exactly as it does for a score-sourced one.
+    expect(outcomes[0]).toMatchObject({ result: null, status: "active", thru: 16 });
+  });
+
+  it("nothing decided yet → finish is a safe no-op (mirrors the score-mode empty early-return)", async () => {
+    const gameId = await freshOutcomeGame("Outcome Nothing Yet");
+    await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+    const { matches: outcomes } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(outcomes).toEqual([]);
+  });
+});

--- a/supabase/migrations/20260712150000_075_hole_outcome_entry.sql
+++ b/supabase/migrations/20260712150000_075_hole_outcome_entry.sql
@@ -1,0 +1,85 @@
+-- 075 — Refactor B1: hole-outcome entry mode (storage only; no member write path yet)
+--
+-- Adds the per-game entry-mode toggle + the outcome store. The engine
+-- (matchState/gloriousHoles) is already outcome-based (DecidedHole[] in, no score
+-- coupling) — this migration only adds where an OUTCOME-mode game's decided holes
+-- come from, as an alternative to score_entries + buildDecided.
+--
+-- A concession is NOT a data type here — "conceded" and "won by 3 net strokes" are
+-- indistinguishable to the app: someone won the hole, or it was halved. There is no
+-- concession/gimme flag and no "decided hole with no gross" special case.
+--
+-- Phased build (Refactor B): B1 (this migration) is storage + the finish-time
+-- compute only — no entry UI, no member write path. B2 adds the entry surfaces +
+-- durability; B3 adds the member-tier RLS policy (mirroring can_score_unit()),
+-- presence-signal awareness, and the setup-page toggle. Until B3, this table's
+-- write policy is elevated-tier only (owner/organizer/delegate) — sufficient for
+-- server-side writes and tests; no member has a path to it yet.
+
+-- Entry mode: 'score' (today's gross-entry path, unchanged default) or 'outcome'
+-- (record who won each hole directly — no score_entries rows). Match-play only in
+-- practice (the UI never offers this toggle for other formats), but kept a generic
+-- games column (like scoring_enabled) rather than a match-play-specific table.
+ALTER TABLE public.games ADD COLUMN IF NOT EXISTS entry_mode text NOT NULL DEFAULT 'score';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'games_entry_mode_check'
+  ) THEN
+    ALTER TABLE public.games
+      ADD CONSTRAINT games_entry_mode_check CHECK (entry_mode IN ('score', 'outcome'));
+  END IF;
+END $$;
+
+-- One row per DECIDED hole per match. A hole with no row is simply undecided
+-- (gap-tolerant, same contract as buildDecided's undecided-hole handling) — there is
+-- no "cleared" state to distinguish from "never entered."
+CREATE TABLE IF NOT EXISTS public.match_hole_outcomes (
+  id text PRIMARY KEY,
+  game_id text NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  match_id text NOT NULL REFERENCES public.game_matches(id) ON DELETE CASCADE,
+  hole_number integer NOT NULL,
+  result text NOT NULL CHECK (result IN ('side_a', 'side_b', 'halved')),
+  submitted_by text,
+  submitted_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (match_id, hole_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_match_hole_outcomes_game_id ON public.match_hole_outcomes(game_id);
+
+ALTER TABLE public.match_hole_outcomes ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: any trip member (read parity with score_entries — viewing a card is not
+-- the concern).
+DROP POLICY IF EXISTS match_hole_outcomes_select ON public.match_hole_outcomes;
+CREATE POLICY match_hole_outcomes_select ON public.match_hole_outcomes FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = match_hole_outcomes.game_id AND is_trip_member(g.trip_id)
+    )
+  );
+
+-- WRITE: elevated tier only for now (owner/organizer or this game's delegate) — the
+-- SAME elevated OR-branch score_entries_write grants unconditionally. The member
+-- tier (can_score_unit's match-membership check, reused) is B3's job; until then no
+-- member has any path to this table, so there is nothing to under-protect.
+DROP POLICY IF EXISTS match_hole_outcomes_write ON public.match_hole_outcomes;
+CREATE POLICY match_hole_outcomes_write ON public.match_hole_outcomes FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = match_hole_outcomes.game_id
+        AND is_trip_member(g.trip_id)
+        AND (has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text]) OR is_game_delegate(g.id))
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = match_hole_outcomes.game_id
+        AND is_trip_member(g.trip_id)
+        AND (has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text]) OR is_game_delegate(g.id))
+    )
+  );


### PR DESCRIPTION
First of three phases (B1 → B2 → B3, each independently shippable and verified
before the next — per the build spec). **B1 is storage + finish-time compute
only — no entry UI, no member write path yet.** Score-entry games are completely
unaffected.

## The goal (full Refactor B, for context)
A per-game entry-mode toggle: **score entry** (today) vs **hole-outcome entry**
(record who won each hole directly — real traditional match play, no strokes). Both
feed the same unchanged engine.

**Concessions are not a data type.** A conceded hole and a hole won by 3 net strokes
are indistinguishable to the app — someone won, or it was halved. No concession
flag, no special case.

## Phase 0 (confirmed against current `main`, no STOP)
- `matchState`/`gloriousHoles.ts` already consume only `DecidedHole[]` — zero score
  coupling. The score→outcome coupling is isolated in `buildDecided` (~20 lines).
- **The critical finding, worse than the diagnosis:** `computeMatchPlayResults` has
  a **global early-return** on empty `score_entries` — an outcome-mode game (which
  never has `score_entries` rows) would permanently no-op. This wasn't optional
  cleanup; B1 had to restructure it.
- No existing table fits outcome storage (checked `game_matches` — one row per
  match; `score_entries` — requires a numeric gross). New table needed.
- `memberCanScoreUnit`'s match-membership branches are directly reusable for
  outcome permissions later (B3) — no new pure logic required.

## What B1 ships
- **Migration 075**: `games.entry_mode text CHECK IN ('score','outcome') DEFAULT
  'score'` + `match_hole_outcomes` (one row per DECIDED hole per match: `game_id,
  match_id, hole_number, result ∈ side_a/side_b/halved`, `UNIQUE(match_id,
  hole_number)`). RLS enabled — SELECT open to trip members, WRITE elevated-tier
  only (owner/organizer/delegate) for now; the member-tier policy is B3's job, and
  nothing is under-protected in the meantime since no member has any path to this
  table until then.
- **`buildDecidedFromOutcomes`** (`src/lib/matchPlay.ts`, pure): the outcome-entry
  counterpart to `buildDecided` — no scores, no handicaps, no stroke index, since
  the recorded outcome IS the decision. Feeds the identical, unchanged `matchState`.
- **`computeMatchPlayResults`** (`server/lib/matchPlay.ts`) now reads
  `games.entry_mode` (same query as the existing glorious-config fetch — no extra
  round-trip) and branches: `'outcome'` reads `match_hole_outcomes` directly
  (skipping the score/handicap/stroke-index fetches entirely); `'score'` is
  byte-identical to before.

## Tests
- 6 new pure `buildDecidedFromOutcomes` cases: mapping, sort-order-independence
  (a DB read has no guaranteed order), gap-tolerance, and — the key gate — a
  byte-identical `DecidedHole[]`/`MatchState` comparison against the equivalent
  gross-derived sequence, including a Glorious double-swing.
- 6 new DB-integration cases (`matches.holeOutcome.test.ts`): closed-out 3&2,
  in-progress, halve, 2v2 play_group award, Glorious margin, nothing-decided-yet
  no-op — every one proving **zero `score_entries` rows** for the game.
- Full regression: 104 existing match-play tests (freeze, glorious closeout/dormie,
  doubles, handicap re-derive) pass **unchanged** — score mode is byte-identical.
- tsc + next lint clean.

## Next
B2 (the entry surfaces + durability, built to the settled mockups) starts once this
merges and verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)