### PR TITLE
Pairings/groupings draft durability — hard-teardown outbox (Option B)

### DIFF
--- a/src/components/games/MatchGameView.tsx
+++ b/src/components/games/MatchGameView.tsx
@@ -7,6 +7,7 @@ import { trpc } from "@/lib/trpc-client";
 import { STRUCTURE_QUERY } from "@/lib/queryConfig";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
 import { useOutcomeSaver } from "@/hooks/useOutcomeSaver";
+import { useDraftOutbox } from "@/hooks/useDraftOutbox";
 import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { useGameEditAccess } from "@/hooks/useGameEditAccess";
 import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
@@ -464,6 +465,24 @@ export function MatchGameView() {
     return m;
   }, [serverParticipants, serverPlayGroups]);
 
+  // Draft durability (Layer 2 — hard-teardown outbox). The in-app flush net
+  // already persists a completed draft on every in-app exit; this mirrors the
+  // in-progress draft to localStorage so a refresh / tab-close / OS-kill /
+  // background can't lose it (incomplete drafts too). `serverFingerprint` is the
+  // persisted state the draft diverged from — the no-clobber guard for recover().
+  const serverFingerprint = useMemo(
+    () => JSON.stringify(serverDraftFrom(serverMatches, handicapOf, membersOfSide)),
+    [serverMatches, handicapOf, membersOfSide]
+  );
+  const { recover: recoverDraft, clear: clearDraftOutbox } = useDraftOutbox<DraftMatch[]>({
+    view: "match",
+    gameId,
+    draft,
+    touched: draftTouched.current,
+    serverFingerprint,
+    enabled: !!gameId && !scoringEnabled,
+  });
+
   // A2b Total Points — the PAIRED server matches resolved to display players + each
   // match's per-match override (game_matches.point_value). Paired-only, so it's the
   // same denominator the award/leaderboard use. Feeds the Total Points row's override
@@ -634,6 +653,16 @@ export function MatchGameView() {
     // and matches are always consistent. This gate remains only so the seed reads
     // a loaded game row for its other fields.
     if (gameId && !gameQ.data) return;
+    // Hard-teardown recovery (Layer 2): if an outbox draft survived a
+    // refresh/kill AND the server is unchanged since it diverged, restore it and
+    // mark it touched — so the in-app net persists it and the server seed below
+    // never clobbers it. A stale outbox (server moved on) returns null + clears.
+    const recovered = recoverDraft();
+    if (recovered && recovered.length > 0) {
+      draftTouched.current = true;
+      setDraft(recovered);
+      return;
+    }
     if (serverMatches.length > 0) {
       setDraft(serverDraftFrom(serverMatches, handicapOf, membersOfSide));
       return;
@@ -642,7 +671,7 @@ export function MatchGameView() {
     // valid empty state (the table hides; only "Add match" shows). "+ Add match"
     // grows it from there (build-as-you-go — W-GAMEPAGE-01 §6.1).
     setDraft([]);
-  }, [cfgOpen, draft.length, serverMatches, handicapOf, membersOfSide, sided, gameId, gameQ.data]);
+  }, [cfgOpen, draft.length, serverMatches, handicapOf, membersOfSide, sided, gameId, gameQ.data, recoverDraft]);
 
   // Seed the modifiers draft from the server — but ONLY while the row is closed,
   // so an in-progress edit is never clobbered. On collapse the row persists +
