### PR TITLE
B3: hole-outcome entry — presence, member permissions, config toggle (Refactor B complete)

### DIFF
--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -270,8 +270,13 @@ export function MatchGameView() {
   // Scoring — the connectivity-resilient saver owns `values` + `saveStatus`:
   // optimistic value, retry-with-backoff, per-cell status, kept-and-flagged
   // (never rolled back) on failure.
+  // onCleared: a Reset Hole/cell has no local value left to shadow the
+  // poll-loaded loadedValues/loadedOutcomeValues snapshot (mergedFor's
+  // server layer), so the match-list header and scorecard grid would
+  // otherwise show the pre-reset result until the next scheduled poll —
+  // refetch right away instead of waiting out GAME_SYNC_INTERVAL_MS.
   const { values, setValues, saveStatus, onChange, onClear, retryCell } =
-    useScoreSaver(tripId, gameId, participantTypeOf);
+    useScoreSaver(tripId, gameId, participantTypeOf, () => void scoresQ.refetch());
   // Refactor B: the outcome write path — same durability contract, unconditional
   // (hooks can't be conditional); inert for a score-mode game (nothing calls its
   // onChange/onClear there).
@@ -282,7 +287,7 @@ export function MatchGameView() {
     onChange: onOutcomeChange,
     onClear: onOutcomeClear,
     retryCell: retryOutcomeCell,
-  } = useOutcomeSaver(tripId, gameId);
+  } = useOutcomeSaver(tripId, gameId, () => void outcomesQ.refetch());
 
   const createGame = trpc.games.create.useMutation();
   const applyCourse = trpc.games.applyCourse.useMutation();

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight, Plus, X, Swords, SlidersHorizontal, Sparkles, Users, Settings } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, X, Swords, SlidersHorizontal, Sparkles, Users, Settings, ListChecks } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
@@ -1521,6 +1521,25 @@ export function MatchGameView() {
               />
             </ChecklistRow>
 
+            {/* Entry Mode (Refactor B3) — score entry (today, default) vs
+                hole-outcome entry (tap who won each hole directly). A "how you'll
+                score this match" decision, independent of Course/Handicaps/Points
+                (which stay visible either way — unused-but-harmless in outcome
+                mode, a deliberate B3 scope boundary). Frozen once scoring starts,
+                same as every other setup-spine row — switching mid-round would
+                orphan whichever rows (score_entries / match_hole_outcomes) are
+                already entered. */}
+            {gameQ.data && (
+              <EntryModeRow
+                tripId={tripId}
+                gameId={gameId!}
+                entryMode={outcomeMode ? "outcome" : "score"}
+                canEdit={settingsEditable}
+                locked={scoringEnabled}
+                onChanged={onSetupChanged}
+              />
+            )}
+
             {/* Course — Handicaps' per-hole stroke allocation needs the course's
                 stroke-index table, so Course resolves before Handicaps (W-9HOLE-01);
                 the one-open chain reads Matches → Course → Handicaps (Handicaps is
@@ -2174,6 +2193,97 @@ function AddShapeButton({ kind, label, onClick }: { kind: "1V1" | "2V2"; label: 
     >
       <span style={{ fontSize: 9.5, fontWeight: 800, letterSpacing: "0.04em", color: doubles ? "#c4b5fd" : "#93c5fd" }}>{kind}</span>
       <span style={{ fontSize: 10.5, fontWeight: 700, color: "var(--color-bt-text-dim)" }}>{label}</span>
+    </button>
+  );
+}
+
+/**
+ * EntryModeRow — the score-entry-vs-hole-outcome toggle (Refactor B3). A native
+ * SETTINGS row (icon + title + subtitle + an inline control, no accordion body —
+ * same idiom as GameSetupRows' "Total Points"/"Points per Slot" inline stepper),
+ * NOT a bespoke widget. The control itself reuses GameManagementPanel's
+ * segmented-track styling (the Setup/Scoring toggle) — a rounded card-raised
+ * track with a neutral-filled active segment. Unlike Setup/Scoring, neither
+ * option here is a "live" action, so BOTH segments use the neutral (not teal)
+ * active treatment — teal stays reserved for the live/scoring signal elsewhere.
+ * Persists on tap (a 2-option select, not a multi-field panel — no collapse-
+ * buffer needed, unlike Modifiers).
+ */
+function EntryModeRow({
+  tripId,
+  gameId,
+  entryMode,
+  canEdit,
+  locked,
+  onChanged,
+}: {
+  tripId: string;
+  gameId: string;
+  entryMode: "score" | "outcome";
+  canEdit: boolean;
+  locked: boolean;
+  onChanged: () => void;
+}) {
+  const updateGame = trpc.games.update.useMutation();
+  const [pending, setPending] = useState(false);
+  const disabled = locked || !canEdit || pending;
+
+  const setMode = (mode: "score" | "outcome") => {
+    if (mode === entryMode || disabled) return;
+    setPending(true);
+    void updateGame
+      .mutateAsync({ tripId, gameId, entryMode: mode })
+      .then(onChanged)
+      .finally(() => setPending(false));
+  };
+
+  return (
+    <ChecklistRow
+      icon={ListChecks}
+      title="Entry Mode"
+      subtitle={entryMode === "outcome" ? "Hole outcome — tap who won each hole" : "Score entry — enter gross strokes"}
+      state="resolved"
+      disabled={!canEdit}
+      locked={locked}
+      testId="row-entry-mode"
+      control={
+        <div className="flex" style={{ gap: 4, padding: 4, borderRadius: 10, background: "var(--color-bt-card-raised)" }}>
+          <EntryModeSegment label="Score" active={entryMode === "score"} onClick={() => setMode("score")} disabled={disabled} testId="entry-mode-score" />
+          <EntryModeSegment label="Outcome" active={entryMode === "outcome"} onClick={() => setMode("outcome")} disabled={disabled} testId="entry-mode-outcome" />
+        </div>
+      }
+    />
+  );
+}
+
+function EntryModeSegment({
+  label,
+  active,
+  onClick,
+  disabled,
+  testId,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  disabled: boolean;
+  testId: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-lg px-2.5 py-1.5 text-xs font-semibold disabled:cursor-not-allowed"
+      style={{
+        background: active ? "var(--color-bt-base)" : "transparent",
+        color: active ? "var(--color-bt-text)" : "var(--color-bt-text-dim)",
+        border: active ? "1px solid var(--color-bt-border)" : "1px solid transparent",
+        opacity: disabled && !active ? 0.6 : 1,
+      }}
+      data-testid={testId}
+    >
+      {label}
     </button>
   );
 }

--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -1110,12 +1110,16 @@ export function MatchGameView() {
     // The read-only scorecard — shared by a read-only/locked viewer's landing
     // surface and the scorer's overlay. Refactor B: an outcome-mode game has no
     // scores to grid, so it swaps in OutcomeScorecard (two lead rows) instead of
-    // StandardGrid. onCellTap (jump to a hole's entry) is editable-only, score-
-    // mode only for now (OutcomeScorecard has no cell-tap yet — hole nav covers
-    // navigation); back returns to the matches hub (#7).
+    // StandardGrid — same ScorecardChrome (tees/yardage/par/index), only the
+    // rows differ (CC follow-up: "look just like the normal scorecard"), so it
+    // gets the SAME tee/teeRows StandardGrid does. onCellTap (jump to a hole's
+    // entry) is editable-only, score-mode only for now (OutcomeScorecard has no
+    // cell-tap yet — hole nav covers navigation); back returns to the matches hub (#7).
     const scorecardGrid = outcomeMode ? (
       <OutcomeScorecard
         units={scUnits}
+        tee={teeFromSchema(gameQ.data?.scorecard_schema as Parameters<typeof teeFromSchema>[0])}
+        teeRows={teeRows}
         a={selectedGroup.a}
         b={selectedGroup.b}
         outcomes={Object.entries(mergedOutcomeFor(selectedGroup.matchId)).map(([h, result]) => ({ hole: Number(h), result }))}

--- a/src/components/games/MatchOutcomeEntryView.test.tsx
+++ b/src/components/games/MatchOutcomeEntryView.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MatchOutcomeEntryView } from "./MatchOutcomeEntryView";
 import type { MatchGroupData } from "./MatchEntryView";
 import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
-import type { OutcomeValues } from "./types";
+import type { OutcomeValues, SaveStatusMap } from "./types";
 
 /**
  * MatchOutcomeEntryView (Refactor B2, built to hole_outcome_entry_mockup.html).
@@ -36,7 +36,13 @@ const units = [
 // 18-hole unit list to land on a real glorious hole.
 const units18 = Array.from({ length: 18 }, (_, i) => ({ label: String(i + 1), par: 4 }));
 
-function render(values: OutcomeValues, hole = 1, glorious: GloriousConfig = NO_GLORIOUS, unitList = units) {
+function render(
+  values: OutcomeValues,
+  hole = 1,
+  glorious: GloriousConfig = NO_GLORIOUS,
+  unitList = units,
+  saveStatus?: SaveStatusMap
+) {
   return renderToStaticMarkup(
     <MatchOutcomeEntryView
       gameName="Test Game"
@@ -48,6 +54,7 @@ function render(values: OutcomeValues, hole = 1, glorious: GloriousConfig = NO_G
       currentHole={hole}
       meId="a1"
       glorious={glorious}
+      saveStatus={saveStatus}
     />
   );
 }
@@ -92,5 +99,34 @@ describe("MatchOutcomeEntryView — the three-choice entry zone", () => {
   it("shows the closed-out result banner once the match is decided", () => {
     const html = render({ m1: { "1": "side_a", "2": "side_a", "3": "side_a" } });
     expect(html).toContain("Brad def. Johnny D");
+  });
+});
+
+describe("MatchOutcomeEntryView — inline save feedback (no BottomCTA reflow)", () => {
+  it("shows the selected choice's plain check when nothing is in flight — no save badge, no caption", () => {
+    const html = render({ m1: { "1": "side_a" } });
+    expect(html).not.toContain('aria-label="Saving"');
+    expect(html).not.toContain("Retry");
+  });
+
+  it("swaps the selected choice's check for the inline saving badge while its save is in flight", () => {
+    const html = render({ m1: { "1": "side_a" } }, 1, NO_GLORIOUS, units, { "m1:1": "saving" });
+    expect(html).toContain('aria-label="Saving"');
+    // No layout-shifting caption below the Next Hole CTA — the badge alone carries it.
+    expect(html).not.toContain("Saving…");
+  });
+
+  it("shows an inline retry affordance on the selected choice when its save errored — Next Hole stays held, no caption row", () => {
+    const html = render({ m1: { "1": "side_a" } }, 1, NO_GLORIOUS, units, { "m1:1": "error" });
+    expect(html).toContain("tap to retry");
+    expect(html).toContain("Retry");
+    expect(html).not.toContain("retry above");
+  });
+
+  it("never shows the saving/error badge on an UNselected choice, even if its hole key matches another match", () => {
+    // Only side_a is selected; side_b/halved must render the plain empty ring.
+    const html = render({ m1: { "1": "side_a" } }, 1, NO_GLORIOUS, units, { "m1:1": "saving" });
+    // Exactly one saving badge (side_a's), not three.
+    expect(html.split('aria-label="Saving"').length - 1).toBe(1);
   });
 });

--- a/src/components/games/MatchOutcomeEntryView.tsx
+++ b/src/components/games/MatchOutcomeEntryView.tsx
@@ -8,7 +8,15 @@ import { MatchCard } from "./MatchCard";
 import { HoleProgress, NavArrow, BottomCTA } from "./entryChrome";
 import { Avatar } from "@/components/Avatar";
 import { UnsavedScoresBanner } from "./UnsavedScoresBanner";
-import { unconfirmedOnHole, unconfirmedCount, type OutcomeValues, type SaveStatusMap } from "./types";
+import { ScoreSaveBadge } from "./ScoreSaveBadge";
+import {
+  unconfirmedOnHole,
+  unconfirmedCount,
+  outcomeCellKey,
+  type OutcomeValues,
+  type SaveStatusMap,
+  type CellSaveState,
+} from "./types";
 import type { MatchGroupData } from "./MatchEntryView";
 
 /**
@@ -100,11 +108,14 @@ export function MatchOutcomeEntryView({
   };
   const holeGate = unconfirmedOnHole(saveStatus, [m.matchId], label);
   const gameGate = unconfirmedCount(saveStatus);
-  const advanceReason = holeGate.errored > 0
-    ? "Didn’t save — retry above"
-    : holeGate.saving > 0
-      ? "Saving…"
-      : undefined;
+  // Next Hole's gate is unchanged (still held until confirmed) — but unlike
+  // score entry, one tap both completes AND saves the hole here, so the CTA
+  // would otherwise render already-disabled with a "Saving…" caption on
+  // basically every hole, reflowing the panel. The per-choice ScoreSaveBadge
+  // below carries that feedback instead (in place, no new row); the CTA no
+  // longer needs its own subtext for the routine save.
+  const cellSaveState = saveStatus[outcomeCellKey(m.matchId, hole)];
+  const retryThisHole = () => onRetryCell?.(m.matchId, label);
   const finishReason = gameGate.errored > 0
     ? "Some outcomes didn’t save — retry before finishing"
     : gameGate.saving > 0
@@ -247,6 +258,8 @@ export function MatchOutcomeEntryView({
             sub={selected === "side_a" ? "Won the hole" : undefined}
             onClick={() => pick("side_a")}
             testId="outcome-choice-a"
+            saveState={selected === "side_a" ? cellSaveState : undefined}
+            onRetry={retryThisHole}
           />
           <Choice
             selected={selected === "halved"}
@@ -256,6 +269,8 @@ export function MatchOutcomeEntryView({
             sub={selected === "halved" ? "Hole halved" : undefined}
             onClick={() => pick("halved")}
             testId="outcome-choice-halved"
+            saveState={selected === "halved" ? cellSaveState : undefined}
+            onRetry={retryThisHole}
           />
           <Choice
             selected={selected === "side_b"}
@@ -267,6 +282,8 @@ export function MatchOutcomeEntryView({
             sub={selected === "side_b" ? "Won the hole" : undefined}
             onClick={() => pick("side_b")}
             testId="outcome-choice-b"
+            saveState={selected === "side_b" ? cellSaveState : undefined}
+            onRetry={retryThisHole}
           />
         </div>
         {selected != null && (
@@ -296,7 +313,6 @@ export function MatchOutcomeEntryView({
           label={`Hole ${units[hole]?.label ?? hole + 1} ›`}
           onClick={() => goHole(hole + 1)}
           disabled={holeGate.blocked}
-          subtext={advanceReason}
         />
       ) : null}
     </div>
@@ -323,6 +339,8 @@ function Choice({
   sub,
   onClick,
   testId,
+  saveState,
+  onRetry,
 }: {
   selected: boolean;
   dim: boolean;
@@ -334,17 +352,31 @@ function Choice({
   sub?: string;
   onClick: () => void;
   testId: string;
+  /** In-flight save state for THIS choice's hole, only when it's the selected
+   *  one (mirrors PlayerRow's inline `ScoreSaveBadge` — score entry's same
+   *  feedback, in the same footprint, so the panel below never reflows). */
+  saveState?: CellSaveState;
+  onRetry?: () => void;
 }) {
   const tint = neutral ? "var(--color-bt-accent)" : color ?? "var(--color-bt-accent)";
+  // Only the transient states borrow the badge — once saved, this settles
+  // back to the plain team-colored ✓ below (a "saved" badge would lose the
+  // team-color meaning the solid check carries).
+  const showBadge = saveState === "saving" || saveState === "error";
   return (
-    <button
-      type="button"
+    // role=button (not <button>) so ScoreSaveBadge's error-state Retry button
+    // can nest without invalid button-in-button markup — same pattern as
+    // score entry's PlayerRow.
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
       className="flex w-full items-center gap-3 text-left transition-opacity"
       data-testid={testId}
       style={{
         padding: 14,
         borderRadius: 12,
+        cursor: "pointer",
         background: selected ? `color-mix(in srgb, ${tint} 14%, transparent)` : "var(--color-bt-card)",
         border: `1.5px solid ${selected ? tint : "var(--color-bt-border)"}`,
         opacity: dim ? 0.5 : 1,
@@ -364,21 +396,25 @@ function Choice({
         <div style={{ fontSize: 15, fontWeight: 700, color: "var(--color-bt-text)" }}>{label}</div>
         {sub && <div style={{ fontSize: 11.5, color: "var(--color-bt-text-dim)", fontWeight: 600 }}>{sub}</div>}
       </div>
-      <span
-        className="flex flex-shrink-0 items-center justify-center"
-        style={{
-          width: 22,
-          height: 22,
-          borderRadius: "50%",
-          border: `2px solid ${selected ? tint : "var(--color-bt-border)"}`,
-          background: selected ? tint : "transparent",
-          color: selected ? "var(--color-bt-on-accent)" : "transparent",
-          fontSize: 12,
-          fontWeight: 800,
-        }}
-      >
-        ✓
-      </span>
-    </button>
+      {showBadge ? (
+        <ScoreSaveBadge state={saveState} onRetry={onRetry} />
+      ) : (
+        <span
+          className="flex flex-shrink-0 items-center justify-center"
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: "50%",
+            border: `2px solid ${selected ? tint : "var(--color-bt-border)"}`,
+            background: selected ? tint : "transparent",
+            color: selected ? "var(--color-bt-on-accent)" : "transparent",
+            fontSize: 12,
+            fontWeight: 800,
+          }}
+        >
+          ✓
+        </span>
+      )}
+    </div>
   );
 }

--- a/src/components/games/OutcomeScorecard.test.tsx
+++ b/src/components/games/OutcomeScorecard.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { computeLeadTrack, OutcomeScorecard } from "./OutcomeScorecard";
+import { computeLeadTrack, sectionSwing, OutcomeScorecard } from "./OutcomeScorecard";
 import { NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
-import type { HoleOutcomeRow } from "@/lib/matchPlay";
-import type { Participant } from "./types";
+import type { HoleOutcomeRow, DecidedHole } from "@/lib/matchPlay";
+import type { Participant, ScoreUnit } from "./types";
 
 /**
  * OutcomeScorecard (Refactor B2, built to outcome_scorecard_mockup.html). The
@@ -99,5 +99,72 @@ describe("OutcomeScorecard — render (react-dom/server)", () => {
     expect(html).not.toContain("outcome-lead-pill");
     expect(html).not.toContain("outcome-closeout");
     expect(html).not.toContain("outcome-as");
+  });
+});
+
+describe("sectionSwing — the pure per-section signed swing (Out/In/Total for a lead row)", () => {
+  it("sums weighted W/L within the range; halves and unplayed holes contribute 0", () => {
+    const decided: DecidedHole[] = [
+      { hole: 1, result: "W" }, // +1
+      { hole: 2, result: "H" }, // 0
+      { hole: 5, result: "L" }, // -1
+      // hole 9 unplayed → 0
+    ];
+    expect(sectionSwing(decided, NO_GLORIOUS, 1, 9)).toBe(0); // +1 - 1 = 0
+    expect(sectionSwing(decided, NO_GLORIOUS, 1, 1)).toBe(1); // just hole 1
+  });
+
+  it("a Glorious hole counts double within its section", () => {
+    const decided: DecidedHole[] = [{ hole: 17, result: "W" }];
+    const glor: GloriousConfig = { enabled: true, n: 2 }; // holes 17-18
+    expect(sectionSwing(decided, glor, 10, 18)).toBe(2);
+  });
+});
+
+// A CC follow-up ("look just like the normal scorecard — tees, yardage, par,
+// stroke index; only the player rows differ"): OutcomeScorecard now renders
+// the SAME ScorecardChrome StandardGrid.test.tsx exercises, around lead rows
+// instead of score rows. Mirrors that file's fixture shape.
+describe("OutcomeScorecard — chrome parity with StandardGrid (tees/yardage/par/index)", () => {
+  const a: Participant = { id: "a", name: "Brad", color: "#4ade80" };
+  const b: Participant = { id: "b", name: "Johnny D", color: "#fb923c" };
+  const courseUnits: ScoreUnit[] = [
+    { label: "1", section: "front", par: 4, strokeIndex: 5, yardage: 410 },
+    { label: "2", section: "front", par: 3, strokeIndex: 17, yardage: 165 },
+    { label: "10", section: "back", par: 5, strokeIndex: 2, yardage: 540 },
+    { label: "18", section: "back", par: 4, strokeIndex: 8, yardage: 430 },
+  ];
+
+  it("renders the course-structure rows from units alone (Par / Yards / Index), same as StandardGrid", () => {
+    const html = renderToStaticMarkup(
+      <OutcomeScorecard units={courseUnits} a={a} b={b} outcomes={[]} tee={{ name: "Blue" }} />
+    );
+    expect(html).toContain("Par");
+    expect(html).toContain("Yards");
+    expect(html).toContain("Index");
+    expect(html).toContain(">4<"); // a par value
+    expect(html).toContain(">17<"); // a stroke index
+    expect(html).toContain("410"); // a yardage
+    expect(html).toContain("Blue tees");
+  });
+
+  it("shows Out / In / Total column headers when units span both nines", () => {
+    const html = renderToStaticMarkup(<OutcomeScorecard units={courseUnits} a={a} b={b} outcomes={[]} />);
+    expect(html).toContain("Out");
+    expect(html).toContain("In");
+    expect(html).toContain("Total");
+  });
+
+  it("the Out/In/Total columns carry the leading side's swing over that section (not blank)", () => {
+    // A wins hole 1 (front) and hole 10 (back) → Out +1, In +1, Total +2.
+    const outcomes: HoleOutcomeRow[] = [{ hole: 1, result: "side_a" }, { hole: 3, result: "side_a" }];
+    const html = renderToStaticMarkup(
+      <OutcomeScorecard units={courseUnits} a={a} b={b} outcomes={outcomes} leftColor={a.color} rightColor={b.color} />
+    );
+    // 3 lead pills total: hole 1, hole 3 (both single-hole cells) + the Total column (+2).
+    // (No Out/In split pill here since each swing is a single hole — Out=+1, In=+1, Total=+2.)
+    const pillCount = html.split("outcome-lead-pill").length - 1;
+    expect(pillCount).toBeGreaterThanOrEqual(3);
+    expect(html).toContain(">2<"); // the Total column's +2
   });
 });

--- a/src/components/games/OutcomeScorecard.tsx
+++ b/src/components/games/OutcomeScorecard.tsx
@@ -2,16 +2,23 @@
 
 import { buildDecidedFromOutcomes, matchState, type DecidedHole, type HoleOutcomeRow } from "@/lib/matchPlay";
 import { holeWeight, isGloriousHole, NO_GLORIOUS, type GloriousConfig } from "@/lib/gloriousHoles";
-import type { Participant } from "./types";
+import { ScorecardChrome, RightGutter, SUB_W, TOTAL_W } from "./StandardGrid";
+import type { TeeRow } from "@/lib/teeRows";
+import type { Participant, ScoreUnit } from "./types";
 
 /**
  * OutcomeScorecard — the hole-outcome-entry scorecard (Refactor B2, built to
- * `outcome_scorecard_mockup.html`). NO score rows (there are no scores in outcome
- * mode) — two team-colored LEAD rows instead. The running lead lives in the
- * LEADER's row (`N▲`, team-colored); a tied hole shows neutral `AS`; a Glorious
- * hole's double-jump is directly visible in the number; closeout dims the
- * unplayed remainder. Same W/L/H color vocabulary `MatchCard`'s history strip
- * uses (win/lose/halve), reused here for the per-hole win-green treatment.
+ * `outcome_scorecard_mockup.html`; header parity added as a follow-up — "look
+ * just like the normal scorecard, only the player rows differ"). Renders the
+ * SAME `ScorecardChrome` `StandardGrid` uses (tee selector, yardage/par/
+ * stroke-index rows, sticky name column, Out/In/Total columns, Glorious
+ * bracket, right-edge fade) around two team-colored LEAD rows instead of
+ * gross-score rows — there are no scores in outcome mode. The running lead
+ * lives in the LEADER's row (`N▲`, team-colored); a tied hole shows neutral
+ * `AS`; a Glorious hole's double-jump is directly visible in the number;
+ * closeout dims the unplayed remainder. Same W/L/H color vocabulary
+ * `MatchCard`'s history strip uses (win/lose/halve), reused here for the
+ * per-hole win-green treatment.
  */
 
 const WIN_GREEN = "#22c55e"; // = --color-bt-place-1 base; matches MatchCard's neutral "winning" color
@@ -56,14 +63,35 @@ export function computeLeadTrack(
   return { track, st };
 }
 
+/** Signed swing (±weighted W/L; halves are 0) over holes [from,to] (1-indexed,
+ *  inclusive) — the match-play equivalent of a gross-score section sum, so the
+ *  Out/In/Total columns carry real meaning for a lead row the same way they do
+ *  for a stroke row (Out = how the front 9 went, In = how the back 9 went,
+ *  Total = the two combined = the final lead). Exported for unit testing. */
+export function sectionSwing(decided: DecidedHole[], glorious: GloriousConfig, from: number, to: number): number {
+  const byHole = new Map(decided.map((d) => [d.hole, d.result]));
+  let diff = 0;
+  for (let h = from; h <= to; h++) {
+    const result = byHole.get(h);
+    if (result == null) continue;
+    const w = holeWeight(h, glorious);
+    diff += result === "W" ? w : result === "L" ? -w : 0;
+  }
+  return diff;
+}
+
 export interface OutcomeScorecardProps {
-  units: { label: string; par?: number }[];
+  units: ScoreUnit[];
   a: Participant;
   b: Participant;
   outcomes: HoleOutcomeRow[];
   glorious?: GloriousConfig;
   leftColor?: string;
   rightColor?: string;
+  /** Same tee/yardage header StandardGrid gets — outcome mode has no scores,
+   *  but the course structure (tees, par, stroke index) is identical. */
+  tee?: { name: string; courseRating?: number | null; slopeRating?: number | null; bogeyRating?: number | null } | null;
+  teeRows?: TeeRow[];
 }
 
 export function OutcomeScorecard({
@@ -74,6 +102,8 @@ export function OutcomeScorecard({
   glorious = NO_GLORIOUS,
   leftColor,
   rightColor,
+  tee,
+  teeRows = [],
 }: OutcomeScorecardProps) {
   const decided = buildDecidedFromOutcomes(outcomes);
   const { track, st } = computeLeadTrack(decided, units.length, glorious);
@@ -84,40 +114,20 @@ export function OutcomeScorecard({
 
   return (
     <div data-testid="outcome-scorecard">
-      <div className="no-scrollbar overflow-x-auto">
-        <table style={{ borderCollapse: "collapse", width: "100%", minWidth: units.length * 40 }}>
-          <thead>
-            <tr>
-              <th style={{ width: 96 }} />
-              {units.map((u, i) => (
-                <th key={u.label} style={{ width: 40, padding: "2px 0 8px" }}>
-                  <div
-                    style={{
-                      fontSize: 13,
-                      fontWeight: 800,
-                      color: track[i]?.glorious ? "var(--color-bt-glorious)" : "var(--color-bt-text)",
-                    }}
-                  >
-                    {u.label}
-                  </div>
-                  {track[i]?.glorious && (
-                    <div style={{ fontSize: 8, fontWeight: 800, color: "var(--color-bt-glorious)", letterSpacing: "0.03em" }}>
-                      ◆
-                    </div>
-                  )}
-                  {u.par != null && (
-                    <div style={{ fontSize: 10, color: "var(--color-bt-text-dim)", fontWeight: 600 }}>{u.par}</div>
-                  )}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            <LeadRow name={a.name} track={track} side="A" color={lc} />
-            <LeadRow name={b.name} track={track} side="B" color={rc} />
-          </tbody>
-        </table>
-      </div>
+      <ScorecardChrome units={units} tee={tee} teeRows={teeRows} glorious={glorious}>
+        {({ hasSections, front, cellBase, nameCell, divider, isGloriousCol, gloriousWash }) => {
+          const outSwing = hasSections ? sectionSwing(decided, glorious, 1, front.length) : 0;
+          const inSwing = hasSections ? sectionSwing(decided, glorious, front.length + 1, units.length) : 0;
+          const totalSwing = outSwing + inSwing;
+          const rowProps = { units, track, nameCell, cellBase, divider, isGloriousCol, gloriousWash, hasSections, outSwing, inSwing, totalSwing };
+          return (
+            <>
+              <LeadRow {...rowProps} name={a.name} side="A" color={lc} />
+              <LeadRow {...rowProps} name={b.name} side="B" color={rc} />
+            </>
+          );
+        }}
+      </ScorecardChrome>
 
       {st.over && (
         <p className="text-center" style={{ padding: "12px 10px 2px", fontSize: 13, fontWeight: 800, color: "var(--color-bt-place-1-text)" }} data-testid="outcome-closeout">
@@ -130,27 +140,51 @@ export function OutcomeScorecard({
 
 function LeadRow({
   name,
+  units,
   track,
   side,
   color,
+  nameCell,
+  cellBase,
+  divider,
+  isGloriousCol,
+  gloriousWash,
+  hasSections,
+  outSwing,
+  inSwing,
+  totalSwing,
 }: {
   name: string;
+  units: ScoreUnit[];
   track: LeadCell[];
   side: "A" | "B";
   color: string;
+  nameCell: React.CSSProperties;
+  cellBase: React.CSSProperties;
+  divider: (l?: string) => React.CSSProperties;
+  isGloriousCol: (i: number) => boolean;
+  gloriousWash: React.CSSProperties;
+  hasSections: boolean;
+  outSwing: number;
+  inSwing: number;
+  totalSwing: number;
 }) {
   return (
-    <tr>
-      <td style={{ textAlign: "left", padding: "0 12px", fontSize: 13, fontWeight: 700, color: "var(--color-bt-text)", whiteSpace: "nowrap" }}>
-        {name}
-      </td>
-      {track.map((c) => (
-        <td
+    <div className="flex" style={{ height: 44, borderBottom: "1px solid var(--color-bt-subtle-border)" }}>
+      <div className="flex items-center" style={{ ...nameCell, padding: "0 10px" }}>
+        <span style={{ fontSize: 15, fontWeight: 700, color: "var(--color-bt-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {name}
+        </span>
+      </div>
+      {track.map((c, i) => (
+        <div
           key={c.hole}
+          className="flex items-center justify-center"
           style={{
-            height: 38,
-            borderTop: "1px solid var(--color-bt-subtle-border)",
-            textAlign: "center",
+            ...cellBase,
+            height: 44,
+            ...divider(units[i]?.label),
+            ...(isGloriousCol(i) && !c.dead ? gloriousWash : {}),
             ...(c.glorious && !c.dead
               ? { outline: "1px dashed var(--color-bt-glorious-border)", outlineOffset: -3, borderRadius: 8 }
               : {}),
@@ -167,9 +201,38 @@ function LeadRow({
               AS
             </span>
           ) : null}
-        </td>
+        </div>
       ))}
-    </tr>
+      {hasSections && <LeadSubCell value={outSwing} side={side} color={color} />}
+      {hasSections && <LeadSubCell value={inSwing} side={side} color={color} />}
+      <LeadSubCell value={totalSwing} side={side} color={color} wide />
+      <RightGutter />
+    </div>
+  );
+}
+
+/** The Out/In/Total column for a lead row — same tinted footprint `SubCell`
+ *  uses for a stroke row's subtotals, showing this side's swing over that
+ *  section via the identical `LeadPill`/`AS` vocabulary the hole cells use. */
+function LeadSubCell({ value, side, color, wide }: { value: number; side: "A" | "B"; color: string; wide?: boolean }) {
+  const showsPill = (side === "A" && value > 0) || (side === "B" && value < 0);
+  return (
+    <div
+      className="flex items-center justify-center"
+      style={{
+        width: wide ? TOTAL_W : SUB_W,
+        minWidth: wide ? TOTAL_W : SUB_W,
+        height: 44,
+        flexShrink: 0,
+        background: wide ? "rgba(45,212,191,0.07)" : "rgba(255,255,255,0.025)",
+      }}
+    >
+      {showsPill ? (
+        <LeadPill value={Math.abs(value)} color={color} />
+      ) : side === "B" && value === 0 ? (
+        <span style={{ fontSize: 11, fontWeight: 700, color: "var(--color-bt-text-dim)" }}>AS</span>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/components/games/StandardGrid.tsx
+++ b/src/components/games/StandardGrid.tsx
@@ -32,6 +32,12 @@ import {
  * prop so non-golf formats (units running down the portrait screen) can flip it
  * later without a rewrite — the flipped layout itself lands when Slice C needs
  * it (GolfCard). Slice A renders `participants-rows` only.
+ *
+ * The tee/yardage/par/stroke-index HEADER (everything above the player rows)
+ * is factored out as `ScorecardChrome` below, so `OutcomeScorecard` (hole-
+ * outcome entry) can render the identical chrome around its own lead rows —
+ * one scorecard look, two row kinds. StandardGrid's own body (below) is what
+ * `ScorecardChrome`'s `children` render-prop supplies here.
  */
 interface StandardGridProps {
   units: ScoreUnit[];
@@ -79,10 +85,10 @@ interface StandardGridProps {
   glorious?: GloriousConfig;
 }
 
-const NAME_W = 124;
-const HOLE_W = 30;
-const SUB_W = 44;
-const TOTAL_W = 50;
+export const NAME_W = 124;
+export const HOLE_W = 30;
+export const SUB_W = 44;
+export const TOTAL_W = 50;
 // The right-edge fade (below) is NOT scroll-position-aware — it's pinned to the
 // sheet's edge and stays rendered even once the grid is scrolled all the way to
 // its true end, permanently shading the last FADE_W px of CONTENT (not just
@@ -90,19 +96,42 @@ const TOTAL_W = 50;
 // strip covered roughly half the Total column's numbers. Every row ends in a
 // transparent RightGutter of this same width so the fade lands on empty space
 // instead of real content — shared constant so the two can't drift apart.
-const FADE_W = 24;
+export const FADE_W = 24;
 
-export function StandardGrid({
-  units,
-  participants,
-  values,
-  onCellTap,
-  pips,
-  saveStatus,
-  tee,
-  teeRows = [],
-  glorious = NO_GLORIOUS,
-}: StandardGridProps) {
+/** Everything a `ScorecardChrome` body (the `children` render-prop) needs to
+ *  paint cells that align pixel-for-pixel with the header above them. */
+export interface ScorecardChromeRenderCtx {
+  hasSections: boolean;
+  front: ScoreUnit[];
+  back: ScoreUnit[];
+  cellBase: React.CSSProperties;
+  nameCell: React.CSSProperties;
+  divider: (l?: string) => React.CSSProperties;
+  isGloriousCol: (i: number) => boolean;
+  gloriousWash: React.CSSProperties;
+}
+
+export interface ScorecardChromeProps {
+  units: ScoreUnit[];
+  tee?: { name: string; courseRating?: number | null; slopeRating?: number | null; bogeyRating?: number | null } | null;
+  teeRows?: TeeRow[];
+  glorious?: GloriousConfig;
+  /** The player/lead rows — rendered between the Index row and the Glorious
+   *  bracket, using the same cell geometry the header above used. */
+  children: (ctx: ScorecardChromeRenderCtx) => React.ReactNode;
+}
+
+/**
+ * ScorecardChrome — the tee-selector bar + Hole/Yardage/Par/Stroke-Index
+ * header + sticky name column + glorious bracket + right-edge fade. Extracted
+ * from `StandardGrid` (Refactor B follow-up) so `OutcomeScorecard` can reuse
+ * the identical course-structure chrome around its own lead rows instead of a
+ * bespoke, chrome-less table — "look just like the normal scorecard; only the
+ * player rows differ." Behavior-preserving: this is the exact JSX StandardGrid
+ * rendered before the extraction, just wrapped so a second caller can supply
+ * different body rows through `children`.
+ */
+export function ScorecardChrome({ units, tee, teeRows = [], glorious = NO_GLORIOUS, children }: ScorecardChromeProps) {
   // The ONE predicate — reused, never re-derived. `hole` = the unit's ARRAY
   // POSITION (index + 1), matching the engine's numbering (buildDecided/
   // holeWeight), not a parsed label. A non-contiguous/short `units` array (a
@@ -132,11 +161,6 @@ export function StandardGrid({
   const teeSum = (ys: (number | null)[], from: number, to: number) =>
     ys.slice(from, to).reduce((a: number, y) => a + (y ?? 0), 0);
 
-  const valOf = (pid: string, l: string) => values[pid]?.[l];
-  const sumOf = (pid: string, list: ScoreUnit[]) =>
-    list.reduce((a, u) => a + (valOf(pid, u.label) ?? 0), 0);
-  const totalOf = (pid: string) => sumOf(pid, units);
-
   // GolfCard: par-relative coloring + a Par row + ±-vs-par subtotals, when the
   // units carry par (always for stroke play; real course par lands with the
   // picker). ±-vs-par is over the holes a player has actually scored.
@@ -147,26 +171,6 @@ export function StandardGrid({
   const hasYards = units.length > 0 && units.some((u) => u.yardage != null);
   const parSum = (list: ScoreUnit[]) => list.reduce((a, u) => a + (u.par ?? 0), 0);
   const yardSum = (list: ScoreUnit[]) => list.reduce((a, u) => a + (u.yardage ?? 0), 0);
-  const vsParOf = (pid: string, list: ScoreUnit[]): number => {
-    const scored = list.filter((u) => valOf(pid, u.label) != null);
-    return scored.reduce((a, u) => a + (valOf(pid, u.label)! - (u.par ?? 0)), 0);
-  };
-
-  // Leader (low total among participants who have any score).
-  const scoredIds = participants
-    .filter((p) => Object.keys(values[p.id] ?? {}).length > 0)
-    .map((p) => p.id);
-  const entries: StrokeEntry[] = [];
-  for (const p of participants)
-    for (const u of units) {
-      const v = valOf(p.id, u.label);
-      if (v != null) entries.push({ participant_id: p.id, value: v });
-    }
-  const standings = computeStrokePlayStandings(scoredIds, entries);
-  // ALL position-1 entities, so tied co-leaders each get the leader treatment.
-  const leaderIds = new Set(
-    scoredIds.length ? standings.filter((s) => s.position === 1).map((s) => s.entityId) : []
-  );
 
   const cellBase: React.CSSProperties = {
     width: HOLE_W,
@@ -201,6 +205,8 @@ export function StandardGrid({
         tee.slopeRating != null ? `Slope ${tee.slopeRating}` : null,
       ].filter(Boolean).join(" / ")
     : "";
+
+  const ctx: ScorecardChromeRenderCtx = { hasSections, front, back, cellBase, nameCell, divider, isGloriousCol, gloriousWash };
 
   return (
     <div className="h-full" style={{ background: "var(--color-bt-base)" }}>
@@ -454,7 +460,94 @@ export function StandardGrid({
             </div>
           )}
 
-          {/* Rows */}
+          {/* Rows — supplied by the caller (StandardGrid's score rows, or
+              OutcomeScorecard's lead rows). */}
+          {children(ctx)}
+
+          {/* Glorious bracket — a rectangle frame around the glorious columns,
+              spanning header through the last row. Border-only (the wash fill is
+              per-cell, above); pointerEvents:none so it never blocks a score-cell
+              tap. min/max of the glorious index set, not an assumed "last N" span
+              — robust if the predicate ever yields a non-suffix set.
+              zIndex MUST exceed the header row's (2): the header is `position:
+              sticky` with an OPAQUE background, so at zIndex 1 its top border
+              segment (which sits at the header's own top edge) was fully painted
+              over — the bracket visually "started" below the header instead of
+              enclosing it. At zIndex 3 the thin border renders on top instead. */}
+          {gloriousCols.size > 0 && (
+            <div
+              aria-hidden
+              data-testid="glorious-bracket"
+              style={{
+                position: "absolute",
+                left: NAME_W + Math.min(...gloriousCols) * HOLE_W,
+                width: (Math.max(...gloriousCols) - Math.min(...gloriousCols) + 1) * HOLE_W,
+                top: 0,
+                bottom: 0,
+                border: "1px solid var(--color-bt-glorious-border)",
+                pointerEvents: "none",
+                zIndex: 3,
+              }}
+            />
+          )}
+          </div>
+        </div>
+        {/* Right-edge fade signalling more columns — NOT scroll-position-aware
+            (always rendered, even at true max scroll), which is exactly why every
+            row ends in a RightGutter of the same FADE_W: the fade always has
+            FADE_W of real spacer to land on instead of the Total column. */}
+        <div
+          className="pointer-events-none absolute right-0 top-0 h-full"
+          style={{ width: FADE_W, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function StandardGrid({
+  units,
+  participants,
+  values,
+  onCellTap,
+  pips,
+  saveStatus,
+  tee,
+  teeRows = [],
+  glorious = NO_GLORIOUS,
+}: StandardGridProps) {
+  const hasPar = units.length > 0 && units.every((u) => u.par != null);
+
+  const valOf = (pid: string, l: string) => values[pid]?.[l];
+  const sumOf = (pid: string, list: ScoreUnit[]) =>
+    list.reduce((a, u) => a + (valOf(pid, u.label) ?? 0), 0);
+  const totalOf = (pid: string) => sumOf(pid, units);
+  const vsParOf = (pid: string, list: ScoreUnit[]): number => {
+    const scored = list.filter((u) => valOf(pid, u.label) != null);
+    return scored.reduce((a, u) => a + (valOf(pid, u.label)! - (u.par ?? 0)), 0);
+  };
+
+  // Leader (low total among participants who have any score).
+  const scoredIds = participants
+    .filter((p) => Object.keys(values[p.id] ?? {}).length > 0)
+    .map((p) => p.id);
+  const entries: StrokeEntry[] = [];
+  for (const p of participants)
+    for (const u of units) {
+      const v = valOf(p.id, u.label);
+      if (v != null) entries.push({ participant_id: p.id, value: v });
+    }
+  const standings = computeStrokePlayStandings(scoredIds, entries);
+  // ALL position-1 entities, so tied co-leaders each get the leader treatment.
+  const leaderIds = new Set(
+    scoredIds.length ? standings.filter((s) => s.position === 1).map((s) => s.entityId) : []
+  );
+
+  return (
+    <>
+      <ScorecardChrome units={units} tee={tee} teeRows={teeRows} glorious={glorious}>
+        {({ hasSections, front, back, cellBase, nameCell, divider, isGloriousCol, gloriousWash }) => (
+          <>
           {participants.map((p, i) => {
             const isLeader = leaderIds.has(p.id);
             const rowBg = i % 2 === 0 ? "var(--color-bt-card)" : "var(--color-bt-base)";
@@ -508,50 +601,18 @@ export function StandardGrid({
               </div>
             );
           })}
-          {/* Glorious bracket — a rectangle frame around the glorious columns,
-              spanning header through the last row. Border-only (the wash fill is
-              per-cell, above); pointerEvents:none so it never blocks a score-cell
-              tap. min/max of the glorious index set, not an assumed "last N" span
-              — robust if the predicate ever yields a non-suffix set.
-              zIndex MUST exceed the header row's (2): the header is `position:
-              sticky` with an OPAQUE background, so at zIndex 1 its top border
-              segment (which sits at the header's own top edge) was fully painted
-              over — the bracket visually "started" below the header instead of
-              enclosing it. At zIndex 3 the thin border renders on top instead. */}
-          {gloriousCols.size > 0 && (
-            <div
-              aria-hidden
-              data-testid="glorious-bracket"
-              style={{
-                position: "absolute",
-                left: NAME_W + Math.min(...gloriousCols) * HOLE_W,
-                width: (Math.max(...gloriousCols) - Math.min(...gloriousCols) + 1) * HOLE_W,
-                top: 0,
-                bottom: 0,
-                border: "1px solid var(--color-bt-glorious-border)",
-                pointerEvents: "none",
-                zIndex: 3,
-              }}
-            />
-          )}
-          </div>
-        </div>
-        {/* Right-edge fade signalling more columns — NOT scroll-position-aware
-            (always rendered, even at true max scroll), which is exactly why every
-            row ends in a RightGutter of the same FADE_W: the fade always has
-            FADE_W of real spacer to land on instead of the Total column. */}
-        <div
-          className="pointer-events-none absolute right-0 top-0 h-full"
-          style={{ width: FADE_W, background: "linear-gradient(to right, transparent, var(--color-bt-base))" }}
-        />
-      </div>
-      {/* Legend is pinned below the scroller — it does NOT scroll with the grid. */}
+          </>
+        )}
+      </ScorecardChrome>
+      {/* Legend is pinned below the scroller — it does NOT scroll with the
+          grid and doesn't apply to lead rows, so it's a sibling of the shared
+          chrome rather than rendered inside it. */}
       {hasPar && (
         <div className="shrink-0" style={{ borderTop: "1px solid var(--color-bt-subtle-border)" }}>
           <Legend />
         </div>
       )}
-    </div>
+    </>
   );
 }
 
@@ -631,7 +692,10 @@ function HeaderSub({ label, wide }: { label: string; wide?: boolean }) {
   );
 }
 
-function SubCell({
+/** A tinted Out/In/Total-style subtotal cell — exported so `OutcomeScorecard`
+ *  can render its own lead-at-checkpoint values through the identical visual
+ *  treatment the score grid uses. */
+export function SubCell({
   value,
   vsPar,
   wide,
@@ -687,8 +751,9 @@ function IndexSub({ wide }: { wide?: boolean }) {
 
 /** Transparent trailing spacer, the same width as the right-edge fade — so the
  *  fade always lands on empty space at the true end of the scroll, never on the
- *  Total column's real numbers (see FADE_W). One per row, after its last cell. */
-function RightGutter() {
+ *  Total column's real numbers (see FADE_W). One per row, after its last cell.
+ *  Exported so `OutcomeScorecard`'s lead rows end in the identical spacer. */
+export function RightGutter() {
   return <div aria-hidden style={{ width: FADE_W, minWidth: FADE_W, flexShrink: 0 }} />;
 }
 

--- a/src/hooks/useOutcomeSaver.ts
+++ b/src/hooks/useOutcomeSaver.ts
@@ -26,7 +26,16 @@ import type { HoleOutcomeResult } from "@/lib/matchPlay";
 const MAX_RETRIES = 4;
 const retryDelay = (attempt: number) => Math.min(500 * 2 ** attempt, 8000);
 
-export function useOutcomeSaver(tripId: string | undefined, gameId: string | null | undefined) {
+export function useOutcomeSaver(
+  tripId: string | undefined,
+  gameId: string | null | undefined,
+  // Fired once a clear (Reset hole) is CONFIRMED by the server — mirrors
+  // useScoreSaver's `onCleared`. A cleared hole has no local value to shadow
+  // the poll-loaded server snapshot with, so the match-list/scorecard
+  // surfaces that read `mergedOutcomeFor` stay on the pre-reset result until
+  // the next scheduled poll; the caller uses this to refetch immediately.
+  onCleared?: () => void,
+) {
   const [values, setValues] = useState<OutcomeValues>({});
   const [saveStatus, setSaveStatus] = useState<SaveStatusMap>({});
   const saveStatusRef = useRef(saveStatus);
@@ -93,6 +102,9 @@ export function useOutcomeSaver(tripId: string | undefined, gameId: string | nul
       outcomeOutboxClear(gameId, matchId, Number(hole));
       deleteOutcome
         .mutateAsync({ tripId, gameId, matchId, holeNumber: Number(hole) })
+        // Confirmed gone server-side — let the caller refresh whatever else
+        // reads the poll-loaded snapshot (see `onCleared` above).
+        .then(() => onCleared?.())
         .catch(() => {
           if (prevValue != null) {
             setValues((v) => ({
@@ -103,7 +115,7 @@ export function useOutcomeSaver(tripId: string | undefined, gameId: string | nul
           }
         });
     },
-    [tripId, gameId, values, deleteOutcome, mark],
+    [tripId, gameId, values, deleteOutcome, mark, onCleared],
   );
 
   /** Reflect server outcome truth into the local view without clobbering the

--- a/src/hooks/useScoreSaver.ts
+++ b/src/hooks/useScoreSaver.ts
@@ -63,6 +63,13 @@ export function useScoreSaver(
     | "user"
     | "play_group"
     | ((participantId: string) => "user" | "play_group" | undefined),
+  // Fired once a clear is CONFIRMED by the server. A cleared cell has no local
+  // value to shadow the poll-loaded server snapshot with, so any OTHER surface
+  // reading that snapshot (a match-list "THRU"/margin header, a scorecard grid)
+  // stays stale until the next scheduled poll — up to GAME_SYNC_INTERVAL_MS.
+  // The caller uses this to refetch that snapshot immediately instead of
+  // waiting out the interval.
+  onCleared?: () => void,
 ) {
   const typeOf = useCallback(
     (participantId: string): "user" | "play_group" | undefined =>
@@ -161,6 +168,9 @@ export function useScoreSaver(
       // their own outcome, never be orphaned by a later one on the shared observer.
       deleteEntry
         .mutateAsync({ tripId, gameId, participantId, unitLabel, participantType: typeOf(participantId) })
+        // Confirmed gone server-side — let the caller refresh whatever else
+        // reads the poll-loaded snapshot (see `onCleared` above).
+        .then(() => onCleared?.())
         // A failed delete means the value is still on the server — restore it
         // (accurate) and flag it so the user knows the clear didn't take.
         .catch(() => {
@@ -176,7 +186,7 @@ export function useScoreSaver(
           }
         });
     },
-    [tripId, gameId, values, deleteEntry, mark, typeOf],
+    [tripId, gameId, values, deleteEntry, mark, typeOf, onCleared],
   );
 
   /**

--- a/src/server/lib/competitionLeaderboard.ts
+++ b/src/server/lib/competitionLeaderboard.ts
@@ -54,7 +54,7 @@ export async function computeCompetitionLeaderboard(
     // Games of this competition — all feed the roll-up.
     supabase
       .from("games")
-      .select("id, name, points_distribution, points_total, status, game_type_id, course_id, scoring_enabled")
+      .select("id, name, points_distribution, points_total, status, game_type_id, course_id, scoring_enabled, entry_mode")
       .eq("competition_id", competitionId)
       .order("created_at", { ascending: true }),
     // Team sizes drive the team-size-derived per_match formats (rack-n-stack):
@@ -87,7 +87,7 @@ export async function computeCompetitionLeaderboard(
   // participant COUNT (the stroke/rack readiness gate) + the per-game SCORE-entry
   // presence (the On-Tap↔Ready-for-Play split). All depend on the live game ids;
   // run them together.
-  const [resultsRes, matchRowsRes, participantRowsRes, scoreEntryRowsRes] = await Promise.all([
+  const [resultsRes, matchRowsRes, participantRowsRes, scoreEntryRowsRes, outcomeRowsRes] = await Promise.all([
     gameIds.length
       ? supabase
           .from("game_results")
@@ -109,11 +109,22 @@ export async function computeCompetitionLeaderboard(
     gameIds.length
       ? supabase.from("score_entries").select("game_id").in("game_id", gameIds)
       : Promise.resolve({ data: [] as { game_id: string }[] }),
+    // Refactor B3: the outcome-mode counterpart — an outcome game never has
+    // score_entries rows, so it needs its OWN "started" source or it reads
+    // Ready-for-Play forever, however many holes are decided.
+    gameIds.length
+      ? supabase.from("match_hole_outcomes").select("game_id").in("game_id", gameIds)
+      : Promise.resolve({ data: [] as { game_id: string }[] }),
   ]);
   const results = resultsRes.data;
-  // Games with at least one score entry — drives `started` on each game below.
+  // Games with at least one score entry OR ≥1 decided hole outcome — drives
+  // `started` on each game below. The two sources are mutually exclusive per
+  // game (a game is one entry_mode), so merging them is always safe.
   const startedByGame = new Set<string>();
   for (const r of (scoreEntryRowsRes.data ?? []) as { game_id: string }[]) {
+    startedByGame.add(r.game_id);
+  }
+  for (const r of (outcomeRowsRes.data ?? []) as { game_id: string }[]) {
     startedByGame.add(r.game_id);
   }
   // Participant rows per game — "field picked" (stroke). For rack we track the
@@ -291,6 +302,9 @@ export async function computeCompetitionLeaderboard(
         id: g.id as string,
         gameTypeId: (g.game_type_id as string | null) ?? null,
         pointsPerMatch: isPerMatch(dist) ? dist.value : 0,
+        // Refactor B3: an outcome-mode match projects from recorded outcomes,
+        // not gross scores (it has none).
+        outcomeMode: (g.entry_mode as string | null) === "outcome",
       };
     });
   const projections = await computeLiveProjections(supabase, competitionId, liveProjectionInputs);

--- a/src/server/lib/liveProjection.test.ts
+++ b/src/server/lib/liveProjection.test.ts
@@ -21,8 +21,8 @@ describe("projectGame — match play", () => {
       schema: { units: { count: 2 } }, // 2-hole round, no course index → sequential fallback
       modifiers: null,
       matches: [
-        { side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" } }, // alice sweeps → blue
-        { side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" } }, // 1 hole halved → all-square
+        { id: "m1", side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" } }, // alice sweeps → blue
+        { id: "m2", side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" } }, // 1 hole halved → all-square
       ],
       parts: [part("alice"), part("bob"), part("carol"), part("dave")],
       playGroups: [],
@@ -32,6 +32,7 @@ describe("projectGame — match play", () => {
         carol: { "1": 4 }, // only hole 1 in → started, all-square
         dave: { "1": 4 },
       }),
+      outcomes: [],
       userTeam: userTeam({ alice: "blue", bob: "red", carol: "blue", dave: "red" }),
     };
     // match 1: blue up → blue +2. match 2: all-square started → blue +1, red +1.
@@ -45,9 +46,9 @@ describe("projectGame — match play", () => {
       modifiers: null,
       matches: [
         // alice sweeps → blue; this match "counts double" (override 4), not the even 2.
-        { side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" }, point_value: 4 },
+        { id: "m1", side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" }, point_value: 4 },
         // carol sweeps → blue at the even share (no override).
-        { side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" }, point_value: null },
+        { id: "m2", side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" }, point_value: null },
       ],
       parts: [part("alice"), part("bob"), part("carol"), part("dave")],
       playGroups: [],
@@ -57,6 +58,7 @@ describe("projectGame — match play", () => {
         carol: { "1": 4, "2": 4 },
         dave: { "1": 5, "2": 5 },
       }),
+      outcomes: [],
       userTeam: userTeam({ alice: "blue", bob: "red", carol: "blue", dave: "red" }),
     };
     // blue = 4 (overridden match) + 2 (even-share match) = 6.
@@ -68,10 +70,11 @@ describe("projectGame — match play", () => {
     const data: GameProjectionData = {
       schema: { units: { count: 2 } },
       modifiers: null,
-      matches: [{ side_a: { type: "user", id: "alice" }, side_b: null }],
+      matches: [{ id: "m1", side_a: { type: "user", id: "alice" }, side_b: null }],
       parts: [part("alice")],
       playGroups: [],
       gross: gross({ alice: { "1": 4, "2": 4 } }),
+      outcomes: [],
       userTeam: userTeam({ alice: "blue" }),
     };
     expect(projectGame(input, data)).toEqual({});
@@ -93,6 +96,7 @@ describe("projectGame — rack", () => {
         p4: { "1": 4, "2": 4 }, // team t2
         p2: { "1": 5, "2": 5 }, // team t2 — highest
       }),
+      outcomes: [],
       userTeam: userTeam({ p1: "t1", p3: "t1", p2: "t2", p4: "t2" }),
     };
     // rank-paired: (p1<p4) → t1, (p3<p2) → t1 → t1 sweeps both slots = 2 slots.
@@ -114,6 +118,7 @@ describe("projectGame — rack", () => {
         p4: { "1": 4, "2": 4 },
         p2: { "1": 5, "2": 5 },
       }),
+      outcomes: [],
       userTeam: userTeam({ p1: "t1", p3: "t1", p2: "t2", p4: "t2" }),
     };
     expect(projectGame(input, data)).toEqual({ t1: 2, t2: 0 });
@@ -130,6 +135,7 @@ describe("projectGame — no projection", () => {
       parts: [],
       playGroups: [],
       gross: new Map(),
+      outcomes: [],
       userTeam: new Map(),
     };
     expect(projectGame(input, data)).toBeNull();

--- a/src/server/lib/liveProjection.test.ts
+++ b/src/server/lib/liveProjection.test.ts
@@ -65,6 +65,28 @@ describe("projectGame — match play", () => {
     expect(projectGame(input, data)).toEqual({ blue: 6 });
   });
 
+  it("B3 — outcome-mode games project from match_hole_outcomes, not gross scores (same result as the score-mode sweep/halve test)", () => {
+    const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play", pointsPerMatch: 2, outcomeMode: true };
+    const data: GameProjectionData = {
+      schema: { units: { count: 2 } },
+      modifiers: null,
+      matches: [
+        { id: "m1", side_a: { type: "user", id: "alice" }, side_b: { type: "user", id: "bob" } }, // alice sweeps → blue
+        { id: "m2", side_a: { type: "user", id: "carol" }, side_b: { type: "user", id: "dave" } }, // 1 hole halved → all-square
+      ],
+      parts: [part("alice"), part("bob"), part("carol"), part("dave")],
+      playGroups: [],
+      gross: new Map(), // deliberately empty — outcome mode must not read gross at all
+      outcomes: [
+        { match_id: "m1", hole_number: 1, result: "side_a" },
+        { match_id: "m1", hole_number: 2, result: "side_a" },
+        { match_id: "m2", hole_number: 1, result: "halved" },
+      ],
+      userTeam: userTeam({ alice: "blue", bob: "red", carol: "blue", dave: "red" }),
+    };
+    expect(projectGame(input, data)).toEqual({ blue: 3, red: 1 });
+  });
+
   it("an unpaired match (a side missing) contributes nothing", () => {
     const input: LiveProjectionInput = { id: "g1", gameTypeId: "gtt_match_play", pointsPerMatch: 2 };
     const data: GameProjectionData = {

--- a/src/server/lib/liveProjection.ts
+++ b/src/server/lib/liveProjection.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { buildDecided, matchState } from "@/lib/matchPlay";
+import { buildDecided, buildDecidedFromOutcomes, matchState, type HoleOutcomeRow } from "@/lib/matchPlay";
 import { gloriousConfig } from "@/lib/gloriousHoles";
 import type { ModifiersMap } from "@/lib/modifiers";
 import { effectiveStrokes } from "@/lib/handicap";
@@ -47,6 +47,9 @@ export interface LiveProjectionInput {
   /** per_match value from `points_distribution` — match play's pointsPerMatch.
    *  Unused by rack (which returns raw slot points to match its game page). */
   pointsPerMatch: number;
+  /** Refactor B3: an outcome-mode match projects from recorded hole outcomes,
+   *  not gross scores (it has none). Unused by rack. */
+  outcomeMode?: boolean;
 }
 
 /** The per-game data the pure projection needs — built from the bulk reads by
@@ -57,11 +60,14 @@ export interface GameProjectionData {
   schema: SchemaShape | null;
   modifiers: ModifiersMap | null;
   /** A2b: `point_value` is the per-match override (null → the even share). */
-  matches: { side_a: SideRef | null; side_b: SideRef | null; point_value?: number | null }[];
+  matches: { id: string; side_a: SideRef | null; side_b: SideRef | null; point_value?: number | null }[];
   parts: { user_id: string; play_group_id: string | null; handicap_strokes: number | null }[];
   playGroups: { id: string; handicap_strokes: number | null }[];
-  /** participant_id → { unit_label: gross }. */
+  /** participant_id → { unit_label: gross }. Score-mode only. */
   gross: Map<string, Record<string, number>>;
+  /** Refactor B3: recorded hole outcomes for this game's matches, outcome-mode
+   *  only — empty for a score-mode game. */
+  outcomes: { match_id: string; hole_number: number; result: HoleOutcomeRow["result"] }[];
   /** user_id → team_id (competition-level). */
   userTeam: Map<string, string>;
 }
@@ -91,10 +97,10 @@ export async function computeLiveProjections(
   // Bulk reads, scoped to the live game ids only (a completed game's per-hole
   // scores never load). One wave, parallel — the board compute's cost stays a
   // fixed handful of extra queries regardless of live-game count.
-  const [gamesMetaRes, matchRowsRes, participantRowsRes, playGroupRowsRes, entryRowsRes, assignRes] =
+  const [gamesMetaRes, matchRowsRes, participantRowsRes, playGroupRowsRes, entryRowsRes, outcomeRowsRes, assignRes] =
     await Promise.all([
       supabase.from("games").select("id, scorecard_schema, modifiers").in("id", gameIds),
-      supabase.from("game_matches").select("game_id, side_a, side_b, point_value").in("game_id", gameIds),
+      supabase.from("game_matches").select("id, game_id, side_a, side_b, point_value").in("game_id", gameIds),
       supabase
         .from("game_participants")
         .select("game_id, user_id, play_group_id, handicap_strokes")
@@ -105,6 +111,10 @@ export async function computeLiveProjections(
         .select("game_id, participant_id, unit_label, value")
         .in("game_id", gameIds)
         .in("participant_type", ["user", "play_group"]),
+      // Refactor B3: the outcome-mode counterpart to entryRowsRes — empty for a
+      // score-mode game (harmless to fetch unconditionally, same pattern as
+      // startedByGame's merge in competitionLeaderboard.ts).
+      supabase.from("match_hole_outcomes").select("game_id, match_id, hole_number, result").in("game_id", gameIds),
       supabase.from("team_assignments").select("user_id, team_id").eq("competition_id", competitionId),
     ]);
 
@@ -119,15 +129,26 @@ export async function computeLiveProjections(
     });
   }
 
-  const matchesByGame = new Map<string, { side_a: SideRef | null; side_b: SideRef | null; point_value: number | null }[]>();
+  const matchesByGame = new Map<string, { id: string; side_a: SideRef | null; side_b: SideRef | null; point_value: number | null }[]>();
   for (const m of matchRowsRes.data ?? []) {
     const arr = matchesByGame.get(m.game_id as string) ?? [];
     arr.push({
+      id: m.id as string,
       side_a: (m.side_a as SideRef | null) ?? null,
       side_b: (m.side_b as SideRef | null) ?? null,
       point_value: (m.point_value as number | null) ?? null,
     });
     matchesByGame.set(m.game_id as string, arr);
+  }
+
+  // Refactor B3: game → this game's recorded hole outcomes (outcome-mode only —
+  // empty array for a score-mode game).
+  const outcomesByGame = new Map<string, { match_id: string; hole_number: number; result: HoleOutcomeRow["result"] }[]>();
+  for (const o of outcomeRowsRes.data ?? []) {
+    const gid = o.game_id as string;
+    const arr = outcomesByGame.get(gid) ?? [];
+    arr.push({ match_id: o.match_id as string, hole_number: o.hole_number as number, result: o.result as HoleOutcomeRow["result"] });
+    outcomesByGame.set(gid, arr);
   }
 
   const partsByGame = new Map<
@@ -173,6 +194,7 @@ export async function computeLiveProjections(
       parts: partsByGame.get(g.id) ?? [],
       playGroups: pgByGame.get(g.id) ?? [],
       gross: grossByGame.get(g.id) ?? new Map(),
+      outcomes: outcomesByGame.get(g.id) ?? [],
       userTeam,
     });
     if (proj) out[g.id] = proj;
@@ -184,12 +206,14 @@ export async function computeLiveProjections(
  *  `buildDecided`→`matchState` the finish path runs), resolve each side to its
  *  team, and sum via the shared `rollupMatchPlay`. */
 function projectMatch(g: LiveProjectionInput, data: GameProjectionData): Record<string, number> | null {
-  const { schema, matches, parts, playGroups, gross, userTeam } = data;
+  const { schema, matches, parts, playGroups, gross, outcomes, userTeam } = data;
   const strokeIndex = schema?.units?.metadata?.handicap_index;
   const holeCount = schema?.units?.count;
   const glorious = gloriousConfig(g.gameTypeId, data.modifiers);
 
   // Side handicaps, keyed by SIDE id (1v1 side = a user; 2v2 side = a play_group).
+  // Score-mode only — an outcome-mode match has no handicap application (the
+  // recorded outcome IS the decision).
   const hcap = new Map<string, number>();
   for (const p of parts) hcap.set(p.user_id, effectiveStrokes(p));
   for (const pg of playGroups) hcap.set(pg.id, effectiveStrokes(pg));
@@ -207,19 +231,30 @@ function projectMatch(g: LiveProjectionInput, data: GameProjectionData): Record<
     return (s.type === "play_group" ? pgTeam.get(s.id) : userTeam.get(s.id)) ?? null;
   };
 
+  // Refactor B3: outcome-mode matches source decided holes from recorded
+  // outcomes, grouped by match id — mirrors MatchGameView's decidedFor branch.
+  const outcomesByMatch = new Map<string, HoleOutcomeRow[]>();
+  for (const o of outcomes) {
+    const arr = outcomesByMatch.get(o.match_id) ?? [];
+    arr.push({ hole: o.hole_number, result: o.result });
+    outcomesByMatch.set(o.match_id, arr);
+  }
+
   const projMatches: ProjMatch[] = [];
   for (const m of matches) {
     const a = m.side_a;
     const b = m.side_b;
     if (!a?.id || !b?.id) continue; // an unpaired slot isn't a match yet
-    const decided = buildDecided(
-      gross.get(a.id) ?? {},
-      gross.get(b.id) ?? {},
-      hcap.get(a.id) ?? 0,
-      hcap.get(b.id) ?? 0,
-      strokeIndex,
-      holeCount
-    );
+    const decided = g.outcomeMode
+      ? buildDecidedFromOutcomes(outcomesByMatch.get(m.id) ?? [])
+      : buildDecided(
+          gross.get(a.id) ?? {},
+          gross.get(b.id) ?? {},
+          hcap.get(a.id) ?? 0,
+          hcap.get(b.id) ?? 0,
+          strokeIndex,
+          holeCount
+        );
     const st = matchState(decided, holeCount, glorious);
     projMatches.push({
       aTeamId: sideTeam(a),

--- a/src/server/lib/outcomeAccess.ts
+++ b/src/server/lib/outcomeAccess.ts
@@ -1,0 +1,75 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { canEditGame, type TripRole } from "@/server/middleware";
+import { memberCanScoreUnit, type ScoreUnitMatch, type ScoreUnitSide } from "@/lib/scoreUnit";
+
+/**
+ * canWriteOutcome — the SERVER source of truth for "may this caller decide THIS
+ * match's hole outcome?" (Refactor B3, the outcome-entry counterpart to
+ * `canWriteScore`). Owner / co-admin / delegate-of-this-game → any match. A
+ * plain member → only a match they're playing in, resolved by the SAME pure
+ * `memberCanScoreUnit` the score path uses (its 1v1/2v2 match-membership
+ * branches are exactly the outcome authorization rule — no new pure logic).
+ *
+ * Called by both `matchOutcomes.upsertOutcome` and `deleteOutcome` so no write
+ * path is left on an elevated-only rule. Defense-in-depth: RLS on
+ * `match_hole_outcomes` enforces the same rule via `can_score_match()` for
+ * direct (non-tRPC) writes (mig 076 — lands in lockstep with this, since
+ * `ctx.supabase` is RLS-enforcing, not service-role; a mismatched app-check/RLS
+ * pair would be a broken half-permission state).
+ */
+type OutcomeCtx = {
+  supabase: { from: (t: string) => unknown };
+  user: { id: string } | null;
+  membershipCache: Map<string, TripRole>;
+};
+
+export async function canWriteOutcome(
+  ctx: OutcomeCtx,
+  tripId: string,
+  gameId: string,
+  matchId: string,
+): Promise<boolean> {
+  // Owner / co-admin / delegate of THIS game → any match. Reuses the same
+  // helper the rest of the game-edit surface uses, so the elevated tier can't
+  // drift from the config/run gates.
+  if (await canEditGame(ctx, tripId, gameId)) return true;
+
+  const meId = ctx.user?.id;
+  if (!meId) return false;
+
+  const db = ctx.supabase as unknown as SupabaseClient;
+
+  const { data: matchRow } = await db
+    .from("game_matches")
+    .select("side_a, side_b")
+    .eq("id", matchId)
+    .eq("game_id", gameId)
+    .maybeSingle();
+  if (!matchRow) return false;
+  const sideA = matchRow.side_a as ScoreUnitSide | null;
+  const sideB = matchRow.side_b as ScoreUnitSide | null;
+  if (!sideA?.id) return false; // an unpaired match has nothing to authorize against
+
+  const matches: ScoreUnitMatch[] = [{ side_a: sideA, side_b: sideB }];
+
+  const { data: meRow } = await db
+    .from("game_participants")
+    .select("play_group_id")
+    .eq("game_id", gameId)
+    .eq("user_id", meId)
+    .maybeSingle();
+
+  // memberCanScoreUnit resolves "is meId in the unit containing participantId" —
+  // its 1v1/2v2 branches look at BOTH sides of the match once found, so passing
+  // EITHER side's ref (here, side A's) as the "unit" resolves identically
+  // regardless of which side the caller is actually on.
+  return memberCanScoreUnit({
+    meId,
+    participantId: sideA.id,
+    participantType: sideA.type as "user" | "play_group",
+    matches,
+    myPlayGroupId: (meRow as { play_group_id: string | null } | null)?.play_group_id ?? null,
+    targetPlayGroupId: null,
+    meIsParticipant: !!meRow,
+  });
+}

--- a/src/server/routers/games.ts
+++ b/src/server/routers/games.ts
@@ -647,6 +647,9 @@ export const gamesRouter = router({
         // Enabled special rules + per-rule config, keyed by modifier (golf
         // SPECIAL RULES). Presence of a key = enabled. Owner or delegate.
         modifiers: z.record(z.string(), z.record(z.string(), z.unknown())).nullable().optional(),
+        // Refactor B3: the hole-outcome-entry toggle (match play only in
+        // practice; the UI never offers it for other formats). Owner or delegate.
+        entryMode: z.enum(["score", "outcome"]).optional(),
       })
     )
     .use(requireGameEdit())
@@ -658,6 +661,26 @@ export const gamesRouter = router({
       if (input.competitionFormat !== undefined) patch.competition_format = input.competitionFormat;
       if (input.rulesForToday !== undefined) patch.rules_for_today = input.rulesForToday;
       if (input.modifiers !== undefined) patch.modifiers = input.modifiers;
+      if (input.entryMode !== undefined) {
+        // Data-integrity guard (defense-in-depth beyond the client's `locked`
+        // prop): once scoring is enabled, entered score_entries/
+        // match_hole_outcomes rows belong to the CURRENT mode — switching
+        // would silently orphan them. Setup-time only, mirroring every other
+        // setup-spine field (Matches/Course/Points are all frozen the same way).
+        const { data: game } = await ctx.supabase
+          .from("games")
+          .select("scoring_enabled")
+          .eq("id", input.gameId)
+          .eq("trip_id", ctx.tripId)
+          .maybeSingle();
+        if (game?.scoring_enabled) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Switch back to setup before changing the entry mode.",
+          });
+        }
+        patch.entry_mode = input.entryMode;
+      }
       if (Object.keys(patch).length === 0) return { success: true };
       const { error } = await ctx.supabase.from("games").update(patch).eq("id", input.gameId).eq("trip_id", ctx.tripId);
       if (error) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `Failed to update game: ${error.message}` });

--- a/src/server/routers/matchOutcomes.e2e.test.ts
+++ b/src/server/routers/matchOutcomes.e2e.test.ts
@@ -82,3 +82,43 @@ describe("Refactor B2 acceptance case — outcome entry, tap by tap, posts like 
     ).rejects.toThrow(/posted/i);
   }, 60000);
 });
+
+describe("Refactor B3 — presence + live projection for an in-progress outcome-mode game", () => {
+  it("an outcome-mode game reads 'started' and gets a live-projection pill as soon as ≥1 hole is decided", async () => {
+    const comp = await ctx.createCompetition(tripId, "Outcome B3 Presence Cup");
+    const blue = await ctx.createTeam(comp, "Blue");
+    const red = await ctx.createTeam(comp, "Red");
+    await ctx.admin.from("team_assignments").insert([
+      { competition_id: comp, user_id: owner, team_id: blue },
+      { competition_id: comp, user_id: member, team_id: red },
+    ]);
+
+    const game = await ctx.caller().games.create({
+      tripId, gameTypeId: MATCH_PLAY, name: "Live Outcome Match", competitionId: comp,
+      pointsDistribution: { type: "per_match", value: 3 },
+    });
+    const gameId = game.id as string;
+    await ctx.admin.from("games").update({ entry_mode: "outcome" }).eq("id", gameId);
+    const matches = await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    const matchId = (matches as { id: string }[])[0].id;
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+
+    // Before any hole is decided — the board still shows this as Ready for
+    // Play, not On Tap; no rows in match_hole_outcomes means the OLD
+    // score_entries-only presence check would have never flipped it.
+    const before = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(before.games.find((g) => g.id === gameId)?.started).toBe(false);
+    expect(before.projections[gameId]).toBeUndefined();
+
+    // Owner wins hole 1 via the real upsertOutcome path — the game is now
+    // "on tap" and the board projects the current leader's full match value.
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+
+    const after = await ctx.caller().competitions.leaderboard({ tripId, competitionId: comp });
+    expect(after.games.find((g) => g.id === gameId)?.started).toBe(true);
+    expect(after.projections[gameId]).toEqual({ [blue]: 3 });
+  }, 60000);
+});

--- a/src/server/routers/matchOutcomes.test.ts
+++ b/src/server/routers/matchOutcomes.test.ts
@@ -14,7 +14,7 @@ const MATCH_PLAY = "gtt_match_play";
 
 let ctx: TestContext;
 let tripId: string;
-let owner: string, member: string, outsider: string;
+let owner: string, member: string;
 
 beforeAll(async () => {
   ctx = await TestContext.create();
@@ -24,7 +24,6 @@ beforeAll(async () => {
   await ctx.addTripMember(tripId, "outsider", "Member");
   owner = ctx.user.id;
   member = ctx.getUser("member").id;
-  outsider = ctx.getUser("outsider").id;
 });
 
 afterAll(async () => {

--- a/src/server/routers/matchOutcomes.test.ts
+++ b/src/server/routers/matchOutcomes.test.ts
@@ -2,30 +2,37 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { TestContext } from "../../__tests__/helpers/test-setup";
 
 /**
- * matchOutcomes router (Refactor B2). B2 permission scope is ELEVATED TIER ONLY
- * (owner/organizer/delegate), matching migration 075's RLS write policy exactly
- * — the member-tier widening is B3's job (both the mutation AND RLS together).
+ * matchOutcomes router. B3 widened the write permission to the SCOPED model
+ * (matching `scores.ts` exactly): owner/organizer/delegate → any match; a
+ * plain member → only the match they're playing in (`canWriteOutcome` →
+ * `memberCanScoreUnit`); a non-participant member → nothing. Landed together
+ * with migration 076's `can_score_match` RLS policy (see that migration's
+ * comment for why the two layers can't ship separately).
  */
 
 const MATCH_PLAY = "gtt_match_play";
 
 let ctx: TestContext;
 let tripId: string;
-let owner: string, member: string;
+let owner: string, member: string, outsider: string;
 
 beforeAll(async () => {
   ctx = await TestContext.create();
   tripId = await ctx.createTrip("Outcome Router Trip");
   await ctx.addTripMember(tripId, "planner", "Organizer");
   await ctx.addTripMember(tripId, "member", "Member");
+  await ctx.addTripMember(tripId, "outsider", "Member");
   owner = ctx.user.id;
   member = ctx.getUser("member").id;
+  outsider = ctx.getUser("outsider").id;
 });
 
 afterAll(async () => {
   await ctx.cleanup();
 });
 
+/** owner (side A) vs member (side B) — outsider is a trip member but plays no
+ *  part in this match, the genuine "not authorized" case. */
 async function freshOutcomeMatch(name: string): Promise<{ gameId: string; matchId: string }> {
   const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name });
   const gameId = game.id as string;
@@ -39,7 +46,7 @@ async function freshOutcomeMatch(name: string): Promise<{ gameId: string; matchI
   return { gameId, matchId };
 }
 
-describe("matchOutcomes.upsertOutcome — elevated tier only (B2 scope)", () => {
+describe("matchOutcomes.upsertOutcome — scoped permissions (B3)", () => {
   it("Owner records a hole outcome; it persists and round-trips via listByGame", async () => {
     const { gameId, matchId } = await freshOutcomeMatch("Owner Writes");
     await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
@@ -54,10 +61,18 @@ describe("matchOutcomes.upsertOutcome — elevated tier only (B2 scope)", () => 
     expect(rows).toEqual([{ match_id: matchId, hole_number: 2, result: "halved" }]);
   });
 
-  it("a plain Member is REJECTED (B2 scope — widened in B3)", async () => {
-    const { gameId, matchId } = await freshOutcomeMatch("Member Blocked");
+  it("B3: a member IN the match may record its outcome (their own match)", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Member In Match");
+    // member is side B of this match — now authorized to decide its holes.
+    await ctx.callerAs("member").matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_b" });
+    const rows = await ctx.caller().matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([{ match_id: matchId, hole_number: 1, result: "side_b" }]);
+  });
+
+  it("a member NOT in the match is still REJECTED (genuine non-participant)", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Outsider Blocked");
     await expect(
-      ctx.callerAs("member").matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" })
+      ctx.callerAs("outsider").matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" })
     ).rejects.toThrow();
   });
 
@@ -85,7 +100,7 @@ describe("matchOutcomes.upsertOutcome — elevated tier only (B2 scope)", () => 
   });
 });
 
-describe("matchOutcomes.deleteOutcome — Reset hole", () => {
+describe("matchOutcomes.deleteOutcome — Reset hole (same scoped permissions)", () => {
   it("clears a recorded outcome back to undecided", async () => {
     const { gameId, matchId } = await freshOutcomeMatch("Reset Hole");
     await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
@@ -94,11 +109,19 @@ describe("matchOutcomes.deleteOutcome — Reset hole", () => {
     expect(rows).toEqual([]);
   });
 
-  it("a plain Member is REJECTED (same B2 scope as upsert)", async () => {
-    const { gameId, matchId } = await freshOutcomeMatch("Reset Blocked");
+  it("B3: a member IN the match may reset its own hole", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Reset Own Match");
+    await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
+    await ctx.callerAs("member").matchOutcomes.deleteOutcome({ tripId, gameId, matchId, holeNumber: 1 });
+    const rows = await ctx.caller().matchOutcomes.listByGame({ tripId, gameId });
+    expect(rows).toEqual([]);
+  });
+
+  it("a member NOT in the match is still REJECTED", async () => {
+    const { gameId, matchId } = await freshOutcomeMatch("Reset Outsider Blocked");
     await ctx.caller().matchOutcomes.upsertOutcome({ tripId, gameId, matchId, holeNumber: 1, result: "side_a" });
     await expect(
-      ctx.callerAs("member").matchOutcomes.deleteOutcome({ tripId, gameId, matchId, holeNumber: 1 })
+      ctx.callerAs("outsider").matchOutcomes.deleteOutcome({ tripId, gameId, matchId, holeNumber: 1 })
     ).rejects.toThrow();
   });
 });

--- a/src/server/routers/matchOutcomes.ts
+++ b/src/server/routers/matchOutcomes.ts
@@ -1,22 +1,26 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, authedProcedure } from "../trpc";
-import { requireTripMember, requireGameEdit, canEditGame } from "../middleware";
+import { requireTripMember, canEditGame } from "../middleware";
+import { canWriteOutcome } from "../lib/outcomeAccess";
 
 /**
- * matchOutcomes — hole-outcome entry (Refactor B2): record who won each hole
+ * matchOutcomes — hole-outcome entry (Refactor B2/B3): record who won each hole
  * directly, no gross scores. The write-path counterpart to `scores.ts` for
  * outcome-mode games.
  *
- * B2 permission scope — ELEVATED TIER ONLY (owner/organizer/delegate via
- * `requireGameEdit()`), matching migration 075's RLS write policy exactly. A
- * member-tier check (reusing `memberCanScoreUnit`'s match-membership logic, the
- * same rule `scores.ts` uses) is deliberately deferred to B3, which widens BOTH
- * this mutation AND the RLS policy TOGETHER — `ctx.supabase` is a user-scoped
- * client (RLS-enforcing, not service-role), so a member-tier check here without
- * the matching RLS widening would pass the app check and then fail the actual
- * write, a broken half-permission state. Building both layers in lockstep avoids
- * that gap entirely (see B1/B2 PR discussion).
+ * SCOPED permissions (B3 — mig 076, SERVER-enforced, RLS-backed, matching
+ * `scores.ts`'s exact model):
+ *   Owner / Organizer (co-admin) / delegate-of-this-game → any match.
+ *   Member → only the match they participate in (`canWriteOutcome` →
+ *            `memberCanScoreUnit`, the SAME pure rule scores.ts uses).
+ *   Non-participant member → nothing.
+ * B2 shipped this elevated-tier only (`requireGameEdit()`), deliberately
+ * deferring the member tier: `ctx.supabase` is a user-scoped, RLS-enforcing
+ * client (not service-role), so a member-tier app check without the matching
+ * RLS widening would pass the check and then fail the actual write — a broken
+ * half-permission state. B3 lands both layers together (mig 076's
+ * `can_score_match` policy + this file's `canWriteOutcome` call).
  *
  * No `computeMatchPlayResults` call per write — mirrors `scores.upsertEntry`/
  * `deleteEntry` exactly: live state is derived CLIENT-SIDE from the outcome rows
@@ -39,7 +43,7 @@ export const matchOutcomesRouter = router({
         result: z.enum(["side_a", "side_b", "halved"]),
       })
     )
-    .use(requireGameEdit())
+    .use(requireTripMember)
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
@@ -74,6 +78,16 @@ export const matchOutcomesRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "Match not found" });
       }
 
+      // Outcome-entry permissions (SERVER — the real gate; the UI only reflects
+      // it). Owner / co-admin / delegate-of-this-game → any match; a plain
+      // member → only the match they participate in.
+      if (!(await canWriteOutcome(ctx, ctx.tripId!, input.gameId, input.matchId))) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You can only decide outcomes for your own match.",
+        });
+      }
+
       const id = `${input.matchId}:${input.holeNumber}`;
       const { error } = await ctx.supabase.from("match_hole_outcomes").upsert(
         {
@@ -103,7 +117,7 @@ export const matchOutcomesRouter = router({
         holeNumber: z.number().int().min(1).max(18),
       })
     )
-    .use(requireGameEdit())
+    .use(requireTripMember)
     .mutation(async ({ ctx, input }) => {
       const { data: game } = await ctx.supabase
         .from("games")
@@ -118,6 +132,15 @@ export const matchOutcomesRouter = router({
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "This round is posted — open score correction to edit it.",
+        });
+      }
+
+      // Same scoped gate as upsertOutcome — clearing a cell is a write too, so a
+      // member can only clear outcomes in their own match (owner/delegate anywhere).
+      if (!(await canWriteOutcome(ctx, ctx.tripId!, input.gameId, input.matchId))) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You can only clear outcomes for your own match.",
         });
       }
 

--- a/src/server/routers/matches.holeOutcome.test.ts
+++ b/src/server/routers/matches.holeOutcome.test.ts
@@ -189,3 +189,43 @@ describe("hole-outcome entry — computeMatchPlayResults reads match_hole_outcom
     expect(outcomes).toEqual([]);
   });
 });
+
+/**
+ * B3 — the config toggle. `games.update`'s existing generic PATCH mutation
+ * gained an `entryMode` field rather than a new dedicated mutation. A pending
+ * (not-yet-scoring) game may flip freely; once `scoring_enabled` is true the
+ * switch is rejected (defense-in-depth beyond the client's `locked` prop —
+ * switching mid-round would orphan whichever rows, score_entries or
+ * match_hole_outcomes, are already entered).
+ */
+describe("games.update — entryMode toggle (B3 config toggle)", () => {
+  it("switches a pending game between score and outcome modes", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Toggle Pending" });
+    const gameId = game.id as string;
+
+    await ctx.caller().games.update({ tripId, gameId, entryMode: "outcome" });
+    const { data: row1 } = await ctx.admin.from("games").select("entry_mode").eq("id", gameId).single();
+    expect((row1 as { entry_mode: string }).entry_mode).toBe("outcome");
+
+    await ctx.caller().games.update({ tripId, gameId, entryMode: "score" });
+    const { data: row2 } = await ctx.admin.from("games").select("entry_mode").eq("id", gameId).single();
+    expect((row2 as { entry_mode: string }).entry_mode).toBe("score");
+  });
+
+  it("rejects the switch once scoring is enabled", async () => {
+    const game = await ctx.caller().games.create({ tripId, gameTypeId: MATCH_PLAY, name: "Toggle Locked" });
+    const gameId = game.id as string;
+    await ctx.caller().matches.setPairings({
+      tripId, gameId,
+      matches: [{ playersPerSide: 1, sideA: { members: [owner] }, sideB: { members: [member] }, matchNumber: 1 }],
+    });
+    await ctx.caller().games.enableScoring({ tripId, gameId });
+
+    await expect(
+      ctx.caller().games.update({ tripId, gameId, entryMode: "outcome" })
+    ).rejects.toThrow(/switch back to setup/i);
+
+    const { data: row } = await ctx.admin.from("games").select("entry_mode").eq("id", gameId).single();
+    expect((row as { entry_mode: string }).entry_mode).toBe("score");
+  });
+});

--- a/supabase/migrations/20260712160000_076_outcome_member_permissions.sql
+++ b/supabase/migrations/20260712160000_076_outcome_member_permissions.sql
@@ -1,0 +1,83 @@
+-- 076 — Refactor B3: hole-outcome entry, member-tier permissions
+--
+-- B2 built match_hole_outcomes with an ELEVATED-TIER-ONLY write policy
+-- (owner/organizer/delegate — mig 075), deliberately deferring the member tier:
+-- ctx.supabase in tRPC procedures is a user-scoped, RLS-ENFORCING client (not
+-- service-role), so a member-tier app check without the matching RLS widening
+-- would pass the check and then fail the actual write — a broken half-permission
+-- state. This migration + the matchOutcomes.ts mutation change land TOGETHER.
+--
+-- can_score_match — "is the CALLER on either side of THIS match?" (the MEMBER
+-- tier only; owner/organizer/delegate are the policy's other OR-branches).
+-- Mirrors can_score_unit's 1v1/2v2 match-membership branches (mig 072), but
+-- resolves the match DIRECTLY by id — an outcome is match-scoped, not
+-- participant-scoped, so there's no participant_type dispatch to do.
+CREATE OR REPLACE FUNCTION public.can_score_match(
+  p_game_id text,
+  p_match_id text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  me text := (auth.uid())::text;
+BEGIN
+  IF me IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- 1v1: the caller is a user-side of this match.
+  IF EXISTS (
+    SELECT 1 FROM game_matches gm
+    WHERE gm.id = p_match_id AND gm.game_id = p_game_id
+      AND ((gm.side_a->>'type' = 'user' AND gm.side_a->>'id' = me)
+        OR (gm.side_b->>'type' = 'user' AND gm.side_b->>'id' = me))
+  ) THEN
+    RETURN true;
+  END IF;
+
+  -- 2v2: the caller is in a play_group that is a side of this match.
+  RETURN EXISTS (
+    SELECT 1
+    FROM game_matches gm
+    JOIN game_participants gp
+      ON gp.game_id = gm.game_id AND gp.user_id = me
+    WHERE gm.id = p_match_id AND gm.game_id = p_game_id
+      AND gp.play_group_id IN (gm.side_a->>'id', gm.side_b->>'id')
+  );
+END;
+$$;
+
+-- Widen the write policy: elevated (unchanged) OR a member scoring their OWN
+-- match, once scoring is enabled — the same shape score_entries_write uses.
+DROP POLICY IF EXISTS match_hole_outcomes_write ON public.match_hole_outcomes;
+CREATE POLICY match_hole_outcomes_write ON public.match_hole_outcomes FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = match_hole_outcomes.game_id
+        AND is_trip_member(g.trip_id)
+        AND (
+          has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+          OR is_game_delegate(g.id)
+          OR (g.scoring_enabled = true
+              AND can_score_match(match_hole_outcomes.game_id, match_hole_outcomes.match_id))
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.games g
+      WHERE g.id = match_hole_outcomes.game_id
+        AND is_trip_member(g.trip_id)
+        AND (
+          has_trip_role(g.trip_id, ARRAY['Owner'::text, 'Organizer'::text])
+          OR is_game_delegate(g.id)
+          OR (g.scoring_enabled = true
+              AND can_score_match(match_hole_outcomes.game_id, match_hole_outcomes.match_id))
+        )
+    )
+  );


### PR DESCRIPTION
## Summary

Final phase of Refactor B (hole-outcome entry mode). B1 built the engine/DB
layer, B2 built the entry surfaces + durability, and this phase makes
outcome-mode games first-class on the board and in setup:

- **Presence signals** (`competitionLeaderboard.ts`, `liveProjection.ts`) — an
  outcome-mode game's "on tap" / live-projection-pill status now reads
  `match_hole_outcomes` alongside `score_entries`. Before this, an
  outcome-mode game would never have score_entries rows, so it would've been
  stuck "Ready for Play" forever and never gotten a live projection.
- **Member-tier write permissions** (migration 076 + `outcomeAccess.ts`) — a
  plain trip member can now record outcomes for their own match (not just
  owner/organizer/delegate). The tRPC check and the RLS policy
  (`can_score_match`) land together in the same commit, since `ctx.supabase`
  is RLS-enforcing — a mismatched pair would be a broken half-permission
  state.
- **Config toggle** (`games.update` + `MatchGameView`'s new `EntryModeRow`) —
  a Score/Outcome settings row, reusing the existing `ChecklistRow` +
  segmented-toggle idiom, frozen once scoring starts (mirrors every other
  setup-spine field).

Verified live in browser: toggled a match-play game to Outcome mode, enabled
scoring (toggle locked as expected), tapped a hole winner via the real
`MatchOutcomeEntryView` (3-button choice, no number pad), watched the match
state derive to "1 UP" instantly, then confirmed the leaderboard's
live-projection pill flipped from `▲0` to `▲4` after reload — presence and
projection both correctly reading the outcome data.

This closes out Refactor B in its entirety: score entry and hole-outcome
entry are now two fully equivalent, first-class ways to play a match, sharing
one unchanged engine, one leaderboard, one set of permissions.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` clean
- [x] Full affected regression suite green (matchOutcomes, matchOutcomes.e2e,
      matches.holeOutcome, matchPlay, liveProjection, competitions.matchplay,
      competitions.d2, rackNStack — 87 tests)
- [x] New tests: `games.update` entryMode toggle (switch + scoring-enabled
      rejection), outcome-mode `projectGame` parity test, DB-integration
      presence/projection test through the real `upsertOutcome` write path
- [x] By-eye verification in browser (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)