### PR TITLE
Refactor B2: hole-outcome entry surfaces + durability

### DIFF
--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -6,12 +6,15 @@ import { ChevronLeft, ChevronRight, Plus, X, Swords, SlidersHorizontal, Sparkles
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
+import { useOutcomeSaver } from "@/hooks/useOutcomeSaver";
 import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useInGamePanel, usePublishGameChrome } from "@/components/games/GameChrome";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MatchEntryView, type MatchGroupData } from "@/components/games/MatchEntryView";
+import { MatchOutcomeEntryView } from "@/components/games/MatchOutcomeEntryView";
+import { OutcomeScorecard } from "@/components/games/OutcomeScorecard";
 import { MemberNotReady } from "@/components/games/MemberNotReady";
 import { SetupPlaceholder } from "@/components/games/SetupPlaceholder";
 import { GameManagementPanel } from "@/components/games/GameManagementPanel";
@@ -40,7 +43,7 @@ import { useScreenHistory } from "@/hooks/useScreenHistory";
 import { ScoringLockBanner } from "@/components/games/ScoringLockBanner";
 import type { GameRow } from "@/components/competition/CompetitionGamesPanel";
 import { parseTime, toTime24 } from "@/lib/time";
-import { buildDecided, matchState, strokeHoles, type DecidedHole } from "@/lib/matchPlay";
+import { buildDecided, buildDecidedFromOutcomes, matchState, strokeHoles, type DecidedHole, type HoleOutcomeRow } from "@/lib/matchPlay";
 import { gloriousConfig, type GloriousConfig } from "@/lib/gloriousHoles";
 import { rollupMatchPlay, type ProjMatch } from "@/lib/gameProjection";
 import { PLAYER_COLORS, unitsFromSchema, strokeIndexOf, teeFromSchema } from "@/lib/strokePlayConfig";
@@ -50,7 +53,7 @@ import { matchRosterValid } from "@/lib/teamRoster";
 import { GAME_TYPES } from "@/lib/gameTypes";
 import { ModifierCards } from "@/components/games/ModifierCards";
 import { enabledCount, type ModifiersMap } from "@/lib/modifiers";
-import { unconfirmedCount, type Participant, type ScoreValues } from "@/components/games/types";
+import { unconfirmedCount, type Participant, type ScoreValues, type OutcomeValues } from "@/components/games/types";
 import { showToast } from "@/lib/toast";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -204,6 +207,15 @@ export function MatchGameView() {
     { tripId: tripId!, gameId: gameId! },
     { enabled: !!tripId && !!gameId, refetchInterval: GAME_SYNC_INTERVAL_MS, refetchIntervalInBackground: false },
   );
+  // Refactor B: the outcome counterpart to scoresQ — polled the same way so a
+  // remote device's recorded outcomes converge here too. Only relevant for an
+  // outcome-mode game; harmless (empty) to poll for a score-mode one, and the
+  // hook name isn't yet determined by entry_mode gating to keep both queries
+  // unconditional (React Hooks can't be called conditionally).
+  const outcomesQ = trpc.matchOutcomes.listByGame.useQuery(
+    { tripId: tripId!, gameId: gameId! },
+    { enabled: !!tripId && !!gameId, refetchInterval: GAME_SYNC_INTERVAL_MS, refetchIntervalInBackground: false },
+  );
 
   // Config sync: on a config change from another device (matchups reassigned,
   // side handicaps, modifiers/rules, course, go-live, finish), silently refetch
@@ -260,6 +272,17 @@ export function MatchGameView() {
   // (never rolled back) on failure.
   const { values, setValues, saveStatus, onChange, onClear, retryCell } =
     useScoreSaver(tripId, gameId, participantTypeOf);
+  // Refactor B: the outcome write path — same durability contract, unconditional
+  // (hooks can't be conditional); inert for a score-mode game (nothing calls its
+  // onChange/onClear there).
+  const {
+    values: outcomeValues,
+    setValues: setOutcomeValues,
+    saveStatus: outcomeSaveStatus,
+    onChange: onOutcomeChange,
+    onClear: onOutcomeClear,
+    retryCell: retryOutcomeCell,
+  } = useOutcomeSaver(tripId, gameId);
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();
@@ -303,6 +326,18 @@ export function MatchGameView() {
     }
     return v;
   }, [scoresQ.data]);
+
+  // Refactor B: this game's entry mode + the loaded outcome-mode counterpart to
+  // loadedValues (keyed by match_id, not participant).
+  const outcomeMode = (gameQ.data as { entry_mode?: string } | undefined)?.entry_mode === "outcome";
+  const loadedOutcomeValues = useMemo(() => {
+    const v: OutcomeValues = {};
+    for (const e of outcomesQ.data ?? []) {
+      (v[e.match_id as string] ??= {})[String(e.hole_number)] = e.result as HoleOutcomeRow["result"];
+    }
+    return v;
+  }, [outcomesQ.data]);
+  const mergedOutcomeFor = (matchId: string) => ({ ...(loadedOutcomeValues[matchId] ?? {}), ...(outcomeValues[matchId] ?? {}) });
 
   // Max singles matches = floor(players ÷ 2): the standalone pool is
   // undifferentiated, so any two of the crew pair up (Slice B). In a 2-team
@@ -517,8 +552,14 @@ export function MatchGameView() {
   );
 
   // Decided holes (A's perspective) for an overview strip — the shared builder.
+  // Refactor B: sourced from recorded outcomes for an outcome-mode game (no
+  // scores exist to derive from); byte-identical shared engine either way.
   const decidedFor = (g: MatchGroupData) =>
-    buildDecided(mergedFor(g.a.id), mergedFor(g.b.id), g.strokesA, g.strokesB, scIndex, scUnits.length);
+    outcomeMode
+      ? buildDecidedFromOutcomes(
+          Object.entries(mergedOutcomeFor(g.matchId)).map(([h, result]) => ({ hole: Number(h), result }))
+        )
+      : buildDecided(mergedFor(g.a.id), mergedFor(g.b.id), g.strokesA, g.strokesB, scIndex, scUnits.length);
 
   // A match's current hole = the first hole either player hasn't scored yet, so
   // opening a match drops you where it's at (not the hole you left from).
@@ -1061,10 +1102,23 @@ export function MatchGameView() {
       : selectedGroup.a.id === meId || selectedGroup.b.id === meId);
     const canScoreMatch = canEdit || inThisMatch;
     const readOnly = locked || !canScoreMatch;