@@ -768,6 +797,7 @@ export function MatchGameView() {
     if (!tripId || !gameId) return;
     const ok = await saveSetup();
     if (!ok) return;
+    clearDraftOutbox(); // durably persisted on Enable → drop the teardown copy
     await enableScoring.mutateAsync({ tripId, gameId });
     const cur = utils.games.getById.getData({ tripId, gameId });
     if (cur) {
@@ -801,6 +831,7 @@ export function MatchGameView() {
         const empty = draft.map((d, i) => ({ playersPerSide: d.playersPerSide, sideA: null, sideB: null, matchNumber: i + 1 }));
         await setPairings.mutateAsync({ tripId, gameId, matches: empty });
         setCollapseError(false);
+        clearDraftOutbox(); // durably persisted → drop the teardown copy
         if (competitionId) {
           utils.competitions.leaderboard.invalidate({ tripId, competitionId });
           utils.games.listByTrip.invalidate({ tripId });
@@ -815,6 +846,7 @@ export function MatchGameView() {
       const ok = await saveSetup();
       if (ok) {
         setCollapseError(false);
+        clearDraftOutbox(); // durably persisted → drop the teardown copy
         // Mark the competition board stale so a LATER view refetches — but do NOT
         // refetch matchesQ here. Refetching mid-setup updates serverMatches with
         // the just-written (read-after-write racy) rows, which re-derives the

--- a/src/components/games/RackGameView.tsx
+++ b/src/components/games/RackGameView.tsx
@@ -10,6 +10,7 @@ import { useGameSettingsOverlay } from "@/hooks/useGameSettingsOverlay";
 import { useInGamePanel, usePublishGameChrome } from "@/components/games/GameChrome";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useScoreSaver } from "@/hooks/useScoreSaver";
+import { useDraftOutbox } from "@/hooks/useDraftOutbox";
 import { useConfigSync, GAME_SYNC_INTERVAL_MS } from "@/hooks/useConfigSync";
 import { showToast } from "@/lib/toast";
 import { CoursePicker } from "@/components/games/course/CoursePicker";
@@ -99,6 +100,9 @@ export function RackGameView() {
     groupingsTouched.current = true;
     setGroupDraft(next);
   };
+  // Surfaced retry when a groupings persist fails (parity with match's
+  // collapseError) — closes rack's silent-loss gap.
+  const [groupSaveError, setGroupSaveError] = useState(false);
   // The ONE settings overlay — owns open/close/back + the leaderboard deep link
   // (?settings=1 → land here directly for an owner/delegate of a setup-mode game).
   const { open: showConfig, openConfig, closeConfig } = useGameSettingsOverlay({
@@ -406,12 +410,23 @@ export function RackGameView() {
   // refreshes the board (incl. faceBootstrap, CLAUDE.md #10).
   async function saveGroups() {
     if (!tripId || !gid) return;
-    await setFoursomes.mutateAsync({ tripId, gameId: gid, groups: groupsToPersist(groupDraft) });
-    await utils.playGroups.listByGame.invalidate({ tripId, gameId: gid });
-    if (competitionId) {
-      utils.competitions.leaderboard.invalidate({ tripId, competitionId });
-      utils.competitions.faceBootstrap.invalidate({ tripId });
-      utils.games.listByTrip.invalidate({ tripId });
+    // try/catch (parity with MatchGameView's persistDraftOnCollapse): a bare
+    // mutateAsync here was a silent loss — a transient failure on close-flush
+    // became an unhandled rejection with the draft already gone from view and no
+    // retry. Now the draft is KEPT (the outbox still holds it) and a retry is
+    // surfaced; success clears both the error and the teardown copy.
+    try {
+      await setFoursomes.mutateAsync({ tripId, gameId: gid, groups: groupsToPersist(groupDraft) });
+      setGroupSaveError(false);
+      clearGroupsOutbox(); // durably persisted → drop the teardown copy
+      await utils.playGroups.listByGame.invalidate({ tripId, gameId: gid });
+      if (competitionId) {
+        utils.competitions.leaderboard.invalidate({ tripId, competitionId });
+        utils.competitions.faceBootstrap.invalidate({ tripId });
+        utils.games.listByTrip.invalidate({ tripId });
+      }
+    } catch {
+      setGroupSaveError(true);
     }
   }
 
@@ -423,8 +438,16 @@ export function RackGameView() {
       setOpenAccordion(null);
       if (groupingsTouched.current) void saveGroups();
     } else {
-      setGroupDraft(currentGroupDraft());
-      groupingsTouched.current = false;
+      // Restore a hard-teardown draft first (only if the server is unchanged
+      // since it diverged); mark it touched so the flush net persists it.
+      const recovered = recoverGroups();
+      if (recovered && recovered.length > 0) {
+        setGroupDraft(recovered);
+        groupingsTouched.current = true;
+      } else {
+        setGroupDraft(currentGroupDraft());
+        groupingsTouched.current = false;
+      }
       setOpenAccordion("groupings");
     }
   }
@@ -541,6 +564,27 @@ export function RackGameView() {
   // Phase 2B.1: a rack with its groups set must be Enabled before the play screen
   // opens (the score saver server-rejects entries until then).
   const scoringEnabled = (gameQ.data as { scoring_enabled?: boolean } | undefined)?.scoring_enabled === true;
+
+  // Draft durability (Layer 2 — hard-teardown outbox), the rack counterpart to
+  // MatchGameView's. The in-app flush net already persists a built grouping on
+  // every in-app exit; this mirrors the in-progress group draft to localStorage
+  // so a refresh / tab-close / OS-kill / background can't lose it (incomplete
+  // groupings too). `serverFingerprint` is the persisted grouping the draft
+  // diverged from — the no-clobber guard for recover().
+  const groupServerFingerprint = useMemo(
+    () => JSON.stringify(currentGroupDraft()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [groupsQ.data, participants]
+  );
+  const { recover: recoverGroups, clear: clearGroupsOutbox } = useDraftOutbox<string[][]>({
+    view: "rack",
+    gameId: gid,
+    draft: groupDraft,
+    touched: groupingsTouched.current,
+    serverFingerprint: groupServerFingerprint,
+    enabled: !!gid && !scoringEnabled,
+  });
+
   async function refreshGame() {
     if (!tripId || !gid) return;
     await utils.games.getById.invalidate({ tripId, gameId: gid });
@@ -733,6 +777,16 @@ export function RackGameView() {
           Add a group per cart, then pick its players from either team — any mix of 1–4. Anyone left out sits this round out.
         </p>
         <RackGroupBuilder groups={groupDraft} onChange={editGroupDraft} teamA={teamA} teamB={teamB} />
+        {groupSaveError && (
+          <button
+            type="button"
+            onClick={() => void saveGroups()}
+            className="mt-2 text-left text-[13px]"
+            style={{ color: "var(--color-bt-danger)" }}
+          >
+            Couldn’t save your groups — tap to retry.
+          </button>
+        )}
       </ChecklistRow>
     );
     // OPTIONS section (extraRows): Handicaps. (Rack has no Game Modifiers — its

--- a/src/hooks/useDraftOutbox.ts
+++ b/src/hooks/useDraftOutbox.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { draftOutboxPut, draftOutboxClear, draftOutboxRecover, type DraftView } from "@/lib/draftOutbox";
+
+/**
+ * useDraftOutbox — mirrors an in-progress setup draft to a localStorage outbox
+ * (see draftOutbox.ts) so a HARD teardown (refresh / tab-close / OS-kill /
+ * background) can't lose it, and restores it on return. Shared by MatchGameView
+ * (pairings) and RackGameView (groupings) — the two forked draft paths.
+ *
+ * This is Layer 2, ON TOP of the existing in-app three-layer flush net (which is
+ * unchanged and still handles every in-app exit). It only fills the teardown gap
+ * that net structurally can't reach.
+ *
+ * Contract:
+ *  - Mirrors `draft` whenever it changes AND the user has TOUCHED it (an
+ *    untouched draft equals the server — nothing to save), while `enabled`
+ *    (setup-mode only). `base` = the server fingerprint the draft diverged from,
+ *    frozen at first touch, so recover() can reject a stale-over-newer restore.
+ *  - `pagehide` + `visibilitychange`→hidden commit the CURRENT draft
+ *    SYNCHRONOUSLY (an async write wouldn't finish during teardown). pagehide is
+ *    the mobile-reliable signal (beforeunload is not); visibilitychange→hidden
+ *    covers app-backgrounding before an OS kill. No beforeunload — matches the
+ *    proven scoreOutbox choice.
+ *  - recover() returns the stored draft iff the server is unchanged since it
+ *    diverged; the view restores it into its editing state (and marks it touched
+ *    so the in-app net will persist it).
+ *  - clear() drops the entry after a durable server persist (or discard).
+ */
+export function useDraftOutbox<T>(opts: {
+  view: DraftView;
+  gameId: string | null | undefined;
+  draft: T;
+  touched: boolean;
+  /** Fingerprint of the server-derived draft (JSON of the persisted state). */
+  serverFingerprint: string;
+  /** Setup-mode only — never mirror/commit against a live/scoring game. */
+  enabled: boolean;
+}) {
+  const { view, gameId, draft, touched, serverFingerprint, enabled } = opts;
+
+  // Latest-refs so the teardown listeners (stable, empty-ish deps) read current
+  // values synchronously without re-subscribing on every edit.
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const touchedRef = useRef(touched);
+  touchedRef.current = touched;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const gameIdRef = useRef(gameId);
+  gameIdRef.current = gameId;
+  // base = the server fingerprint the current draft diverged from. Tracks the
+  // live server fingerprint WHILE untouched (draft == server), then freezes at
+  // the first edit so it records what the edits diverged from.
+  const baseRef = useRef(serverFingerprint);
+
+  const draftStr = JSON.stringify(draft);
+
+  // Mirror-on-edit (+ base tracking). Runs after each render where the draft,
+  // touched, or server fingerprint changed.
+  useEffect(() => {
+    if (!enabled || !gameId) return;
+    if (!touched) {
+      // Still equal to the server — nothing to persist; keep base current.
+      baseRef.current = serverFingerprint;
+      return;
+    }
+    draftOutboxPut(view, gameId, draft, baseRef.current, Date.now());
+    // draft is captured via draftStr in deps; ref not needed here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftStr, touched, serverFingerprint, enabled, gameId, view]);
+
+  // Synchronous commit on hard teardown — the ONE gap the in-app flush net can't
+  // reach (React cleanup doesn't run on refresh/tab-close/OS-kill).
+  useEffect(() => {
+    const commit = () => {
+      if (!enabledRef.current || !gameIdRef.current || !touchedRef.current) return;
+      draftOutboxPut(view, gameIdRef.current, draftRef.current, baseRef.current, Date.now());
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") commit();
+    };
+    window.addEventListener("pagehide", commit);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("pagehide", commit);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [view]);
+
+  /** Restore the stored draft iff the server is unchanged since it diverged. */
+  const recover = useCallback((): T | null => {
+    if (!gameId) return null;
+    return draftOutboxRecover(view, gameId, serverFingerprint) as T | null;
+  }, [view, gameId, serverFingerprint]);
+
+  /** Drop the entry after a durable persist / discard. */
+  const clear = useCallback(() => {
+    if (gameId) draftOutboxClear(view, gameId);
+  }, [view, gameId]);
+
+  return { recover, clear };
+}

--- a/src/lib/draftOutbox.test.ts
+++ b/src/lib/draftOutbox.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  draftOutboxPut,
+  draftOutboxClear,
+  draftOutboxRecover,
+  draftOutboxPeek,
+} from "./draftOutbox";
+
+/**
+ * draftOutbox (Wave 1 pairings — hard-teardown durability). Tested against an
+ * in-memory localStorage polyfill (node env), mirroring scoreOutbox.test. The
+ * headline behaviours: a whole-draft snapshot round-trips; recover restores ONLY
+ * when the base fingerprint still matches the server (no stale-over-newer
+ * clobber); per-(view, game) namespacing keeps match and rack drafts separate.
+ */
+
+describe("draftOutbox — localStorage snapshot + no-clobber recover", () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    (globalThis as unknown as { window: unknown; localStorage: unknown }).window = globalThis;
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: () => null,
+      length: 0,
+    } as Storage;
+  });
+
+  const DRAFT = [{ matchNumber: 1, playersPerSide: 2, a: ["u1", "u2"], b: ["u3", "u4"], handicap: 0 }];
+
+  it("put → recover returns the stored draft when the server is unchanged (base matches)", () => {
+    draftOutboxPut("match", "g1", DRAFT, "BASE_FP", 111);
+    expect(draftOutboxRecover("match", "g1", "BASE_FP")).toEqual(DRAFT);
+  });
+
+  it("recover returns null AND clears when the server moved on (base mismatch — no clobber)", () => {
+    draftOutboxPut("match", "g1", DRAFT, "BASE_FP", 111);
+    // A different current server fingerprint = someone else persisted since.
+    expect(draftOutboxRecover("match", "g1", "NEWER_FP")).toBeNull();
+    // Stale entry is dropped, so a later matching-base recover can't resurrect it.
+    expect(draftOutboxPeek("match", "g1")).toBeNull();
+  });
+
+  it("recover on an empty store is null (nothing to restore)", () => {
+    expect(draftOutboxRecover("match", "g1", "ANY")).toBeNull();
+  });
+
+  it("clear drops the entry (durable persist / discard)", () => {
+    draftOutboxPut("rack", "g1", [["u1", "u2"]], "B", 1);
+    draftOutboxClear("rack", "g1");
+    expect(draftOutboxPeek("rack", "g1")).toBeNull();
+  });
+
+  it("is namespaced per (view, gameId) — match and rack drafts never collide", () => {
+    draftOutboxPut("match", "g1", DRAFT, "MB", 1);
+    draftOutboxPut("rack", "g1", [["u9"]], "RB", 2);
+    draftOutboxPut("match", "g2", [{ matchNumber: 1, playersPerSide: 1, a: ["x"], b: ["y"], handicap: 0 }], "MB2", 3);
+    expect(draftOutboxRecover("match", "g1", "MB")).toEqual(DRAFT);
+    expect(draftOutboxRecover("rack", "g1", "RB")).toEqual([["u9"]]);
+    expect(draftOutboxRecover("match", "g2", "MB2")).toEqual([{ matchNumber: 1, playersPerSide: 1, a: ["x"], b: ["y"], handicap: 0 }]);
+  });
+
+  it("stores incomplete drafts too (a half-built pairing survives teardown)", () => {
+    const incomplete = [{ matchNumber: 1, playersPerSide: 2, a: ["u1"], b: [], handicap: 0 }];
+    draftOutboxPut("match", "g1", incomplete, "B", 1);
+    expect(draftOutboxRecover("match", "g1", "B")).toEqual(incomplete);
+  });
+
+  it("last put wins (the latest teardown snapshot is what recovers)", () => {
+    draftOutboxPut("match", "g1", DRAFT, "B", 1);
+    const later = [{ matchNumber: 1, playersPerSide: 2, a: ["u1", "u2"], b: ["u3", "u9"], handicap: 2 }];
+    draftOutboxPut("match", "g1", later, "B", 2);
+    expect(draftOutboxRecover("match", "g1", "B")).toEqual(later);
+  });
+
+  it("survives a simulated reload (same backing store, fresh read)", () => {
+    draftOutboxPut("rack", "g5", [["a", "b"], ["c"]], "FP", 1);
+    // A reload is just another read of the same store.
+    expect(draftOutboxRecover("rack", "g5", "FP")).toEqual([["a", "b"], ["c"]]);
+  });
+});

--- a/src/lib/draftOutbox.ts
+++ b/src/lib/draftOutbox.ts
@@ -1,0 +1,86 @@
+"use client";
+
+/**
+ * draftOutbox — durability for in-progress SETUP drafts (match pairings / rack
+ * groupings), the Layer-2 companion to the in-app three-layer flush net.
+ *
+ * The in-app net (accordion-collapse persist + overlay-close flush + unmount
+ * cleanup) already persists a COMPLETE draft on every IN-APP exit (collapse,
+ * back, route change, panel close). It cannot cover the ONE remaining loss
+ * window: HARD teardown — refresh / tab-close / OS-kill / background-then-killed
+ * — where React cleanup never runs. This outbox closes that window, and (unlike
+ * the server-persist path) covers INCOMPLETE drafts too, since an incomplete
+ * pairing/grouping is never valid enough to persist to the server.
+ *
+ * Mirrors scoreOutbox: best-effort localStorage, SSR-safe, never throws into the
+ * setup path. Differs in shape — scoreOutbox stores per-cell values re-sent
+ * idempotently; this stores a WHOLE-DRAFT snapshot plus `base`, the fingerprint
+ * of the server state the draft diverged from. `base` is the no-clobber guard:
+ * on return we restore the draft ONLY when the server is unchanged since it
+ * diverged (base === current server fingerprint) — never stale-over-newer.
+ */
+
+export type DraftView = "match" | "rack";
+
+export interface StoredDraft {
+  /** The view's serializable draft (DraftMatch[] for match, string[][] for rack). */
+  draft: unknown;
+  /** Fingerprint of the server-derived draft this local draft diverged from. */
+  base: string;
+  ts: number;
+}
+
+const NS = "bt.setupDraft.v1";
+const storeKey = (view: DraftView, gameId: string) => `${NS}:${view}:${gameId}`;
+
+function read(view: DraftView, gameId: string): StoredDraft | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(storeKey(view, gameId));
+    return raw ? (JSON.parse(raw) as StoredDraft) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRaw(view: DraftView, gameId: string, entry: StoredDraft | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (entry === null) window.localStorage.removeItem(storeKey(view, gameId));
+    else window.localStorage.setItem(storeKey(view, gameId), JSON.stringify(entry));
+  } catch {
+    /* quota exceeded / storage disabled — best-effort; never throw into setup. */
+  }
+}
+
+/** Mirror the current draft (called on edit + synchronously on teardown). */
+export function draftOutboxPut(view: DraftView, gameId: string, draft: unknown, base: string, ts: number): void {
+  writeRaw(view, gameId, { draft, base, ts });
+}
+
+/** Drop the entry — on durable server persist, or explicit discard. */
+export function draftOutboxClear(view: DraftView, gameId: string): void {
+  writeRaw(view, gameId, null);
+}
+
+/**
+ * Recover a stored draft IFF it diverged from the SAME server state we see now
+ * (`base === currentServerFingerprint`). A mismatch means the server moved on
+ * (another device persisted) since this draft diverged — the stored draft is
+ * stale, so drop it and return null (no clobber). Returns the raw draft for the
+ * caller to cast to its own draft type.
+ */
+export function draftOutboxRecover(view: DraftView, gameId: string, currentServerFingerprint: string): unknown | null {
+  const stored = read(view, gameId);
+  if (!stored) return null;
+  if (stored.base !== currentServerFingerprint) {
+    draftOutboxClear(view, gameId); // stale — server changed underneath it
+    return null;
+  }
+  return stored.draft;
+}
+
+/** Peek at the raw stored entry (tests / diagnostics). */
+export function draftOutboxPeek(view: DraftView, gameId: string): StoredDraft | null {
+  return read(view, gameId);
+}


### PR DESCRIPTION
## Summary

Closes the one real data-loss window for match-pairing / rack-grouping setup
drafts. **Phase 0 corrected the premise**: the in-app three-layer flush net
(accordion-collapse + overlay-close + unmount cleanup) already persists a draft
on every *in-app* exit (back, route change, panel close). The only genuine loss
is **hard teardown** — refresh / tab-close / OS-kill / background — where React
cleanup never runs and there was no `pagehide`/`visibilitychange` handler or
draft persistence. This is **Option B** (Zach's call after the premise
correction): a localStorage draft outbox mirroring `scoreOutbox`, covering both
**complete and incomplete** drafts (the incomplete case is what persist-on-valid
couldn't cover).

## Changes

- **`draftOutbox` + `useDraftOutbox`** (shared by both views) — mirrors the
  in-progress draft to localStorage while touched + setup-mode, commits
  **synchronously** on `pagehide`/`visibilitychange`→hidden (mobile-reliable; no
  fragile `beforeunload`), and restores on return. Stores a whole-draft snapshot
  plus `base` (the server fingerprint it diverged from) so `recover()` restores
  **only when the server is unchanged** — no stale-over-newer clobber.
- **MatchGameView** (pairings) + **RackGameView** (groupings — separate path)
  wired: recover before the server seed; clear the outbox at every durable-persist
  point.
- **Rack `saveGroups` silent-loss fix**: it had no try/catch, so a transient
  close-flush failure was an unhandled rejection with the draft gone. Now wrapped
  (parity with match's `persistDraftOnCollapse`) with a surfaced "tap to retry".

The existing in-app flush net is **unchanged** — this is Layer 2 on top of it.
Global cache config untouched; no polling.

## Test plan

- [x] `tsc` + `next lint` clean
- [x] 8 unit tests: snapshot round-trip, **base-mismatch no-clobber** (drops the
      stale entry), incomplete-draft storage, per-(view,game) namespacing,
      last-write-wins, reload survival
- [x] **By-eye on preview (the real bug window):** assign a player → an incomplete
      1-of-2 draft mirrors to the outbox (`base:"[]"`) → **hard refresh** (never
      collapsed → never server-persisted) → reopen → the player is **restored**
      into the slot. Outbox survives the reload (pagehide re-commit), recover
      restores it, and it clears on a durable persist. No console errors.
- Both views share the hook; incomplete drafts covered; no clobber (base guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)