### PR TITLE
Wave 1 bugs: agenda location field + tee-select delay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ ANTHROPIC_API_KEY=sk-ant-...
 # manual course entry.
 GOLFCOURSE_API_KEY=
 
+# Google Places API key (SECRET — server-only, proxied by /api/places). Powers
+# the LOCATION autocomplete in the agenda add/edit modal (venue + golf-course
+# location fields). Requires "Places API (New)" enabled with billing on.
+# If unset/misconfigured, the location field can't return results — the modal
+# now shows a "search unavailable" note (was a silent empty dropdown). MUST be
+# set in the deployed (Vercel) environment, not just locally.
+GOOGLE_PLACES_API_KEY=
+
 # --- CI-only (set as GitHub Actions secrets) ---
 
 # Supabase DB connection string for `supabase db push` in CI

--- a/src/app/api/places/route.ts
+++ b/src/app/api/places/route.ts
@@ -67,7 +67,11 @@ export async function POST(req: NextRequest) {
     if (!res.ok) {
       const errText = await res.text();
       console.error("Places API error:", res.status, errText);
-      return NextResponse.json({ predictions: [] });
+      // Surface the failure so the client can show "search unavailable" instead
+      // of a silent empty dropdown that reads as "no matches" (the exact way a
+      // misconfigured key / disabled API / billing-off used to look like a dead
+      // field). 502 = upstream failed, distinct from a real 200 empty result.
+      return NextResponse.json({ error: "Places search unavailable", predictions: [] }, { status: 502 });
     }
 
     const data = await res.json();
@@ -99,7 +103,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ predictions });
   } catch (err) {
     console.error("Places API fetch error:", err);
-    return NextResponse.json({ predictions: [] });
+    return NextResponse.json({ error: "Places search unavailable", predictions: [] }, { status: 502 });
   }
 }
 

--- a/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
+++ b/src/app/trips/[tripId]/components/AddScheduleItemSheet.tsx
@@ -62,6 +62,12 @@ function usePlacesSearch(types?: string[]) {
   const [query, setQuery] = useState("");
   const [predictions, setPredictions] = useState<PlacePrediction[]>([]);
   const [loading, setLoading] = useState(false);
+  // "unavailable" when the proxy fails (missing/misconfigured GOOGLE_PLACES_API_KEY,
+  // Places API not enabled/billed, network) — distinct from a genuine 200 empty
+  // result. Without this the field silently shows nothing on any failure, reading
+  // as a dead field (the reported bug: no results in the deployed env where the
+  // key isn't set).
+  const [unavailable, setUnavailable] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
   const search = useCallback((q: string) => {
@@ -69,6 +75,7 @@ function usePlacesSearch(types?: string[]) {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (q.length < 2) {
       setPredictions([]);
+      setUnavailable(false);
       return;
     }
     setLoading(true);
@@ -79,10 +86,19 @@ function usePlacesSearch(types?: string[]) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ query: q, types }),
         });
-        const data = await res.json();
-        setPredictions(data.predictions ?? []);
+        const data = await res.json().catch(() => ({}));
+        // A non-OK status or an { error } body means the lookup couldn't run —
+        // surface it rather than coalescing to an empty "no matches" list.
+        if (!res.ok || data.error) {
+          setPredictions([]);
+          setUnavailable(true);
+        } else {
+          setPredictions(data.predictions ?? []);
+          setUnavailable(false);
+        }
       } catch {
         setPredictions([]);
+        setUnavailable(true);
       } finally {
         setLoading(false);
       }
@@ -92,9 +108,10 @@ function usePlacesSearch(types?: string[]) {
   const clear = useCallback(() => {
     setQuery("");
     setPredictions([]);
+    setUnavailable(false);
   }, []);
 
-  return { query, predictions, loading, search, clear };
+  return { query, predictions, loading, unavailable, search, clear };
 }
 
 // ── Component ────────────────────────────────────────────────────────────