-    // The read-only scorecard grid — shared by a read-only/locked viewer's landing
-    // surface and the scorer's overlay. onCellTap (jump to a hole's entry) is
-    // editable-only; back returns to the matches hub (#7).
-    const scorecardGrid = (
+    // The read-only scorecard — shared by a read-only/locked viewer's landing
+    // surface and the scorer's overlay. Refactor B: an outcome-mode game has no
+    // scores to grid, so it swaps in OutcomeScorecard (two lead rows) instead of
+    // StandardGrid. onCellTap (jump to a hole's entry) is editable-only, score-
+    // mode only for now (OutcomeScorecard has no cell-tap yet — hole nav covers
+    // navigation); back returns to the matches hub (#7).
+    const scorecardGrid = outcomeMode ? (
+      <OutcomeScorecard
+        units={scUnits}
+        a={selectedGroup.a}
+        b={selectedGroup.b}
+        outcomes={Object.entries(mergedOutcomeFor(selectedGroup.matchId)).map(([h, result]) => ({ hole: Number(h), result }))}
+        glorious={glorious}
+        leftColor={selectedGroup.leftColor}
+        rightColor={selectedGroup.rightColor}
+      />
+    ) : (
       <StandardGrid
         units={scUnits}
         tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
@@ -1091,6 +1145,33 @@ export function MatchGameView() {
           <ScorecardSheet title={locked ? "Scorecard · Final" : "Scorecard"} onClose={matchBack}>
             {scorecardGrid}
           </ScorecardSheet>
+        ) : outcomeMode ? (
+          <>
+            <MatchOutcomeEntryView
+              hideHeader={inPanel}
+              gameName={`${selectedGroup.a.name} v ${selectedGroup.b.name}`}
+              subtitle={sided ? "Doubles match · 2v2" : "Singles match · 1v1"}
+              units={scUnits}
+              match={selectedGroup}
+              values={outcomeValues}
+              currentHole={currentHole}
+              onHoleChange={setCurrentHole}
+              onChange={onOutcomeChange}
+              onClear={onOutcomeClear}
+              saveStatus={outcomeSaveStatus}
+              onRetryCell={retryOutcomeCell}
+              onBack={matchBack}
+              onOpenGrid={() => setGridOpen(true)}
+              onFinish={matchBack}
+              finishLabel="Back to matches"
+              finishSubtext="Outcomes save as you enter"
+              meId={me?.id}
+              glorious={glorious}
+            />
+            {gridOpen && (
+              <ScorecardSheet title="Scorecard" onClose={matchBack}>{scorecardGrid}</ScorecardSheet>
+            )}
+          </>
         ) : (
           <>
             <MatchEntryView
@@ -1604,6 +1685,7 @@ export function MatchGameView() {
             if (g) setCurrentHole(currentHoleFor(g));
             setSelectedMatchId(matchId);
             setValues((v) => (Object.keys(v).length ? v : loadedValues));
+            setOutcomeValues((v) => (Object.keys(v).length ? v : loadedOutcomeValues));
             // Locked → land on the read-only scorecard overlay; otherwise editable
             // entry (a non-scorer still resolves to read-only in the score screen).
             setGridOpen(locked);

--- a/src/components/games/MatchOutcomeEntryView.test.tsx
+++ b/src/components/games/MatchOutcomeEntryView.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MatchOutcomeEntryView } from "./MatchOutcomeEntryView";
+import type { MatchGroupData } from "./MatchEntryView";
+import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
+import type { OutcomeValues } from "./types";
+
+/**
+ * MatchOutcomeEntryView (Refactor B2, built to hole_outcome_entry_mockup.html).
+ * The entry zone is three stacked choice rows (side A / Halved / side B) — no
+ * number pad, one tap records the whole hole. Rendered via react-dom/server
+ * (node env); `useState` initializes fine under SSR (no interactivity needed
+ * for these render-shape assertions).
+ */
+
+const GLOR1: GloriousConfig = { enabled: true, n: 1 }; // last hole only
+
+const match: MatchGroupData = {
+  matchId: "m1",
+  label: "Match 1",
+  a: { id: "a1", name: "Brad", color: "#4ade80" },
+  b: { id: "b1", name: "Johnny D", color: "#fb923c" },
+  strokesA: 0,
+  strokesB: 0,
+  leftColor: "#4ade80",
+  rightColor: "#fb923c",
+};
+const units = [
+  { label: "1", par: 4 },
+  { label: "2", par: 4 },
+  { label: "3", par: 3 },
+];
+// Glorious weighting is hardcoded relative to an 18-hole round (ROUND_HOLES in
+// gloriousHoles.ts) regardless of the caller's actual unit count — an existing,
+// deliberate engine simplification. The Glorious-banner test below needs a full
+// 18-hole unit list to land on a real glorious hole.
+const units18 = Array.from({ length: 18 }, (_, i) => ({ label: String(i + 1), par: 4 }));
+
+function render(values: OutcomeValues, hole = 1, glorious: GloriousConfig = NO_GLORIOUS, unitList = units) {
+  return renderToStaticMarkup(
+    <MatchOutcomeEntryView
+      gameName="Test Game"
+      units={unitList}
+      match={match}
+      values={values}
+      onChange={() => {}}
+      onClear={() => {}}
+      currentHole={hole}
+      meId="a1"
+      glorious={glorious}
+    />
+  );
+}
+
+describe("MatchOutcomeEntryView — the three-choice entry zone", () => {
+  it("shows both players' names + a neutral Halved choice — no number pad anywhere", () => {
+    const html = render({});
+    expect(html).toContain("Brad");
+    expect(html).toContain("Johnny D");
+    expect(html).toContain("Halved");
+    expect(html).not.toContain("keypad"); // no StrokeKeypad-style number entry
+  });
+
+  it("marks the recorded choice as selected via its testid and check ring", () => {
+    const html = render({ m1: { "1": "side_a" } });
+    // The selected choice renders "Won the hole"; the others show no sub-label.
+    expect(html).toContain("Won the hole");
+    expect(html).toContain("outcome-choice-a");
+  });
+
+  it("shows Reset hole only once a choice is recorded", () => {
+    expect(render({})).not.toContain("outcome-reset-hole");
+    expect(render({ m1: { "1": "halved" } })).toContain("outcome-reset-hole");
+  });
+
+  it("shows the Glorious banner only on a glorious hole", () => {
+    // Glorious weighting is hardcoded relative to an 18-hole round — hole 18 is
+    // "the last 1" (GLOR1); a full 18-hole unit list is needed to land on it.
+    const onGlorious = render({}, 18, GLOR1, units18);
+    const notGlorious = render({}, 1, GLOR1, units18);
+    expect(onGlorious).toContain("glorious-entry-banner");
+    expect(notGlorious).not.toContain("glorious-entry-banner");
+  });
+
+  it("shows the live match board (MatchCard) derived from recorded outcomes", () => {
+    const html = render({ m1: { "1": "side_a" } });
+    // MatchCard renders the match label + a live "1 UP" while in progress.
+    expect(html).toContain("Match 1");
+    expect(html).toContain("1 UP");
+  });
+
+  it("shows the closed-out result banner once the match is decided", () => {
+    const html = render({ m1: { "1": "side_a", "2": "side_a", "3": "side_a" } });
+    expect(html).toContain("Brad def. Johnny D");
+  });
+});

--- a/src/components/games/MatchOutcomeEntryView.tsx
+++ b/src/components/games/MatchOutcomeEntryView.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, Table2, Equal } from "lucide-react";
+import { buildDecidedFromOutcomes, matchState, type HoleOutcomeResult } from "@/lib/matchPlay";
+import { NO_GLORIOUS, isGloriousHole, type GloriousConfig } from "@/lib/gloriousHoles";
+import { MatchCard } from "./MatchCard";
+import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
+import { Avatar } from "@/components/Avatar";
+import { UnsavedScoresBanner } from "./UnsavedScoresBanner";
+import { unconfirmedOnHole, unconfirmedCount, type OutcomeValues, type SaveStatusMap } from "./types";
+import type { MatchGroupData } from "./MatchEntryView";
+
+/**
+ * MatchOutcomeEntryView — the hole-outcome-entry counterpart to `MatchEntryView`
+ * (Refactor B2, built to `hole_outcome_entry_mockup.html`). Reuses the SAME
+ * scorecard chrome verbatim — app bar, `MatchCard` state band, hole nav, par,
+ * Glorious banner, the unsaved-writes banner, the confirmation-gated bottom CTA
+ * (`entryChrome`) — only the ENTRY ZONE differs: three stacked player-row-styled
+ * choice buttons (side A won / Halved / side B won), tap-to-select, team-colored,
+ * ✓, "Reset hole." No number pad — one tap records the whole hole.
+ *
+ * `strokesA`/`strokesB` on `MatchGroupData` are ignored here (unused — no
+ * handicaps in outcome mode; the recorded outcome IS the decision).
+ */
+interface MatchOutcomeEntryViewProps {
+  gameName: string;
+  units: { label: string; par?: number }[];
+  match: MatchGroupData;
+  values: OutcomeValues;
+  onChange: (matchId: string, hole: string, result: HoleOutcomeResult) => void;
+  onClear?: (matchId: string, hole: string) => void;
+  currentHole?: number;
+  onHoleChange?: (hole: number) => void;
+  onFinish?: () => void;
+  onBack?: () => void;
+  onOpenGrid?: () => void;
+  subtitle?: string;
+  finishLabel?: string;
+  finishSubtext?: string;
+  meId?: string;
+  saveStatus?: SaveStatusMap;
+  onRetryCell?: (matchId: string, hole: string) => void;
+  hideHeader?: boolean;
+  glorious?: GloriousConfig;
+}
+
+export function MatchOutcomeEntryView({
+  gameName,
+  units,
+  match: m,
+  values,
+  onChange,
+  onClear,
+  currentHole,
+  onHoleChange,
+  onFinish,
+  onBack,
+  onOpenGrid,
+  subtitle,
+  finishLabel = "Finish",
+  finishSubtext = "Saves results · shows final standings",
+  meId,
+  saveStatus = {},
+  onRetryCell,
+  hideHeader = false,
+  glorious = NO_GLORIOUS,
+}: MatchOutcomeEntryViewProps) {
+  const [holeInternal, setHoleInternal] = useState(currentHole ?? 1);
+  const hole = currentHole ?? holeInternal;
+  const setHole = (h: number) => {
+    if (onHoleChange) onHoleChange(h);
+    else setHoleInternal(h);
+  };
+  const goHole = (h: number) => {
+    if (h >= 1 && h <= units.length) setHole(h);
+  };
+
+  const unit = units[hole - 1];
+  const label = unit?.label ?? String(hole);
+  const par = unit?.par;
+  const holeIsGlorious = isGloriousHole(hole, glorious);
+
+  const outcomeRows = Object.entries(values[m.matchId] ?? {}).map(([h, result]) => ({ hole: Number(h), result }));
+  const decided = buildDecidedFromOutcomes(outcomeRows);
+  const st = matchState(decided, units.length, glorious);
+  const winner = st.leader === "A" ? m.a : st.leader === "B" ? m.b : null;
+  const loser = st.leader === "A" ? m.b : st.leader === "B" ? m.a : null;
+
+  const selected = values[m.matchId]?.[label] as HoleOutcomeResult | undefined;
+
+  // ── Save status (Connectivity Layer 1 — same discipline as score entry) ────
+  const errorCount = Object.values(saveStatus).filter((s) => s === "error").length;
+  const retryAll = () => {
+    for (const [k, s] of Object.entries(saveStatus)) {
+      if (s !== "error") continue;
+      const { matchId, holeNumber } = parseKey(k);
+      onRetryCell?.(matchId, String(holeNumber));
+    }
+  };
+  const holeGate = unconfirmedOnHole(saveStatus, [m.matchId], label);
+  const gameGate = unconfirmedCount(saveStatus);
+  const advanceReason = holeGate.errored > 0
+    ? "Didn’t save — retry above"
+    : holeGate.saving > 0
+      ? "Saving…"
+      : undefined;
+  const finishReason = gameGate.errored > 0
+    ? "Some outcomes didn’t save — retry before finishing"
+    : gameGate.saving > 0
+      ? "Saving…"
+      : undefined;
+
+  // Progress + completion — a hole is complete once it HAS a recorded outcome
+  // (unlike stroke entry, which needs both players; one tap decides the whole
+  // hole here).
+  const completedHoleNumbers = units
+    .map((u, i) => (values[m.matchId]?.[u.label] != null ? i + 1 : 0))
+    .filter((n) => n > 0);
+  const currentComplete = selected != null;
+  const allHolesComplete = completedHoleNumbers.length === units.length && units.length > 0;
+  const canFinish = st.over || allHolesComplete;
+
+  const pick = (result: HoleOutcomeResult) => {
+    onChange(m.matchId, label, result);
+  };
+  const reset = () => {
+    onClear?.(m.matchId, label);
+  };
+
+  return (
+    <div className="flex h-full flex-col" style={{ background: "var(--color-bt-base)" }}>
+      {!hideHeader && (
+        <header
+          className="flex shrink-0 items-center justify-between"
+          style={{
+            height: 52,
+            padding: "0 12px",
+            background: "var(--color-bt-nav-bg)",
+            backdropFilter: "blur(14px)",
+            borderBottom: "1px solid var(--color-bt-subtle-border)",
+          }}
+        >
+          <button onClick={onBack} aria-label="Back" className="flex h-9 w-9 items-center justify-center">
+            <ChevronLeft size={20} style={{ color: "var(--color-bt-text)" }} />
+          </button>
+          <div className="text-center">
+            <div style={{ fontSize: 17, fontWeight: 600, color: "var(--color-bt-text)" }}>{gameName}</div>
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)" }}>
+              {subtitle ?? `Hole ${hole} of ${units.length}`}
+            </div>
+          </div>
+          <button onClick={onOpenGrid} aria-label="Scorecard grid" className="flex h-9 w-9 items-center justify-center">
+            <Table2 size={20} style={{ color: "var(--color-bt-text-dim)" }} />
+          </button>
+        </header>
+      )}
+
+      <UnsavedScoresBanner count={errorCount} onRetry={retryAll} />
+
+      {/* Match board — the SAME MatchCard score entry uses, fed from outcome-
+          derived DecidedHole[] instead of gross-derived. */}
+      <div className="shrink-0" style={{ padding: "12px 12px 0" }}>
+        <MatchCard
+          a={m.a}
+          b={m.b}
+          results={decided}
+          glorious={glorious}
+          label={m.label}
+          holeCount={units.length}
+          youId={meId}
+          leftColor={m.leftColor}
+          rightColor={m.rightColor}
+          hideFormat
+          onScorecard={onOpenGrid}
+        />
+        {st.over && (
+          <div
+            className="flex items-center justify-between"
+            style={{
+              marginTop: 6,
+              padding: "7px 12px",
+              borderRadius: 10,
+              background: "var(--color-bt-place-1-bg)",
+              border: "1px solid rgba(34,197,94,0.25)",
+            }}
+          >
+            <span style={{ fontSize: 13, fontWeight: 600, color: "var(--color-bt-place-1-text)" }}>
+              {winner && loser ? `${winner.name} def. ${loser.name} · ${st.margin}` : `Match halved · ${st.margin}`}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Hole navigation — verbatim reuse of entryChrome. */}
+      <div className="flex shrink-0 items-center justify-between" style={{ padding: "8px 16px 12px" }}>
+        <NavArrow dir="prev" disabled={hole <= 1} onClick={() => goHole(hole - 1)} />
+        <div className="flex flex-col items-center" style={{ gap: 12, flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: "-0.02em", color: "var(--color-bt-text)" }}>
+            Hole {label}
+          </div>
+          {par != null && (
+            <div style={{ fontSize: 13, color: "var(--color-bt-text-dim)", fontVariantNumeric: "tabular-nums" }}>
+              Par {par}
+            </div>
+          )}
+          <HoleProgress count={units.length} currentHole={hole} completed={completedHoleNumbers} />
+        </div>
+        <NavArrow dir="next" disabled={hole >= units.length} onClick={() => goHole(hole + 1)} />
+      </div>
+
+      {holeIsGlorious && (
+        <div
+          data-testid="glorious-entry-banner"
+          style={{
+            margin: "0 16px 10px",
+            padding: "8px 12px",
+            borderRadius: 10,
+            textAlign: "center",
+            background: "var(--color-bt-glorious-faint)",
+            border: "1px solid var(--color-bt-glorious-border)",
+          }}
+        >
+          <span style={{ fontSize: 13, fontWeight: 700, color: "var(--color-bt-glorious)" }}>
+            Glorious Finishing Hole · Worth Double
+          </span>
+        </div>
+      )}
+
+      {/* Entry zone — three stacked player-row-styled choices. No number pad;
+          one tap records the whole hole. */}
+      <div className="flex-1 overflow-y-auto" style={{ padding: "0 16px 8px" }}>
+        <p
+          className="text-center"
+          style={{ fontSize: 12, fontWeight: 600, color: "var(--color-bt-text-dim)", letterSpacing: "0.02em", margin: "2px 0 10px" }}
+        >
+          Who won this hole?
+        </p>
+        <div className="flex flex-col" style={{ gap: 9 }}>
+          <Choice
+            selected={selected === "side_a"}
+            dim={selected != null && selected !== "side_a"}
+            color={m.leftColor}
+            avatarName={m.a.name}
+            avatarIcon={m.a.avatarIcon}
+            label={m.a.name}
+            sub={selected === "side_a" ? "Won the hole" : undefined}
+            onClick={() => pick("side_a")}
+            testId="outcome-choice-a"
+          />
+          <Choice
+            selected={selected === "halved"}
+            dim={selected != null && selected !== "halved"}
+            neutral
+            label="Halved"
+            sub={selected === "halved" ? "Hole halved" : undefined}
+            onClick={() => pick("halved")}
+            testId="outcome-choice-halved"
+          />
+          <Choice
+            selected={selected === "side_b"}
+            dim={selected != null && selected !== "side_b"}
+            color={m.rightColor}
+            avatarName={m.b.name}
+            avatarIcon={m.b.avatarIcon}
+            label={m.b.name}
+            sub={selected === "side_b" ? "Won the hole" : undefined}
+            onClick={() => pick("side_b")}
+            testId="outcome-choice-b"
+          />
+        </div>
+        {selected != null && (
+          <button
+            type="button"
+            onClick={reset}
+            className="w-full text-center"
+            style={{ padding: 10, fontSize: 13, fontWeight: 600, color: "var(--color-bt-text-dim)" }}
+            data-testid="outcome-reset-hole"
+          >
+            Reset hole
+          </button>
+        )}
+      </div>
+
+      {/* Bottom: Next Hole | Finish — confirmation-gated, same idiom as score entry. */}
+      {canFinish ? (
+        <BottomCTA
+          label={finishLabel}
+          icon
+          onClick={() => onFinish?.()}
+          disabled={gameGate.total > 0}
+          subtext={finishReason ?? finishSubtext}
+        />
+      ) : currentComplete && hole < units.length ? (
+        <BottomCTA
+          label={`Hole ${units[hole]?.label ?? hole + 1} ›`}
+          onClick={() => goHole(hole + 1)}
+          disabled={holeGate.blocked}
+          subtext={advanceReason}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function parseKey(key: string): { matchId: string; holeNumber: number } {
+  const i = key.indexOf(":");
+  return { matchId: key.slice(0, i), holeNumber: Number(key.slice(i + 1)) };
+}
+
+/** One outcome choice — a player-row-styled button (avatar-left OR a neutral
+ *  glyph for "Halved") + label + a trailing check-circle. Selected = team-colored
+ *  wash + border + filled check (or teal for Halved); the other rows dim once
+ *  something is picked. */
+function Choice({
+  selected,
+  dim,
+  color,
+  neutral,
+  avatarName,
+  avatarIcon,
+  label,
+  sub,
+  onClick,
+  testId,
+}: {
+  selected: boolean;
+  dim: boolean;
+  color?: string;
+  neutral?: boolean;
+  avatarName?: string;
+  avatarIcon?: string | null;
+  label: string;
+  sub?: string;
+  onClick: () => void;
+  testId: string;
+}) {
+  const tint = neutral ? "var(--color-bt-accent)" : color ?? "var(--color-bt-accent)";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-3 text-left transition-opacity"
+      data-testid={testId}
+      style={{
+        padding: 14,
+        borderRadius: 12,
+        background: selected ? `color-mix(in srgb, ${tint} 14%, transparent)` : "var(--color-bt-card)",
+        border: `1.5px solid ${selected ? tint : "var(--color-bt-border)"}`,
+        opacity: dim ? 0.5 : 1,
+      }}
+    >
+      {neutral ? (
+        <span
+          className="flex flex-shrink-0 items-center justify-center"
+          style={{ width: 30, height: 30, borderRadius: "50%", background: "var(--color-bt-card-raised)", color: "var(--color-bt-text-dim)" }}
+        >
+          <Equal size={14} />
+        </span>
+      ) : (
+        <Avatar name={avatarName ?? label} avatarIcon={avatarIcon} teamColor={color} sizePx={30} />
+      )}
+      <div className="min-w-0 flex-1">
+        <div style={{ fontSize: 15, fontWeight: 700, color: "var(--color-bt-text)" }}>{label}</div>
+        {sub && <div style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", fontWeight: 600 }}>{sub}</div>}
+      </div>
+      <span
+        className="flex flex-shrink-0 items-center justify-center"
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: "50%",
+          border: `2px solid ${selected ? tint : "var(--color-bt-border)"}`,
+          background: selected ? tint : "transparent",
+          color: selected ? "var(--color-bt-on-accent)" : "transparent",
+          fontSize: 12,
+          fontWeight: 800,
+        }}
+      >
+        ✓
+      </span>
+    </button>
+  );
+}

--- a/src/components/games/OutcomeScorecard.test.tsx
+++ b/src/components/games/OutcomeScorecard.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { computeLeadTrack, OutcomeScorecard } from "./OutcomeScorecard";
+import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
+import type { HoleOutcomeRow } from "@/lib/matchPlay";
+import type { Participant } from "./types";
+
+/**
+ * OutcomeScorecard (Refactor B2, built to outcome_scorecard_mockup.html). The
+ * running lead lives in the LEADER's row; a tied hole reads "AS" (B's row only,
+ * mirroring the mockup); a Glorious win's double-jump is visible in the number;
+ * closeout dims the never-played remainder.
+ */
+
+const GLOR2: GloriousConfig = { enabled: true, n: 2 }; // last 2 holes (17,18) worth 2×
+
+describe("computeLeadTrack — the pure per-hole running lead", () => {
+  it("the lead hands off between sides as momentum shifts", () => {
+    const outcomes: HoleOutcomeRow[] = [
+      { hole: 1, result: "side_a" }, // A +1 → 1
+      { hole: 2, result: "side_b" }, // A -1 → 0 (AS)
+      { hole: 3, result: "side_a" }, // A +1 → 1
+    ];
+    const { track } = computeLeadTrack(outcomes.map((o) => ({ hole: o.hole, result: o.result === "side_a" ? "W" : o.result === "side_b" ? "L" : "H" })), 18, NO_GLORIOUS);
+    expect(track.slice(0, 3)).toEqual([
+      { hole: 1, lead: 1, dead: false, glorious: false },
+      { hole: 2, lead: 0, dead: false, glorious: false },
+      { hole: 3, lead: 1, dead: false, glorious: false },
+    ]);
+  });
+
+  it("a halved hole CARRIES FORWARD the unchanged lead — not blank", () => {
+    const decided = [{ hole: 1, result: "W" as const }, { hole: 2, result: "H" as const }];
+    const { track } = computeLeadTrack(decided, 18, NO_GLORIOUS);
+    expect(track[1]).toMatchObject({ hole: 2, lead: 1 }); // still 1, carried from hole 1
+  });
+
+  it("a Glorious win jumps the lead by 2, not 1 — visible in the number", () => {
+    // Holes 1-16 halved (no swing), hole 17 (glorious, GLOR2) won by A.
+    const decided = [
+      ...Array.from({ length: 16 }, (_, i) => ({ hole: i + 1, result: "H" as const })),
+      { hole: 17, result: "W" as const },
+    ];
+    const { track } = computeLeadTrack(decided, 18, GLOR2);
+    expect(track[16]).toMatchObject({ hole: 17, lead: 2, glorious: true }); // +2, not +1
+  });
+
+  it("an unplayed (not-yet-entered) hole is neither a lead nor dead — simply blank", () => {
+    const decided = [{ hole: 1, result: "W" as const }];
+    const { track } = computeLeadTrack(decided, 18, NO_GLORIOUS);
+    expect(track[5]).toEqual({ hole: 6, lead: null, dead: false, glorious: false }); // hole 7, untouched
+  });
+
+  it("closeout DIMS the never-played remainder — dead, not just unplayed", () => {
+    // A wins 1-4, halves 5-13 → 4 up thru 13, 5 to play, swing 5 > 4 → NOT yet closed.
+    // Push to a real close-out: A wins 1-7 → 7 up thru 7, 11 to play (still live), then
+    // halve the rest so it closes at 18 as "7 UP", nothing dead. Use a smaller, decisive
+    // case instead: 3-hole round, A wins holes 1-2 → 2 up thru 2, 1 to play, swing 1 < 2
+    // → closed early (2&1). Hole 3 is dead (never played).
+    const decided = [{ hole: 1, result: "W" as const }, { hole: 2, result: "W" as const }];
+    const { track, st } = computeLeadTrack(decided, 3, NO_GLORIOUS);
+    expect(st).toMatchObject({ closed: true, margin: "2&1" });
+    expect(track[2]).toEqual({ hole: 3, lead: null, dead: true, glorious: false }); // dead, not blank
+  });
+});
+
+describe("OutcomeScorecard — render (react-dom/server)", () => {
+  const a: Participant = { id: "a", name: "Brad", color: "#4ade80" };
+  const b: Participant = { id: "b", name: "Johnny D", color: "#fb923c" };
+  const units = Array.from({ length: 3 }, (_, i) => ({ label: String(i + 1), par: 4 }));
+
+  it("shows a team-colored lead pill in the LEADING side's row only", () => {
+    const outcomes: HoleOutcomeRow[] = [{ hole: 1, result: "side_a" }];
+    const html = renderToStaticMarkup(
+      <OutcomeScorecard units={units} a={a} b={b} outcomes={outcomes} leftColor={a.color} rightColor={b.color} />
+    );
+    expect(html).toContain("outcome-lead-pill");
+    expect(html).toContain(">1<"); // the pill's value
+    expect(html).not.toContain("outcome-as"); // not tied — no AS anywhere yet
+  });
+
+  it("shows neutral AS (in B's row) when the match is tied", () => {
+    const outcomes: HoleOutcomeRow[] = [{ hole: 1, result: "halved" }];
+    const html = renderToStaticMarkup(<OutcomeScorecard units={units} a={a} b={b} outcomes={outcomes} />);
+    expect(html).toContain("outcome-as");
+    expect(html).toContain(">AS<");
+  });
+
+  it("shows the closeout line once the match is decided", () => {
+    const outcomes: HoleOutcomeRow[] = [{ hole: 1, result: "side_a" }, { hole: 2, result: "side_a" }];
+    const html = renderToStaticMarkup(<OutcomeScorecard units={units} a={a} b={b} outcomes={outcomes} />);
+    expect(html).toContain("outcome-closeout");
+    expect(html).toContain("Brad def. Johnny D");
+    expect(html).toContain("2&amp;1"); // React-escaped "2&1"
+  });
+
+  it("no outcomes yet → no pills, no closeout, no AS", () => {
+    const html = renderToStaticMarkup(<OutcomeScorecard units={units} a={a} b={b} outcomes={[]} />);
+    expect(html).not.toContain("outcome-lead-pill");
+    expect(html).not.toContain("outcome-closeout");
+    expect(html).not.toContain("outcome-as");
+  });
+});

--- a/src/components/games/OutcomeScorecard.tsx
+++ b/src/components/games/OutcomeScorecard.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { buildDecidedFromOutcomes, matchState, type DecidedHole, type HoleOutcomeRow } from "@/lib/matchPlay";
+import { holeWeight, isGloriousHole, NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
+import type { Participant } from "./types";
+
+/**
+ * OutcomeScorecard — the hole-outcome-entry scorecard (Refactor B2, built to
+ * `outcome_scorecard_mockup.html`). NO score rows (there are no scores in outcome
+ * mode) — two team-colored LEAD rows instead. The running lead lives in the
+ * LEADER's row (`N▲`, team-colored); a tied hole shows neutral `AS`; a Glorious
+ * hole's double-jump is directly visible in the number; closeout dims the
+ * unplayed remainder. Same W/L/H color vocabulary `MatchCard`'s history strip
+ * uses (win/lose/halve), reused here for the per-hole win-green treatment.
+ */
+
+const WIN_GREEN = "#22c55e"; // = --color-bt-place-1 base; matches MatchCard's neutral "winning" color
+
+interface LeadCell {
+  hole: number;
+  /** Signed running lead as of this hole (+A, −B), or null when not yet played. */
+  lead: number | null;
+  /** Past the freeze boundary of a decided match — never played. */
+  dead: boolean;
+  glorious: boolean;
+}
+
+/** Pure — the per-hole running lead track + the final match state. Exported for
+ *  unit testing apart from render. */
+export function computeLeadTrack(
+  decided: DecidedHole[],
+  holeCount: number,
+  glorious: GloriousConfig
+): { track: LeadCell[]; st: ReturnType<typeof matchState> } {
+  const st = matchState(decided, holeCount, glorious);
+  const byHole = new Map(decided.map((d) => [d.hole, d.result]));
+  let diff = 0;
+  const track: LeadCell[] = [];
+  for (let h = 1; h <= holeCount; h++) {
+    const glor = isGloriousHole(h, glorious);
+    if (st.closed && h > st.thru) {
+      track.push({ hole: h, lead: null, dead: true, glorious: glor });
+      continue;
+    }
+    const result = byHole.get(h);
+    if (result == null) {
+      track.push({ hole: h, lead: null, dead: false, glorious: glor }); // not yet played
+      continue;
+    }
+    const w = holeWeight(h, glorious);
+    if (result === "W") diff += w;
+    else if (result === "L") diff -= w;
+    // "H" (halved) carries the lead forward unchanged — still shown, not blank.
+    track.push({ hole: h, lead: diff, dead: false, glorious: glor });
+  }
+  return { track, st };
+}
+
+export interface OutcomeScorecardProps {
+  units: { label: string; par?: number }[];
+  a: Participant;
+  b: Participant;
+  outcomes: HoleOutcomeRow[];
+  glorious?: GloriousConfig;
+  leftColor?: string;
+  rightColor?: string;
+}
+
+export function OutcomeScorecard({
+  units,
+  a,
+  b,
+  outcomes,
+  glorious = NO_GLORIOUS,
+  leftColor,
+  rightColor,
+}: OutcomeScorecardProps) {
+  const decided = buildDecidedFromOutcomes(outcomes);
+  const { track, st } = computeLeadTrack(decided, units.length, glorious);
+  const lc = leftColor || WIN_GREEN;
+  const rc = rightColor || WIN_GREEN;
+  const winner = st.leader === "A" ? a : st.leader === "B" ? b : null;
+  const loser = st.leader === "A" ? b : st.leader === "B" ? a : null;
+
+  return (
+    <div data-testid="outcome-scorecard">
+      <div className="no-scrollbar overflow-x-auto">
+        <table style={{ borderCollapse: "collapse", width: "100%", minWidth: units.length * 40 }}>
+          <thead>
+            <tr>
+              <th style={{ width: 96 }} />
+              {units.map((u, i) => (
+                <th key={u.label} style={{ width: 40, padding: "2px 0 8px" }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 800,
+                      color: track[i]?.glorious ? "var(--color-bt-glorious)" : "var(--color-bt-text)",
+                    }}
+                  >
+                    {u.label}
+                  </div>
+                  {track[i]?.glorious && (
+                    <div style={{ fontSize: 8, fontWeight: 800, color: "var(--color-bt-glorious)", letterSpacing: "0.03em" }}>
+                      ◆
+                    </div>
+                  )}
+                  {u.par != null && (
+                    <div style={{ fontSize: 10, color: "var(--color-bt-text-dim)", fontWeight: 600 }}>{u.par}</div>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <LeadRow name={a.name} track={track} side="A" color={lc} />
+            <LeadRow name={b.name} track={track} side="B" color={rc} />
+          </tbody>
+        </table>
+      </div>
+
+      {st.over && (
+        <p className="text-center" style={{ padding: "12px 10px 2px", fontSize: 13, fontWeight: 800, color: "var(--color-bt-place-1-text)" }} data-testid="outcome-closeout">
+          {winner && loser ? `${winner.name} def. ${loser.name} — ${st.margin}` : `Match halved — ${st.margin}`}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LeadRow({
+  name,
+  track,
+  side,
+  color,
+}: {
+  name: string;
+  track: LeadCell[];
+  side: "A" | "B";
+  color: string;
+}) {
+  return (
+    <tr>
+      <td style={{ textAlign: "left", padding: "0 12px", fontSize: 13, fontWeight: 700, color: "var(--color-bt-text)", whiteSpace: "nowrap" }}>
+        {name}
+      </td>
+      {track.map((c) => (
+        <td
+          key={c.hole}
+          style={{
+            height: 38,
+            borderTop: "1px solid var(--color-bt-subtle-border)",
+            textAlign: "center",
+            ...(c.glorious && !c.dead
+              ? { outline: "1px dashed var(--color-bt-glorious-border)", outlineOffset: -3, borderRadius: 8 }
+              : {}),
+          }}
+        >
+          {c.dead ? (
+            <span style={{ color: "var(--color-bt-text-dim)", opacity: 0.4 }}>·</span>
+          ) : c.lead == null ? null : side === "A" && c.lead > 0 ? (
+            <LeadPill value={c.lead} color={color} />
+          ) : side === "B" && c.lead < 0 ? (
+            <LeadPill value={-c.lead} color={color} />
+          ) : side === "B" && c.lead === 0 ? (
+            <span style={{ fontSize: 11, fontWeight: 700, color: "var(--color-bt-text-dim)" }} data-testid="outcome-as">
+              AS
+            </span>
+          ) : null}
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+/** Team-tinted lead pill — same visual grammar as the board's ProjectionPill
+ *  (16%-alpha team fill, value in plain team color). */
+function LeadPill({ value, color }: { value: number; color: string }) {
+  return (
+    <span
+      className="inline-flex items-center justify-center"
+      data-testid="outcome-lead-pill"
+      style={{
+        minWidth: 30,
+        height: 26,
+        padding: "0 7px",
+        borderRadius: 7,
+        fontSize: 13,
+        fontWeight: 800,
+        background: `color-mix(in srgb, ${color} 16%, transparent)`,
+        color,
+      }}
+    >
+      {value}
+      <span style={{ fontSize: 8, marginLeft: 2 }}>▲</span>
+    </span>
+  );
+}

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -65,6 +65,23 @@ export function parseScoreCellKey(key: string): {
   return { participantId: key.slice(0, i), unitLabel: key.slice(i + 1) };
 }
 
+/** Cell key for hole-OUTCOME entry (Refactor B) — `SaveStatusMap`/
+ *  `unconfirmedOnHole`/`unconfirmedCount` are generic over the key string, so they
+ *  apply unchanged to outcomes; only the key shape differs (a match+hole, not a
+ *  participant+unit — an outcome belongs to the MATCH, not either player). */
+export function outcomeCellKey(matchId: string, holeNumber: number): string {
+  return `${matchId}:${holeNumber}`;
+}
+
+/** Inverse of {@link outcomeCellKey}. */
+export function parseOutcomeCellKey(key: string): {
+  matchId: string;
+  holeNumber: number;
+} {
+  const i = key.indexOf(":");
+  return { matchId: key.slice(0, i), holeNumber: Number(key.slice(i + 1)) };
+}
+
 /**
  * Confirmation gate (Spec 1a — honest advance). A hole is safe to advance/finish
  * PAST only when none of its cells is mid-save (`saving`) or failed (`error`) —

--- a/src/components/games/types.ts
+++ b/src/components/games/types.ts
@@ -34,6 +34,11 @@ export interface Participant {
 /** { [participantId]: { [unitLabel]: value } } */
 export type ScoreValues = Record<string, Record<string, number>>;
 
+/** { [matchId]: { [holeLabel]: HoleOutcomeResult } } — the hole-outcome-entry
+ *  (Refactor B) counterpart to `ScoreValues`. Keyed by MATCH (not participant) —
+ *  an outcome belongs to the match, not either player. */
+export type OutcomeValues = Record<string, Record<string, import("@/lib/matchPlay").HoleOutcomeResult>>;
+
 /** Slice A is always low_wins; typed so later strategies can extend. */
 export type ScoreDirection = "low_wins";
 

--- a/src/hooks/useOutcomeSaver.ts
+++ b/src/hooks/useOutcomeSaver.ts
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { trpc } from "@/lib/trpc-client";
+import { outcomeOutboxPut, outcomeOutboxClear, outcomeOutboxEntries } from "@/lib/outcomeOutbox";
+import { reconcileOutcomes } from "@/lib/outcomeReconcile";
+import { showToast } from "@/lib/toast";
+import {
+  outcomeCellKey,
+  type CellSaveState,
+  type SaveStatusMap,
+  type OutcomeValues,
+} from "@/components/games/types";
+import type { HoleOutcomeResult } from "@/lib/matchPlay";
+
+/**
+ * useOutcomeSaver — the hole-outcome-entry write path (Refactor B2), the outcome
+ * counterpart to `useScoreSaver`. One tap records a WHOLE hole (no per-player
+ * cells) — every mechanic below mirrors useScoreSaver's durability contract
+ * exactly (optimistic → durable outbox → retried → visible-on-failure), just
+ * keyed by match+hole instead of participant+unit. See useScoreSaver's header
+ * comment for the full rationale (never consults navigator.onLine, etc.) — not
+ * re-explained here since it's identical.
+ */
+
+const MAX_RETRIES = 4;
+const retryDelay = (attempt: number) => Math.min(500 * 2 ** attempt, 8000);
+
+export function useOutcomeSaver(tripId: string | undefined, gameId: string | null | undefined) {
+  const [values, setValues] = useState<OutcomeValues>({});
+  const [saveStatus, setSaveStatus] = useState<SaveStatusMap>({});
+  const saveStatusRef = useRef(saveStatus);
+  useEffect(() => {
+    saveStatusRef.current = saveStatus;
+  }, [saveStatus]);
+
+  const upsertOutcome = trpc.matchOutcomes.upsertOutcome.useMutation({
+    retry: MAX_RETRIES,
+    retryDelay,
+    meta: { suppressErrorToast: true },
+  });
+  const deleteOutcome = trpc.matchOutcomes.deleteOutcome.useMutation({
+    retry: MAX_RETRIES,
+    retryDelay,
+    meta: { suppressErrorToast: true },
+  });
+
+  const mark = useCallback((key: string, state: CellSaveState | null) => {
+    setSaveStatus((s) => {
+      if (state === null) {
+        if (!(key in s)) return s;
+        const next = { ...s };
+        delete next[key];
+        return next;
+      }
+      if (s[key] === state) return s;
+      return { ...s, [key]: state };
+    });
+  }, []);
+
+  const onChange = useCallback(
+    (matchId: string, hole: string, result: HoleOutcomeResult) => {
+      if (!tripId || !gameId) return;
+      const key = outcomeCellKey(matchId, Number(hole));
+      setValues((v) => ({
+        ...v,
+        [matchId]: { ...(v[matchId] ?? {}), [hole]: result },
+      }));
+      mark(key, "saving");
+      outcomeOutboxPut(gameId, matchId, Number(hole), result);
+      upsertOutcome
+        .mutateAsync({ tripId, gameId, matchId, holeNumber: Number(hole), result })
+        .then(() => {
+          mark(key, "saved");
+          outcomeOutboxClear(gameId, matchId, Number(hole));
+        })
+        .catch(() => mark(key, "error"));
+    },
+    [tripId, gameId, upsertOutcome, mark],
+  );
+
+  const onClear = useCallback(
+    (matchId: string, hole: string) => {
+      if (!tripId || !gameId) return;
+      const key = outcomeCellKey(matchId, Number(hole));
+      const prevValue = values[matchId]?.[hole];
+      setValues((v) => {
+        const row = { ...(v[matchId] ?? {}) };
+        delete row[hole];
+        return { ...v, [matchId]: row };
+      });
+      mark(key, null);
+      outcomeOutboxClear(gameId, matchId, Number(hole));
+      deleteOutcome
+        .mutateAsync({ tripId, gameId, matchId, holeNumber: Number(hole) })
+        .catch(() => {
+          if (prevValue != null) {
+            setValues((v) => ({
+              ...v,
+              [matchId]: { ...(v[matchId] ?? {}), [hole]: prevValue },
+            }));
+            mark(key, "error");
+          }
+        });
+    },
+    [tripId, gameId, values, deleteOutcome, mark],
+  );
+
+  /** Reflect server outcome truth into the local view without clobbering the
+   *  active enterer — same contract as useScoreSaver.reconcile. */
+  const reconcile = useCallback(
+    (server: OutcomeValues) => {
+      setValues((cur) => {
+        const protectedKeys = new Set<string>();
+        for (const [k, st] of Object.entries(saveStatusRef.current)) {
+          if (st === "saving" || st === "error") protectedKeys.add(k);
+        }
+        if (gameId) {
+          for (const e of outcomeOutboxEntries(gameId)) {
+            protectedKeys.add(outcomeCellKey(e.matchId, e.holeNumber));
+          }
+        }
+        return reconcileOutcomes(cur, server, protectedKeys);
+      });
+    },
+    [gameId],
+  );
+
+  /** Re-fire the save for a flagged cell using its current value. */
+  const retryCell = useCallback(
+    (matchId: string, hole: string) => {
+      const value = values[matchId]?.[hole];
+      if (value == null) return;
+      onChange(matchId, hole, value);
+    },
+    [values, onChange],
+  );
+
+  // Recover-on-mount: any entries still in the outbox are unconfirmed (a prior
+  // nav/reload/kill left them un-acked) — re-send through the same idempotent
+  // path. Runs once per game.
+  const recoveredForGame = useRef<string | null>(null);
+  useEffect(() => {
+    if (!tripId || !gameId) return;
+    if (recoveredForGame.current === gameId) return;
+    recoveredForGame.current = gameId;
+    const pending = outcomeOutboxEntries(gameId);
+    if (pending.length === 0) return;
+    const t = setTimeout(() => {
+      for (const e of pending) onChange(e.matchId, String(e.holeNumber), e.result);
+      showToast(
+        `Recovered ${pending.length} unsaved outcome${pending.length > 1 ? "s" : ""} — retrying`,
+        "info",
+      );
+    }, 0);
+    return () => clearTimeout(t);
+  }, [tripId, gameId, onChange]);
+
+  const errorCount = Object.values(saveStatus).filter((s) => s === "error").length;
+
+  return {
+    values,
+    setValues,
+    saveStatus,
+    errorCount,
+    onChange,
+    onClear,
+    retryCell,
+    reconcile,
+  };
+}

--- a/src/lib/outcomeOutbox.test.ts
+++ b/src/lib/outcomeOutbox.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  putIn,
+  clearIn,
+  entriesOf,
+  outcomeOutboxPut,
+  outcomeOutboxClear,
+  outcomeOutboxEntries,
+  type OutcomeOutboxMap,
+} from "./outcomeOutbox";
+
+/**
+ * outcomeOutbox (Refactor B2 — durable WAL, forked from scoreOutbox per the B
+ * Phase-0 finding). Same test shape as scoreOutbox.test.ts, keyed by
+ * matchId:holeNumber instead of participantId:unitLabel, values are the
+ * HoleOutcomeResult enum instead of a number.
+ */
+
+describe("outcomeOutbox — pure map ops", () => {
+  it("putIn adds a keyed entry (key = matchId:holeNumber)", () => {
+    const m = putIn({}, "m1", 3, "side_a");
+    expect(m).toEqual({ "m1:3": "side_a" });
+  });
+
+  it("putIn overwrites the same cell (last-write-wins)", () => {
+    let m: OutcomeOutboxMap = putIn({}, "m1", 3, "side_a");
+    m = putIn(m, "m1", 3, "halved");
+    expect(m).toEqual({ "m1:3": "halved" });
+  });
+
+  it("clearIn removes only the target cell; no-ops when absent", () => {
+    const m = { "m1:3": "side_a" as const, "m2:3": "side_b" as const };
+    expect(clearIn(m, "m1", 3)).toEqual({ "m2:3": "side_b" });
+    expect(clearIn(m, "mX", 9)).toBe(m); // unchanged reference when absent
+  });
+
+  it("entriesOf round-trips keys back to {matchId, holeNumber, result}", () => {
+    const m = { "m1:3": "side_a" as const, "m2:12": "halved" as const };
+    expect(entriesOf(m).sort((a, b) => a.matchId.localeCompare(b.matchId))).toEqual([
+      { matchId: "m1", holeNumber: 3, result: "side_a" },
+      { matchId: "m2", holeNumber: 12, result: "halved" },
+    ]);
+  });
+});
+
+describe("outcomeOutbox — localStorage wrappers", () => {
+  beforeEach(() => {
+    // Minimal in-memory localStorage polyfill for the node test env.
+    const store = new Map<string, string>();
+    (globalThis as unknown as { window: unknown; localStorage: unknown }).window = globalThis;
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } as Storage;
+  });
+
+  it("persist → read an unconfirmed outcome", () => {
+    outcomeOutboxPut("g1", "m1", 3, "side_a");
+    expect(outcomeOutboxEntries("g1")).toEqual([{ matchId: "m1", holeNumber: 3, result: "side_a" }]);
+  });
+
+  it("clear-on-confirm removes the entry; emptied game clears its key", () => {
+    outcomeOutboxPut("g1", "m1", 3, "side_a");
+    outcomeOutboxClear("g1", "m1", 3);
+    expect(outcomeOutboxEntries("g1")).toEqual([]);
+  });
+
+  it("is per-game namespaced (one game's outbox never leaks into another)", () => {
+    outcomeOutboxPut("g1", "m1", 3, "side_a");
+    outcomeOutboxPut("g2", "m9", 1, "halved");
+    expect(outcomeOutboxEntries("g1")).toEqual([{ matchId: "m1", holeNumber: 3, result: "side_a" }]);
+    expect(outcomeOutboxEntries("g2")).toEqual([{ matchId: "m9", holeNumber: 1, result: "halved" }]);
+  });
+
+  it("is namespaced SEPARATELY from the score outbox (no key collision, different NS)", () => {
+    outcomeOutboxPut("g1", "m1", 3, "side_a");
+    // The score outbox's storeKey would be `bt.scoreOutbox.v1:g1` — a different
+    // localStorage key entirely, so a game with BOTH mid-migration data (unlikely
+    // in practice, since a game is one mode) can never cross-contaminate.
+    const raw = window.localStorage.getItem("bt.outcomeOutbox.v1:g1");
+    expect(raw).not.toBeNull();
+    expect(window.localStorage.getItem("bt.scoreOutbox.v1:g1")).toBeNull();
+  });
+
+  it("survives a simulated reload (same backing store, fresh reads)", () => {
+    outcomeOutboxPut("g1", "m1", 3, "side_a");
+    outcomeOutboxPut("g1", "m2", 3, "side_b");
+    // A 'reload' is just another read of the same store.
+    expect(outcomeOutboxEntries("g1")).toHaveLength(2);
+  });
+});

--- a/src/lib/outcomeOutbox.ts
+++ b/src/lib/outcomeOutbox.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { outcomeCellKey, parseOutcomeCellKey } from "@/components/games/types";
+import type { HoleOutcomeResult } from "@/lib/matchPlay";
+
+/**
+ * outcomeOutbox — the hole-outcome-entry counterpart to `scoreOutbox` (Refactor
+ * B2 Phase 0 finding: the key scheme FORKS rather than widens — an outcome
+ * belongs to a MATCH+HOLE, not a participant+unit, so `scoreCellKey` doesn't fit).
+ * Same durability contract: a tiny write-ahead log covering the gap between "the
+ * outcome was tapped" and "the server confirmed the write," so a nav/reload/
+ * app-kill on poor signal can't silently drop a recorded hole.
+ *
+ * Shape: localStorage, one entry-map per game (separate namespace from the score
+ * outbox), entries keyed by `outcomeCellKey(matchId, holeNumber)`. Written on tap,
+ * cleared ONLY on server confirmation; on failure it stays for the next mount's
+ * re-send (idempotent upsert on `UNIQUE(match_id, hole_number)` → safe).
+ */
+
+/** { [outcomeCellKey]: result } — the persisted unconfirmed outcomes for one game. */
+export type OutcomeOutboxMap = Record<string, HoleOutcomeResult>;
+export interface OutcomeOutboxEntry {
+  matchId: string;
+  holeNumber: number;
+  result: HoleOutcomeResult;
+}
+
+// ── Pure map ops (unit-tested) ───────────────────────────────────────────────
+export function putIn(map: OutcomeOutboxMap, matchId: string, holeNumber: number, result: HoleOutcomeResult): OutcomeOutboxMap {
+  return { ...map, [outcomeCellKey(matchId, holeNumber)]: result };
+}
+export function clearIn(map: OutcomeOutboxMap, matchId: string, holeNumber: number): OutcomeOutboxMap {
+  const key = outcomeCellKey(matchId, holeNumber);
+  if (!(key in map)) return map;
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+export function entriesOf(map: OutcomeOutboxMap): OutcomeOutboxEntry[] {
+  return Object.entries(map).map(([key, result]) => ({ ...parseOutcomeCellKey(key), result }));
+}
+
+// ── localStorage wrappers (best-effort, SSR-safe) ────────────────────────────
+const NS = "bt.outcomeOutbox.v1";
+const storeKey = (gameId: string) => `${NS}:${gameId}`;
+
+function read(gameId: string): OutcomeOutboxMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(storeKey(gameId));
+    return raw ? (JSON.parse(raw) as OutcomeOutboxMap) : {};
+  } catch {
+    return {};
+  }
+}
+function write(gameId: string, map: OutcomeOutboxMap): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (Object.keys(map).length === 0) window.localStorage.removeItem(storeKey(gameId));
+    else window.localStorage.setItem(storeKey(gameId), JSON.stringify(map));
+  } catch {
+    /* quota exceeded / storage disabled — best-effort; never throw into scoring. */
+  }
+}
+
+/** Persist an unconfirmed outcome (on tap). */
+export function outcomeOutboxPut(gameId: string, matchId: string, holeNumber: number, result: HoleOutcomeResult): void {
+  write(gameId, putIn(read(gameId), matchId, holeNumber, result));
+}
+/** Remove an outcome from the outbox (on server confirmation, or on reset). */
+export function outcomeOutboxClear(gameId: string, matchId: string, holeNumber: number): void {
+  write(gameId, clearIn(read(gameId), matchId, holeNumber));
+}
+/** All still-unconfirmed outcomes for a game (read on mount → re-send + reflect). */
+export function outcomeOutboxEntries(gameId: string): OutcomeOutboxEntry[] {
+  return entriesOf(read(gameId));
+}

--- a/src/lib/outcomeReconcile.ts
+++ b/src/lib/outcomeReconcile.ts
@@ -1,0 +1,28 @@
+import { outcomeCellKey, type OutcomeValues } from "@/components/games/types";
+
+/**
+ * reconcileOutcomes — the pure merge behind useOutcomeSaver.reconcile, the
+ * hole-outcome-entry counterpart to `reconcileScores` (forked, not genericized —
+ * matching the outbox/key-scheme fork decision from B Phase 0).
+ *
+ * Same rule: keep every local cell, then overlay the server's value for each
+ * cell the server has, EXCEPT cells in `protectedKeys` (an unconfirmed local
+ * write), which keep their local value. Deliberate gap: a remotely-CLEARED
+ * outcome isn't removed here — reflecting adds/edits is the requirement,
+ * never-clobber-the-enterer is the hard rule.
+ */
+export function reconcileOutcomes(
+  local: OutcomeValues,
+  server: OutcomeValues,
+  protectedKeys: ReadonlySet<string>,
+): OutcomeValues {
+  const next: OutcomeValues = {};
+  for (const mid of Object.keys(local)) next[mid] = { ...local[mid] };
+  for (const mid of Object.keys(server)) {
+    for (const hole of Object.keys(server[mid])) {
+      if (protectedKeys.has(outcomeCellKey(mid, Number(hole)))) continue;
+      (next[mid] ??= {})[hole] = server[mid][hole];
+    }
+  }
+  return next;
+}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -22,6 +22,7 @@ import { newsRouter } from "./routers/news";
 import { gamesRouter } from "./routers/games";
 import { scoresRouter } from "./routers/scores";
 import { matchesRouter } from "./routers/matches";
+import { matchOutcomesRouter } from "./routers/matchOutcomes";
 import { playGroupsRouter } from "./routers/playGroups";
 
 export const appRouter = router({
@@ -48,6 +49,7 @@ export const appRouter = router({
   games: gamesRouter,
   scores: scoresRouter,
   matches: matchesRouter,
+  matchOutcomes: matchOutcomesRouter,
   playGroups: playGroupsRouter,
 });
 

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -23,7 +23,7 @@ import { computeConfigHash } from "@/lib/configHash";
  * alongside these — see `configHash` below.
  */
 const GAME_CONFIG_COLS =
-  "name, status, game_type_id, config, modifiers, rules_for_today, scorecard_schema, tee_time, points_distribution, points_total, competition_format, scoring_enabled, course_id, back_course_id, corrections_open, pairings_published_at";
+  "name, status, game_type_id, config, modifiers, rules_for_today, scorecard_schema, tee_time, points_distribution, points_total, competition_format, scoring_enabled, course_id, back_course_id, corrections_open, pairings_published_at, entry_mode";
 
 /**
  * games — the competition-engine spine (Slice A: individual stroke play).

--- a/src/server/routers/matchOutcomes.e2e.test.ts
+++ b/src/server/routers/matchOutcomes.e2e.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * Refactor B2 — the headline acceptance case, end to end through the REAL write
+ * path (matchOutcomes.upsertOutcome, not an admin insert — B1's test used admin
+ * inserts to isolate the compute layer; this proves the full B2 pipeline: tap →
+ * router mutation → finish → leaderboard, exactly the flow the entry surface
+ * drives). "a match-play game set to hole-outcome mode: tap the winner of each
+ * hole... finishes + posts to the leaderboard identically to a stroke game —
+ * with no score_entries rows anywhere."
+ */
+
+const MATCH_PLAY = "gtt_match_play";
+
+let ctx: TestContext;
+let tripId: string;
+let owner: string, member: string;
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Outcome E2E Trip");
+  await ctx.addTripMember(tripId, "member", "Member");
+  owner = ctx.user.id;
+  member = ctx.getUser("member").id;
+});
+
+afterAll(async () => {
+  await ctx.cleanup();
+});
+
+describe("Refactor B2 acceptance case — outcome entry, tap by tap, posts like a stroke game", () => {
+  it("records 3&2 via real upsertOutcome calls, finishes, and posts to the leaderboard — zero score_entries", async () => {
+    const comp = await ctx.createCompetition(tripId, "Outcome E2E Cup");
+    const blue = await ctx.createTeam(comp, "Blue");
+    const red = await ctx.createTeam(comp, "Red");
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: owner, team_id: blue },
+      { competition_id: comp, user_id: member, team_id: red },
+    ]);
+
+    const game = await ctx.caller().games.create({
+      tripId, gameTypeId: MATCH_PLAY, name: "Buddy v Rival", competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 3 },
+    });
+    const gameId = game.id as string;
+    await ctx.admin.from("games").update({ entry_mode: "outcome" }).eq("id", gameId);
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+
+    // Tap the winner of each hole — the SAME mutation MatchOutcomeEntryView's
+    // choice buttons call. Owner wins 1-3, halves 4-16 → 3&2 (mirrors the
+    // score-mode "Close 3&2" acceptance case exactly, decided the outcome way).
+    for (let h = 1; h <= 3; h++) {
+      await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: h, result: "side_a" });
+    }
+    for (let h = 4; h <= 16; h++) {
+      await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: h, result: "halved" });
+    }
+
+    const { matches: outcome } = await ctx.caller().games.finish({ tripId, gameId });
+    expect(outcome[0]).toMatchObject({ result: "a_win", margin: "3&2", status: "complete" });
+
+    // Posts to the leaderboard exactly like a stroke game — the SAME payload
+    // shape, the SAME per_match team-points adapter.
+    const lb = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(lb.teamTotals[blue]).toBe(3);
+    expect(lb.teamTotals[red] ?? 0).toBe(0);
+
+    // The headline: zero score_entries anywhere for this game.
+    const { data: scoreRows } = await ctx.admin.from("score_entries").select("id").eq("game_id", gameId);
+    expect(scoreRows).toHaveLength(0);
+
+    // The posted-lock applies to outcomes exactly like scores: a finished
+    // (complete, not re-opened for correction) game rejects further edits.
+    await expect(
+      ctx.caller().matchOutcomes.deleteOutcome({ tripId, gameId, matchId, holeNumber: 3 })
+    ).rejects.toThrow(/posted/i);
+  }, 60000);
+});

--- a/src/server/routers/matchOutcomes.test.ts
+++ b/src/server/routers/matchOutcomes.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { TestContext } from "../../__tests__/helpers/test-setup";
+
+/**
+ * matchOutcomes router (Refactor B2). B2 permission scope is ELEVATED TIER ONLY
+ * (owner/organizer/delegate), matching migration 075's RLS write policy exactly
+ * — the member-tier widening is B3's job (both the mutation AND RLS together).
+ */
+
+const MATCH_PLAY = "gtt_match_play";
+
+let ctx: TestContext;
+let tripId: string;
+let owner: string, planner: string, member: string;
+
+beforeAll(async () => {
+  ctx = await TestContext.create();
+  tripId = await ctx.createTrip("Outcome Router Trip");
+  await ctx.addTripMember(tripId, "planner", "Organizer");
+  await ctx.addTripMember(tripId, "member", "Member");
+  owner = ctx.user.id;
+  planner = ctx.getUser("planner").id;
+  member = ctx.getUser("member").id;
+});
+
+afterAll(async () => {
+  await ctx.cleanup();
+});
+
+async function freshOutcomeMatch(name: string): Promise<{ gameId: string; matchId: string }> {
+  const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name });
+  const gameId = game.id as string;
+  await ctx.admin.from("games").update({ entry_mode: "outcome" }).eq("id", gameId);
+  const matches = await ctx.caller().matches.setPairings({
+    tripId, gameId,
+    matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+  });
+  const matchId = (matches as { id: string }[])[0].id;
+  await ctx.caller().games.enableScoring({ tripId, gameId });
+  return { gameId, matchId };
+}
+
+describe("matchOutcomes.upsertOutcome — elevated tier only (B2 scope)", () => {
+  it("Owner records a hole outcome; it persists and round-trips via listByGame", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Owner Writes");
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+    const rows = await ctx.caller().matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([{ match_id: matchId, hole_number: 1, result: "side_a" }]);
+  });
+
+  it("Organizer (delegate-equivalent elevated tier) may also write", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Organizer Writes");
+    await ctx.callerAs("planner").matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 2, result: "halved" });
+    const rows = await ctx.caller().matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([{ match_id: matchId, hole_number: 2, result: "halved" }]);
+  });
+
+  it("a plain Member is REJECTED (B2 scope — widened in B3)", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Member Blocked");
+    await expect(
+      ctx.callerAs("member").matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" })
+    ).rejects.toThrow();
+  });
+
+  it("is idempotent on (match_id, hole_number) — a re-tap UPDATES the same row, not a duplicate", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Idempotent");
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "halved" });
+    const { data } = await ctx.admin.from("match_hole_outcomes").select("result").eq("match_id", matchId).eq("hole_number", 1);
+    expect(data).toHaveLength(1);
+    expect((data as { result: string }[])[0].result).toBe("halved");
+  });
+
+  it("rejects a write once scoring hasn't been enabled yet", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Not Enabled" });
+    const gameId = game.id as string;
+    await ctx.admin.from("games").update({ entry_mode: "outcome" }).eq("id", gameId);
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+    await expect(
+      ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" })
+    ).rejects.toThrow(/enable scoring/i);
+  });
+});
+
+describe("matchOutcomes.deleteOutcome — Reset hole", () => {
+  it("clears a recorded outcome back to undecided", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Reset Hole");
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+    await ctx.caller().matchOutcomes.deleteOutcome({ tripId, gameId, matchId, holeNumber: 1 });
+    const rows = await ctx.caller().matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([]);
+  });
+
+  it("a plain Member is REJECTED (same B2 scope as upsert)", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Reset Blocked");
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+    await expect(
+      ctx.callerAs("member").matchOutcomes.deleteOutcome({ tripId, gameId, matchId, holeNumber: 1 })
+    ).rejects.toThrow();
+  });
+});
+
+describe("matchOutcomes.listByGame — read parity with scores.listByGame", () => {
+  it("a plain Member CAN read (read is not the elevated-tier concern)", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Member Reads");
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+    const rows = await ctx.callerAs("member").matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([{ match_id: matchId, hole_number: 1, result: "side_a" }]);
+  });
+
+  it("a Member sees nothing for a SETUP-mode (pending) game they can't edit", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Still Pending" });
+    const gameId = game.id as string;
+    await ctx.admin.from("games").update({ entry_mode: "outcome" }).eq("id", gameId);
+    const rows = await ctx.callerAs("member").matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([]);
+  });
+});