@@ -674,6 +691,12 @@ export function AddScheduleItemSheet({
                   </p>
                 )}
 
+                {placesSearch.unavailable && !placesSearch.loading && (
+                  <p className="mt-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                    Course search is unavailable right now — enter the course manually below.
+                  </p>
+                )}
+
                 {/* "Can't find it?" fallback — shown once the user has typed something */}
                 {!placesSearch.loading && placesSearch.query.length >= 2 && (
                   <button
@@ -882,6 +905,11 @@ export function AddScheduleItemSheet({
                 {locationSearch.loading && locationSearch.query.length >= 2 && (
                   <p className="mt-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
                     Searching...
+                  </p>
+                )}
+                {locationSearch.unavailable && !locationSearch.loading && (
+                  <p className="mt-1 text-xs" style={{ color: "var(--color-bt-text-dim)" }}>
+                    Location search is unavailable right now — you can still type the venue name.
                   </p>
                 )}
               </div>

--- a/src/components/games/course/CourseRowContent.tsx
+++ b/src/components/games/course/CourseRowContent.tsx
@@ -64,14 +64,32 @@ export function CourseRowContent({
     !!backId && !!appliedTeeName && backTees.length > 0 &&
     !backTees.some((t) => (t.name ?? "").trim() === appliedTeeName);
 
-  function refresh(courseId?: string) {
+  // Apply mutations are in flight → drive the tee chooser's pending feedback.
+  const applying = applyCourse.isPending || setBackNine.isPending;
+
+  // Fast-path the course/tee-apply response (the reported "long delay"): the
+  // mutation RETURNS the updated game row, so merge it straight into the getById
+  // cache — the parent (gameQ) repaints the resolved course INSTANTLY instead of
+  // waiting on the shared onSetupChanged cascade (gameQ.refetch + the board's
+  // faceBootstrap/leaderboard/listByTrip refetches, heavy because the board stays
+  // mounted under the panel). A course/tee change is pre-scoring (frozen once
+  // scores exist), so the board can't have changed — skipping that cascade here
+  // is safe. Merge (not overwrite): applyCourse returns SELECT * (no
+  // `participants`), while getById caches game + participants, so spread over prev.
+  const patchGameFromReturn = (row: unknown, courseId?: string) => {
+    if (row && typeof row === "object") {
+      utils.games.getById.setData(
+        { tripId, gameId },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (prev: any) => (prev ? { ...prev, ...(row as Record<string, unknown>) } : prev)
+      );
+    }
     if (courseId) utils.courses.getById.invalidate({ courseId });
-    onChanged();
-  }
+  };
   const onPickFront = ({ id, teeName }: { id: string; teeName?: string }) =>
-    applyCourse.mutate({ tripId, gameId, courseId: id, teeSetName: teeName }, { onSuccess: () => refresh(id) });
+    applyCourse.mutate({ tripId, gameId, courseId: id, teeSetName: teeName }, { onSuccess: (row) => patchGameFromReturn(row, id) });
   const onPickBack = ({ id, teeName }: { id: string; teeName?: string }) =>
-    setBackNine.mutate({ tripId, gameId, backCourseId: id, backTeeSetName: teeName }, { onSuccess: () => refresh(id) });
+    setBackNine.mutate({ tripId, gameId, backCourseId: id, backTeeSetName: teeName }, { onSuccess: (row) => patchGameFromReturn(row, id) });
   // Remove the back nine (per-nine × — Task 2b): re-apply the FRONT alone, which
   // resets back_course_id and shrinks the schema back to 9 → the "needs a back
   // nine" state (re-pick from there). Reuses applyCourse — no new server machinery
@@ -79,13 +97,15 @@ export function CourseRowContent({
   const onRemoveBack = () =>
     applyCourse.mutate(
       { tripId, gameId, courseId: frontId!, teeSetName: appliedTeeName || undefined },
-      { onSuccess: () => refresh(frontId!) }
+      { onSuccess: (row) => patchGameFromReturn(row, frontId!) }
     );
-  const onClearCourse = () => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => refresh() });
+  // Clearing the course fully is rare and not the hot tee-select path — keep the
+  // broad refresh (onChanged) so every dependent surface re-derives from scratch.
+  const onClearCourse = () => clearCourse.mutate({ tripId, gameId }, { onSuccess: () => { onChanged(); } });
 
   // ── No course → front picker ──────────────────────────────────────────────
   if (!frontId) {
-    return <CourseSearchPanel tripId={tripId} gameId={gameId} onApply={onPickFront} />;
+    return <CourseSearchPanel tripId={tripId} gameId={gameId} onApply={onPickFront} busy={applying} />;
   }
 
   // ── 9-hole front, no back → needs a back nine ─────────────────────────────
@@ -97,7 +117,7 @@ export function CourseRowContent({
         <div>
           <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-accent)" }}>Add the back nine</span>
           <p className="mb-2 mt-0.5 text-[12px]" style={{ color: "var(--color-bt-text-dim)" }}>A 9-hole course needs a back nine to make a full 18.</p>
-          <CourseSearchPanel tripId={tripId} gameId={gameId} mode="back" onApply={onPickBack} />
+          <CourseSearchPanel tripId={tripId} gameId={gameId} mode="back" onApply={onPickBack} busy={applying} />
         </div>
       </div>
     );

--- a/src/components/games/course/CourseSearchPanel.tsx
+++ b/src/components/games/course/CourseSearchPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Search, AlertTriangle, PencilLine, ChevronRight } from "lucide-react";
+import { Search, AlertTriangle, PencilLine, ChevronRight, Loader2 } from "lucide-react";
 import { trpc } from "@/lib/trpc-client";
 import { searchCourses, teeColor, type CourseSummary } from "@/lib/courseService";
 import { manualEntryVisible, dedupeApiCourses } from "@/lib/courseSearch";
@@ -22,7 +22,7 @@ import type { RecentCourse } from "./CoursePicker";
  * applied tee is what the row's loud value shows).
  */
 export function CourseSearchPanel({
-  tripId, gameId, onApply, mode = "front",
+  tripId, gameId, onApply, mode = "front", busy = false,
 }: {
   tripId: string;
   gameId: string;
@@ -32,6 +32,10 @@ export function CourseSearchPanel({
    *  the golfcourseapi search (a back nine is a saved/manual 9-holer), and the
    *  entry page lands in back-slot mode. Default "front" (the whole course). */
   mode?: "front" | "back";
+  /** The parent's apply mutation is in flight — disable + spinner the tapped tee
+   *  so a tee-select gives IMMEDIATE feedback instead of looking frozen while the
+   *  apply + refresh runs. */
+  busy?: boolean;
 }) {
   const back = mode === "back";
   const router = useRouter();
@@ -42,6 +46,8 @@ export function CourseSearchPanel({
   const [apiSearched, setApiSearched] = useState(false);
   // The saved course whose tee chooser is expanded (multi-tee select-before-apply).
   const [teePickFor, setTeePickFor] = useState<RecentCourse | null>(null);
+  // The tee label currently being applied — drives the per-tee spinner (feedback).
+  const [pendingTee, setPendingTee] = useState<string | null>(null);
 
   const recent = trpc.courses.list.useQuery({ limit: 8 });
   const apiUsage = trpc.courses.apiUsage.useQuery(undefined, { staleTime: 0 });
@@ -109,17 +115,26 @@ export function CourseSearchPanel({
         </div>
         <span className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: "var(--color-bt-text-dim)" }}>Choose a tee</span>
         <div className="flex flex-wrap gap-2">
-          {(teePickFor.tee_sets ?? []).map((t, i) => (
-            <button
-              key={i}
-              onClick={() => onApply({ id: teePickFor.id, name: teePickFor.name, teeName: t.name?.trim() || undefined })}
-              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm"
-              style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
-            >
-              <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(t.name || `Tee ${i + 1}`) }} />
-              {t.name || `Tee ${i + 1}`}
-            </button>
-          ))}
+          {(teePickFor.tee_sets ?? []).map((t, i) => {
+            const label = t.name || `Tee ${i + 1}`;
+            const isPending = busy && pendingTee === label;
+            return (
+              <button
+                key={i}
+                onClick={() => { setPendingTee(label); onApply({ id: teePickFor.id, name: teePickFor.name, teeName: t.name?.trim() || undefined }); }}
+                disabled={busy}
+                className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm disabled:opacity-60"
+                style={{ background: "var(--color-bt-card-raised)", color: "var(--color-bt-text)", border: "1px solid var(--color-bt-border)" }}
+              >
+                {isPending ? (
+                  <Loader2 size={13} className="animate-spin" style={{ color: "var(--color-bt-text-dim)" }} />
+                ) : (
+                  <span style={{ width: 9, height: 9, borderRadius: "50%", background: teeColor(label) }} />
+                )}
+                {label}
+              </button>
+            );
+          })}
         </div>
       </div>
     );


### PR DESCRIPTION
Two independent Wave 1 bugs, diagnosed then fixed (independent commits).

## Bug 1 — agenda location field returns nothing

**Root (diagnosed):** the location autocomplete (agenda add/edit modal — venue +
golf-course fields) proxies Google Places via `/api/places`, which needs
`GOOGLE_PLACES_API_KEY`. **It works locally** (key present → I confirmed 200 +
predictions), so the reported "returns nothing" is the **deployed env** where the
key isn't set — and `.env.example` never documented it, so it's easy to miss. The
route silently swallowed every failure into `{ predictions: [] }`, indistinguishable
from a real "no matches", so the field read as dead.

**Fix (code):**
- `/api/places`: return `502 + { error }` on upstream failure / fetch throw (the
  503 missing-key case already errored), so the client can tell "unavailable" from
  "no matches".
- `usePlacesSearch`: track `unavailable`; on `!res.ok` / `{ error }`, show a legible
  "search unavailable — type it manually" note instead of an empty dropdown. Both
  the venue and golf-course fields.
- `.env.example`: document `GOOGLE_PLACES_API_KEY`.

**⚠ Action required (config, not code):** set `GOOGLE_PLACES_API_KEY` in the Vercel
environment and ensure "Places API (New)" is enabled with billing — that's the
actual prod fix; this PR makes the failure legible + documents the var.

## Bug 2 — long delay after selecting a golf tee

**Root (diagnosed):** tapping a tee fired an un-awaited `applyCourse`/`setBackNine`
with **no pending UI** on the tee chooser, and its success ran the shared
`onSetupChanged` cascade (`gameQ.refetch` + `faceBootstrap`/`leaderboard`/
`listByTrip` invalidations — heavy because the board stays mounted under the panel).
The button looked frozen for the whole round-trip + refetch storm.

**Fix (removed the cause, not just a spinner):**
- Immediate feedback: the tapped tee spinners + disables via the mutation's
  `isPending`.
- The apply mutations RETURN the updated game row, so merge it into the
  `games.getById` cache (preserving `participants`) instead of `gameQ.refetch` + the
  competition cascade. A course/tee change is pre-scoring (frozen once scores
  exist), so the board can't have changed — the cascade was pure waste. The row
  repaints instantly from the cache patch. `clearCourse` (rare) keeps the broad
  refresh.

## Test plan
- [x] `tsc` + `next lint` clean
- [x] Bug 1: `/api/places` returns predictions locally (confirmed); route/hook now
      surface failures as "unavailable"
- [x] Bug 2: by-eye — tap a tee → spinner shows immediately → course resolves in the
      mutation's own round-trip, no cascade on top; no console errors
  (verification changed a *test* game's course, harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)