--- a/src/server/routers/matchOutcomes.test.ts
+++ b/src/server/routers/matchOutcomes.test.ts
@@ -11,7 +11,7 @@ const MATCH_PLAY = "gtt_match_play";
 
 let ctx: TestContext;
 let tripId: string;
-let owner: string, planner: string, member: string;
+let owner: string, member: string;
 
 beforeAll(async () => {
   ctx = await TestContext.create();
@@ -19,7 +19,6 @@ beforeAll(async () => {
   await ctx.addTripMember(tripId, "planner", "Organizer");
   await ctx.addTripMember(tripId, "member", "Member");
   owner = ctx.user.id;
-  planner = ctx.getUser("planner").id;
   member = ctx.getUser("member").id;
 });
 

--- a/src/server/routers/matchOutcomes.ts
+++ b/src/server/routers/matchOutcomes.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { router, authedProcedure } from "../trpc";
+import { requireTripMember, requireGameEdit, canEditGame } from "../middleware";
+
+/**
+ * matchOutcomes — hole-outcome entry (Refactor B2): record who won each hole
+ * directly, no gross scores. The write-path counterpart to `scores.ts` for
+ * outcome-mode games.
+ *
+ * B2 permission scope — ELEVATED TIER ONLY (owner/organizer/delegate via
+ * `requireGameEdit()`), matching migration 075's RLS write policy exactly. A
+ * member-tier check (reusing `memberCanScoreUnit`'s match-membership logic, the
+ * same rule `scores.ts` uses) is deliberately deferred to B3, which widens BOTH
+ * this mutation AND the RLS policy TOGETHER — `ctx.supabase` is a user-scoped
+ * client (RLS-enforcing, not service-role), so a member-tier check here without
+ * the matching RLS widening would pass the app check and then fail the actual
+ * write, a broken half-permission state. Building both layers in lockstep avoids
+ * that gap entirely (see B1/B2 PR discussion).
+ *
+ * No `computeMatchPlayResults` call per write — mirrors `scores.upsertEntry`/
+ * `deleteEntry` exactly: live state is derived CLIENT-SIDE from the outcome rows
+ * (same pattern as score entry deriving live state from `score_entries`); the
+ * server's `game_matches.result/margin/status` updates only at `finish` (or a
+ * future incremental trigger, of which outcome mode currently has none — no
+ * handicaps to edit mid-round).
+ */
+export const matchOutcomesRouter = router({
+  // upsertOutcome — record one hole's decided winner (or halved). Idempotent on
+  // the UNIQUE(match_id, hole_number) key (same upsert-on-conflict shape as
+  // scores.upsertEntry).
+  upsertOutcome: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        matchId: z.string().min(1),
+        holeNumber: z.number().int().min(1).max(18),
+        result: z.enum(["side_a", "side_b", "halved"]),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, status, corrections_open, scoring_enabled")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+      // Same posted/enabled gates as scores.upsertEntry — format-agnostic rules.
+      if (game.status === "complete" && !game.corrections_open) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "This round is posted — open score correction to edit it.",
+        });
+      }
+      if (!game.scoring_enabled) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Enable scoring before entering outcomes.",
+        });
+      }
+
+      const { data: match } = await ctx.supabase
+        .from("game_matches")
+        .select("id")
+        .eq("id", input.matchId)
+        .eq("game_id", input.gameId)
+        .maybeSingle();
+      if (!match) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
+      }
+
+      const id = `${input.matchId}:${input.holeNumber}`;
+      const { error } = await ctx.supabase.from("match_hole_outcomes").upsert(
+        {
+          id,
+          game_id: input.gameId,
+          match_id: input.matchId,
+          hole_number: input.holeNumber,
+          result: input.result,
+          submitted_by: ctx.user!.id,
+          submitted_at: new Date().toISOString(),
+        },
+        { onConflict: "match_id,hole_number" }
+      );
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to save outcome: ${error.message}` });
+      }
+      return { ok: true };
+    }),
+
+  // deleteOutcome — "Reset hole" (clear a recorded outcome back to undecided).
+  deleteOutcome: authedProcedure
+    .input(
+      z.object({
+        tripId: z.string(),
+        gameId: z.string(),
+        matchId: z.string().min(1),
+        holeNumber: z.number().int().min(1).max(18),
+      })
+    )
+    .use(requireGameEdit())
+    .mutation(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, status, corrections_open")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+      if (game.status === "complete" && !game.corrections_open) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "This round is posted — open score correction to edit it.",
+        });
+      }
+
+      const { error } = await ctx.supabase
+        .from("match_hole_outcomes")
+        .delete()
+        .eq("game_id", input.gameId)
+        .eq("match_id", input.matchId)
+        .eq("hole_number", input.holeNumber);
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to clear outcome: ${error.message}` });
+      }
+      return { ok: true };
+    }),
+
+  // listByGame — all recorded hole outcomes for a game (any trip member — read
+  // parity with scores.listByGame; a setup-mode game is hidden from non-editors,
+  // same gate).
+  listByGame: authedProcedure
+    .input(z.object({ tripId: z.string(), gameId: z.string() }))
+    .use(requireTripMember)
+    .query(async ({ ctx, input }) => {
+      const { data: game } = await ctx.supabase
+        .from("games")
+        .select("id, status")
+        .eq("id", input.gameId)
+        .eq("trip_id", ctx.tripId)
+        .maybeSingle();
+      if (!game) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Game not found" });
+      }
+      if ((game.status as string) === "pending" && !(await canEditGame(ctx, ctx.tripId, input.gameId))) {
+        return [];
+      }
+      const { data, error } = await ctx.supabase
+        .from("match_hole_outcomes")
+        .select("match_id, hole_number, result")
+        .eq("game_id", input.gameId);
+      if (error) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to list outcomes: ${error.message}` });
+      }
+      return data ?? [];
+    }),
+});


### PR DESCRIPTION
Second of three phases (B1 merged → **B2** → B3). Builds the two entry surfaces
(`hole_outcome_entry_mockup.html` + `outcome_scorecard_mockup.html`) + durability
on top of B1's storage/compute. **An outcome-mode game is now fully playable
end-to-end** (enter outcomes → live state → scorecard → finish) — except
permissions, which stay elevated-tier only (owner/organizer/delegate) until B3.

## Scope decision: B2 is elevated-tier only, matching B1's RLS exactly
`ctx.supabase` in tRPC procedures is a user-scoped, RLS-enforcing client (not
service-role) — so a member-tier app check without the matching RLS widening
would pass the check and then fail the actual write, a broken half-permission
state. B3 widens the mutation AND the RLS policy together (reusing
`memberCanScoreUnit`'s match-membership logic, confirmed reusable in B's Phase 0).
`matchOutcomes.upsertOutcome`/`deleteOutcome` use `requireGameEdit()`
(owner/organizer/delegate), exactly matching migration 075's current write policy.

## What B2 ships
- **`outcomeOutbox.ts`** — the durable write-ahead log for outcome entries,
  forked from `scoreOutbox.ts` (B Phase 0 finding: the key scheme forks, not
  widens — an outcome belongs to a match+hole, not a participant+unit).
- **`matchOutcomes` router** — `upsertOutcome`/`deleteOutcome` (elevated tier,
  idempotent on `(match_id, hole_number)`, same posted/scoring-enabled gates as
  `scores.ts`) + `listByGame` (any trip member, read parity).
- **`useOutcomeSaver`** — the outcome write path, mirroring `useScoreSaver`'s
  full durability contract (optimistic → durable outbox → retried →
  visible-on-failure, recovery on mount) exactly.
- **`MatchOutcomeEntryView`** (built to the mockup) — reuses the *existing*
  scorecard chrome verbatim (app bar, `MatchCard` state band, hole nav, par,
  Glorious banner, unsaved-writes banner, confirmation-gated bottom CTA). Only
  the entry zone is new: three stacked choice buttons (side A / Halved / side
  B), tap-to-select, team-colored, ✓, "Reset hole" — no number pad.
- **`OutcomeScorecard`** (built to the mockup) — no score rows; two
  team-colored **lead** rows. The running lead lives in the leader's row (`N▲`,
  same `ProjectionPill` grammar), neutral `AS` when tied, a Glorious hole's
  double-jump directly visible in the number, closeout dims the never-played
  remainder.
- **`MatchGameView` wiring** — one branch point (`decidedFor`) makes the
  overview strips, header projection, and live match state outcome-aware for
  free; the score-screen render swaps `MatchEntryView`→`MatchOutcomeEntryView`
  and `StandardGrid`→`OutcomeScorecard` for an outcome-mode game.
- `entry_mode` added to `GAME_CONFIG_COLS` (the `configHash` fingerprint) —
  CLAUDE.md #16: a config field must be included or a remote device's mid-round
  mode change (once B3 wires the toggle) won't converge.

## Tests (77 total, all green)
- 9 pure outbox ops + 6 render checks (`MatchOutcomeEntryView`) + 9 render
  checks (`OutcomeScorecard`, incl. 5 pure `computeLeadTrack` cases — lead
  hand-off, halved-carries-forward, Glorious 2× jump, unplayed-vs-dead,
  closeout margin).
- 9 DB-integration (`matchOutcomes.test.ts`): elevated-tier write, member
  rejection, idempotent upsert, posted/enabled gates, read parity.
- **The headline acceptance case** (`matchOutcomes.e2e.test.ts`), through the
  REAL write path (`matchOutcomes.upsertOutcome`, the same mutation the entry
  surface's buttons call — not an admin insert): tap the winner of each hole →
  `games.finish` (3&2) → posts to the leaderboard with correct team points →
  **zero `score_entries` rows**. Also confirms the posted-lock applies to
  outcomes exactly like scores.
- Full B1 regression (`matches.holeOutcome.test.ts`, 6 tests) + the existing
  144-test match-play suite green, unchanged — score mode is byte-identical.
- tsc + next lint clean.

## Verified live
Deep-linked a real outcome-mode match (Zach Grether v Brad) in a live trip:
- Tapped "Zach Grether won" hole 1 → the board updated live (`1 UP`), the
  choice showed "Won the hole," "Reset hole" appeared, the CTA became
  "Hole 2 ›" — all confirmed persisted to `match_hole_outcomes`
  (`{match_id, hole_number:1, result:"side_a"}`), **zero** `score_entries` rows.
- Advanced to hole 2, tapped "Halved" → the board correctly held `1 UP` (a
  halved hole carries the lead forward, doesn't reset it).
- Opened the scorecard overlay → `OutcomeScorecard` rendered the 18-hole grid
  with Zach Grether's row showing `1▲` at holes 1 and 2, Brad's row empty —
  exactly matching the mockup.
- No console errors throughout.

## Next
B3 (presence signals, the member-tier RLS+mutation widening, the config
toggle) starts once this merges and verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)